### PR TITLE
Added bridges for Wikipedia FR, EN and EO

### DIFF
--- a/bridges/WikipediaENBridge.php
+++ b/bridges/WikipediaENBridge.php
@@ -1,0 +1,41 @@
+<?php
+/**
+* RssBridgeWikipediaEN
+* Retrieve latest highlighted articles from Wikipedia in English.
+*
+* @name Wikipedia EN "Today's Featured Article..."
+* @description Returns the highlighted en.wikipedia.org article.
+*/
+class WikipediaENBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = '';
+        $host = 'http://en.wikipedia.org';
+        // If you want HTTPS access instead, uncomment the following line:
+        //$host = 'https://en.wikipedia.org';
+        $link = '/wiki/Main_Page';
+
+        $html = file_get_html($host.$link) or $this->returnError('Could not request Wikipedia EN.', 404);
+
+		$element = $html->find('div[id=mp-tfa]', 0);
+		// Clean the bottom of the featured article
+		$element->find('div', -1)->outertext = '';
+		$item = new \Item();
+		$item->uri = $host.$element->find('p', 0)->find('a', 0)->href;
+		$item->title = $element->find('p',0)->find('a',0)->title;
+		$item->content = str_replace('href="/', 'href="'.$host.'/', $element->innertext);
+		$this->items[] = $item;
+    }
+
+    public function getName(){
+        return 'Wikipedia EN "Today\'s Featued Article"';
+    }
+
+    public function getURI(){
+        return 'https://en.wikipedia.org/wiki/Main_Page';
+    }
+
+    public function getCacheDuration(){
+        return 3600*4; // 4 hours
+    }
+}

--- a/bridges/WikipediaEOBridge.php
+++ b/bridges/WikipediaEOBridge.php
@@ -1,0 +1,41 @@
+<?php
+/**
+* RssBridgeWikipediaEO
+* Retrieve latest highlighted articles from Wikipedia in Esperanto.
+*
+* @name Wikipedia EO "Artikolo de la semajno"
+* @description Returns the highlighted eo.wikipedia.org article.
+*/
+class WikipediaEOBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = '';
+        $host = 'http://eo.wikipedia.org';
+        // If you want HTTPS access instead, uncomment the following line:
+        //$host = 'https://eo.wikipedia.org';
+        $link = '/wiki/Vikipedio:%C4%88efpa%C4%9Do';
+
+        $html = file_get_html($host.$link) or $this->returnError('Could not request Wikipedia EO.', 404);
+
+		$element = $html->find('div[id=mf-tfa]', 0);
+		// Link to article
+		$link = $element->find('p', -2)->find('a', 0);
+		$item = new \Item();
+		$item->uri = $host.$link->href;
+		$item->title = $link->title;
+		$item->content = str_replace('href="/', 'href="'.$host.'/', $element->innertext);
+		$this->items[] = $item;
+    }
+
+    public function getName(){
+        return 'Wikipedia EO "Artikolo de la semajno"';
+    }
+
+    public function getURI(){
+        return 'https://eo.wikipedia.org/wiki/Vikipedio:%C4%88efpa%C4%9Do';
+    }
+
+    public function getCacheDuration(){
+        return 3600*12; // 12 hours
+    }
+}

--- a/bridges/WikipediaFRBridge.php
+++ b/bridges/WikipediaFRBridge.php
@@ -1,0 +1,39 @@
+<?php
+/**
+* RssBridgeWikipediaFR
+* Retrieve latest highlighted articles from Wikipedia in French.
+*
+* @name Wikipedia FR "Lumière sur..."
+* @description Returns the highlighted fr.wikipedia.org article.
+*/
+class WikipediaFRBridge extends BridgeAbstract{
+
+    public function collectData(array $param){
+        $html = '';
+        $host = 'http://fr.wikipedia.org';
+        // If you want HTTPS access instead, uncomment the following line:
+        //$host = 'https://fr.wikipedia.org';
+        $link = '/wiki/Wikip%C3%A9dia:Accueil_principal';
+
+        $html = file_get_html($host.$link) or $this->returnError('Could not request Wikipedia FR.', 404);
+
+		$element = $html->find('div[id=accueil-lumieresur]', 0);
+		$item = new \Item();
+		$item->uri = $host.$element->find('p', 0)->find('a', 0)->href;
+		$item->title = $element->find('p',0)->find('a',0)->title;
+		$item->content = str_replace('href="', 'href="'.$host, $html->find('div[id=mf-lumieresur]', 0)->innertext);
+		$this->items[] = $item;
+    }
+
+    public function getName(){
+        return 'Wikipedia FR "Lumière sur..."';
+    }
+
+    public function getURI(){
+        return 'https://fr.wikipedia.org/wiki/Wikip%C3%A9dia:Accueil_principal';
+    }
+
+    public function getCacheDuration(){
+        return 0*3600*4; // 4 hours
+    }
+}

--- a/bridges/WikipediaFRBridge.php
+++ b/bridges/WikipediaFRBridge.php
@@ -21,7 +21,7 @@ class WikipediaFRBridge extends BridgeAbstract{
 		$item = new \Item();
 		$item->uri = $host.$element->find('p', 0)->find('a', 0)->href;
 		$item->title = $element->find('p',0)->find('a',0)->title;
-		$item->content = str_replace('href="', 'href="'.$host, $html->find('div[id=mf-lumieresur]', 0)->innertext);
+		$item->content = str_replace('href="', 'href="'.$host, $element->find('div[id=mf-lumieresur]', 0)->innertext);
 		$this->items[] = $item;
     }
 
@@ -34,6 +34,6 @@ class WikipediaFRBridge extends BridgeAbstract{
     }
 
     public function getCacheDuration(){
-        return 0*3600*4; // 4 hours
+        return 3600*4; // 4 hours
     }
 }

--- a/bridges/WikipediaFRBridge.php
+++ b/bridges/WikipediaFRBridge.php
@@ -21,7 +21,7 @@ class WikipediaFRBridge extends BridgeAbstract{
 		$item = new \Item();
 		$item->uri = $host.$element->find('p', 0)->find('a', 0)->href;
 		$item->title = $element->find('p',0)->find('a',0)->title;
-		$item->content = str_replace('href="', 'href="'.$host, $element->find('div[id=mf-lumieresur]', 0)->innertext);
+		$item->content = str_replace('href="/', 'href="'.$host.'/', $element->find('div[id=mf-lumieresur]', 0)->innertext);
 		$this->items[] = $item;
     }
 


### PR DESCRIPTION
Added bridges for:
- Wikipedia EN "Today's Featured Article"
- Wikipedia FR "Lumière sur..."
- Wikipedia EO "Artikolo de la semajno"

The main page of the different wikipedias are too different to make a single parametric bridge (with short and easy-to-understand code).
