### PR TITLE
Media RSS

### DIFF
--- a/bridges/HDWallpapersBridge.php
+++ b/bridges/HDWallpapersBridge.php
@@ -1,0 +1,73 @@
+<?php
+/**
+* HDWallpapersBridge
+* Returns the latests wallpapers from http://www.hdwallpapers.in
+*
+* @name HD Wallpapers Bridge
+* @homepage http://www.hdwallpapers.in/
+* @description Returns the latests wallpapers from HDWallpapers
+* @maintainer nel50n
+* @update 2015-04-08
+* @use1(c="category",m="max number of wallpapers",r="resolution (1920x1200, 1680x1050, ...)")
+*/
+class HDWallpapersBridge extends BridgeAbstract {
+
+    private $category;
+    private $resolution;
+
+    public function collectData(array $param){
+        $html = '';
+        $baseUri = 'http://www.hdwallpapers.in';
+
+        $this->category   = $param['c'] ?: 'latest_wallpapers'; // Latest default
+        $this->resolution = $param['r'] ?: '1920x1200';         // Wide wallpaper default
+
+        $category = $this->category;
+        if (strrpos($category, 'wallpapers') !== strlen($category)-strlen('wallpapers')) {
+            $category .= '-desktop-wallpapers';
+        }
+
+        $num = 0;
+        $max = $param['m'] ?: 14;
+        $lastpage = 1;
+
+        for ($page = 1; $page <= $lastpage; $page++) {
+            $link = $baseUri.'/'.$category.'/page/'.$page;
+            $html = file_get_html($link) or $this->returnError('No results for this query.', 404);
+
+            if ($page === 1) {
+                preg_match('/page\/(\d+)$/', $html->find('.pagination a', -2)->href, $matches);
+                $lastpage = min($matches[1], ceil($max/14));
+            }
+
+            foreach($html->find('.wallpapers .wall a') as $element) {
+                $thumbnail = $element->find('img', 0);
+
+                $item = new \Item();
+                // http://www.hdwallpapers.in/download/yosemite_reflections-1680x1050.jpg
+                $item->uri = $baseUri.'/download'.str_replace('wallpapers.html', $this->resolution.'.jpg', $element->href);
+                $item->timestamp = time();
+                $item->title = $element->find('p', 0)->text();
+                $item->thumbnailUri = $baseUri.$thumbnail->src;
+                $item->content = $item->title.'<br><a href="'.$item->uri.'"><img src="'.$item->thumbnailUri.'" /></a>';
+                $this->items[] = $item;
+
+                $num++;
+                if ($num >= $max)
+                    break 2;
+            }
+        }
+    }
+
+    public function getName(){
+        return 'HDWallpapers - '.str_replace(['__', '_'], [' & ', ' '], $this->category).' ['.$this->resolution.']';
+    }
+
+    public function getURI(){
+        return 'http://www.hdwallpapers.in';
+    }
+
+    public function getCacheDuration(){
+        return 43200; // 12 hours
+    }
+}

--- a/bridges/PickyWallpapersBridge.php
+++ b/bridges/PickyWallpapersBridge.php
@@ -1,0 +1,72 @@
+<?php
+/**
+* PickyWallpapersBridge
+* Returns the latests wallpapers from http://www.pickywallpapers.com
+*
+* @name PickyWallpapers Bridge
+* @homepage http://www.pickywallpapers.com/
+* @description Returns the latests wallpapers from PickyWallpapers
+* @maintainer nel50n
+* @update 2014-03-31
+* @use1(c="category",s="subcategory",m="max number of wallpapers",r="resolution (1920x1200, 1680x1050, ...)")
+*/
+class PickyWallpapersBridge extends BridgeAbstract {
+
+    private $category;
+    private $subcategory;
+    private $resolution;
+
+    public function collectData(array $param){
+        $html = '';
+        if (!isset($param['c'])) {
+            $this->returnError('You must specify at least a category (?c=...).', 400);
+        } else {
+            $baseUri = 'http://www.pickywallpapers.com';
+
+            $this->category = $param['c'];
+            $this->subcategory = $param['s'] ?: '';
+            $this->resolution = $param['r'] ?: '1920x1200';    // Wide wallpaper default
+
+            $num = 0;
+            $max = $param['m'] ?: 12;
+            $lastpage = 1;
+
+            for ($page = 1; $page <= $lastpage; $page++) {
+                $link = $baseUri.'/'.$this->resolution.'/'.$this->category.'/'.(!empty($this->subcategory)?$this->subcategory.'/':'').'page-'.$page.'/';
+                $html = file_get_html($link) or $this->returnError('No results for this query.', 404);
+
+                if ($page === 1) {
+                    preg_match('/page-(\d+)\/$/', $html->find('.pages li a', -2)->href, $matches);
+                    $lastpage = min($matches[1], ceil($max/12));
+                }
+
+                foreach($html->find('.items li img') as $element) {
+
+                    $item = new \Item();
+                    $item->uri = str_replace('www', 'wallpaper', $baseUri).'/'.$this->resolution.'/'.basename($element->src);
+                    $item->timestamp = time();
+                    $item->title = $element->alt;
+                    $item->thumbnailUri = $element->src;
+                    $item->content = $item->title.'<br><a href="'.$item->uri.'">'.$element.'</a>';
+                    $this->items[] = $item;
+
+                    $num++;
+                    if ($num >= $max)
+                        break 2;
+                }
+            }
+        }
+    }
+
+    public function getName(){
+        return 'PickyWallpapers - '.$this->category.(!empty($this->subcategory) ? ' > '.$this->subcategory : '').' ['.$this->resolution.']';
+    }
+
+    public function getURI(){
+        return 'http://www.pickywallpapers.com';
+    }
+
+    public function getCacheDuration(){
+        return 43200; // 12 hours
+    }
+}

--- a/bridges/SuperbWallpapersBridge.php
+++ b/bridges/SuperbWallpapersBridge.php
@@ -1,0 +1,67 @@
+<?php
+/**
+* SuperbWallpapersBridge
+* Returns the latests wallpapers from http://www.superbwallpapers.com
+*
+* @name Superb Wallpapers Bridge
+* @homepage http://www.superbwallpapers.com/
+* @description Returns the latests wallpapers from SuperbWallpapers
+* @maintainer nel50n
+* @update 2015-04-08
+* @use1(c="category",m="max number of wallpapers",r="resolution (1920x1200, 1680x1050, ...)")
+*/
+class SuperbWallpapersBridge extends BridgeAbstract {
+
+    private $category;
+    private $resolution;
+
+    public function collectData(array $param){
+        $html = '';
+        $baseUri = 'http://www.superbwallpapers.com';
+
+        $this->category   = $param['c'] ?: '';           // All default
+        $this->resolution = $param['r'] ?: '1920x1200';  // Wide wallpaper default
+
+        $num = 0;
+        $max = $param['m'] ?: 36;
+        $lastpage = 1;
+
+        // Get last page number
+        $link = $baseUri.'/'.$this->category.'/9999.html';
+        $html = file_get_html($link);
+        $lastpage = min($html->find('.paging .cpage', 0)->innertext(), ceil($max/36));
+
+        for ($page = 1; $page <= $lastpage; $page++) {
+            $link = $baseUri.'/'.$this->category.'/'.$page.'.html';
+            $html = file_get_html($link) or $this->returnError('No results for this query.', 404);
+
+            foreach($html->find('.wpl .i a') as $element) {
+                $thumbnail = $element->find('img', 0);
+
+                $item = new \Item();
+                $item->uri = str_replace('200x125', $this->resolution, $thumbnail->src);
+                $item->timestamp = time();
+                $item->title = $element->title;
+                $item->thumbnailUri = $thumbnail->src;
+                $item->content = $item->title.'<br><a href="'.$item->uri.'">'.$thumbnail.'</a>';
+                $this->items[] = $item;
+
+                $num++;
+                if ($num >= $max)
+                    break 2;
+            }
+        }
+    }
+
+    public function getName(){
+        return 'HDWallpapers - '.$this->category.' ['.$this->resolution.']';
+    }
+
+    public function getURI(){
+        return 'http://www.superbwallpapers.com';
+    }
+
+    public function getCacheDuration(){
+        return 43200; // 12 hours
+    }
+}

--- a/bridges/UnsplashBridge.php
+++ b/bridges/UnsplashBridge.php
@@ -1,0 +1,67 @@
+<?php
+/**
+* UnsplashBridge
+* Returns the latests photos from http://unsplash.com
+*
+* @name Unsplash Bridge
+* @homepage http://unsplash.com/
+* @description Returns the latests photos from Unsplash
+* @maintainer nel50n
+* @update 2015-03-02
+* @use1(m="max number of photos",w="width (1920, 1680, ...)",q="jpeg quality (0..100)")
+*/
+class UnsplashBridge extends BridgeAbstract {
+
+    public function collectData(array $param){
+        $html = '';
+        $baseUri = 'http://unsplash.com';
+
+        $width = $param['w'] ?: '1920';    // Default width
+
+        $num = 0;
+        $max = $param['m'] ?: 20;
+        $quality = $param['q'] ?: 75;
+        $lastpage = 1;
+
+        for ($page = 1; $page <= $lastpage; $page++) {
+            $link = $baseUri.'/grid?page='.$page;
+            $html = file_get_html($link) or $this->returnError('No results for this query.', 404);
+
+            if ($page === 1) {
+                preg_match('/=(\d+)$/', $html->find('.pagination > a[!class]', -1)->href, $matches);
+                $lastpage = min($matches[1], ceil($max/40));
+            }
+
+            foreach($html->find('.photo') as $element) {
+                $thumbnail = $element->find('img', 0);
+                $thumbnail->src = str_replace('https://', 'http://', $thumbnail->src);
+
+                $item = new \Item();
+                $item->uri = str_replace(array('q=75', 'w=400'),
+                                         array("q=$quality", "w=$width"),
+                                         $thumbnail->src).'.jpg';           // '.jpg' only for format hint
+                $item->timestamp = time();
+                $item->title = $thumbnail->alt;
+                $item->thumbnailUri = $thumbnail->src;
+                $item->content = $item->title.'<br><a href="'.$item->uri.'"><img src="'.$item->thumbnailUri.'" /></a>';
+                $this->items[] = $item;
+
+                $num++;
+                if ($num >= $max)
+                    break 2;
+            }
+        }
+    }
+
+    public function getName(){
+        return 'Unsplash';
+    }
+
+    public function getURI(){
+        return 'http://unsplash.com';
+    }
+
+    public function getCacheDuration(){
+        return 43200; // 12 hours
+    }
+}

--- a/bridges/WallpaperStopBridge.php
+++ b/bridges/WallpaperStopBridge.php
@@ -1,0 +1,78 @@
+<?php
+/**
+* WallpaperStopBridge
+* Returns the latests wallpapers from http://www.wallpaperstop.com
+*
+* @name WallpaperStop Bridge
+* @homepage http://www.wallpaperstop.com/
+* @description Returns the latests wallpapers from WallpaperStop
+* @maintainer nel50n
+* @update 2014-11-05
+* @use1(c="category",s="subcategory",m="max number of wallpapers",r="resolution (1920x1200, 1680x1050, ...)")
+*/
+class WallpaperStopBridge extends BridgeAbstract {
+
+    private $category;
+    private $subcategory;
+    private $resolution;
+
+    public function collectData(array $param){
+        $html = '';
+        if (!isset($param['c'])) {
+            $this->returnError('You must specify at least a category (?c=...).', 400);
+        } else {
+            $baseUri = 'http://www.wallpaperstop.com';
+
+            $this->category = $param['c'];
+            $this->subcategory = $param['s'] ?: '';
+            $this->resolution = $param['r'] ?: '1920x1200';    // Wide wallpaper default
+
+            $num = 0;
+            $max = $param['m'] ?: 20;
+            $lastpage = 1;
+
+            for ($page = 1; $page <= $lastpage; $page++) {
+                $link = $baseUri.'/'.$this->category.'-wallpaper/'.(!empty($this->subcategory)?$this->subcategory.'-wallpaper/':'').'desktop-wallpaper-'.$page.'.html';
+                $html = file_get_html($link) or $this->returnError('No results for this query.', 404);
+
+                if ($page === 1) {
+                    preg_match('/-(\d+)\.html$/', $html->find('.pagination > .last', 0)->href, $matches);
+                    $lastpage = min($matches[1], ceil($max/20));
+                }
+
+                foreach($html->find('article.item') as $element) {
+                    $wplink = $element->getAttribute('data-permalink');
+                    if (preg_match('%^http://www\.wallpaperstop\.com/(.+)/([^/]+)-(\d+)\.html$%', $wplink, $matches)) {
+                        $thumbnail = $element->find('img', 0);
+
+                        $item = new \Item();
+                        $item->uri = $baseUri.'/wallpapers/'.str_replace('wallpaper', 'wallpapers', $matches[1]).'/'.$matches[2].'-'.$this->resolution.'-'.$matches[3].'.jpg';
+                        $item->id = $matches[3];
+                        $item->timestamp = time();
+                        $item->title = $thumbnail->title;
+                        $item->thumbnailUri = $baseUri.$thumbnail->src;
+                        $item->content = $item->title.'<br><a href="'.$wplink.'"><img src="'.$item->thumbnailUri.'" /></a>';
+                        $this->items[] = $item;
+
+                        $num++;
+                        if ($num >= $max)
+                            break 2;
+                    }
+
+                }
+            }
+        }
+    }
+
+    public function getName(){
+        return 'WallpaperStop - '.$this->category.(!empty($this->subcategory) ? ' > '.$this->subcategory : '').' ['.$this->resolution.']';
+    }
+
+    public function getURI(){
+        return 'http://www.wallpaperstop.com';
+    }
+
+    public function getCacheDuration(){
+        return 43200; // 12 hours
+    }
+}

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -1,0 +1,86 @@
+<?php
+/**
+* Mrss
+* Documentation Source http://www.rssboard.org/media-rss
+*
+* @name Media RSS
+*/
+class MrssFormat extends FormatAbstract{
+
+    public function stringify(){
+        /* Datas preparation */
+        $https = ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 's' : '' );
+        $httpHost = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
+        $httpInfo = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : '';
+
+        $serverRequestUri = htmlspecialchars($_SERVER['REQUEST_URI']);
+
+        $extraInfos = $this->getExtraInfos();
+        $title = htmlspecialchars($extraInfos['name']);
+        $uri = htmlspecialchars($extraInfos['uri']);
+        $icon = 'http://g.etfv.co/'. $uri .'?icon.jpg';
+
+        $items = '';
+        foreach($this->getDatas() as $data){
+            $itemTitle = strip_tags(is_null($data->title) ? '' : $data->title);
+            $itemUri = is_null($data->uri) ? '' : $data->uri;
+            $itemThumbnailUri = is_null($data->thumbnailUri) ? '' : $data->thumbnailUri;
+            $itemTimestamp = is_null($data->timestamp) ? '' : date(DATE_RFC2822, $data->timestamp);
+            // We prevent content from closing the CDATA too early.
+            $itemContent = is_null($data->content) ? '' : htmlspecialchars($this->sanitizeHtml(str_replace(']]>','',$data->content)));
+
+            $items .= <<<EOD
+
+    <item>
+        <title>{$itemTitle}</title>
+        <link>{$itemUri}</link>
+        <guid isPermaLink="true">{$itemUri}</guid>
+        <pubDate>{$itemTimestamp}</pubDate>
+        <description>{$itemContent}</description>
+        <media:title>{$itemTitle}</media:title>
+        <media:thumbnail url="{$itemThumbnailUri}" />
+    </item>
+
+EOD;
+        }
+
+        /*
+        TODO :
+        - Security: Disable Javascript ?
+        - <updated> : Define new extra info ?
+        - <content type="html"> : RFC look with xhtml, keep this in spite of ?
+        */
+
+        /* Data are prepared, now let's begin the "MAGIE !!!" */
+        $toReturn  = '<?xml version="1.0" encoding="UTF-8"?>';
+        $toReturn .= <<<EOD
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{$title}</title>
+        <link>{$uri}/</link>
+        <description>{$title}</description>
+        <atom:link rel="self" href="http{$https}://{$httpHost}{$serverRequestUri}" />
+        {$items}
+    </channel>
+</rss>
+EOD;
+
+        // Remove invalid non-UTF8 characters
+
+        // We cannot use iconv because of a bug in some versions of iconv.
+        // See http://www.php.net/manual/fr/function.iconv.php#108643
+        //$toReturn = iconv("UTF-8", "UTF-8//IGNORE", $toReturn);
+        // So we use mb_convert_encoding instead:
+        ini_set('mbstring.substitute_character', 'none');
+        $toReturn= mb_convert_encoding($toReturn, 'UTF-8', 'UTF-8');
+        return $toReturn;
+    }
+
+    public function display(){
+        $this
+            ->setContentType('application/rss+xml; charset=UTF-8')  // We force UTF-8 in RSS output.
+            ->callContentType();
+
+        return parent::display();
+    }
+}


### PR DESCRIPTION
Le format de flux `Media RSS` est utilisé par certains outils comme [John’s Background Switcher](http://johnsad.ventures/software/backgroundswitcher/), malheureusement les sites proposant des images ne disposent pas tous de flux RSS, et encore moins à ce format.

---

Voici donc un début de solution :
- Nouveau format basique de flux `Media RSS` pour les images,
- Nouveau bridge pour le site [WallPaperStop](http://www.wallpaperstop.com),
- Nouveau bridge pour le site [Unsplash](http://unsplash.com).

Les nouveaux bridges étant bien sûr prévus pour être utilisés avec le nouveau format (mais sont compatibles avec les autres).
