### PR TITLE
[DuckDuckGoBridge] Add ability to sort by relevance instead of date.

### DIFF
--- a/bridges/DuckDuckGoBridge.php
+++ b/bridges/DuckDuckGoBridge.php
@@ -5,16 +5,29 @@ class DuckDuckGoBridge extends BridgeAbstract{
 	const NAME = "DuckDuckGo";
 	const URI = "https://duckduckgo.com/";
 	const CACHE_TIMEOUT = 21600; // 6h
-	const DESCRIPTION = "Returns most recent results from DuckDuckGo.";
+	const DESCRIPTION = "Returns results from DuckDuckGo.";
+
+	const SORT_DATE = '+sort:date';
+	const SORT_RELEVANCE = '';
 
     const PARAMETERS = array( array(
         'u'=>array(
             'name'=>'keyword',
-            'required'=>true)
+            'required'=>true),
+        'sort'=>array(
+            'name'=>'sort by',
+            'type'=>'list',
+            'required'=>false,
+            'values'=>array(
+                'date'=>self::SORT_DATE,
+                'relevance'=>self::SORT_RELEVANCE
+                ),
+            'defaultValue'=>self::SORT_DATE
+            )
         ));
 
     public function collectData(){
-        $html = getSimpleHTMLDOM(self::URI.'html/?q='.$this->getInput('u').'+sort:date')
+        $html = getSimpleHTMLDOM(self::URI.'html/?q='.$this->getInput('u').$this->getInput('sort'))
             or returnServerError('Could not request DuckDuckGo.');
 
         foreach($html->find('div.results_links') as $element) {


### PR DESCRIPTION
This PR adds the ability to sort DuckDuckGo results by relevance instead of date.  Date remains the default behavior.
