### PR TITLE
Update youtube bridge

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -31,10 +31,10 @@ class YoutubeBridge extends BridgeAbstract {
 		$this->parameters['By channel id'] =
 		'[
 			{
-				"type" : "number",
+				"type" : "text",
 				"identifier" : "c",
 				"name" : "channel id",
-				"exampleValue" : "15",
+				"exampleValue" : "test",
 				"required" : "required"
 			}
 		]';


### PR DESCRIPTION
Before, the channel id was supposed to be a number. But Youtube changed how they store a
channel id. It's no longer a number, it's a string.
Now, user can enter a text string instead of a number.

See the example with this channel id: UC9fGq2-6FaftcegcIadLf6A
