### PR TITLE
Fix Cache write verification

### DIFF
--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -14,7 +14,7 @@ class FileCache implements CacheInterface {
 	public function saveData($datas){
 		$writeStream = file_put_contents($this->getCacheFile(), json_encode($datas, JSON_PRETTY_PRINT));
 
-		if(!$writeStream) {
+		if($writeStream === FALSE) {
 			throw new \Exception("Cannot write the cache... Do you have the right permissions ?");
 		}
 


### PR DESCRIPTION
PHP operator '===' is the only strict way to not mix up the value '0' and
the value 'FALSE'.

The function saveData of the FileCache tests if the write of the cache
files was done with success and raise an Exception if not. The test was
done without the '===' operator, and if the data is 0 bytes long the
error message says there is a permission error, which is false.

A data 0 bytes long is another issue, either in the json_encode function
either in the Bridge, but not a permission issue.