### PR TITLE
Fix posts discovery.

### DIFF
--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -5,10 +5,10 @@
  * Returns the 3 newest full posts of a Wordpress blog
  *
  * @name Wordpress Bridge
-* @homepage https://wordpress.com/
+ * @homepage https://wordpress.com/
  * @description Returns the 3 newest full posts of a Wordpress blog
-* @maintainer aledeg 
-* @update 2014-05-26
+ * @maintainer aledeg
+ * @update 2014-05-26
  * @use1(url="blog URL (required)", name="blog name")
  */
 class WordpressBridge extends BridgeAbstract {
@@ -25,7 +25,8 @@ class WordpressBridge extends BridgeAbstract {
 
 		$html = file_get_html($this->url) or $this->returnError("Could not request {$this->url}.", 404);
 
-		if(!empty($html->find('.post')) ) {
+                $posts = $html->find('.post');
+		if(!empty($posts) ) {
 			$i=0;
 			foreach ($html->find('.post') as $article) {
 				if($i < 3) {


### PR DESCRIPTION
For PHP before 5.5, the bridge is not working. It returns the following error: "Can't use method return value in write context".
See the following message for explanations: http://stackoverflow.com/questions/1075534/cant-use-method-return-value-in-write-context/4328049#4328049
