### PR TITLE
Fix some errors in the pinterest bridge

### DIFF
--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -39,7 +39,7 @@ class PinterestBridge extends BridgeAbstract{
         	
         	$item = new \Item();
         	$item->uri = $this->getURI().$a->getAttribute('href');
-        	$item->content = '<img src="' . htmlentities($img->getAttribute('src')) . '" alt="" />';
+        	$item->content = '<img src="' . htmlentities(str_replace('/236x/', '/736x/', $img->getAttribute('src'))) . '" alt="" />';
         	
         	
         	if (isset($this->query))
@@ -83,6 +83,6 @@ class PinterestBridge extends BridgeAbstract{
     }
 
     public function getCacheDuration(){
-        return 0; 
+        return 3600; 
     }
 }

--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -68,13 +68,9 @@ class PinterestBridge extends BridgeAbstract{
         		
         		$item->content .= '<br /><img align="left" style="margin: 2px 4px;" src="'.htmlentities($item->avatar).'" /> <strong>'.$item->username.'</strong>';
         		$item->content .= '<br />'.$item->fullname;
-        	} else {
-        	
-        		$credit = $div->find('a.creditItem',0);
-        		$item->content .= '<br />'.$credit->innertext;
         	}
         	
-        	$item->title = basename($img->getAttribute('alt'));
+        	$item->title = $img->getAttribute('alt');
         	
         	//$item->timestamp = $media->created_time;
         	$this->items[] = $item;


### PR DESCRIPTION
Fix warning in a user board page, set the cache duration, fix the item title when the image title contain a /
