### PR TITLE
Embedding youtube videos into the feed

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -65,6 +65,7 @@ class YoutubeBridge extends BridgeAbstract{
             $item->uri = 'https://www.youtube.com'.$element->find('a',0)->href;
             $item->thumbnailUri = 'https:'.$element->find('img',0)->src;
             $item->attachment = htmlspecialchars($video);
+            $item->attachmentCodec = "video/mp4";
             $item->title = trim($element->find('h3',0)->plaintext);
             $item->content = '<a href="' . $item->uri . '"><img src="' . $item->thumbnailUri . '" /></a><br><a href="' . $item->uri . '">' . $item->title . '</a>';
             $this->items[] = $item;

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -23,9 +23,49 @@ class YoutubeBridge extends BridgeAbstract{
         
     
         foreach($html->find('li.channels-content-item') as $element) {
+            
+            
+            $opts = array('http' =>
+              array(
+                "method" => "GET",
+                'header'  => "User-Agent: Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0)\r\n"
+                )
+            );
+            $context  = stream_context_create($opts);
+            
+            $html_video = file_get_contents('http://www.youtube.com'.$element->find('a',0)->href, false, $context);
+            
+            if(!preg_match('/stream_map=(.[^&]*?)&/i',$html_video,$match))
+            {
+                $this->returnError ("Error Locating Downlod URL's", 400);
+            }
+    
+            if(!preg_match('/stream_map=(.[^&]*?)(?:\\\\|&)/i',$html_video,$match))
+            {
+                $this->returnError ("Problem", 400);
+            }
+    
+            $fmt_url =  urldecode($match[1]);
+       
+            $urls = explode(',',$fmt_url);
+                    
+            $foundArray = array();
+    
+            foreach($urls as $url)
+            {            
+                if(preg_match('/itag=([0-9]+)/',$url,$tm) && preg_match('/sig=(.*?)&/', $url , $si) && preg_match('/url=(.*?)&/', $url , $um))
+                {
+                    $u = urldecode($um[1]);
+                    $foundArray[$tm[1]] = $u.'&signature='.$si[1];
+                }
+            }
+            print_r($foundarray);
+            $video = $foundArray[22];
+
             $item = new \Item();
             $item->uri = 'https://www.youtube.com'.$element->find('a',0)->href;
             $item->thumbnailUri = 'https:'.$element->find('img',0)->src;
+            $item->attachment = htmlspecialchars($video);
             $item->title = trim($element->find('h3',0)->plaintext);
             $item->content = '<a href="' . $item->uri . '"><img src="' . $item->thumbnailUri . '" /></a><br><a href="' . $item->uri . '">' . $item->title . '</a>';
             $this->items[] = $item;

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -59,7 +59,6 @@ class YoutubeBridge extends BridgeAbstract{
                     $foundArray[$tm[1]] = $u.'&signature='.$si[1];
                 }
             }
-            print_r($foundarray);
             $video = $foundArray[22];
 
             $item = new \Item();

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -37,35 +37,52 @@ class YoutubeBridge extends BridgeAbstract{
             
             if(!preg_match('/stream_map=(.[^&]*?)&/i',$html_video,$match))
             {
-                $this->returnError ("Error Locating Downlod URL's", 400);
+                //$this->returnError ("Error Locating Downlod URL's", 400);
             }
     
             if(!preg_match('/stream_map=(.[^&]*?)(?:\\\\|&)/i',$html_video,$match))
             {
-                $this->returnError ("Problem", 400);
+                //$this->returnError ("Problem", 400);
             }
     
             $fmt_url =  urldecode($match[1]);
        
             $urls = explode(',',$fmt_url);
                     
-            $foundArray = array();
+            $videos = array();
     
             foreach($urls as $url)
             {            
                 if(preg_match('/itag=([0-9]+)/',$url,$tm) && preg_match('/sig=(.*?)&/', $url , $si) && preg_match('/url=(.*?)&/', $url , $um))
                 {
                     $u = urldecode($um[1]);
-                    $foundArray[$tm[1]] = $u.'&signature='.$si[1];
+                    $videos[$tm[1]] = $u.'&signature='.$si[1];
                 }
             }
-            $video = $foundArray[22];
+            
+            $codecs = array();
+            $codecs[13] = "video/3gpp";
+            $codecs[17] =  "video/3gpp";
+            $codecs[36] =  "video/3gpp";
+            $codecs[5]  =  "video/x-flv";
+            $codecs[6]  =  "video/x-flv";
+            $codecs[34] =  "video/x-flv";
+            $codecs[35] =  "video/x-flv";
+            $codecs[43] =  "video/webm";
+            $codecs[44] =  "video/webm";
+            $codecs[45] =  "video/webm";
+            $codecs[18] =  "video/mp4";
+            $codecs[22] =  "video/mp4";
+            $codecs[37] =  "video/mp4";
+            $codecs[33] =  "video/mp4";
 
             $item = new \Item();
             $item->uri = 'https://www.youtube.com'.$element->find('a',0)->href;
             $item->thumbnailUri = 'https:'.$element->find('img',0)->src;
-            $item->attachment = htmlspecialchars($video);
-            $item->attachmentCodec = "video/mp4";
+            $item->attachments = array();
+            foreach ($videos as $key => $value){
+                $item->attachments[] = array("URL" => htmlspecialchars($value), "codec" => $codecs[$key]);
+            }
             $item->title = trim($element->find('h3',0)->plaintext);
             $item->content = '<a href="' . $item->uri . '"><img src="' . $item->thumbnailUri . '" /></a><br><a href="' . $item->uri . '">' . $item->title . '</a>';
             $this->items[] = $item;

--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -21,17 +21,23 @@ class AtomFormat extends FormatAbstract{
         $timestamps = array();
         $entries = '';
         foreach($this->getDatas() as $data){
+            $attachments = '';
             $entryName = is_null($data->name) ? $title : $data->name;
             $entryAuthor = is_null($data->author) ? $uri : $data->author;
             $entryTitle = is_null($data->title) ? '' : $data->title;
             $entryUri = is_null($data->uri) ? '' : $data->uri;
-            $entryAttachment = is_null($data->attachment) ? '' : $data->attachment;
-            $entryAttachmentCodec = is_null($data->attachmentCodec) ? '' : $data->attachmentCodec;
+            $entryAttachments = is_null($data->attachments) ? array() : $data->attachments;
             $entryTimestamp = is_null($data->timestamp) ? date(DATE_ATOM, 0) : date(DATE_ATOM, $data->timestamp);
             $timestamps[] = (int)$entryTimestamp;
             // We prevent content from closing the CDATA too early.
             $entryContent = is_null($data->content) ? '' : '<![CDATA[' . $this->sanitizeHtml(str_replace(']]>','',$data->content)) . ']]>';
-
+            foreach ($entryAttachments as $key => $attachment){
+                $url = $attachment["URL"];
+                $codec = $attachment["codec"];
+                $attachments .= <<<EOD
+    <link rel="enclosure" href="{$url}" type="{$codec}" />
+EOD;
+            }
             $entries .= <<<EOD
 
     <entry>
@@ -44,7 +50,7 @@ class AtomFormat extends FormatAbstract{
         <id>{$entryUri}</id>
         <updated>{$entryTimestamp}</updated>
         <content type="html">{$entryContent}</content>
-        <link rel="enclosure" href="{$entryAttachment}" type="{$entryAttachmentCodec}" />
+        {$attachments}
     </entry>
 
 EOD;

--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 /**
 * Atom
 * Documentation Source http://en.wikipedia.org/wiki/Atom_%28standard%29 and http://tools.ietf.org/html/rfc4287
@@ -18,7 +18,7 @@ class AtomFormat extends FormatAbstract{
         $extraInfos = $this->getExtraInfos();
         $title = htmlspecialchars($extraInfos['name']);
         $uri = htmlspecialchars($extraInfos['uri']);
-
+        $timestamps = array();
         $entries = '';
         foreach($this->getDatas() as $data){
             $entryName = is_null($data->name) ? $title : $data->name;
@@ -26,7 +26,8 @@ class AtomFormat extends FormatAbstract{
             $entryTitle = is_null($data->title) ? '' : $data->title;
             $entryUri = is_null($data->uri) ? '' : $data->uri;
             $entryAttachment = is_null($data->attachment) ? '' : $data->attachment;
-            $entryTimestamp = is_null($data->timestamp) ? '' : date(DATE_ATOM, $data->timestamp);
+            $entryTimestamp = is_null($data->timestamp) ? date(DATE_ATOM, 0) : date(DATE_ATOM, $data->timestamp);
+            $timestamps[] = (int)$entryTimestamp;
             // We prevent content from closing the CDATA too early.
             $entryContent = is_null($data->content) ? '' : '<![CDATA[' . $this->sanitizeHtml(str_replace(']]>','',$data->content)) . ']]>';
 
@@ -47,6 +48,7 @@ class AtomFormat extends FormatAbstract{
 
 EOD;
         }
+        $update_timestamp = date(DATE_ATOM, max($timestamps));
 
         /*
         TODO :
@@ -62,7 +64,7 @@ EOD;
 
     <title type="text">{$title}</title>
     <id>http{$https}://{$httpHost}{$httpInfo}/</id>
-    <updated></updated>
+    <updated>{$update_timestamp}</updated>
     <link rel="alternate" type="text/html" href="{$uri}" />
     <link rel="self" href="http{$https}://{$httpHost}{$serverRequestUri}" />
 {$entries}

--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -26,6 +26,7 @@ class AtomFormat extends FormatAbstract{
             $entryTitle = is_null($data->title) ? '' : $data->title;
             $entryUri = is_null($data->uri) ? '' : $data->uri;
             $entryAttachment = is_null($data->attachment) ? '' : $data->attachment;
+            $entryAttachmentCodec = is_null($data->attachmentCodec) ? '' : $data->attachmentCodec;
             $entryTimestamp = is_null($data->timestamp) ? date(DATE_ATOM, 0) : date(DATE_ATOM, $data->timestamp);
             $timestamps[] = (int)$entryTimestamp;
             // We prevent content from closing the CDATA too early.
@@ -43,7 +44,7 @@ class AtomFormat extends FormatAbstract{
         <id>{$entryUri}</id>
         <updated>{$entryTimestamp}</updated>
         <content type="html">{$entryContent}</content>
-        <link rel="enclosure" href="{$entryAttachment}" />
+        <link rel="enclosure" href="{$entryAttachment}" type="{$entryAttachmentCodec}" />
     </entry>
 
 EOD;

--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -1,4 +1,4 @@
-<?php
+ <?php
 /**
 * Atom
 * Documentation Source http://en.wikipedia.org/wiki/Atom_%28standard%29 and http://tools.ietf.org/html/rfc4287
@@ -25,6 +25,7 @@ class AtomFormat extends FormatAbstract{
             $entryAuthor = is_null($data->author) ? $uri : $data->author;
             $entryTitle = is_null($data->title) ? '' : $data->title;
             $entryUri = is_null($data->uri) ? '' : $data->uri;
+            $entryAttachment = is_null($data->attachment) ? '' : $data->attachment;
             $entryTimestamp = is_null($data->timestamp) ? '' : date(DATE_ATOM, $data->timestamp);
             // We prevent content from closing the CDATA too early.
             $entryContent = is_null($data->content) ? '' : '<![CDATA[' . $this->sanitizeHtml(str_replace(']]>','',$data->content)) . ']]>';
@@ -41,6 +42,7 @@ class AtomFormat extends FormatAbstract{
         <id>{$entryUri}</id>
         <updated>{$entryTimestamp}</updated>
         <content type="html">{$entryContent}</content>
+        <link rel="enclosure" href="{$entryAttachment}" />
     </entry>
 
 EOD;


### PR DESCRIPTION
With these commits, Youtube feed have videos attached, in all available codecs and qualities, for use with Antennapod, podax, or any feed reader that supports video podcasts.
Still a bit buggy (Sometimes there aren't any files attached) but i'll try to improve that
