### PR TITLE
Update Facebook, add Debug whitelist ability

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -146,7 +146,7 @@ class FacebookBridge extends BridgeAbstract{
 		}
 
 		//No captcha? We can carry on retrieving page contents :)
-		$element = $html->find('[id^=PagePostsSectionPagelet-]')[0]->children(0)->children(0)->children(0);
+		$element = $html->find('#pagelet_timeline_main_column')[0]->children(0)->children(0)->children(0)->next_sibling()->children(0);
 
 		if(isset($element)) {
 
@@ -158,7 +158,7 @@ class FacebookBridge extends BridgeAbstract{
 			
 				$item = new \Item();
 
-				if($post->hasAttribute("data-time")) {
+				if (count($post->find('abbr')) > 0) {
 
 					//Retrieve post contents
 					$content = preg_replace('/(?i)><div class=\"clearfix([^>]+)>(.+?)div\ class=\"userContent\"/i', '', $post);
@@ -198,9 +198,10 @@ class FacebookBridge extends BridgeAbstract{
 						$title = substr($title, 0, strpos(wordwrap($title, 64), "\n")).'...';
 
 					//Use first image as thumbnail if available, or profile pic fallback
-					$thumbnail = $post->find('img', 1)->src;
-					if (strlen($thumbnail) == 0)
-						$thumbnail = $profilePic;
+					$thumbnail = $post->find('img', 1);
+					if (is_object($thumbnail))
+						$thumbnail = $thumbnail->src;
+					else $thumbnail = $profilePic;
 
 					//Build and add final item
 					$item->uri = 'https://facebook.com'.$post->find('abbr')[0]->parent()->getAttribute('href');

--- a/index.php
+++ b/index.php
@@ -15,11 +15,30 @@ TODO :
 date_default_timezone_set('UTC');
 error_reporting(0);
 
-if(file_exists("DEBUG")) {
-    
-    ini_set('display_errors','1'); error_reporting(E_ALL); //Report all errors
-    define("DEBUG", "true");
-    
+/*
+  Create a file named 'DEBUG' for enabling debug mode.
+  For further security, you may put whitelisted IP addresses
+  in the 'DEBUG' file, one IP per line. Empty file allows anyone (!).
+  Debugging allows displaying PHP error messages and bypasses the cache: this can allow a malicious
+  client to retrieve data about your server and hammer a provider throught your rss-bridge instance.
+*/
+if (file_exists('DEBUG')) {
+    $debug_enabled = true;
+    $debug_whitelist = trim(file_get_contents('DEBUG'));
+    if (strlen($debug_whitelist) > 0) {
+        $debug_enabled = false;
+        foreach (explode("\n", $debug_whitelist) as $allowed_ip) {
+            if (trim($allowed_ip) === $_SERVER['REMOTE_ADDR']) {
+                $debug_enabled = true;
+                break;
+            }
+        }
+    }
+    if ($debug_enabled) {
+        ini_set('display_errors', '1');
+        error_reporting(E_ALL);
+        define('DEBUG', 'true');
+    }
 }
 
 require_once __DIR__ . '/lib/RssBridge.php';


### PR DESCRIPTION
Facebook:
- Update field retrieval, which was broken. See #253

Core:
- If `DEBUG` file is not empty, then debug mode is enabled only for IP addresses specified in the file, one IP address per line. Allows further securing debug mode.
