### PR TITLE
Add IdenticaBridge: get major user activity

### DIFF
--- a/bridges/IdenticaBridge.php
+++ b/bridges/IdenticaBridge.php
@@ -1,0 +1,41 @@
+<?php
+/**
+* RssBridgeIdentica 
+*
+* @name Identica Bridge
+* @description Returns user timelines
+* @use1(u="username")
+*/
+class IdenticaBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = '';
+        if (isset($param['u'])) {   /* user timeline mode */
+            $html = file_get_html('https://identi.ca/'.urlencode($param['u'])) or $this->returnError('Requested username can\'t be found.', 404);
+        }
+        else {
+            $this->returnError('You must specify an Identica username (?u=...).', 400);
+        }
+
+        foreach($html->find('li.major') as $dent) {
+            $item = new \Item();
+            $item->uri = html_entity_decode($dent->find('a', 0)->href);	// get dent link
+            $item->timestamp = strtotime($dent->find('abbr.easydate', 0)->plaintext);	// extract dent timestamp
+            $item->content = trim($dent->find('div.activity-content', 0)->innertext);	// extract dent text
+            $item->title = $param['u'] . ' | ' . $item->content;
+            $this->items[] = $item;
+        }
+    }
+
+    public function getName(){
+        return 'Identica Bridge';
+    }
+
+    public function getURI(){
+        return 'https://identica.com';
+    }
+
+    public function getCacheDuration(){
+        return 300; // 5 minutes
+    }
+}

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -1,0 +1,36 @@
+<?php
+/**
+* RssBridgeYoutube 
+* Returns the newest videos
+*
+* @name Youtube Bridge
+* @description Returns the newest videos
+* @use1(u="username")
+*/
+class YoutubeBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = file_get_html('https://www.youtube.com/user/'.urlencode($param['u']).'/videos') or $this->returnError('Could not request Youtube.', 404);
+    
+        foreach($html->find('li.channels-content-item') as $element) {
+            $item = new \Item();
+            $item->uri = 'https://www.youtube.com'.$element->find('a',0)->href;
+            $item->thumbnailUri = 'https:'.$element->find('img',0)->src;
+            $item->title = trim($element->find('h3',0)->plaintext);
+            $item->content = '<a href="' . $item->uri . '"><img src="' . $item->thumbnailUri . '" /></a><br><a href="' . $item->uri . '">' . $item->title . '</a>';
+            $this->items[] = $item;
+        }
+    }
+
+    public function getName(){
+        return 'Youtube Bridge';
+    }
+
+    public function getURI(){
+        return 'https://www.youtube.com/';
+    }
+
+    public function getCacheDuration(){
+        return 21600; // 6 hours
+    }
+}


### PR DESCRIPTION
Ajout d'une bridge pour Identica (normalement applicable à toute instance Pump.io): ça récupère les dernières activités majeures d'un certain username (en gros: les notes)
