### PR TITLE
Fix FacebookBridge feed name empty when data loaded from cache

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -205,6 +205,6 @@ class FacebookBridge extends BridgeAbstract{
 	}
 
 	public function getName() {
-		return (isset($this->authorName) ? $this->authorName.' - ' : '').'Facebook Bridge';
+		return isset($this->extraInfos['name']) ? $this->extraInfos['name'] : $this->authorName.' - Facebook Bridge';
 	}
 }


### PR DESCRIPTION
Steps to reproduce the problem:
1. Add a Facebook feed, for example `/rss-bridge/?action=display&bridge=Facebook&u=IndieDrinkster&format=Atom`
2. Observe that the feed's title is `<title type="text">Indie Drinkster - Facebook Bridge</title>`
3. Refresh the page
4. Feed title changes to `<title type="text">- Facebook Bridge</title>`

Expected result:
In step 4, the title should be the same as step 2.