### PR TITLE
add Google+ base URL in front of item entry URI

### DIFF
--- a/bridges/GooglePlusPostBridge.php
+++ b/bridges/GooglePlusPostBridge.php
@@ -56,7 +56,7 @@ class GooglePlusPostBridge extends BridgeAbstract
 //			$item->title = $item->fullname = $post->find('header.lea', 0)->plaintext;
 			$item->avatar = $post->find('div.ys img', 0)->src;
 //			var_dump((($post->find('a.o-U-s', 0)->getAllAttributes())));
-			$item->uri = $post->find('a.o-U-s', 0)->href;
+			$item->uri = self::GOOGLE_PLUS_BASE_URL . $post->find('a.o-U-s', 0)->href;
 			$item->timestamp = strtotime($post->find('a.o-U-s', 0)->plaintext);
 			$this->items[] = $item;
 


### PR DESCRIPTION
This fixes the atom feed entries URLs to point from
https://example.com/rss-bridge/+Perspn/posts/N6fgHam5e2ik to 
https://plus.google.com/+Perspn/posts/N6fgHam5e2ik. Otherwise the URL
could not be found on the server where i host rss-bridge. 
