### PR TITLE
[WIP] Proper Media-RSS format

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -172,7 +172,7 @@ button {
 	background: #2196F3 none repeat scroll 0% 0%;
 	cursor: pointer;
 
-	width: calc(20% - 4px);
+	width: calc(16% - 4px);
 
 }
 


### PR DESCRIPTION
The format Mrss did not return Media-RSS according to
http://www.rssboard.org/media-rss, but instead returned regular RSS
2.0 feeds. Feed readers expecting Media-RSS cannot work with that
format.

This adds RSS as a separate format via '&format=Rss' and changes the
existing MRSS format to adhere to the standards.

Notice: Existing feeds might break. If this is happening to you,
change the format from '&format=Mrss' to '&format=Rss'.

References #566

Any feedback welcome, I don't have a feed reader that properly handles Media-RSS