### PR TITLE
[PROPOSAL] Article link is the magnet link

### DIFF
--- a/bridges/ThePirateBayBridge.php
+++ b/bridges/ThePirateBayBridge.php
@@ -63,8 +63,8 @@ class ThePirateBayBridge extends BridgeAbstract{
 
             foreach($html->find('tr') as $element) {
                 $item = new \Item();
-                $item->uri = 'https://thepiratebay.vg/'.$element->find('a.detLink',0)->href;
-                $item->id = $item->uri;
+                $item->id = 'https://thepiratebay.vg'.$element->find('a.detLink',0)->href;
+                $item->uri = $element->find('a',3)->href;
                 $item->timestamp = parseDateTimestamp($element);
                 $item->title = $element->find('a.detLink',0)->plaintext;
                 $item->seeders = (int)$element->find('td',2)->plaintext;


### PR DESCRIPTION
CAUTION : this is just a proposal, because this pull-request change the way articles are given in your RSS feed reader.
The main link don't point anymore on the corresponding PB result page, but directly to the magnet link.

This proposition is for BT clients who are able to read RSS-feed and download subsequents files.

Maybe, you can add a link in the description field, or add an option to invert the two links¹, or fork this bridge, etc.
I'm open to discussion.

¹ : result page / magnet link (like in Shaarli, with &permalink option)
