### PR TITLE
NextImpactBridge Improvements

### DIFF
--- a/bridges/NextInpactBridge.php
+++ b/bridges/NextInpactBridge.php
@@ -9,34 +9,39 @@
 * @description Returns the newest articles.
 * @maintainer qwertygc
 */
-class NextInpactBridge extends BridgeAbstract{
+class NextInpactBridge extends BridgeAbstract {
 
-        public function collectData(array $param){
+	public function collectData(array $param) {
 
-			function StripCDATA($string) {
+		function StripCDATA($string) {
 			$string = str_replace('<![CDATA[', '', $string);
 			$string = str_replace(']]>', '', $string);
 			return $string;
 		}
+
 		function ExtractContent($url) {
-		$html2 = file_get_html($url);
-    $text = '<h2>'.$html2->find('div#actu_entete > h2', 0)->innertext.'</h2><br><br>';
-		$text = $text.$html2->find('div[itemprop=articleBody]', 0)->innertext;
-		return $text;
+			$html2 = file_get_html($url);
+			$text = '<p><em>'.$html2->find('span.sub_title', 0)->innertext.'</em></p>'
+				.'<p><img src="'.$html2->find('div.container_main_image_article', 0)->find('img.dedicated',0)->src.'" /></p>'
+				.'<div>'.$html2->find('div[itemprop=articleBody]', 0)->innertext.'</div>';
+			return $text;
 		}
+
 		$html = file_get_html('http://www.nextinpact.com/rss/news.xml') or $this->returnError('Could not request Nextinpact.', 404);
 		$limit = 0;
 
 		foreach($html->find('item') as $element) {
 		 if($limit < 3) {
-		 $item = new \Item();
-		 $item->title = StripCDATA($element->find('title', 0)->innertext);
-		 $item->uri = StripCDATA($element->find('guid', 0)->plaintext);
-		 $item->timestamp = strtotime($element->find('pubDate', 0)->plaintext);
-		 $item->content = ExtractContent($item->uri);
-		 $this->items[] = $item;
-		 $limit++;
-		 }
+				$item = new \Item();
+				$item->title = StripCDATA($element->find('title', 0)->innertext);
+				$item->uri = StripCDATA($element->find('guid', 0)->plaintext);
+				$item->thumbnailUri = StripCDATA($element->find('enclosure', 0)->url);
+				$item->author = StripCDATA($element->find('author', 0)->innertext);
+				$item->timestamp = strtotime($element->find('pubDate', 0)->plaintext);
+				$item->content = ExtractContent($item->uri);
+				$this->items[] = $item;
+				$limit++;
+			}
 		}
 
     }

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -24,6 +24,7 @@ class MrssFormat extends FormatAbstract{
         foreach($this->getDatas() as $data){
             $itemTitle = strip_tags(is_null($data->title) ? '' : $data->title);
             $itemUri = is_null($data->uri) ? '' : $data->uri;
+            $itemAuthor = is_null($data->author) ? '' : $data->author;
             $itemThumbnailUri = is_null($data->thumbnailUri) ? '' : $data->thumbnailUri;
             $itemTimestamp = is_null($data->timestamp) ? '' : date(DATE_RFC2822, $data->timestamp);
             // We prevent content from closing the CDATA too early.
@@ -37,6 +38,7 @@ class MrssFormat extends FormatAbstract{
         <guid isPermaLink="true">{$itemUri}</guid>
         <pubDate>{$itemTimestamp}</pubDate>
         <description>{$itemContent}</description>
+        <author>{$itemAuthor}</author>
         <media:title>{$itemTitle}</media:title>
         <media:thumbnail url="{$itemThumbnailUri}" />
     </item>


### PR DESCRIPTION
Hello, and congrats for this great project!
Here is a small contribution for the NextImpactBridge module:
- Fixed article subtitle not extracted anymore
- Added main image at the beginning of article content
- Added thumbnail and author rss fields
- Minor code cleanup (indentation...)

Tested OK on my own `rss-bridge` setup ;)

PS: The `author` field does not seems to be used by `MrssFormat` yet,
but it is already set by [some bridges](https://github.com/sebsauvage/rss-bridge/blob/54c5e9f5ead3be7cd345dc9e5f039312e5653405/bridges/CoinDeskBridge.php#L34) and field name seems logical.
EDIT: Added `author` field into `MrssFormat`, as it's already used in `AtomFormat`.
