### PR TITLE
Customizable tooltip for input parameter

### DIFF
--- a/CREATE_BRIDGE.md
+++ b/CREATE_BRIDGE.md
@@ -90,6 +90,7 @@ Parameter Name | Parameter values | Description
 type|text, number, list, checkbox| Type of the input, default is text
 required| true | Set this if you want your attribute to be required
 values| [ {"name" : option1Name, "value" : "option1Value"}, ...] | Values list, required with the 'list' type
+title| text | Will be shown as tooltip when mouse-hovering over the input
 
 #### Guidelines
 

--- a/lib/HTMLUtils.php
+++ b/lib/HTMLUtils.php
@@ -80,6 +80,11 @@ CARD;
 					$additionalInfoString .= " pattern=\"".$inputEntry['pattern']."\"";
 
 				}
+                if(isset($inputEntry['title'])) {
+                    
+                    $additionalInfoString .= " title=\"" .$inputEntry['title']."\"";
+                    
+                }
 				if(!isset($inputEntry['exampleValue'])) $inputEntry['exampleValue'] = "";
 
 				$idArg = 'arg-' . urlencode($bridgeName) . '-' . urlencode($parameterName) . '-' . urlencode($inputEntry['identifier']);


### PR DESCRIPTION
Currently when mouse-hovering over an input field the default message "Please fill out this field" is shown. This can be customized by applying the 'title' tag which is useful for complex parameters that require a certain degree of explanation.
