### PR TITLE
[lib/Bridge] Fix typo

### DIFF
--- a/lib/Bridge.php
+++ b/lib/Bridge.php
@@ -111,7 +111,7 @@ abstract class BridgeAbstract implements BridgeInterface{
         }
       }
       return file_get_html($url,$use_include_path,$context,$offset,$maxLen,
-        $lowercase,$forceTagsClosed,$target_charset,$stripRN,$defaultBRtext,
+        $lowercase,$forceTagsClosed,$target_charset,$stripRN,$defaultBRText,
         $defaultSpanText);
     }
 


### PR DESCRIPTION
This fixes "Notice: Undefined variable: defaultBRtext in
C:\xampp\htdocs\rss-bridge_dev\lib\Bridge.php on line 114"
