### PR TITLE
Update T411, CNET, LeMondeInformatique, Add 9èmeArt

### DIFF
--- a/bridges/AnimeUltimeBridge.php
+++ b/bridges/AnimeUltimeBridge.php
@@ -3,44 +3,45 @@ class AnimeUltimeBridge extends BridgeAbstract {
 
     private $filter = 'Releases';
 
-	public function loadMetadatas() {
+    public function loadMetadatas() {
 
-		$this->maintainer = "ORelio";
-		$this->name = "Anime-Ultime";
-		$this->uri = "http://www.anime-ultime.net/";
-		$this->description = "Returns the 10 newest releases posted on Anime-Ultime";
-		$this->update = "2015-10-30";
+        $this->maintainer = 'ORelio';
+        $this->name = 'Anime-Ultime';
+        $this->uri = 'http://www.anime-ultime.net/';
+        $this->description = 'Returns the 10 newest releases posted on Anime-Ultime';
+        $this->update = '2015-10-30';
 
-		$this->parameters[] =
-		'[
-			{
-				"name" : "Type",
-				"type" : "list",
-				"identifier" : "type",
-				"values" : [
-					{
-						"name" : "everything",
-						"value" : ""
+        $this->parameters[] =
+        '[
+            {
+                "name" : "Type",
+                "type" : "list",
+                "identifier" : "type",
+                "values" :
+                [
+                    {
+                        "name" : "Everything",
+                        "value" : ""
 
-					},
-					{
-						"name" : "Anime",
-						"value" : "A"
+                    },
+                    {
+                        "name" : "Anime",
+                        "value" : "A"
 
-					},
-					{
-						"name" : "Drama",
-						"value" : "D"
-					},
-					{
-						"name" : "Tokusatsu",
-						"value" : "T"
+                    },
+                    {
+                        "name" : "Drama",
+                        "value" : "D"
+                    },
+                    {
+                        "name" : "Tokusatsu",
+                        "value" : "T"
 
-					}
-				]
-			}
-		]';
-	}
+                    }
+                ]
+            }
+        ]';
+    }
 
     public function collectData(array $param) {
 

--- a/bridges/CNETBridge.php
+++ b/bridges/CNETBridge.php
@@ -9,7 +9,7 @@ class CNETBridge extends BridgeAbstract {
         $this->name = 'CNET News';
         $this->uri = 'http://www.cnet.com/';
         $this->description = 'Returns the newest articles. <br /> You may specify a topic found in some section URLs, else all topics are selected.';
-        $this->update = '2016-01-23';
+        $this->update = '2016-02-06';
 
         $this->parameters[] =
         '[
@@ -41,7 +41,7 @@ class CNETBridge extends BridgeAbstract {
         function CleanArticle($article_html) {
             $article_html = '<p>'.substr($article_html, strpos($article_html, '<p>') + 3);
             $article_html = StripWithDelimiters($article_html, '<span class="credit">', '</span>');
-            $article_html = StripWithDelimiters($article_html, '<script>', '</script>');
+            $article_html = StripWithDelimiters($article_html, '<script', '</script>');
             $article_html = StripWithDelimiters($article_html, '<div class="shortcode related-links', '</div>');
             $article_html = StripWithDelimiters($article_html, '<a class="clickToEnlarge">', '</a>');
             return $article_html;

--- a/bridges/LeMondeInformatiqueBridge.php
+++ b/bridges/LeMondeInformatiqueBridge.php
@@ -1,15 +1,15 @@
 <?php
 class LeMondeInformatiqueBridge extends BridgeAbstract {
 
-	public function loadMetadatas() {
+    public function loadMetadatas() {
 
-		$this->maintainer = "ORelio";
-		$this->name = "Le Monde Informatique";
-		$this->uri = "http://www.lemondeinformatique.fr/";
-		$this->description = "Returns the newest articles.";
-		$this->update = "2015-09-08";
+        $this->maintainer = "ORelio";
+        $this->name = "Le Monde Informatique";
+        $this->uri = "http://www.lemondeinformatique.fr/";
+        $this->description = "Returns the newest articles.";
+        $this->update = "2016-01-28";
 
-	}
+    }
 
     public function collectData(array $param) {
 
@@ -29,7 +29,7 @@ class LeMondeInformatiqueBridge extends BridgeAbstract {
 
         function CleanArticle($article_html) {
             $article_html = StripWithDelimiters($article_html, '<script', '</script>');
-            $article_html = StripWithDelimiters($article_html, '<h1 class="cleanprint-title">', '</h1>');
+            $article_html = StripWithDelimiters($article_html, '<h1 class="cleanprint-title"', '</h1>');
             return $article_html;
         }
 
@@ -73,6 +73,5 @@ class LeMondeInformatiqueBridge extends BridgeAbstract {
 
     public function getCacheDuration() {
         return 1800; // 30 minutes
-        // return 0;
     }
 }

--- a/bridges/NeuviemeArtBridge.php
+++ b/bridges/NeuviemeArtBridge.php
@@ -1,0 +1,70 @@
+<?php
+class NeuviemeArtBridge extends BridgeAbstract {
+
+    public function loadMetadatas() {
+        $this->maintainer = "ORelio";
+        $this->name = "9ème Art";
+        $this->uri = "http://www.9emeart.fr/";
+        $this->description = "Returns the newest articles.";
+        $this->update = "2016-02-05";
+    }
+
+    public function collectData(array $param) {
+
+        function StripWithDelimiters($string, $start, $end) {
+            while (strpos($string, $start) !== false) {
+                $section_to_remove = substr($string, strpos($string, $start));
+                $section_to_remove = substr($section_to_remove, 0, strpos($section_to_remove, $end) + strlen($end));
+                $string = str_replace($section_to_remove, '', $string);
+            } return $string;
+        }
+
+        $feedUrl = 'http://www.9emeart.fr/9emeart.rss';
+        $html = file_get_html($feedUrl) or $this->returnError('Could not request 9eme Art: '.$feedUrl, 500);
+        $limit = 0;
+
+        foreach ($html->find('item') as $element) {
+            if ($limit < 5) {
+
+                //Retrieve article Uri and get that page
+                $article_uri = $element->find('guid', 0)->plaintext;
+                $article_html = file_get_html($article_uri) or $this->returnError('Could not request 9eme Art: '.$article_uri, 500);
+
+                //Build article contents from corresponding elements
+                $article_title = trim($element->find('title', 0)->plaintext);
+                $article_image = $element->find('enclosure', 0)->url;
+                foreach ($article_html->find('img.img_full') as $img)
+                    if ($img->alt == $article_title)
+                        $article_image = 'http://www.9emeart.fr'.$img->src;
+                $article_content = '<p><img src="'.$article_image.'" /></p>'
+                    .str_replace('src="/', 'src="http://www.9emeart.fr/', $article_html->find('div.newsGenerique_con', 0)->innertext);
+                $article_content = StripWithDelimiters($article_content, '<script', '</script>');
+                $article_content = StripWithDelimiters($article_content, '<style', '</style>');
+                $article_content = StripWithDelimiters($article_content, '<link', '>');
+
+                //Build and add final item
+                $item = new \Item();
+                $item->uri = $article_uri;
+                $item->title = $article_title;
+                $item->thumbnailUri = $element->find('enclosure', 0)->url;
+                $item->author = $article_html->find('a[class=upp transition_fast upp]', 0)->plaintext;
+                $item->timestamp = strtotime($element->find('pubDate', 0)->plaintext);
+                $item->content = $article_content;
+                $this->items[] = $item;
+                $limit++;
+            }
+        }
+    }
+
+    public function getName() {
+        return '9ème Art Bridge';
+    }
+
+    public function getURI() {
+        return 'http://www.9emeart.fr/';
+    }
+
+    public function getCacheDuration() {
+        return 3600; //1 hour
+    }
+}

--- a/bridges/T411Bridge.php
+++ b/bridges/T411Bridge.php
@@ -37,7 +37,9 @@ class T411Bridge extends BridgeAbstract {
         //Retrieve torrent listing as truncated rss, which does not contain torrent description
         $url = 'http://www.t411.in/torrents/search/?'.$param['search'].'&order=added&type=desc';
         $html = file_get_html($url) or $this->returnError('Could not request t411: '.$url, 500);
-        $results = $html->find('table.results')[0] or $this->returnError('No results from t411: '.$url, 500);
+        $results = $html->find('table.results', 0);
+        if (is_null($results))
+            $this->returnError('No results from t411: '.$url, 500);
         $limit = 0;
 
         //Process each item individually
@@ -77,7 +79,7 @@ class T411Bridge extends BridgeAbstract {
                     $item->author = $item_author;
                     $item->timestamp = $item_date;
                     $item->thumbnailUri = $item_image;
-                    $item->content = utf8_encode($item_desc->innertext);
+                    $item->content = $item_desc->innertext;
                     $this->items[] = $item;
                     $limit++;
                 }

--- a/bridges/T411Bridge.php
+++ b/bridges/T411Bridge.php
@@ -7,7 +7,7 @@ class T411Bridge extends BridgeAbstract {
         $this->name = "T411";
         $this->uri = "https://t411.in/";
         $this->description = "Returns the 5 newest torrents with specified search terms <br /> Use url part after '?' mark when using their search engine";
-        $this->update = "2015-12-17";
+        $this->update = "2016-02-06";
 
         $this->parameters[] =
         '[
@@ -46,10 +46,10 @@ class T411Bridge extends BridgeAbstract {
         foreach($results->find('tr') as $element) {
 
             //Limit total amount of requests
-            if ($limit < 5) {
+            if ($limit < 10) {
 
                 //Requests are rate-limited
-                sleep(1); //So we need to wait
+                usleep(500000); //So we need to wait (500ms)
 
                 //Retrieve data from RSS entry
                 $item_uri = 'http://'.ExtractFromDelimiters($element->outertext, '<a href="//', '"');
@@ -66,7 +66,7 @@ class T411Bridge extends BridgeAbstract {
                     //Retrieve image for thumbnail or generic logo fallback
                     $item_image = 'http://www.t411.in/themes/blue/images/logo.png';
                     foreach ($item_desc->find('img') as $img) {
-                        if (strpos($img->src, 'dreamprez') === false) {
+                        if (strpos($img->src, 'prez') === false) {
                             $item_image = $img->src;
                             break;
                         }


### PR DESCRIPTION
Hello,

Here are some updates for the bridges I'm maintaining:
- LeMondeInformatique : Fix title stripping in content field
- T411 : Handle contents as UTF-8 to reflect changes, fetch more items at once (5->10)
- CNET : Improve javascript removal to reflect changes on their site
- AnimeUltime : Minor coding style improvement (fix mixed tab/spaces)

This pull request also adds a new bridge:
- NeuviemeArt : http://9emeart.fr/ - French news about comic books / manga / us comics

As usual, these updates have been tested on my own setup prior to opening the pull request.
