### PR TITLE
Add Torrent9bridge

### DIFF
--- a/bridges/CpasbienBridge.php
+++ b/bridges/CpasbienBridge.php
@@ -3,7 +3,7 @@ class CpasbienBridge extends BridgeAbstract {
 
     const MAINTAINER = "lagaisse";
     const NAME = "Cpasbien Bridge";
-    const URI = "http://www.cpasbien.io";
+    const URI = "http://www.cpasbien.cm";
     const CACHE_TIMEOUT = 86400; // 24h
     const DESCRIPTION = "Returns latest torrents from a request query";
 
@@ -24,11 +24,14 @@ class CpasbienBridge extends BridgeAbstract {
             if ($episode->getAttribute('class')=='ligne0' ||
                 $episode->getAttribute('class')=='ligne1')
             {
-                $htmlepisode=getSimpleHTMLDOMCached($episode->find('a', 0)->getAttribute('href'));
+
+                $urlepisode = $episode->find('a', 0)->getAttribute('href');           
+                $htmlepisode=getSimpleHTMLDOMCached($urlepisode, 86400*366*30);
 
                 $item = array();
                 $item['author'] = $episode->find('a', 0)->text();
                 $item['title'] = $episode->find('a', 0)->text();
+                $item['pubdate'] = $this->getCachedDate($urlepisode);
                 $textefiche=$htmlepisode->find('#textefiche', 0)->find('p',1);
                 if (isset($textefiche)) {
                     $item['content'] = $textefiche->text();
@@ -49,5 +52,20 @@ class CpasbienBridge extends BridgeAbstract {
 
     public function getName(){
         return $this->getInput('q').' : '.self::NAME;
+    }
+
+    private function getCachedDate($url){
+        debugMessage('getting pubdate from url ' . $url . '');
+
+        // Initialize cache
+        $cache = Cache::create('FileCache');
+        $cache->setPath(CACHE_DIR . '/pages');
+
+        $params = [$url];
+        $cache->setParameters($params);
+
+        // Get cachefile timestamp
+        $time = $cache->getTime();
+        return ($time!==false?$time:time());
     }
 }

--- a/bridges/Torrent9Bridge.php
+++ b/bridges/Torrent9Bridge.php
@@ -1,0 +1,97 @@
+<?php
+class Torrent9Bridge extends BridgeAbstract {
+
+    const MAINTAINER = "lagaisse";
+    const NAME = "Torrent9 Bridge";
+    const URI = "http://www.torrent9.biz";
+    const CACHE_TIMEOUT = 86400 ; // 24h = 86400s
+    const DESCRIPTION = "Returns latest torrents";
+
+    const PAGE_SERIES = "torrents_series";
+    const PAGE_SERIES_VOSTFR = "torrents_series_vostfr";
+    const PAGE_SERIES_FR = "torrents_series_french";
+
+    const PARAMETERS = array(
+    'From search' => array(
+        'q' => array(
+            'name'=>'Search',
+            'required'=>true,
+            'title'=>'Type your search'
+        )
+    ),
+    'By page' => array(
+        'page' => array(
+            'name'=>'Page',
+            'type'=>'list',
+            'required'=>false,
+            'values'=>array(
+                'Series'=>self::PAGE_SERIES,
+                'Series VOST'=>self::PAGE_SERIES_VOSTFR,
+                'Series FR'=>self::PAGE_SERIES_FR,
+            ),
+            'defaultValue'=>self::PAGE_SERIES
+        )
+    ));
+
+    public function collectData(){
+
+        if($this->queriedContext === 'From search'){
+
+            $request = str_replace(" ","-",trim($this->getInput('q')));
+            $page = self::URI.'/search_torrent/'.urlencode($request).'.html';
+        } else {
+            $request = $this->getInput('page');
+            $page = self::URI.'/'.$request.'.html';
+        }
+        
+        $html = getSimpleHTMLDOM($page)
+            or returnServerError('No results for this query.');
+
+        foreach ($html->find('table',0)->find('tr') as $episode) {
+            if ($episode->parent->tag == 'tbody') {
+                
+
+                $urlepisode = self::URI . $episode->find('a', 0)->getAttribute('href');
+                $htmlepisode = getSimpleHTMLDOMCached($urlepisode, 86400*366*30); //30 years = forever
+
+                $item = array();
+                $item['author'] = $episode->find('a', 0)->text();
+                $item['title'] = $episode->find('a', 0)->text();
+                $item['id'] = $episode->find('a', 0)->getAttribute('href');
+                $item['pubdate'] = $this->getCachedDate($urlepisode);
+                
+                $textefiche=$htmlepisode->find('.movie-information', 0)->find('p',1);
+                if (isset($textefiche)) {
+                    $item['content'] = $textefiche->text();
+                } else {
+                    $p=$htmlepisode->find('.movie-information',0)->find('p');
+                    if(!empty($p)){
+                        $item['content'] = $htmlepisode->find('.movie-information', 0)->find('p',0)->text();
+                    }
+                }
+
+                $item['id'] = $episode->find('a', 0)->getAttribute('href');
+                $item['uri'] = self::URI . $htmlepisode->find('.download',0)->getAttribute('href');
+                
+                $this->items[] = $item;
+            }
+        }
+    }
+
+
+    public function getName(){
+        return $this->getInput('q').' : '.self::NAME;
+    }
+
+    private function getCachedDate($url){
+        debugMessage('getting pubdate from url ' . $url . '');
+        // Initialize cache
+        $cache = Cache::create('FileCache');
+        $cache->setPath(CACHE_DIR . '/pages');
+        $params = [$url];
+        $cache->setParameters($params);
+        // Get cachefile timestamp
+        $time = $cache->getTime();
+        return ($time!==false?$time:time());
+    }
+}


### PR DESCRIPTION
Add Torrent9bridge (search + some pages. 24h retention time)
update cpasbienbridge (website doesn't seem updated)

NB: The pubdate, which is often mandatory, was added from the datetime of the cached file (in cache/pages). Retention of the cached files is set to 30yrs (=forever). These mechanisms are bypassed each 24h by the purge put in place in content.php L:110.

