### PR TITLE
Allow "Toute la France" as a "Région"

### DIFF
--- a/bridges/LeBonCoinBridge.php
+++ b/bridges/LeBonCoinBridge.php
@@ -12,6 +12,7 @@ class LeBonCoinBridge extends BridgeAbstract{
             'name'=>'Région',
             'type'=>'list',
             'values'=>array(
+              'Toute la France'=>'ile_de_france/occasions',
               'Alsace'=>'alsace',
               'Aquitaine'=>'aquitaine',
               'Auvergne'=>'auvergne',


### PR DESCRIPTION
The way Leboncoin.fr handles "Toute la France" is weird, but the value is "ile_de_france/occasions"

Adding it as the first value shows it as the default value, and mimics the Website.
