### PR TITLE
Cleanup bridges

### DIFF
--- a/CREATE_BRIDGE.md
+++ b/CREATE_BRIDGE.md
@@ -9,8 +9,8 @@ Read the following chapters an make sure to read the [Guidelines](#guidelines)!
 
 A rss bridge must extend the `BridgeAbstract` class and implement the following functions :
 
-* [`loadMetadatas`](#the-loadmetadatas-function)
-* [`collectData`](#the-collectdata-function)
+* [`loadMetadatas`](#the-loadmetadatas-function) (**required**)
+* [`collectData`](#the-collectdata-function) (**required**)
 * [`getName`](#the-getname-function)
 * [`getURI`](#the-geturi-function)
 * [`getCacheDuration`](#the-getcacheduration-function)
@@ -149,9 +149,11 @@ Parameter | ATOM | HTML | (M)RSS
 
 This function returns the name of the bridge as it will be displayed on the main page of rss-bridge or on top of the feed output (HTML, ATOM, etc...).
 
+**Notice:** rss-bridge will by default return `$this->name` which is defined in the [`loadMetadatas`](#the-loadmetadatas-function) function, so you only have to implement this function if you require different behavior!
+
 ```PHP
 	public function getName(){
-		return ''; // Insert your bridge name here!
+		return $this->name;
 	}
 ```
 
@@ -159,9 +161,11 @@ This function returns the name of the bridge as it will be displayed on the main
 
 This function returns the URI to the destination site of the bridge. It will be used on the main page of rss-bridge when clicking your bridge name.
 
+**Notice:** rss-bridge will by default return `$this->uri` which is defined in the [`loadMetadatas`](#the-loadmetadatas-function) function, so you only have to implement this function if you require different behavior!
+
 ```PHP
 	public function getURI(){
-		return ''; // Insert your URI here!
+		return $this-uri;
 	}
 ```
 
@@ -223,22 +227,14 @@ This is the minimum template for a new bridge:
 class MySiteBridge extends BridgeAbstract{
 	public function loadMetadatas(){
 		$this->maintainer = 'No maintainer';
-		$this->name = $this->getName();
-		$this->uri = $this->getURI();
+		$this->name = 'Unnamed bridge';
+		$this->uri = '';
 		$this->description = 'No description provided';
 		$this->parameters = array();
 	}
 
 	public function collectData(array $params){
 		// Implement your bridge here!
-	}
-
-	public function getName(){
-		return ''; // Insert your bridge name here!
-	}
-
-	public function getURI(){
-		return ''; // Insert your URI here!
 	}
 }
 

--- a/CREATE_BRIDGE.md
+++ b/CREATE_BRIDGE.md
@@ -165,7 +165,7 @@ This function returns the URI to the destination site of the bridge. It will be 
 
 ```PHP
 	public function getURI(){
-		return $this-uri;
+		return $this->uri;
 	}
 ```
 
@@ -202,7 +202,7 @@ Check the [list of error codes](https://en.wikipedia.org/wiki/List_of_HTTP_statu
 
 ## The `file_get_html` function
 
-This function is a wrapper around the simple_html_dom file_get_html function in order to provide context by design. It is considered good practice to use this function.
+This function is a wrapper around the [simple_html_dom](http://simplehtmldom.sourceforge.net/) [file_get_html](http://simplehtmldom.sourceforge.net/manual_api.htm#api) function in order to provide context by design. It is considered good practice to use this function.
 
 ```PHP
 $html = $this->file_get_html('your URI');

--- a/CREATE_BRIDGE.md
+++ b/CREATE_BRIDGE.md
@@ -169,6 +169,8 @@ This function returns the URI to the destination site of the bridge. It will be 
 
 This function returns the time in **seconds** during which rss-bridge will output cached values instead of re-generating a RSS feed.
 
+**Notice:** rss-bridge will return `3600` seconds (1 hour) by default, so you only have to implement this function if you require different timing!
+
 ```PHP
 	public function getCacheDuration(){
 		return 3600; // 1 hour
@@ -214,7 +216,7 @@ $html = $this->file_get_html('your URI');
 
 # Template
 
-This is a template for a new bridge:
+This is the minimum template for a new bridge:
 
 ```PHP
 <?php
@@ -237,10 +239,6 @@ class MySiteBridge extends BridgeAbstract{
 
 	public function getURI(){
 		return ''; // Insert your URI here!
-	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hour
 	}
 }
 

--- a/bridges/ABCTabsBridge.php
+++ b/bridges/ABCTabsBridge.php
@@ -9,7 +9,7 @@ class ABCTabsBridge extends BridgeAbstract{
 		$this->name = "ABC Tabs Bridge";
 		$this->uri = "http://www.abc-tabs.com/";
 		$this->description = "Returns 22 newest tabs";
-		$this->update = "2014-07-23";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -40,9 +40,5 @@ class ABCTabsBridge extends BridgeAbstract{
 
 		return "http://www.abc-tabs.com/";
 
-	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hour
 	}
 }

--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -10,7 +10,7 @@ class AllocineFRBridge extends BridgeAbstract{
 		$this->name = "Allo Cine : Faux Raccord";
 		$this->uri = "http://www.allocine.fr/video/programme-12284/saison-24580/";
 		$this->description = "Allo Cine : Faux Raccord";
-		$this->update = "07/11/2013";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -49,9 +49,6 @@ class AllocineFRBridge extends BridgeAbstract{
 
     public function getCacheDuration(){
         return 25200; // 7 hours
-    }
-    public function getDescription(){
-        return "Allo Cine : " . $this->_NOM . " via rss-bridge";
     }
 }
 ?>

--- a/bridges/AllocineT5Bridge.php
+++ b/bridges/AllocineT5Bridge.php
@@ -10,7 +10,7 @@ class AllocineT5Bridge extends BridgeAbstract{
 		$this->name = "Allo Cine : Top 5";
 		$this->uri = "http://www.allocine.fr/video/programme-12299/saison-22542/";
 		$this->description = "Allo Cine : Top 5 via rss-bridge";
-		$this->update = "07/11/2013";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -49,9 +49,6 @@ class AllocineT5Bridge extends BridgeAbstract{
 
     public function getCacheDuration(){
         return 25200; // 7 hours
-    }
-    public function getDescription(){
-        return "Allo Cine : " . $this->_NOM . " via rss-bridge";
     }
 }
 ?>

--- a/bridges/AllocineTueursEnSerieBridge.php
+++ b/bridges/AllocineTueursEnSerieBridge.php
@@ -10,7 +10,7 @@ class AllocineTueursEnSerieBridge extends BridgeAbstract{
 		$this->name = "Allo Cine : Tueurs En Serie";
 		$this->uri = "http://www.allocine.fr/video/programme-12286/saison-22938/";
 		$this->description = "Allo Cine : Tueurs En Serie";
-		$this->update = "12/11/2013";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -49,9 +49,6 @@ class AllocineTueursEnSerieBridge extends BridgeAbstract{
 
     public function getCacheDuration(){
         return 25200; // 7 hours
-    }
-    public function getDescription(){
-        return "Allo Cine : " . $this->_NOM . " via rss-bridge";
     }
 }
 ?>

--- a/bridges/BlaguesDeMerdeBridge.php
+++ b/bridges/BlaguesDeMerdeBridge.php
@@ -7,7 +7,7 @@ class BlaguesDeMerdeBridge extends BridgeAbstract{
 		$this->name = "Blagues De Merde";
 		$this->uri = "http://www.blaguesdemerde.fr/";
 		$this->description = "Blagues De Merde";
-		$this->update = "16/10/2013";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -42,9 +42,6 @@ class BlaguesDeMerdeBridge extends BridgeAbstract{
 
     public function getCacheDuration(){
         return 7200; // 2h hours
-    }
-    public function getDescription(){
-        return "Blagues De Merde via rss-bridge";
     }
 }
 ?>

--- a/bridges/CADBridge.php
+++ b/bridges/CADBridge.php
@@ -5,10 +5,10 @@ class CADBridge extends BridgeAbstract{
 		$this->name = "CAD Bridge";
 		$this->uri = "http://www.cad-comic.com/";
 		$this->description = "Returns the newest articles.";
-		$this->update = "2016-08-02";
+		$this->update = "2016-08-06";
 	}
 
-	function CADExtractContent($url) {
+	private function CADExtractContent($url) {
 		$html3 = $this->file_get_html($url);
 
 		// The request might fail due to missing https support or wrong URL

--- a/bridges/CNETBridge.php
+++ b/bridges/CNETBridge.php
@@ -9,7 +9,7 @@ class CNETBridge extends BridgeAbstract {
         $this->name = 'CNET News';
         $this->uri = 'http://www.cnet.com/';
         $this->description = 'Returns the newest articles. <br /> You may specify a topic found in some section URLs, else all topics are selected.';
-        $this->update = '2016-03-16';
+        $this->update = '2016-08-06';
 
         $this->parameters[] =
         '[
@@ -96,12 +96,7 @@ class CNETBridge extends BridgeAbstract {
         return 'CNET News Bridge'.(empty($this->topicName) ? '' : ' - '.$this->topicName);
     }
 
-    public function getURI() {
-        return 'http://www.cnet.com/';
-    }
-
     public function getCacheDuration() {
         return 1800; // 30 minutes
-        // return 0;
     }
 }

--- a/bridges/CastorusBridge.php
+++ b/bridges/CastorusBridge.php
@@ -5,7 +5,7 @@ class CastorusBridge extends BridgeAbstract {
 		$this->name = "Castorus Bridge";
 		$this->uri = $this->getURI();
 		$this->description = "Returns the latest changes";
-		$this->update = "2016-08-05";
+		$this->update = "2016-08-06";
 
 		$this->parameters["Get latest changes"] = '[]';
 		$this->parameters["Get latest changes via ZIP code"] = 
@@ -33,7 +33,7 @@ class CastorusBridge extends BridgeAbstract {
 	}
 
 	// Extracts the tile from an actitiy
-	function ExtractActivityTitle($activity){
+	private function ExtractActivityTitle($activity){
 		$title = $activity->find('a', 0);
 
 		if(!$title)
@@ -43,7 +43,7 @@ class CastorusBridge extends BridgeAbstract {
 	}
 
 	// Extracts the url from an actitiy
-	function ExtractActivityUrl($activity){
+	private function ExtractActivityUrl($activity){
 		$url = $activity->find('a', 0);
 
 		if(!$url)
@@ -53,7 +53,7 @@ class CastorusBridge extends BridgeAbstract {
 	}
 
 	// Extracts the time from an activity
-	function ExtractActivityTime($activity){
+	private function ExtractActivityTime($activity){
 		// Unfortunately the time is part of the parent node, 
 		// so we have to clear all child nodes first
 		$nodes = $activity->find('*');
@@ -69,7 +69,7 @@ class CastorusBridge extends BridgeAbstract {
 	}
 
 	// Extracts the price change
-	function ExtractActivityPrice($activity){
+	private function ExtractActivityPrice($activity){
 		$price = $activity->find('span', 1);
 
 		if(!$price)

--- a/bridges/CommonDreamsBridge.php
+++ b/bridges/CommonDreamsBridge.php
@@ -6,10 +6,10 @@ class CommonDreamsBridge extends BridgeAbstract{
 		$this->name = "CommonDreams Bridge";
 		$this->uri = "http://www.commondreams.org/";
 		$this->description = "Returns the newest articles.";
-		$this->update = "2016-08-02";
+		$this->update = "2016-08-06";
 	}
 
-	function CommonDreamsExtractContent($url) {
+	private function CommonDreamsExtractContent($url) {
 		$html3 = $this->file_get_html($url);
 		$text = $html3->find('div[class=field--type-text-with-summary]', 0)->innertext;
 		$html3->clear();

--- a/bridges/CommonDreamsBridge.php
+++ b/bridges/CommonDreamsBridge.php
@@ -47,8 +47,4 @@ class CommonDreamsBridge extends BridgeAbstract{
 	public function getURI(){
 		return 'http://www.commondreams.org/';
 	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hours
-	}
 }

--- a/bridges/CopieDoubleBridge.php
+++ b/bridges/CopieDoubleBridge.php
@@ -7,7 +7,7 @@ class CopieDoubleBridge extends BridgeAbstract{
 		$this->name = "CopieDouble";
 		$this->uri = "http://www.copie-double.com/";
 		$this->description = "CopieDouble";
-		$this->update = "12/12/2013";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -50,13 +50,7 @@ class CopieDoubleBridge extends BridgeAbstract{
         return 'http://www.copie-double.com';
     }
 
-    public function getDescription(){
-        return 'CopieDouble via rss-bridge';
-    }
-
     public function getCacheDuration(){
         return 14400; // 4 hours
     }
 }
-
-?>

--- a/bridges/CpasbienBridge.php
+++ b/bridges/CpasbienBridge.php
@@ -24,7 +24,7 @@ class CpasbienBridge extends HttpCachingBridgeAbstract{
 		$this->name = "Cpasbien Bridge";
 		$this->uri = "http://www.cpasbien.io";
 		$this->description = "Returns latest torrents from a request query";
-		$this->update = "2016-01-26";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -81,10 +81,6 @@ class CpasbienBridge extends HttpCachingBridgeAbstract{
 
     public function getName(){
         return (!empty($this->request) ? $this->request .' - ' : '') . $this->name;
-    }
-
-    public function getURI(){
-        return $this->uri;
     }
 
     public function getCacheDuration(){

--- a/bridges/DauphineLibereBridge.php
+++ b/bridges/DauphineLibereBridge.php
@@ -7,7 +7,7 @@ class DauphineLibereBridge extends BridgeAbstract {
 		$this->name = "DauphineLibereBridge Bridge";
 		$this->uri = "http://www.ledauphine.com/";
 		$this->description = "Returns the newest articles.";
-		$this->update = "2016-08-02";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -81,7 +81,7 @@ class DauphineLibereBridge extends BridgeAbstract {
 		]';
 	}
 
-	function ExtractContent($url, $context) {
+	private function ExtractContent($url, $context) {
 		$html2 = $this->file_get_html($url, false, $context);
 		$text = $html2->find('div.column', 0)->innertext;
 		$text = preg_replace('@<script[^>]*?>.*?</script>@si', '', $text);

--- a/bridges/DeveloppezDotComBridge.php
+++ b/bridges/DeveloppezDotComBridge.php
@@ -6,10 +6,10 @@ class DeveloppezDotComBridge extends BridgeAbstract{
 		$this->name = "Developpez.com Actus (FR)";
 		$this->uri = "http://www.developpez.com/";
 		$this->description = "Returns the 15 newest posts from DeveloppezDotCom (full text).";
-		$this->update = "2016-08-03";
+		$this->update = "2016-08-06";
 	}
 
-	function DeveloppezDotComStripCDATA($string) {
+	private function DeveloppezDotComStripCDATA($string) {
 		$string = str_replace('<![CDATA[', '', $string);
 		$string = str_replace(']]>', '', $string);
 		return $string;
@@ -17,7 +17,7 @@ class DeveloppezDotComBridge extends BridgeAbstract{
 
 	// F***ing quotes from Microsoft Word badly encoded, here was the trick: 
 	// http://stackoverflow.com/questions/1262038/how-to-replace-microsoft-encoded-quotes-in-php
-	function convert_smart_quotes($string)
+	private function convert_smart_quotes($string)
 	{
 		$search = array(chr(145),
 						chr(146),
@@ -34,7 +34,7 @@ class DeveloppezDotComBridge extends BridgeAbstract{
 		return str_replace($search, $replace, $string);
 	}
 
-	function DeveloppezDotComExtractContent($url) {
+	private function DeveloppezDotComExtractContent($url) {
 		$articleHTMLContent = $this->file_get_html($url);
 		$text = $this->convert_smart_quotes($articleHTMLContent->find('div.content', 0)->innertext);
 		$text = utf8_encode($text);

--- a/bridges/DilbertBridge.php
+++ b/bridges/DilbertBridge.php
@@ -6,8 +6,8 @@ class DilbertBridge extends BridgeAbstract {
         $this->maintainer = 'kranack';
         $this->name = $this->getName();
         $this->uri = $this->getURI();
-        $this->description = $this->getDescription();
-        $this->update = "14/05/2016";
+        $this->description = 'The Unofficial Dilbert Daily Comic Strip';
+        $this->update = "2016-08-06";
 
     }
 
@@ -44,10 +44,6 @@ class DilbertBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'http://dilbert.com';
-    }
-
-    public function getDescription() {
-        return 'The Unofficial Dilbert Daily Comic Strip';
     }
 
     public function getCacheDuration() {

--- a/bridges/DilbertBridge.php
+++ b/bridges/DilbertBridge.php
@@ -4,8 +4,8 @@ class DilbertBridge extends BridgeAbstract {
     public function loadMetadatas() {
 
         $this->maintainer = 'kranack';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'Dilbert Daily Strip';
+        $this->uri = 'http://dilbert.com';
         $this->description = 'The Unofficial Dilbert Daily Comic Strip';
         $this->update = "2016-08-06";
 
@@ -39,11 +39,11 @@ class DilbertBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'Dilbert Daily Strip';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'http://dilbert.com';
+        return $this->uri;
     }
 
     public function getCacheDuration() {

--- a/bridges/DilbertBridge.php
+++ b/bridges/DilbertBridge.php
@@ -38,14 +38,6 @@ class DilbertBridge extends BridgeAbstract {
         }
     }
 
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
-
     public function getCacheDuration() {
         return 21600; // 6 hours
     }

--- a/bridges/EZTVBridge.php
+++ b/bridges/EZTVBridge.php
@@ -7,7 +7,7 @@ class EZTVBridge extends BridgeAbstract{
 		$this->name = "EZTV";
 		$this->uri = "https://eztv.ch/";
 		$this->description = "Returns list of *recent* torrents for a specific show on EZTV. Get showID from URLs in https://eztv.ch/shows/showID/show-full-name.";
-		$this->update = "2014-01-20";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -79,9 +79,5 @@ class EZTVBridge extends BridgeAbstract{
 
     public function getURI(){
         return 'https://eztv.ch/';
-    }
-
-    public function getCacheDuration(){
-        return 3600; // 1 hour
     }
 }

--- a/bridges/ElsevierBridge.php
+++ b/bridges/ElsevierBridge.php
@@ -6,7 +6,7 @@ class ElsevierBridge extends BridgeAbstract{
 		$this->name = 'Elsevier journals recent articles';
 		$this->uri = 'http://www.journals.elsevier.com';
 		$this->description = 'Returns the recent articles published in Elsevier journals';
-		$this->update = '2016-08-02';
+		$this->update = '2016-08-06';
 
 		$this->parameters[] =
 			'[
@@ -21,7 +21,7 @@ class ElsevierBridge extends BridgeAbstract{
 	}
 
 	// Extracts the list of names from an article as string
-	function ExtractArticleName ($article){
+	private function ExtractArticleName ($article){
 		$names = $article->find('small', 0);
 		if($names)
 			return trim($names->plaintext);
@@ -29,7 +29,7 @@ class ElsevierBridge extends BridgeAbstract{
 	}
 
 	// Extracts the timestamp from an article
-	function ExtractArticleTimestamp ($article){
+	private function ExtractArticleTimestamp ($article){
 		$time = $article->find('.article-info', 0);
 		if($time){
 			$timestring = trim($time->plaintext);
@@ -53,7 +53,7 @@ class ElsevierBridge extends BridgeAbstract{
 	}
 
 	// Extracts the content from an article
-	function ExtractArticleContent ($article){
+	private function ExtractArticleContent ($article){
 		$content = $article->find('.article-content', 0);
 		if($content){
 			return trim($content->plaintext);

--- a/bridges/EstCeQuonMetEnProdBridge.php
+++ b/bridges/EstCeQuonMetEnProdBridge.php
@@ -5,8 +5,8 @@ class EstCeQuonMetEnProdBridge extends BridgeAbstract {
         $this->maintainer = 'ORelio';
         $this->name = $this->getName();
         $this->uri = $this->getURI();
-        $this->description = $this->getDescription();
-        $this->update = "02/07/2016";
+        $this->description = 'Should we put a website in production today? (French)';
+        $this->update = "2016-08-06";
     }
 
     public function collectData(array $param) {
@@ -43,10 +43,6 @@ class EstCeQuonMetEnProdBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'https://www.estcequonmetenprodaujourdhui.info/';
-    }
-
-    public function getDescription() {
-        return 'Should we put a website in production today? (French)';
     }
 
     public function getCacheDuration() {

--- a/bridges/EstCeQuonMetEnProdBridge.php
+++ b/bridges/EstCeQuonMetEnProdBridge.php
@@ -37,14 +37,6 @@ class EstCeQuonMetEnProdBridge extends BridgeAbstract {
         $this->items[] = $item;
     }
 
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
-
     public function getCacheDuration() {
         return 21600; // 6 hours
     }

--- a/bridges/EstCeQuonMetEnProdBridge.php
+++ b/bridges/EstCeQuonMetEnProdBridge.php
@@ -3,8 +3,8 @@ class EstCeQuonMetEnProdBridge extends BridgeAbstract {
 
     public function loadMetadatas() {
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'Est-ce qu\'on met en prod aujourd\'hui ?';
+        $this->uri = 'https://www.estcequonmetenprodaujourdhui.info/';
         $this->description = 'Should we put a website in production today? (French)';
         $this->update = "2016-08-06";
     }
@@ -38,11 +38,11 @@ class EstCeQuonMetEnProdBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'Est-ce qu\'on met en prod aujourd\'hui ?';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'https://www.estcequonmetenprodaujourdhui.info/';
+        return $this->uri;
     }
 
     public function getCacheDuration() {

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -7,7 +7,7 @@ class FacebookBridge extends BridgeAbstract{
 		$this->name = "Facebook";
 		$this->uri = "http://www.facebook.com/";
 		$this->description = "Input a page title or a profile log. For a profile log, please insert the parameter as follow : myExamplePage/132621766841117";
-		$this->update = "31/03/2016";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -224,10 +224,6 @@ class FacebookBridge extends BridgeAbstract{
 
 	public function getName() {
 		return (isset($this->name) ? $this->name.' - ' : '').'Facebook Bridge';
-	}
-
-	public function getURI() {
-		return 'http://facebook.com';
 	}
 
 	public function getCacheDuration() {

--- a/bridges/FootitoBridge.php
+++ b/bridges/FootitoBridge.php
@@ -7,7 +7,7 @@ class FootitoBridge extends BridgeAbstract{
 		$this->name = "Footito";
 		$this->uri = "http://www.footito.fr/";
 		$this->description = "Footito";
-		$this->update = "21/11/2013";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -53,8 +53,4 @@ class FootitoBridge extends BridgeAbstract{
     public function getCacheDuration(){
         return 3600; // 1h hours
     }
-    public function getDescription(){
-        return "Footito via rss-bridge";
-    }
 }
-?>

--- a/bridges/FootitoBridge.php
+++ b/bridges/FootitoBridge.php
@@ -49,8 +49,4 @@ class FootitoBridge extends BridgeAbstract{
     public function getURI(){
         return 'http://www.footito.fr/';
     }
-
-    public function getCacheDuration(){
-        return 3600; // 1h hours
-    }
 }

--- a/bridges/FuturaSciencesBridge.php
+++ b/bridges/FuturaSciencesBridge.php
@@ -218,12 +218,4 @@ class FuturaSciencesBridge extends BridgeAbstract {
         }
 
     }
-
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
 }

--- a/bridges/FuturaSciencesBridge.php
+++ b/bridges/FuturaSciencesBridge.php
@@ -7,7 +7,7 @@ class FuturaSciencesBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'Returns the newest articles.';
-        $this->update = '2016-08-03';
+        $this->update = '2016-08-06';
 
         $this->parameters[] =
         '[
@@ -225,9 +225,5 @@ class FuturaSciencesBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'http://www.futura-sciences.com/';
-    }
-
-    public function getCacheDuration() {
-        return 3600;
     }
 }

--- a/bridges/FuturaSciencesBridge.php
+++ b/bridges/FuturaSciencesBridge.php
@@ -4,8 +4,8 @@ class FuturaSciencesBridge extends BridgeAbstract {
     public function loadMetadatas() {
 
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'Futura-Sciences Bridge';
+        $this->uri = 'http://www.futura-sciences.com/';
         $this->description = 'Returns the newest articles.';
         $this->update = '2016-08-06';
 
@@ -220,10 +220,10 @@ class FuturaSciencesBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'Futura-Sciences Bridge';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'http://www.futura-sciences.com/';
+        return $this->uri;
     }
 }

--- a/bridges/GBAtempBridge.php
+++ b/bridges/GBAtempBridge.php
@@ -9,7 +9,7 @@ class GBAtempBridge extends BridgeAbstract {
         $this->name = 'GBAtemp';
         $this->uri = $this->getURI();
         $this->description = 'GBAtemp is a user friendly underground video game community.';
-        $this->update = '2016-08-02';
+        $this->update = '2016-08-06';
 
         $this->parameters[] =
         '[
@@ -40,7 +40,7 @@ class GBAtempBridge extends BridgeAbstract {
         ]';
     }
 
-    function ExtractFromDelimiters($string, $start, $end) {
+    private function ExtractFromDelimiters($string, $start, $end) {
         if (strpos($string, $start) !== false) {
             $section_retrieved = substr($string, strpos($string, $start) + strlen($start));
             $section_retrieved = substr($section_retrieved, 0, strpos($section_retrieved, $end));
@@ -48,7 +48,7 @@ class GBAtempBridge extends BridgeAbstract {
         } return false;
     }
 
-    function StripWithDelimiters($string, $start, $end) {
+    private function StripWithDelimiters($string, $start, $end) {
         while (strpos($string, $start) !== false) {
             $section_to_remove = substr($string, strpos($string, $start));
             $section_to_remove = substr($section_to_remove, 0, strpos($section_to_remove, $end) + strlen($end));
@@ -56,7 +56,7 @@ class GBAtempBridge extends BridgeAbstract {
         } return $string;
     }
 
-    function build_item($uri, $title, $author, $timestamp, $thumnail, $content) {
+    private function build_item($uri, $title, $author, $timestamp, $thumnail, $content) {
         $item = new \Item();
         $item->uri = $uri;
         $item->title = $title;
@@ -67,14 +67,14 @@ class GBAtempBridge extends BridgeAbstract {
         return $item;
     }
 
-    function cleanup_post_content($content, $site_url) {
+    private function cleanup_post_content($content, $site_url) {
         $content = str_replace(':arrow:', '&#x27a4;', $content);
         $content = str_replace('href="attachments/', 'href="'.$site_url.'attachments/', $content);
         $content = $this->StripWithDelimiters($content, '<script', '</script>');
         return $content;
     }
 
-    function fetch_post_content($uri, $site_url) {
+    private function fetch_post_content($uri, $site_url) {
         $html = $this->file_get_html($uri) or $this->returnError('Could not request GBAtemp: '.$uri, 500);
         $content = $html->find('div.messageContent', 0)->innertext;
         return $this->cleanup_post_content($content, $site_url);

--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -9,7 +9,7 @@ class GiphyBridge extends BridgeAbstract{
 		$this->name = "Giphy Bridge";
 		$this->uri = "http://giphy.com/";
 		$this->description = "Bridge for giphy.com";
-		$this->update = "2014-12-05";
+		$this->update = "2016-08-06";
 
 		$this->parameters["By tag"] =
 		'[
@@ -91,9 +91,5 @@ class GiphyBridge extends BridgeAbstract{
 
 	public function getCacheDuration(){
 		return 300; // 5 minutes
-	}
-    
-	public function getUsername(){
-		return $this->items[0]->username;
 	}
 }

--- a/bridges/GitlabCommitsBridge.php
+++ b/bridges/GitlabCommitsBridge.php
@@ -12,7 +12,7 @@ class GitlabCommitsBridge extends BridgeAbstract{
     $this->name = 'Gitlab Commits';
     $this->uri = '';
     $this->description = 'Returns the commits of a project hosted on a gitlab instance';
-    $this->update = '2016-06-19';
+    $this->update = '2016-08-06';
 
     $this->parameters[] =
       '[
@@ -86,9 +86,5 @@ class GitlabCommitsBridge extends BridgeAbstract{
 
   public function getURI(){
     return '';
-  }
-
-  public function getCacheDuration(){
-    return 3600; // one hour
   }
 }

--- a/bridges/GuruMedBridge.php
+++ b/bridges/GuruMedBridge.php
@@ -39,8 +39,4 @@ class GuruMedBridge extends BridgeAbstract{
 	public function getURI(){
 		return 'http://gurumed.org/';
 	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hour
-	}
 }

--- a/bridges/GuruMedBridge.php
+++ b/bridges/GuruMedBridge.php
@@ -6,10 +6,10 @@ class GuruMedBridge extends BridgeAbstract{
 		$this->name = "GuruMed";
 		$this->uri = "http://www.gurumed.org";
 		$this->description = "Returns the 5 newest posts from Gurumed (full text)";
-		$this->update = "2016-08-03";
+		$this->update = "2016-08-06";
 	}
 
-	function GurumedStripCDATA($string) {
+	private function GurumedStripCDATA($string) {
 		$string = str_replace('<![CDATA[', '', $string);
 		$string = str_replace(']]>', '', $string);
 		return $string;

--- a/bridges/HentaiHavenBridge.php
+++ b/bridges/HentaiHavenBridge.php
@@ -7,7 +7,7 @@ class HentaiHavenBridge extends BridgeAbstract{
 		$this->name = "Hentai Haven";
 		$this->uri = "http://hentaihaven.org/";
 		$this->description = "Returns releases from Hentai Haven";
-		$this->update = "2015-01-16";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -28,9 +28,6 @@ class HentaiHavenBridge extends BridgeAbstract{
     }
     public function getURI(){
         return '';
-    }
-    public function getDescription(){
-        return "Hentai Haven | Everything Else is Irrelevant";
     }
     public function getCacheDuration(){
         return 21600; // 6 hours

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -9,7 +9,7 @@ class InstagramBridge extends BridgeAbstract{
 		$this->name = "Instagram Bridge";
 		$this->uri = "http://instagram.com/";
 		$this->description = "Returns the newest images";
-		$this->update = "2014-05-25";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -80,9 +80,5 @@ class InstagramBridge extends BridgeAbstract{
 
     public function getURI(){
         return 'http://instagram.com/';
-    }
-
-    public function getCacheDuration(){
-        return 3600; 
     }
 }

--- a/bridges/KoreusBridge.php
+++ b/bridges/KoreusBridge.php
@@ -46,8 +46,4 @@ class KoreusBridge extends BridgeAbstract{
 	public function getURI(){
 		return 'http://www.koreus.com/';
 	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hour
-	}
 }

--- a/bridges/KoreusBridge.php
+++ b/bridges/KoreusBridge.php
@@ -6,16 +6,16 @@ class KoreusBridge extends BridgeAbstract{
 		$this->name = "Koreus";
 		$this->uri = "http://www.koreus.com/";
 		$this->description = "Returns the 5 newest posts from Koreus (full text)";
-		$this->update = "2016-08-03";
+		$this->update = "2016-08-06";
 	}
 
-	function KoreusStripCDATA($string) {
+	private function KoreusStripCDATA($string) {
 		$string = str_replace('<![CDATA[', '', $string);
 		$string = str_replace(']]>', '', $string);
 		return $string;
 	}
 
-	function KoreusExtractContent($url) {
+	private function KoreusExtractContent($url) {
 		$html2 = $this->file_get_html($url);
 		$text = $html2->find('p[class=itemText]', 0)->innertext;
 		$text = utf8_encode(preg_replace('/(Sur le m.+?)+$/i','',$text));

--- a/bridges/LeBonCoinBridge.php
+++ b/bridges/LeBonCoinBridge.php
@@ -7,7 +7,7 @@ class LeBonCoinBridge extends BridgeAbstract{
 		$this->name = "LeBonCoin";
 		$this->uri = "http://www.leboncoin.fr";
 		$this->description = "Returns most recent results from LeBonCoin for a region, and optionally a category and a keyword .";
-		$this->update = "2016-05-02";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
             '[
@@ -282,9 +282,5 @@ class LeBonCoinBridge extends BridgeAbstract{
 
 	public function getURI(){
 		return 'http://www.leboncoin.fr';
-	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hour
 	}
 }

--- a/bridges/LeJournalDuGeekBridge.php
+++ b/bridges/LeJournalDuGeekBridge.php
@@ -6,16 +6,16 @@ class LeJournalDuGeekBridge extends BridgeAbstract{
 		$this->name = "journaldugeek.com (FR)";
 		$this->uri = "http://www.journaldugeek.com/";
 		$this->description = "Returns the 5 newest posts from LeJournalDuGeek (full text).";
-		$this->update = "2016-08-03";
+		$this->update = "2016-08-06";
 	}
 
-	function LeJournalDuGeekStripCDATA($string) {
+	private function LeJournalDuGeekStripCDATA($string) {
 		$string = str_replace('<![CDATA[', '', $string);
 		$string = str_replace(']]>', '', $string);
 		return $string;
 	}
 
-	function LeJournalDuGeekExtractContent($url) {
+	private function LeJournalDuGeekExtractContent($url) {
 		$articleHTMLContent = $this->file_get_html($url);
 		$text = $articleHTMLContent->find('div.post-content', 0)->innertext;
 

--- a/bridges/LesJoiesDuCodeBridge.php
+++ b/bridges/LesJoiesDuCodeBridge.php
@@ -7,7 +7,7 @@ class LesJoiesDuCodeBridge extends BridgeAbstract{
 		$this->name = "Les Joies Du Code";
 		$this->uri = "http://lesjoiesducode.fr/";
 		$this->description = "LesJoiesDuCode";
-		$this->update = "04/02/2015";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -59,8 +59,4 @@ class LesJoiesDuCodeBridge extends BridgeAbstract{
     public function getCacheDuration(){
         return 7200; // 2h hours
     }
-    public function getDescription(){
-        return "Les Joies Du Code via rss-bridge";
-    }
 }
-?>

--- a/bridges/LichessBridge.php
+++ b/bridges/LichessBridge.php
@@ -5,10 +5,10 @@ class LichessBridge  extends BridgeAbstract
     public function loadMetadatas()
     {
         $this->maintainer = 'AmauryCarrade';
-        $this->name = $this->getName() . ' Bridge';
-        $this->uri = $this->getURI();
+        $this->name = 'Lichess Blog';
+        $this->uri = 'http://lichess.org/blog';
         $this->description = 'Returns the 5 newest posts from the Lichess blog (full text)';
-        $this->update = "2016-03-22";
+        $this->update = "2016-08-06";
     }
 
     public function collectData(array $param)
@@ -51,11 +51,11 @@ class LichessBridge  extends BridgeAbstract
 
     public function getName()
     {
-        return 'Lichess Blog';
+        return $this->name;
     }
 
     public function getURI()
     {
-        return 'http://lichess.org/blog';
+        return $this->uri;
     }
 }

--- a/bridges/LichessBridge.php
+++ b/bridges/LichessBridge.php
@@ -48,14 +48,4 @@ class LichessBridge  extends BridgeAbstract
 
         return $content;
     }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    public function getURI()
-    {
-        return $this->uri;
-    }
 }

--- a/bridges/MsnMondeBridge.php
+++ b/bridges/MsnMondeBridge.php
@@ -37,8 +37,4 @@ class MsnMondeBridge extends BridgeAbstract{
 	public function getURI(){
 		return 'http://www.msn.com/fr-fr/actualite/monde';
 	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hour
-	}
 }

--- a/bridges/MsnMondeBridge.php
+++ b/bridges/MsnMondeBridge.php
@@ -6,10 +6,10 @@ class MsnMondeBridge extends BridgeAbstract{
 		$this->name = "MSN Actu Monde";
 		$this->uri = "http://www.msn.com/fr-fr/actualite/monde";
 		$this->description = "Returns the 10 newest posts from MSN Actualités (full text)";
-		$this->update = "2016-08-03";
+		$this->update = "2016-08-06";
 	}
 
-	function MsnMondeExtractContent($url, &$item) {
+	private function MsnMondeExtractContent($url, &$item) {
 		$html2 = $this->file_get_html($url);
 		$item->content = $html2->find('#content', 0)->find('article', 0)->find('section', 0)->plaintext;
 		$item->timestamp = strtotime($html2->find('.authorinfo-txt', 0)->find('time', 0)->datetime);

--- a/bridges/NakedSecurityBridge.php
+++ b/bridges/NakedSecurityBridge.php
@@ -69,12 +69,4 @@ class NakedSecurityBridge extends BridgeAbstract {
             }
         }
     }
-
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
 }

--- a/bridges/NakedSecurityBridge.php
+++ b/bridges/NakedSecurityBridge.php
@@ -6,7 +6,7 @@ class NakedSecurityBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'Returns the newest articles.';
-        $this->update = '2016-04-30';
+        $this->update = '2016-08-06';
     }
 
     public function collectData(array $param) {
@@ -76,9 +76,5 @@ class NakedSecurityBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'https://nakedsecurity.sophos.com/';
-    }
-
-    public function getCacheDuration() {
-        return 3600; //1 hour
     }
 }

--- a/bridges/NakedSecurityBridge.php
+++ b/bridges/NakedSecurityBridge.php
@@ -3,8 +3,8 @@ class NakedSecurityBridge extends BridgeAbstract {
 
     public function loadMetadatas() {
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'Naked Security';
+        $this->uri = 'https://nakedsecurity.sophos.com/';
         $this->description = 'Returns the newest articles.';
         $this->update = '2016-08-06';
     }
@@ -71,10 +71,10 @@ class NakedSecurityBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'Naked Security';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'https://nakedsecurity.sophos.com/';
+        return $this->uri;
     }
 }

--- a/bridges/NeuviemeArtBridge.php
+++ b/bridges/NeuviemeArtBridge.php
@@ -6,7 +6,7 @@ class NeuviemeArtBridge extends BridgeAbstract {
         $this->name = "9ème Art";
         $this->uri = "http://www.9emeart.fr/";
         $this->description = "Returns the newest articles.";
-        $this->update = "2016-02-05";
+        $this->update = "2016-08-06";
     }
 
     public function collectData(array $param) {
@@ -62,9 +62,5 @@ class NeuviemeArtBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'http://www.9emeart.fr/';
-    }
-
-    public function getCacheDuration() {
-        return 3600; //1 hour
     }
 }

--- a/bridges/NextInpactBridge.php
+++ b/bridges/NextInpactBridge.php
@@ -6,16 +6,16 @@ class NextInpactBridge extends BridgeAbstract {
 		$this->name = "NextInpact Bridge";
 		$this->uri = "http://www.nextinpact.com/";
 		$this->description = "Returns the newest articles.";
-		$this->update = "2016-08-03";
+		$this->update = "2016-08-06";
 	}
 
-	function StripCDATA($string) {
+	private function StripCDATA($string) {
 		$string = str_replace('<![CDATA[', '', $string);
 		$string = str_replace(']]>', '', $string);
 		return $string;
 	}
 
-	function ExtractContent($url) {
+	private function ExtractContent($url) {
 		$html2 = $this->file_get_html($url);
 		$text = '<p><em>'.$html2->find('span.sub_title', 0)->innertext.'</em></p>'
 			.'<p><img src="'.$html2->find('div.container_main_image_article', 0)->find('img.dedicated',0)->src.'" alt="-" /></p>'

--- a/bridges/NextInpactBridge.php
+++ b/bridges/NextInpactBridge.php
@@ -52,8 +52,4 @@ class NextInpactBridge extends BridgeAbstract {
 	public function getURI() {
 		return 'http://www.nextinpact.com/';
 	}
-
-	public function getCacheDuration() {
-		return 3600; // 1 hour
-	}
 }

--- a/bridges/NextgovBridge.php
+++ b/bridges/NextgovBridge.php
@@ -7,7 +7,7 @@ class NextgovBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'USA Federal technology news, best practices, and web 2.0 tools.';
-        $this->update = '2016-07-20';
+        $this->update = '2016-08-06';
 
         $this->parameters[] =
         '[
@@ -102,9 +102,5 @@ class NextgovBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'https://www.nextgov.com/';
-    }
-
-    public function getCacheDuration() {
-        return 3600; //1 hour
     }
 }

--- a/bridges/NextgovBridge.php
+++ b/bridges/NextgovBridge.php
@@ -95,12 +95,4 @@ class NextgovBridge extends BridgeAbstract {
         }
 
     }
-
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
 }

--- a/bridges/NextgovBridge.php
+++ b/bridges/NextgovBridge.php
@@ -4,8 +4,8 @@ class NextgovBridge extends BridgeAbstract {
     public function loadMetadatas() {
 
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'Nextgov Bridge';
+        $this->uri = 'https://www.nextgov.com/';
         $this->description = 'USA Federal technology news, best practices, and web 2.0 tools.';
         $this->update = '2016-08-06';
 
@@ -97,10 +97,10 @@ class NextgovBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'Nextgov Bridge';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'https://www.nextgov.com/';
+        return $this->uri;
     }
 }

--- a/bridges/NiceMatinBridge.php
+++ b/bridges/NiceMatinBridge.php
@@ -53,8 +53,4 @@ class NiceMatinBridge extends BridgeAbstract{
 	public function getURI(){
 		return 'http://www.nicematin.com/';
 	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hour
-	}
 }

--- a/bridges/NiceMatinBridge.php
+++ b/bridges/NiceMatinBridge.php
@@ -6,10 +6,10 @@ class NiceMatinBridge extends BridgeAbstract{
 		$this->name = "NiceMatin";
 		$this->uri = "http://www.nicematin.com/";
 		$this->description = "Returns the 10 newest posts from NiceMatin (full text)";
-		$this->update = "2016-08-03";
+		$this->update = "2016-08-06";
 	}
 
-	function NiceMatinExtractContent($url) {
+	private function NiceMatinExtractContent($url) {
 		$html = $this->file_get_html($url);
 		if(!$html)
 			$this->returnError('Could not acquire content from url: ' . $url . '!', 404);

--- a/bridges/NovelUpdatesBridge.php
+++ b/bridges/NovelUpdatesBridge.php
@@ -7,7 +7,7 @@ class NovelUpdatesBridge extends BridgeAbstract{
 		$this->name = "Novel Updates";
 		$this->uri = "http://www.novelupdates.com/";
 		$this->description = "Returns releases from Novel Updates";
-		$this->update = "2016-05-21";
+		$this->update = "2016-08-06";
 		$this->parameters[] =
 		'[
 			{
@@ -49,9 +49,6 @@ class NovelUpdatesBridge extends BridgeAbstract{
     }
     public function getURI(){
         return 'http://www.novelupdates.com/';
-    }
-    public function getDescription(){
-        return "Novel Updates - Directory of Translated Novels";
     }
     public function getCacheDuration(){
         return 21600; // 6 hours

--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -9,7 +9,7 @@ class PinterestBridge extends BridgeAbstract{
 
 		$this->maintainer = "pauder";
 		$this->name = "Pinterest Bridge";
-		$this->uri = "http://www.pinterest.com/";
+		$this->uri = "http://www.pinterest.com";
 		$this->description = "Returns the newest images on a board";
 		$this->update = "2016-08-06";
 
@@ -109,9 +109,5 @@ class PinterestBridge extends BridgeAbstract{
     	} else {
         	return $this->username .' - '. $this->board.' - Pinterest';
     	}
-    }
-
-    public function getURI(){
-        return 'http://www.pinterest.com';
     }
 }

--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -11,7 +11,7 @@ class PinterestBridge extends BridgeAbstract{
 		$this->name = "Pinterest Bridge";
 		$this->uri = "http://www.pinterest.com/";
 		$this->description = "Returns the newest images on a board";
-		$this->update = "2014-05-25";
+		$this->update = "2016-08-06";
 
 		$this->parameters["By username and board"] =
 		'[
@@ -113,9 +113,5 @@ class PinterestBridge extends BridgeAbstract{
 
     public function getURI(){
         return 'http://www.pinterest.com';
-    }
-
-    public function getCacheDuration(){
-        return 3600; 
     }
 }

--- a/bridges/PlanetLibreBridge.php
+++ b/bridges/PlanetLibreBridge.php
@@ -6,10 +6,10 @@ class PlanetLibreBridge extends BridgeAbstract{
 		$this->name = "PlanetLibre";
 		$this->uri = "http://www.planet-libre.org";
 		$this->description = "Returns the 5 newest posts from PlanetLibre (full text)";
-		$this->update = "2016-08-04";
+		$this->update = "2016-08-06";
 	}
 
-	function PlanetLibreExtractContent($url){
+	private function PlanetLibreExtractContent($url){
 		$html2 = $this->file_get_html($url);
 		$text = $html2->find('div[class="post-text"]', 0)->innertext;
 		return $text;

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -6,10 +6,10 @@ class ReporterreBridge extends BridgeAbstract{
 			$this->name = "Reporterre Bridge";
 			$this->uri = "http://www.reporterre.net/";
 			$this->description = "Returns the newest articles.";
-			$this->update = "2016-08-04";
+			$this->update = "2016-08-06";
 		}
 
-		function ExtractContentReporterre($url) {
+		private function ExtractContentReporterre($url) {
 			$html2 = $this->file_get_html($url);
 
 			foreach($html2->find('div[style=text-align:justify]') as $e) {

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -50,8 +50,4 @@ class ReporterreBridge extends BridgeAbstract{
 	public function getURI(){
 		return 'http://www.reporterre.net/';
 	}
-
-	public function getCacheDuration(){
-		return 3600; // 1 hours
-	}
 }

--- a/bridges/Rue89Bridge.php
+++ b/bridges/Rue89Bridge.php
@@ -7,7 +7,7 @@ class Rue89Bridge extends BridgeAbstract{
 		$this->name = "Rue89";
 		$this->uri = "http://rue89.nouvelobs.com/";
 		$this->description = "Returns the 5 newest posts from Rue89 (full text)";
-		$this->update = "2015-01-30";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -49,8 +49,5 @@ class Rue89Bridge extends BridgeAbstract{
     }
     public function getURI(){
         return 'http://rue89.nouvelobs.com/';
-    }
-    public function getCacheDuration(){
-        return 3600; // 1 hour
     }
 }

--- a/bridges/SensCritiqueBridge.php
+++ b/bridges/SensCritiqueBridge.php
@@ -8,7 +8,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		$this->name = "Sens Critique";
 		$this->uri = "http://www.senscritique.com";
 		$this->description = "Sens Critique news";
-		$this->update = "2016-07-29";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -63,7 +63,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		}
   }
 
-	public function collectMoviesData() {
+	private function collectMoviesData() {
 		$html = '';
     $html = $this->file_get_html('http://www.senscritique.com/films/cette-semaine') or $this->returnError('No results for this query.', 404);
 		$list = $html->find('ul.elpr-list', 0);
@@ -71,7 +71,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		$this->extractDataFromList($list);
 	}
 
-	public function collectSeriesData() {
+	private function collectSeriesData() {
 		$html = '';
 		$html = $this->file_get_html('http://www.senscritique.com/series/actualite') or $this->returnError('No results for this query.', 404);
 		$list = $html->find('ul.elpr-list', 0);
@@ -79,7 +79,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		$this->extractDataFromList($list);
 	}
 
-	public function collectGamesData() {
+	private function collectGamesData() {
 		$html = '';
 		$html = $this->file_get_html('http://www.senscritique.com/jeuxvideo/actualite') or $this->returnError('No results for this query.', 404);
 		$list = $html->find('ul.elpr-list', 0);
@@ -87,7 +87,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		$this->extractDataFromList($list);
 	}
 
-	public function collectBooksData() {
+	private function collectBooksData() {
 		$html = '';
 		$html = $this->file_get_html('http://www.senscritique.com/livres/actualite') or $this->returnError('No results for this query.', 404);
 		$list = $html->find('ul.elpr-list', 0);
@@ -95,7 +95,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		$this->extractDataFromList($list);
 	}
 
-	public function collectBDsData() {
+	private function collectBDsData() {
 		$html = '';
 		$html = $this->file_get_html('http://www.senscritique.com/bd/actualite') or $this->returnError('No results for this query.', 404);
 		$list = $html->find('ul.elpr-list', 0);
@@ -103,7 +103,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		$this->extractDataFromList($list);
 	}
 
-	public function collectMusicsData() {
+	private function collectMusicsData() {
 		$html = '';
 		$html = $this->file_get_html('http://www.senscritique.com/musique/actualite') or $this->returnError('No results for this query.', 404);
 		$list = $html->find('ul.elpr-list', 0);
@@ -111,7 +111,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		$this->extractDataFromList($list);
 	}
 
-	public function extractDataFromList($list) {
+	private function extractDataFromList($list) {
 		if ($list === null) {
 			$this->returnError('Cannot extract data from list', 400);
 		}

--- a/bridges/SensCritiqueBridge.php
+++ b/bridges/SensCritiqueBridge.php
@@ -131,10 +131,6 @@ class SensCritiqueBridge extends BridgeAbstract {
 		}
 	}
 
-	public function getName() {
-		return $this->name;
-	}
-
 	public function getURI() {
 		return (trim($this->uri) === "") ? "http://www.senscritique.com" : $this->uri;
 	}

--- a/bridges/Sexactu.php
+++ b/bridges/Sexactu.php
@@ -8,7 +8,7 @@ class Sexactu extends BridgeAbstract{
 		$this->name = "Sexactu";
 		$this->uri = "http://www.gqmagazine.fr";
 		$this->description = "Sexactu via rss-bridge";
-		$this->update = "04/02/2014";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -69,11 +69,8 @@ $replace = array('January', 'February', 'March', 'April', 'May', 'June', 'July',
     public function getCacheDuration(){
         return 7200; // 2h hours
     }
-    public function getDescription(){
-        return "Sexactu via rss-bridge";
-    }
     
-    public function correctCase($str) {
+    private function correctCase($str) {
         $sentences=explode('.', mb_strtolower($str, "UTF-8"));
         $str="";
         $sep="";

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -2,8 +2,8 @@
 class ShanaprojectBridge extends BridgeAbstract {
     public function loadMetadatas() {
         $this->maintainer = 'logmanoriginal';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'Shanaproject Bridge';
+        $this->uri = 'http://www.shanaproject.com';
         $this->description = 'Returns a list of anime from the current Season Anime List';
         $this->update = '2016-08-06';
     }
@@ -111,10 +111,10 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     public function getName(){
-        return 'Shanaproject Bridge';
+        return $this->name;
     }
 
     public function getURI(){
-        return 'http://www.shanaproject.com';
+        return $this->uri;
     }
 }

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -5,11 +5,11 @@ class ShanaprojectBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'Returns a list of anime from the current Season Anime List';
-        $this->update = '2016-08-04';
+        $this->update = '2016-08-06';
     }
 
     // Returns an html object for the Season Anime List (latest season)
-    function LoadSeasonAnimeList(){
+    private function LoadSeasonAnimeList(){
         // First we need to find the URI to the latest season from the 'seasons' page searching for 'Season Anime List'
         $html = $this->file_get_html($this->getURI() . '/seasons');
         if(!$html) 
@@ -27,7 +27,7 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     // Extracts the anime title
-    function ExtractAnimeTitle($anime){
+    private function ExtractAnimeTitle($anime){
         $title = $anime->find('a', 0);
         if(!$title)
             $this->returnError('Could not find anime title!', 404);
@@ -35,7 +35,7 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     // Extracts the anime URI
-    function ExtractAnimeURI($anime){
+    private function ExtractAnimeURI($anime){
         $uri = $anime->find('a', 0);
         if(!$uri)
             $this->returnError('Could not find anime URI!', 404);
@@ -43,7 +43,7 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     // Extracts the anime release date (timestamp)
-    function ExtractAnimeTimestamp($anime){
+    private function ExtractAnimeTimestamp($anime){
         $timestamp = $anime->find('span.header_info_block', 1);
         if(!$timestamp)
             $this->returnError('Could not find anime timestamp!', 404);
@@ -51,7 +51,7 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     // Extracts the anime studio name (author)
-    function ExtractAnimeAuthor($anime){
+    private function ExtractAnimeAuthor($anime){
         $author = $anime->find('span.header_info_block', 2);
         if(!$author)
             return; // Sometimes the studio is unknown, so leave empty
@@ -59,7 +59,7 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     // Extracts the episode information (x of y released)
-    function ExtractAnimeEpisodeInformation($anime){
+    private function ExtractAnimeEpisodeInformation($anime){
         $episode = $anime->find('div.header_info_episode', 0);
         if(!$episode)
             $this->returnError('Could not find anime episode information!', 404);
@@ -67,7 +67,7 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     // Extracts the background image
-    function ExtractAnimeBackgroundImage($anime){
+    private function ExtractAnimeBackgroundImage($anime){
         // Getting the picture is a little bit tricky as it is part of the style.
         // Luckily the style is part of the parent div :)
 
@@ -78,12 +78,12 @@ class ShanaprojectBridge extends BridgeAbstract {
     }
 
     // Builds an URI to search for a specific anime (subber is left empty)
-    function BuildAnimeSearchURI($anime){
+    private function BuildAnimeSearchURI($anime){
         return $this->getURI() . '/search/?title=' . urlencode($this->ExtractAnimeTitle($anime)) . '&subber=';
     }
 
     // Builds the content string for a given anime
-    function BuildAnimeContent($anime){
+    private function BuildAnimeContent($anime){
         // We'll use a template string to place our contents
         return '<a href="' . $this->ExtractAnimeURI($anime) . '">
                     <img src="http://' . $this->ExtractAnimeBackgroundImage($anime) . '" alt="' . htmlspecialchars($this->ExtractAnimeTitle($anime)) . '" style="border: 1px solid black">

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -109,12 +109,4 @@ class ShanaprojectBridge extends BridgeAbstract {
             $this->items[] = $item;
         }
     }
-
-    public function getName(){
-        return $this->name;
-    }
-
-    public function getURI(){
-        return $this->uri;
-    }
 }

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -117,8 +117,4 @@ class ShanaprojectBridge extends BridgeAbstract {
     public function getURI(){
         return 'http://www.shanaproject.com';
     }
-
-    public function getCacheDuration(){
-        return 3600; // 1 hour
-    }
 }

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -10,7 +10,7 @@ class SoundCloudBridge extends BridgeAbstract{
 		$this->name = "Soundcloud Bridge";
 		$this->uri = "http://www.soundcloud.com/";
 		$this->description = "Returns 10 newest music from user profile";
-		$this->update = "2015-09-08";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -51,10 +51,6 @@ class SoundCloudBridge extends BridgeAbstract{
     }
 	public function getName(){
 		return (!empty($this->name) ? $this->name .' - ' : '') . (!empty($this->request) ? $this->request : '');
-	}
-
-	public function getURI(){
-		return 'https://www.soundcloud.com/';
 	}
 
 	public function getCacheDuration(){

--- a/bridges/T411Bridge.php
+++ b/bridges/T411Bridge.php
@@ -7,7 +7,7 @@ class T411Bridge extends BridgeAbstract {
         $this->name = 'T411';
         $this->uri = $this->getURI();
         $this->description = 'Returns the 10 newest torrents with specified search terms <br /> Use url part after "?" mark when using their search engine.';
-        $this->update = '2016-06-25';
+        $this->update = '2016-08-06';
 
         $this->parameters[] =
         '[
@@ -102,10 +102,5 @@ class T411Bridge extends BridgeAbstract {
     public function getURI() {
         return 'https://t411.ch/';
     }
-
-    public function getCacheDuration() {
-        return 3600; // 1 hour
-    }
-
 }
 

--- a/bridges/TheCodingLoveBridge.php
+++ b/bridges/TheCodingLoveBridge.php
@@ -7,7 +7,7 @@ class TheCodingLoveBridge extends BridgeAbstract{
 		$this->name = "The Coding Love";
 		$this->uri = "http://thecodinglove.com/";
 		$this->description = "The Coding Love";
-		$this->update = "04/02/2015";
+		$this->update = "2016-08-06";
 
 	}
 
@@ -60,8 +60,4 @@ class TheCodingLoveBridge extends BridgeAbstract{
     public function getCacheDuration(){
         return 7200; // 2h hours
     }
-    public function getDescription(){
-        return "The Coding Love via rss-bridge";
-    }
 }
-?>

--- a/bridges/TheHackerNewsBridge.php
+++ b/bridges/TheHackerNewsBridge.php
@@ -4,8 +4,8 @@ class TheHackerNewsBridge extends BridgeAbstract {
     public function loadMetadatas() {
 
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'The Hacker News Bridge';
+        $this->uri = 'https://thehackernews.com/';
         $this->description = 'Cyber Security, Hacking, Technology News.';
         $this->update = '2016-08-06';
 
@@ -77,10 +77,10 @@ class TheHackerNewsBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'The Hacker News Bridge';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'https://thehackernews.com/';
+        return $this->uri;
     }
 }

--- a/bridges/TheHackerNewsBridge.php
+++ b/bridges/TheHackerNewsBridge.php
@@ -7,7 +7,7 @@ class TheHackerNewsBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'Cyber Security, Hacking, Technology News.';
-        $this->update = '2016-07-22';
+        $this->update = '2016-08-06';
 
     }
 
@@ -82,9 +82,5 @@ class TheHackerNewsBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'https://thehackernews.com/';
-    }
-
-    public function getCacheDuration() {
-        return 3600; //1 hour
     }
 }

--- a/bridges/TheHackerNewsBridge.php
+++ b/bridges/TheHackerNewsBridge.php
@@ -75,12 +75,4 @@ class TheHackerNewsBridge extends BridgeAbstract {
         }
 
     }
-
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
 }

--- a/bridges/ThePirateBayBridge.php
+++ b/bridges/ThePirateBayBridge.php
@@ -7,7 +7,7 @@ class ThePirateBayBridge extends BridgeAbstract{
 		$this->name = "The Pirate Bay";
 		$this->uri = "https://thepiratebay.org/";
 		$this->description = "Returns results for the keywords. You can put several list of keywords by separating them with a semicolon (e.g. \"one show;another show\")";
-		$this->update = "2015-01-09";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -87,9 +87,5 @@ class ThePirateBayBridge extends BridgeAbstract{
 
     public function getURI(){
         return 'https://thepiratebay.org/';
-    }
-
-    public function getCacheDuration(){
-        return 3600; // 1 hour
     }
 }

--- a/bridges/TwitterBridgeTweaked.php
+++ b/bridges/TwitterBridgeTweaked.php
@@ -7,7 +7,7 @@ class TwitterBridgeTweaked extends BridgeAbstract{
 		$this->name = "Twitter Bridge Tweaked";
 		$this->uri = "https://twitter.com/";
 		$this->description = "(same as Twitter Bridge Extended, but with cleaned title & content)";
-		$this->update = "2014-12-05";
+		$this->update = "2016-08-06";
 
 		$this->parameters["By keyword or hashtag"] =
 		'[
@@ -157,9 +157,5 @@ class TwitterBridgeTweaked extends BridgeAbstract{
 
 	public function getCacheDuration(){
 		return 300; // 5 minutes
-	}
-
-	public function getUsername(){
-		return $this->items[0]->username;
 	}
 }

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -9,7 +9,7 @@ class VkBridge extends BridgeAbstract {
         $this->name = "VK.com";
         $this->uri = "http://www.vk.com/";
         $this->description = "Working with open pages";
-        $this->update = "21/02/2016";
+        $this->update = "2016-08-06";
         $this->parameters["Url on page group or user"] = '[
 			{
 				"name" : "Url",
@@ -51,10 +51,6 @@ class VkBridge extends BridgeAbstract {
 
     public function getName() {
         return(isset($this->name) ? $this->name . ' - ' : '') . 'VK Bridge';
-    }
-
-    public function getURI() {
-        return 'http://vk.com';
     }
 
     public function getCacheDuration() {

--- a/bridges/WeLiveSecurityBridge.php
+++ b/bridges/WeLiveSecurityBridge.php
@@ -6,7 +6,7 @@ class WeLiveSecurityBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'Returns the newest articles.';
-        $this->update = '2016-07-19';
+        $this->update = '2016-08-06';
     }
 
     public function collectData(array $param) {
@@ -67,9 +67,5 @@ class WeLiveSecurityBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'http://www.welivesecurity.com/';
-    }
-
-    public function getCacheDuration() {
-        return 3600; //1 hour
     }
 }

--- a/bridges/WeLiveSecurityBridge.php
+++ b/bridges/WeLiveSecurityBridge.php
@@ -60,12 +60,4 @@ class WeLiveSecurityBridge extends BridgeAbstract {
             }
         }
     }
-
-    public function getName() {
-        return $this-name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
 }

--- a/bridges/WeLiveSecurityBridge.php
+++ b/bridges/WeLiveSecurityBridge.php
@@ -3,8 +3,8 @@ class WeLiveSecurityBridge extends BridgeAbstract {
 
     public function loadMetadatas() {
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'We Live Security';
+        $this->uri = 'http://www.welivesecurity.com/';
         $this->description = 'Returns the newest articles.';
         $this->update = '2016-08-06';
     }
@@ -62,10 +62,10 @@ class WeLiveSecurityBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'We Live Security';
+        return $this-name;
     }
 
     public function getURI() {
-        return 'http://www.welivesecurity.com/';
+        return $this->uri;
     }
 }

--- a/bridges/WhydBridge.php
+++ b/bridges/WhydBridge.php
@@ -10,7 +10,7 @@ class WhydBridge extends BridgeAbstract{
 		$this->name = "Whyd Bridge";
 		$this->uri = "http://www.whyd.com/";
 		$this->description = "Returns 10 newest music from user profile";
-		$this->update = "2014-07-18";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -58,10 +58,6 @@ class WhydBridge extends BridgeAbstract{
     }
 	public function getName(){
 		return (!empty($this->name) ? $this->name .' - ' : '') .'Whyd Bridge';
-	}
-
-	public function getURI(){
-		return 'http://www.whyd.com/';
 	}
 
 	public function getCacheDuration(){

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -12,7 +12,7 @@ class WordPressBridge extends BridgeAbstract {
 		$this->name = "Wordpress Bridge";
 		$this->uri = "https://wordpress.org/";
 		$this->description = "Returns the 3 newest full posts of a Wordpress blog";
-		$this->update = "2016-08-04";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -25,7 +25,7 @@ class WordPressBridge extends BridgeAbstract {
 	}
 
 	// Returns the content type for a given html dom
-	function DetectContentType($html){
+	private function DetectContentType($html){
 		if($html->find('entry'))
 			return WORDPRESS_TYPE_ATOM;
 		if($html->find('item'))
@@ -34,7 +34,7 @@ class WordPressBridge extends BridgeAbstract {
 	}
 
 	// Replaces all 'link' tags with 'url' for simplehtmldom to actually find 'links' ('url')	
-	function ReplaceLinkTagsWithUrlTags($element){
+	private function ReplaceLinkTagsWithUrlTags($element){
 		// We need to fix the 'link' tag as simplehtmldom cannot parse it (just rename it and load back as dom)
 		$element_text = $element->outertext;
 		$element_text = str_replace('<link>', '<url>', $element_text);
@@ -43,13 +43,13 @@ class WordPressBridge extends BridgeAbstract {
 		return str_get_html($element_text);
 	}
 
-	function StripCDATA($string) {
+	private function StripCDATA($string) {
 		$string = str_replace('<![CDATA[', '', $string);
 		$string = str_replace(']]>', '', $string);
 		return $string;
 	}
 
-	function ClearContent($content) {
+	private function ClearContent($content) {
 		$content = preg_replace('/<script[^>]*>[^<]*<\/script>/', '', $content);
 		$content = preg_replace('/<div class="wpa".*/', '', $content);
 		$content = preg_replace('/<form.*\/form>/', '', $content);

--- a/bridges/WorldOfTanks.php
+++ b/bridges/WorldOfTanks.php
@@ -101,8 +101,4 @@ class WorldOfTanks extends HttpCachingBridgeAbstract{
     public function getURI(){
         return $this->uri;
     }
-
-    public function getCacheDuration(){
-        return 3600; // 2h hours
-    }
 }

--- a/bridges/WorldOfTanks.php
+++ b/bridges/WorldOfTanks.php
@@ -93,12 +93,4 @@ class WorldOfTanks extends HttpCachingBridgeAbstract{
         $item->timestamp = $content->find('.b-statistic_time', 0)->getAttribute("data-timestamp");
         $this->items[] = $item;
     }
-
-    public function getName(){
-        return $this->name;
-    }
-
-    public function getURI(){
-        return $this->uri;
-    }
 }

--- a/bridges/WorldOfTanks.php
+++ b/bridges/WorldOfTanks.php
@@ -12,7 +12,7 @@ class WorldOfTanks extends HttpCachingBridgeAbstract{
 		$this->name = "World of Tanks";
 		$this->uri = "http://worldoftanks.eu/";
 		$this->description = "News about the tank slaughter game.";
-		$this->update = "2015-09-12";
+		$this->update = "2016-08-06";
 
 		$this->parameters[] =
 		'[
@@ -79,7 +79,7 @@ class WorldOfTanks extends HttpCachingBridgeAbstract{
        }
     }
     
-    public function parseLine($infoLink) {
+    private function parseLine($infoLink) {
         $item = new Item();
         $item->uri = WORLD_OF_TANKS.$infoLink->href;
         // now load that uri from cache
@@ -104,8 +104,5 @@ class WorldOfTanks extends HttpCachingBridgeAbstract{
 
     public function getCacheDuration(){
         return 3600; // 2h hours
-    }
-    public function getDescription(){
-        return "Toutes les actualités les plus brulantes de ce simulateur de destruction d'acier.";
     }
 }

--- a/bridges/ZDNetBridge.php
+++ b/bridges/ZDNetBridge.php
@@ -4,8 +4,8 @@ class ZDNetBridge extends BridgeAbstract {
     public function loadMetadatas() {
 
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'ZDNet Bridge';
+        $this->uri = 'http://www.zdnet.com/';
         $this->description = 'Technology News, Analysis, Comments and Product Reviews for IT Professionals.';
         $this->update = '2016-08-06';
 
@@ -304,10 +304,10 @@ class ZDNetBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'ZDNet Bridge';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'http://www.zdnet.com/';
+        return $this->uri;
     }
 }

--- a/bridges/ZDNetBridge.php
+++ b/bridges/ZDNetBridge.php
@@ -302,12 +302,4 @@ class ZDNetBridge extends BridgeAbstract {
         }
 
     }
-
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
 }

--- a/bridges/ZDNetBridge.php
+++ b/bridges/ZDNetBridge.php
@@ -7,7 +7,7 @@ class ZDNetBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'Technology News, Analysis, Comments and Product Reviews for IT Professionals.';
-        $this->update = '2016-07-20';
+        $this->update = '2016-08-06';
 
         $this->parameters[] =
         // http://www.zdnet.com/zdnet.opml
@@ -309,9 +309,5 @@ class ZDNetBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'http://www.zdnet.com/';
-    }
-
-    public function getCacheDuration() {
-        return 3600; //1 hour
     }
 }

--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -43,12 +43,4 @@ class ZoneTelechargementBridge extends BridgeAbstract {
             $limit++;
         }
     }
-
-    public function getName() {
-        return $this->name;
-    }
-
-    public function getURI() {
-        return $this->uri;
-    }
 }

--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -7,7 +7,7 @@ class ZoneTelechargementBridge extends BridgeAbstract {
         $this->name = $this->getName();
         $this->uri = $this->getURI();
         $this->description = 'RSS proxy returning the newest releases.<br />You may specify a category found in RSS URLs, else main feed is selected.';
-        $this->update = "2016-03-16";
+        $this->update = "2016-08-06";
 
         $this->parameters[] =
         '[
@@ -50,9 +50,5 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 
     public function getURI() {
         return 'https://www.zone-telechargement.com/';
-    }
-
-    public function getCacheDuration() {
-        return 3600;
     }
 }

--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -4,8 +4,8 @@ class ZoneTelechargementBridge extends BridgeAbstract {
     public function loadMetadatas() {
 
         $this->maintainer = 'ORelio';
-        $this->name = $this->getName();
-        $this->uri = $this->getURI();
+        $this->name = 'Zone Telechargement Bridge';
+        $this->uri = 'https://www.zone-telechargement.com/';
         $this->description = 'RSS proxy returning the newest releases.<br />You may specify a category found in RSS URLs, else main feed is selected.';
         $this->update = "2016-08-06";
 
@@ -45,10 +45,10 @@ class ZoneTelechargementBridge extends BridgeAbstract {
     }
 
     public function getName() {
-        return 'Zone Telechargement Bridge';
+        return $this->name;
     }
 
     public function getURI() {
-        return 'https://www.zone-telechargement.com/';
+        return $this->uri;
     }
 }

--- a/index.php
+++ b/index.php
@@ -113,8 +113,8 @@ try{
                     } else {
                         $bridge->setCache($cache); // just add disable cache to your query to disable caching
                     }
-                    $bridge->setDatas($_REQUEST);
 					$bridge->loadMetadatas();
+                    $bridge->setDatas($_REQUEST);
                     // Data transformation
                     try {
 		                $format = Format::create($format);

--- a/lib/Bridge.php
+++ b/lib/Bridge.php
@@ -75,6 +75,20 @@ abstract class BridgeAbstract implements BridgeInterface{
     }
 
     /**
+    * Define default bridge name
+    */ 
+    public function getName(){
+        return $this->name;
+    }
+
+    /**
+    * Define default bridge URI
+    */
+    public function getURI(){
+        return $this->uri;
+    }
+
+    /**
     * Define default duraction for cache
     */
     public function getCacheDuration(){
@@ -364,15 +378,6 @@ abstract class RssExpander extends HttpCachingBridgeAbstract{
      * @return a RSS-Bridge Item, with (hopefully) the whole content)
      */
     abstract protected function parseRSSItem($item);
-
-
-    public function getName(){
-        return $this->name;
-    }
-
-    public function getURI(){
-        return $this->uri;
-    }
 
     public function getDescription() {
         return $this->description;

--- a/lib/Bridge.php
+++ b/lib/Bridge.php
@@ -23,14 +23,6 @@ abstract class BridgeAbstract implements BridgeInterface{
 	public $maintainer = 'No maintainer';
 	public $parameters = array();
 
-	/**
-	* Loads the Bridge Metadatas
-	*/
-	public function loadMetadatas() {
-
-
-	}
-
     /**
     * Launch probative exception
     */


### PR DESCRIPTION
I have done some general cleanup of functions that weren't used by the bridges or rss-bridge. I also changed the BridgeAbstract class slightly to get default behavior for getName and getURI as many bridges typically return $this->name and $this->uri.

Also BridgeAbstract no longer implements loadMetadatas because it makes no sense whatsoever.
