### PR TITLE
make the bridge compatible with wordpress with no static URL

### DIFF
--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -66,8 +66,11 @@ class WordPressBridge extends FeedExpander {
 			// just in case someone find a way to access local files by playing with the url
 			returnClientError('The url parameter must either refer to http or https protocol.');
 		}
-
-		$this->collectExpandableDatas($this->getURI().'/feed/atom/');
+		try{
+			$this->collectExpandableDatas($this->getURI().'/feed/atom/');
+		}catch (HttpException $e){
+			$this->collectExpandableDatas($this->getURI().'/?feed=atom');
+		}
 
 	}
 }


### PR DESCRIPTION
There is two way to get the feed of WordPress and it depend of the configuration of the "permalink" (the default one or the static one). This change allow the bridge to work in both case.