### PR TITLE
Anti-hotlinking was apparently disabled

### DIFF
--- a/bridges/Rue89Bridge.php
+++ b/bridges/Rue89Bridge.php
@@ -21,7 +21,8 @@ class Rue89Bridge extends BridgeAbstract{
         //$text = $html2->find('div[class=text]', 0)->innertext;
 
 	foreach($html2->find('img') as $image) {
-		$image->src = $image->getAttribute('data-src');
+		$src = $image->getAttribute('data-src');
+		if($src) $image->src = $src;
 	}
         $text = $html2->find('div.content', 0)->innertext;
 


### PR DESCRIPTION
It seems that anti-hotlinking method (data-src + JS) was disabled on Rue89 site.
Because I'm not sure that modification is permanent, I put an "if" for testing it before replacement.
--> tested ok on my rssbridge instance. IMG are back.
