### PR TITLE
Add scalingo one click deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By default, the script creates `whitelist.txt` and adds the main bridges (see ab
  * to enable extra bridges (one bridge per line)
  * to disable main bridges (remove the line)
 
-New bridges are disabled by default, so make sure to check regularly what's new and whitelist what you want !
+New bridges are disabled by default, so make sure to check regularly what's new and whitelist what you want!
 
 [![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/sebsauvage/rss-bridge)
  

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ By default, the script creates `whitelist.txt` and adds the main bridges (see ab
  * to disable main bridges (remove the line)
 
 New bridges are disabled by default, so make sure to check regularly what's new and whitelist what you want !
+
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/sebsauvage/rss-bridge)
  
 Author
 ===

--- a/scalingo.json
+++ b/scalingo.json
@@ -2,5 +2,5 @@
 	"name": "RSS Bridge",
 	"description": "rss-bridge is a PHP project capable of generating ATOM feeds for websites which don't have one.",
 	"repository": "https://github.com/sebsauvage/rss-bridge",
-	"website": "https://github.com/sebsauvage/rss-bridge",
+	"website": "https://github.com/sebsauvage/rss-bridge"
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,6 @@
+{
+	"name": "RSS Bridge",
+	"description": "rss-bridge is a PHP project capable of generating ATOM feeds for websites which don't have one.",
+	"repository": "https://github.com/sebsauvage/rss-bridge",
+	"website": "https://github.com/sebsauvage/rss-bridge",
+}


### PR DESCRIPTION
I find it interesting to have such easy to use button to deploy this app. We could also add other deployment platform. 

Add a link to deploy in one click to the [Scalingo platform](https://scalingo.com/).

These changes add the scalingo.json file to provide deployment informations to Scalingo and add a _deploy to Scalingo_ button on the README.md.
