### PR TITLE
[WIP] Add action for bridge listing

### DIFF
--- a/index.php
+++ b/index.php
@@ -135,7 +135,6 @@ try {
 
 		header('Content-Type: application/json');
 		echo json_encode($list, JSON_PRETTY_PRINT);
-		die;
 	} elseif($action === 'display' && !empty($bridge)) {
 		// DEPRECATED: 'nameBridge' scheme is replaced by 'name' in bridge parameter values
 		//             this is to keep compatibility until futher complete removal


### PR DESCRIPTION
This PR is work in progress, do not merge!
This PR provides a possible solution for #482

Adds a new action `&action=list` which returns a list of all bridges as JSON formatted text. Each bridge brings following information:

- status (active/inactive)
- uri
- name
- parameters
- maintainer
- description

For inactive bridges only the status is returned.
Bridges that cannot be instantiated are considered inactive.

Additional things to consider before merging:
- [ ] ~Should this code be placed in a file outside index.php?~
- [ ] ~Is the information provided sufficient/too much/not enough?~