### PR TITLE
[Facebook] Convert textual emoticons to ASCII

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -34,6 +34,39 @@ class FacebookBridge extends BridgeAbstract{
 			}
 		};
 
+		//Utility function for converting facebook emoticons
+		$unescape_fb_emote = function ($matches) {
+			static $facebook_emoticons = array(
+				'smile' => ':)',
+				'frown' => ':(',
+				'tongue' => ':P',
+				'grin' => ':D',
+				'gasp' => ':O',
+				'wink' => ';)',
+				'pacman' => ':<',
+				'grumpy' => '>_<',
+				'unsure' => ':/',
+				'cry' => ':\'(',
+				'kiki' => '^_^',
+				'glasses' => '8-)',
+				'sunglasses' => 'B-)',
+				'heart' => '<3',
+				'devil' => ']:D',
+				'angel' => '0:)',
+				'squint' => '-_-',
+				'confused' => 'o_O',
+				'upset' => 'xD',
+				'colonthree' => ':3',
+				'like' => '&#x1F44D;');
+			$len = count($matches);
+			if ($len > 1)
+				for ($i = 1; $i < $len; $i++)
+					foreach ($facebook_emoticons as $name => $emote)
+						if ($matches[$i] === $name)
+							return $emote;
+			return $matches[0];
+		};
+
 		$html = '';
 
 		if(isset($param['u'])) {
@@ -77,6 +110,9 @@ class FacebookBridge extends BridgeAbstract{
 						'class', 'style', 'data-[^=]*', 'aria-[^=]*', 'role', 'rel', 'id') as $property_name)
 							$content = preg_replace('/ '.$property_name.'=\"[^"]*\"/i', '', $content);
 					$content = preg_replace('/<\/a [^>]+>/i', '</a>', $content);
+
+					//Convert textual representation of emoticons eg "<i><u>smile emoticon</u></i>" back to ASCII emoticons eg ":)"
+					$content = preg_replace_callback('/<i><u>([^ <>]+) ([^<>]+)<\/u><\/i>/i', $unescape_fb_emote, $content);
 
 					//Retrieve date of the post
 					$date = $post->find("abbr")[0];


### PR DESCRIPTION
Its-a-me, ~~mario~~ again!

Here is a new improvement for the `Facebook` bridge... emoticons! `^_^`

Currently emoticons are retrived in textual form eg `<i><u>smile emoticon</u></i>`.
That is not really visual... so let's convert them back to ASCII emoticons eg `:)`.

This works using a hardcoded table mapping emoticon names to their visual representation.

``` php
static $facebook_emoticons = array(
    'smile' => ':)',
    'frown' => ':(',
    'tongue' => ':P',
    'grin' => ':D',
    'gasp' => ':O',
    'wink' => ';)',
    'pacman' => ':<',
    'grumpy' => '>_<',
    'unsure' => ':/',
    'cry' => ':\'(',
    'kiki' => '^_^',
    'glasses' => '8-)',
    'sunglasses' => 'B-)',
    'heart' => '<3',
    'devil' => ']:D',
    'angel' => '0:)',
    'squint' => '-_-',
    'confused' => 'o_O',
    'upset' => 'xD',
    'colonthree' => ':3',
    'like' => '&#x1F44D;'); //Unicode thumb up 👍
```

The regular expression `/<i><u>([^ <>]+) ([^<>]+)<\/u><\/i>/i` will match when two words are detected between `<i><u>`, and both words will be tested against the table using a callback function...

``` php
for ($i = 1; $i < $len; $i++)
    foreach ($facebook_emoticons as $name => $emote)
        if ($matches[$i] === $name)
            return $emote;
```

Yes, we need to test  _both_, eg in french localization facebook will display `<i><u>émoticône smile</u></i>` so we need to test both because we can't predict which one represents the emoticon's name.
If no match is found in the table, no replacement will be made and the italic underlined text is left as is.

``` php
return $matches[0];
```
