### PR TITLE
Alternative for g.etfv.co favicon services

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -23,7 +23,7 @@ class AtomFormat extends FormatAbstract{
         $extraInfos = $this->getExtraInfos();
         $title = xml_encode($extraInfos['name']);
         $uri = $extraInfos['uri'];
-        $icon = xml_encode('http://g.etfv.co/'. $uri .'?icon.jpg');
+        $icon = xml_encode('http://icons.better-idea.org/icon?url='. $uri .'&size=64');
         $uri = xml_encode($uri);
 
         $entries = '';


### PR DESCRIPTION
g.etfv.co favicon services seems to be down since some time
I replaced it with another open source project: besticon
sauce: https://github.com/mat/besticon
