### PR TITLE
Add DribbbleBridge

### DIFF
--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -17,16 +17,25 @@ class DribbbleBridge extends BridgeAbstract {
 			$item['title'] = $shot->find('.dribbble-over strong', 0)->plaintext;
 			$item['author'] = trim($shot->find('.attribution-user a', 0)->plaintext);
 			$item['content'] = $shot->find('.comment', 0)->plaintext;
-			$item['content'] .= $this->getFullSizeImage($shot);
+
+            $preview_path = $shot->find('picture source', 0)->attr['srcset'];
+			$item['content'] .= $this->getImageTag($preview_path, $item['title']);
+			$item['enclosures'] = [ $this->getFullSizeImagePath($preview_path) ];
 
 			$this->items[] = $item;
 		}
 	}
 
-	private function getFullSizeImage($shot){
-		$image_preview = $shot->find('picture source', 0)->attr['srcset'];
-		$image_path = str_replace('_1x', '', $image_preview);
-
-		return '<br /> <img src="'.$image_path.'" alt="" />';
+    private function getImageTag($preview_path, $title){
+        return sprintf(
+            '<br /> <a href="%s"><img src="%s" alt="%s" /></a>',
+            $this->getFullSizeImagePath($preview_path),
+            $preview_path,
+            $title
+        );
 	}
+
+	private function getFullSizeImagePath($preview_path){
+        return str_replace('_1x', '', $preview_path);
+    }
 }

--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -1,5 +1,4 @@
 <?php
-error_reporting(E_ALL);
 class DribbbleBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'quentinus95';

--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -1,5 +1,5 @@
 <?php
-class DribbbleBridge extends FeedExpander {
+class DribbbleBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'quentinus95';
 	const NAME = 'Dribbble popular shots';
@@ -23,8 +23,7 @@ class DribbbleBridge extends FeedExpander {
 		}
 	}
 
-	private function getFullSizeImage($shot)
-	{
+	private function getFullSizeImage($shot){
 		$image_preview = $shot->find('picture source', 0)->attr['srcset'];
 		$image_path = str_replace('_1x', '', $image_preview);
 

--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -1,0 +1,33 @@
+<?php
+class DribbbleBridge extends FeedExpander {
+
+	const MAINTAINER = 'quentinus95';
+	const NAME = 'Dribbble popular shots';
+	const URI = 'https://dribbble.com';
+	const CACHE_TIMEOUT = 1800;
+	const DESCRIPTION = 'Returns the newest popular shots from Dribbble.';
+
+	public function collectData(){
+		$html = getSimpleHTMLDOM(self::URI . '/shots')
+			or returnServerError('Error while downloading the website content');
+
+		foreach($html->find('li[id^="screenshot-"]') as $shot) {
+			$item = [];
+			$item['uri'] = self::URI . $shot->find('a', 0)->href;
+			$item['title'] = $shot->find('.dribbble-over strong', 0)->plaintext;
+			$item['author'] = trim($shot->find('.attribution-user a', 0)->plaintext);
+			$item['content'] = $shot->find('.comment', 0)->plaintext;
+			$item['content'] .= $this->getFullSizeImage($shot);
+
+			$this->items[] = $item;
+		}
+	}
+
+	private function getFullSizeImage($shot)
+	{
+		$image_preview = $shot->find('picture source', 0)->attr['srcset'];
+		$image_path = str_replace('_1x', '', $image_preview);
+
+		return '<br /> <img src="'.$image_path.'" alt="" />';
+	}
+}

--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -11,20 +11,68 @@ class DribbbleBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM(self::URI . '/shots')
 			or returnServerError('Error while downloading the website content');
 
+		$json = $this->loadEmbeddedJsonData($html);
+
 		foreach($html->find('li[id^="screenshot-"]') as $shot) {
 			$item = [];
-			$item['uri'] = self::URI . $shot->find('a', 0)->href;
-			$item['title'] = $shot->find('.dribbble-over strong', 0)->plaintext;
-			$item['author'] = trim($shot->find('.attribution-user a', 0)->plaintext);
-			$item['content'] = $shot->find('.comment', 0)->plaintext;
 
-			$preview_path = $shot->find('picture source', 0)->attr['srcset'];
-			$item['content'] .= $this->getImageTag($preview_path, $item['title']);
-			$item['enclosures'] = [ $this->getFullSizeImagePath($preview_path) ];
+            $additional_data = $this->findJsonForShot($shot, $json);
+            if($additional_data !== null) {
+                $item['timestamp'] = strtotime($additional_data['published_at']);
+                $item['uri'] = self::URI . $additional_data['path'];
+                $item['title'] = $additional_data['title'];
+            } else {
+                $item['uri'] = self::URI . $shot->find('a', 0)->href;
+                $item['title'] = $shot->find('.dribbble-over strong', 0)->plaintext;
+            }
 
-			$this->items[] = $item;
+            $item['author'] = trim($shot->find('.attribution-user a', 0)->plaintext);
+            $item['content'] = $shot->find('.comment', 0)->plaintext;
+
+            $preview_path = $shot->find('picture source', 0)->attr['srcset'];
+            $item['content'] .= $this->getImageTag($preview_path, $item['title']);
+            $item['enclosures'] = [ $this->getFullSizeImagePath($preview_path) ];
+
+            $this->items[] = $item;
 		}
 	}
+
+    private function loadEmbeddedJsonData($html){
+        $json = [];
+        $scripts = $html->find('script');
+
+        foreach($scripts as $script) {
+            if(strpos($script->innertext, 'newestShots') !== false) {
+                // fix single quotes
+                $script->innertext = str_replace('\'', '"', $script->innertext);
+
+                // fix JavaScript JSON (why do they not adhere to the standard?)
+                $script->innertext = preg_replace('/(\w+):/i', '"\1":', $script->innertext);
+
+                // find beginning of JSON array
+                $start = strpos($script->innertext, '[');
+
+                // find end of JSON array, compensate for missing character!
+                $end = strpos($script->innertext, '];') + 1;
+
+                // convert JSON to PHP array
+                $json = json_decode(substr($script->innertext, $start, $end - $start), true);
+                break;
+            }
+        }
+
+        return $json;
+	}
+
+	private function findJsonForShot($shot, $json){
+        foreach($json as $element) {
+            if(strpos($shot->getAttribute('id'), (string)$element['id']) !== false) {
+                return $element;
+            }
+        }
+
+        return null;
+    }
 
 	private function getImageTag($preview_path, $title){
 		return sprintf(

--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -18,7 +18,7 @@ class DribbbleBridge extends BridgeAbstract {
 			$item['author'] = trim($shot->find('.attribution-user a', 0)->plaintext);
 			$item['content'] = $shot->find('.comment', 0)->plaintext;
 
-            $preview_path = $shot->find('picture source', 0)->attr['srcset'];
+			$preview_path = $shot->find('picture source', 0)->attr['srcset'];
 			$item['content'] .= $this->getImageTag($preview_path, $item['title']);
 			$item['enclosures'] = [ $this->getFullSizeImagePath($preview_path) ];
 
@@ -26,16 +26,16 @@ class DribbbleBridge extends BridgeAbstract {
 		}
 	}
 
-    private function getImageTag($preview_path, $title){
-        return sprintf(
-            '<br /> <a href="%s"><img src="%s" alt="%s" /></a>',
-            $this->getFullSizeImagePath($preview_path),
-            $preview_path,
-            $title
-        );
+	private function getImageTag($preview_path, $title){
+		return sprintf(
+			'<br /> <a href="%s"><img src="%s" alt="%s" /></a>',
+			$this->getFullSizeImagePath($preview_path),
+			$preview_path,
+			$title
+		);
 	}
 
 	private function getFullSizeImagePath($preview_path){
-        return str_replace('_1x', '', $preview_path);
-    }
+		return str_replace('_1x', '', $preview_path);
+	}
 }

--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -29,7 +29,7 @@ class DribbbleBridge extends BridgeAbstract {
 			$item['author'] = trim($shot->find('.attribution-user a', 0)->plaintext);
 
 			$description = $shot->find('.comment', 0);
-			$item['content'] = $description === null ? '' : $description;
+			$item['content'] = $description === null ? '' : $description->plaintext;
 
 			$preview_path = $shot->find('picture source', 0)->attr['srcset'];
 			$item['content'] .= $this->getImageTag($preview_path, $item['title']);


### PR DESCRIPTION
About three months ago, Dribbble removed its RSS feed...

> Hello,
> I can't reach the RSS feed https://dribbble.com/shots/popular.rss.
> Is this intentional? If it is, is there any way to get the latest/popular shots on an RSS Feed?
> Thanks,
> Quentin

Answer:

> Hi Quentin,
> We've made the decision to no longer support our RSS feeds moving forward. Sorry for the inconvenience. 
> Alison, Community Manager

This bridge brings back the popular shots RSS Feed. It automatically retrieves and adds the high quality images to the RSS feed.

Example:

![image](https://user-images.githubusercontent.com/8060564/28938200-a5b5ce6e-788d-11e7-8c0a-95e933d375fe.png)

The RSS entry link brings to the full shot description.