### PR TITLE
Project M game Bridge

### DIFF
--- a/bridges/ProjectMGameBridge.php
+++ b/bridges/ProjectMGameBridge.php
@@ -1,0 +1,47 @@
+<?php
+/**
+* 2014-08-27
+* @name Project M Game Bridge
+* @homepage http://projectmgame.com/en/
+* @description Returns the newest articles.
+* @maintainer corenting
+*/
+class ProjectMGameBridge extends BridgeAbstract{
+  public function collectData(array $param){
+    $html = '';
+    $html = file_get_html('http://projectmgame.com/en/') or $this->returnError('Error while downloading the Project M homepage', 404);
+
+    foreach($html->find('article') as $article) {
+      $item = new \Item();
+      $item->uri = 'http://projectmgame.com/en/'.$article->find('section div.info_block a',0)->href;
+      $item->title = $article->find('h1 p',0)->innertext;
+
+      $p_list = $article->find('section p');
+      $content = '';
+      foreach($p_list as $p)
+      {
+        $content .= $p->innertext;
+      }
+      $item->content = $content;
+
+      // get publication date
+      $str_date = $article->find('section div.info_block a',0)->innertext;
+      $timestamp = strtotime($str_date);
+      $item->timestamp = $timestamp;
+
+      $this->items[] = $item;
+    }
+  }
+
+  public function getName(){
+    return 'Project M Game Bridge';
+  }
+
+  public function getURI(){
+    return 'http://projectmgame.com/en/';
+  }
+
+  public function getCacheDuration(){
+    return 10800;
+  }
+}

--- a/bridges/ProjectMGameBridge.php
+++ b/bridges/ProjectMGameBridge.php
@@ -7,6 +7,7 @@
 * @maintainer corenting
 */
 class ProjectMGameBridge extends BridgeAbstract{
+
   public function collectData(array $param){
     $html = '';
     $html = file_get_html('http://projectmgame.com/en/') or $this->returnError('Error while downloading the Project M homepage', 404);
@@ -18,17 +19,12 @@ class ProjectMGameBridge extends BridgeAbstract{
 
       $p_list = $article->find('section p');
       $content = '';
-      foreach($p_list as $p)
-      {
-        $content .= $p->innertext;
-      }
+      foreach($p_list as $p) $content .= $p->innertext;
       $item->content = $content;
 
       // get publication date
       $str_date = $article->find('section div.info_block a',0)->innertext;
-      $timestamp = strtotime($str_date);
-      $item->timestamp = $timestamp;
-
+      $item->timestamp = strtotime($str_date);
       $this->items[] = $item;
     }
   }
@@ -42,6 +38,6 @@ class ProjectMGameBridge extends BridgeAbstract{
   }
 
   public function getCacheDuration(){
-    return 10800;
+    return 10800; //3 hours
   }
 }


### PR DESCRIPTION
This PR adds a bridge for the Project M game (a Super Smash Bros Brawl modification).

This only gets the newest articles (those which are on the frontpage). In fact, getting all the articles from the news archive page is too slow because we must get each article's individual page to get the full content.
