### PR TITLE
[new] Bridges for DTC, SDZ and DDG

### DIFF
--- a/bridges/DansTonChatBridge.php
+++ b/bridges/DansTonChatBridge.php
@@ -19,10 +19,6 @@ class DansTonChatBridge extends BridgeAbstract{
                 $item = new \Item();
                 $item->uri = $element->find('a', 0)->href;
                 $item->title = 'DansTonChat '.$element->find('a', 1)->plaintext;
-<<<<<<< HEAD
-=======
-                //$item->content = $element->find('p.item-content', 0)->innertext;
->>>>>>> d194d02... [new] Bridges for DTC and SDZ
                 $item->content = $element->find('a', 0)->innertext;
                 $this->items[] = $item;
         }

--- a/bridges/DansTonChatBridge.php
+++ b/bridges/DansTonChatBridge.php
@@ -1,0 +1,42 @@
+<?php
+/**
+* RssBridgeDansTonChat
+* Retrieve lastest quotes from DansTonChat.
+* Returns the most recent quotes, sorting by date (most recent first).
+*
+* @name DansTonChat Bridge
+* @description Returns latest quotes from DansTonChat.
+*/
+class DansTonChatBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = '';
+        $link = 'http://danstonchat.com/latest.html';
+
+        $html = file_get_html($link) or $this->returnError('Could not request DansTonChat.', 404);
+
+        foreach($html->find('div.item') as $element) {
+                $item = new \Item();
+                $item->uri = $element->find('a', 0)->href;
+                $item->title = 'DansTonChat '.$element->find('a', 1)->plaintext;
+<<<<<<< HEAD
+=======
+                //$item->content = $element->find('p.item-content', 0)->innertext;
+>>>>>>> d194d02... [new] Bridges for DTC and SDZ
+                $item->content = $element->find('a', 0)->innertext;
+                $this->items[] = $item;
+        }
+    }
+
+    public function getName(){
+        return 'DansTonChat';
+    }
+
+    public function getURI(){
+        return 'http://danstonchat.com';
+    }
+
+    public function getCacheDuration(){
+        return 21600; // 6 hours
+    }
+}

--- a/bridges/DuckDuckGoBridge.php
+++ b/bridges/DuckDuckGoBridge.php
@@ -1,0 +1,39 @@
+<?php
+/**
+* RssBridgeDuckDuckGo
+* Search DuckDuckGo for most recent pages regarding a specific topic.
+* Returns the most recent links in results, sorting by date (most recent first).
+*
+* @name DuckDuckGo
+* @description Returns most recent results from DuckDuckGo.
+* @use1(u="keyword")
+*/
+class DuckDuckGoBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = '';
+        $link = 'https://duckduckgo.com/html/?q='.$param[u].'+sort:date';
+
+        $html = file_get_html($link) or $this->returnError('Could not request DuckDuckGo.', 404);
+
+        foreach($html->find('div.results_links') as $element) {
+                $item = new \Item();
+                $item->uri = $element->find('a', 0)->href;
+                $item->title = $element->find('a', 1)->innertext;
+                $item->content = $element->find('div.snippet', 0)->plaintext;
+                $this->items[] = $item;
+        }
+    }
+
+    public function getName(){
+        return 'DuckDuckGo';
+    }
+
+    public function getURI(){
+        return 'https://duckduckgo.com';
+    }
+
+    public function getCacheDuration(){
+        return 21600; // 6 hours
+    }
+}

--- a/bridges/OpenClassroomsBridge.php
+++ b/bridges/OpenClassroomsBridge.php
@@ -1,0 +1,39 @@
+<?php
+/**
+* RssBridgeOpenClassrooms
+* Retrieve lastest tutorials from OpenClassrooms.
+* Returns the most recent tutorials, sorting by date (most recent first).
+*
+* @name OpenClassrooms Bridge
+* @description Returns latest tutorials from OpenClassrooms.
+* @use1(u="informatique or sciences")
+*/
+class OpenClassroomsBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = '';
+        $link = 'http://fr.openclassrooms.com/'.$param[u].'/cours?title=&sort=updatedAt+desc';
+
+        $html = file_get_html($link) or $this->returnError('Could not request OpenClassrooms.', 404);
+
+        foreach($html->find('li.col6') as $element) {
+                $item = new \Item();
+                $item->uri = 'http://fr.openclassrooms.com'.$element->find('a', 0)->href;
+                $item->title = $element->find('div.courses-content strong', 0)->innertext;
+                $item->content = $element->find('span.course-tags', 0)->innertext;
+                $this->items[] = $item;
+        }
+    }
+
+    public function getName(){
+        return 'OpenClassrooms';
+    }
+
+    public function getURI(){
+        return 'http://fr.openclassrooms.com';
+    }
+
+    public function getCacheDuration(){
+        return 21600; // 6 hours
+    }
+}

--- a/bridges/ScmbBridge.php
+++ b/bridges/ScmbBridge.php
@@ -1,0 +1,49 @@
+<?php
+/**
+* RssBridgeSeCoucherMoinsBete 
+* Returns the newest anecdotes
+*
+* @name Se Coucher Moins Bête Bridge
+* @description Returns the newest anecdotes.
+*/
+class ScmbBridge extends BridgeAbstract{
+    
+    public function collectData(array $param){
+        $html = '';
+        $html = file_get_html('http://secouchermoinsbete.fr/') or $this->returnError('Could not request Se Coucher Moins Bete.', 404);
+    
+        foreach($html->find('article') as $article) {
+        	$item = new \Item();
+			$item->uri = 'http://secouchermoinsbete.fr'.$article->find('p.summary a',0)->href;
+			$item->title = $article->find('header h1 a',0)->innertext;
+			
+			$article->find('span.read-more',0)->outertext=''; // remove text "En savoir plus" from anecdote content
+			$content = $article->find('p.summary a',0)->innertext;
+			$content =substr($content,0,strlen($content)-17); // remove superfluous spaces at the end
+			
+			// get publication date
+			$str_date = $article->find('time',0)->datetime;
+			list($date, $time) = explode(' ', $str_date);
+			list($y, $m, $d) = explode('-', $date);
+			list($h, $i) = explode(':', $time);
+			$timestamp = mktime($h,$i,0,$m,$d,$y);
+			$item->timestamp = $timestamp;
+			
+			
+			$item->content = $content;
+			$this->items[] = $item;
+		}
+    }
+
+    public function getName(){
+        return 'Se Coucher Moins Bête Bridge';
+    }
+
+    public function getURI(){
+        return 'http://secouchermoinsbete.fr/';
+    }
+
+    public function getCacheDuration(){
+        return 21600; // 6 hours
+    }
+}


### PR DESCRIPTION
New bridges for DTC, OpenClassrooms (the new SDZ) and DuckDuckGo.

The bridge for DTC returns the latest quotes.
The bridge for SDZ returns the latest tutorials, for the info or the sciences section. (needs improvement in design/usuability)
The bridge for DDG returns the latest search results, sorted by date.
The bridge for SCMB didn't work correctly on my server, so I deleted some informations.
