### PR TITLE
Cache made by var_export (performances)

### DIFF
--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -1,14 +1,20 @@
 <?php
 /**
 * Cache with file system
+* 
+* 
 */
 class FileCache extends CacheAbstract{
-    protected $cacheDirCreated; // boolean to avoid always chck dir cache existance
+    protected
+        $cacheDirCreated,   // boolean to avoid always chck dir cache existance
+        $hash_algo = 'sha1' // hash method for cache key
+    ; 
+    
 
     public function loadData(){
         $this->isPrepareCache();
 
-        $datas = json_decode(file_get_contents($this->getCacheFile()),true);
+        $datas = include( $this->getCacheFile() );
         $items = array();
         foreach($datas as $aData){
             $item = new \Item();
@@ -24,7 +30,7 @@ class FileCache extends CacheAbstract{
     public function saveData($datas){
         $this->isPrepareCache();
 
-        file_put_contents($this->getCacheFile(), json_encode($datas));
+        file_put_contents($this->getCacheFile(), '<?php return '.var_export($datas) );
 
         return $this;
     }
@@ -87,6 +93,6 @@ class FileCache extends CacheAbstract{
         $this->isPrepareCache();
 
         $stringToEncode = $_SERVER['REQUEST_URI'] . http_build_query($this->param);
-        return hash('sha1', $stringToEncode) . '.cache';
+        return hash($this->hash_algo , $stringToEncode) . '.cache.php';
     }
 }

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -30,7 +30,7 @@ class FileCache extends CacheAbstract{
     public function saveData($datas){
         $this->isPrepareCache();
 
-        file_put_contents($this->getCacheFile(), '<?php return '.var_export($datas) );
+        file_put_contents($this->getCacheFile(), '<?php return '.var_export($datas).';' );
 
         return $this;
     }


### PR DESCRIPTION
Added:
- choice of hash algo (for large sets of cache)
- cache made by var_export instead of json_encode
- fs cache is now put in a php file to be opcode cached by APC or OPcache 

var_export conv : if your cache values are only numbers, var_export will create larger files. But in this project, cache are mostly characters. So, your files will be smaller because they won't be 'json encoded'. 
- No json_encode/decode : better performances

Other things : var_export returns the exact PHP code so that it could be cached as opcode.
