### PR TITLE
Fix AllocineFRBridge base URL & Season Links

### DIFF
--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -4,7 +4,7 @@ class AllocineFRBridge extends BridgeAbstract{
 
     const MAINTAINER = "superbaillot.net";
     const NAME = "Allo Cine Bridge";
-    const URI = "http://www.allocine.fr";
+    const URI = "http://www.allocine.fr/";
     const DESCRIPTION = "Bridge for allocine.fr";
     const PARAMETERS = array( array(
         'category'=>array(

--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -24,10 +24,10 @@ class AllocineFRBridge extends BridgeAbstract{
     public function getURI(){
         switch($this->getInput('category')){
         case 'faux-raccord':
-            $uri = static::URI.'video/programme-12284/saison-24580/';
+            $uri = static::URI.'video/programme-12284/saison-27129/';
             break;
         case 'top-5':
-            $uri = static::URI.'video/programme-12299/saison-22542/';
+            $uri = static::URI.'video/programme-12299/saison-29561/';
             break;
         case 'tueurs-en-serie':
             $uri = static::URI.'video/programme-12286/saison-22938/';


### PR DESCRIPTION
The Leading slash in the base URL was missing, breaking the HTTP requests
The URL of each category has been updated to the lastest season
