### PR TITLE
Revive enclosures.

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -26,6 +26,9 @@ class AtomFormat extends FormatAbstract{
 			$entryUri = isset($item['uri']) ? $this->xml_encode($item['uri']) : '';
 			$entryTimestamp = isset($item['timestamp']) ? $this->xml_encode(date(DATE_ATOM, $item['timestamp'])) : '';
 			$entryContent = isset($item['content']) ? $this->xml_encode($this->sanitizeHtml($item['content'])) : '';
+  		$entryEnclosures = "";
+  		foreach($item['enclosures'] as $enclosure)
+  			$entryEnclosures .= "<link rel=\"enclosure\" href=\"".$this->xml_encode($enclosure)."\"/>";
 			$entries .= <<<EOD
 
 	<entry>
@@ -37,6 +40,7 @@ class AtomFormat extends FormatAbstract{
 		<id>{$entryUri}</id>
 		<updated>{$entryTimestamp}</updated>
 		<content type="html">{$entryContent}</content>
+		{$entryEnclosures}
 	</entry>
 
 EOD;

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -30,6 +30,9 @@ class MrssFormat extends FormatAbstract {
 			$itemUri = isset($item['uri']) ? $this->xml_encode($item['uri']) : '';
 			$itemTimestamp = isset($item['timestamp']) ? $this->xml_encode(date(DATE_RFC2822, $item['timestamp'])) : '';
 			$itemContent = isset($item['content']) ? $this->xml_encode($this->sanitizeHtml($item['content'])) : '';
+  		$entryEnclosures = "";
+  		foreach($item['enclosures'] as $enclosure)
+  			$entryEnclosures .= "<enclosure url=\"".xml_encode($enclosure)."\"/>";
 			$items .= <<<EOD
 
 	<item>
@@ -39,6 +42,7 @@ class MrssFormat extends FormatAbstract {
 		<pubDate>{$itemTimestamp}</pubDate>
 		<description>{$itemContent}</description>
 		<author>{$itemAuthor}</author>
+		{$entryEnclosures}
 	</item>
 
 EOD;


### PR DESCRIPTION
Reverts 0663c95. Refs #198 #175.

Enclosures are not currently used in one of the bridges. And not enabling them will ensure this will remain like this.

But e.g. Arte+7 could benefit from enclosures. And I know some bridges outside the official repo that could as well.