### PR TITLE
Fix double forward-slash in returned post URI leading to 404

### DIFF
--- a/bridges/MixCloudBridge.php
+++ b/bridges/MixCloudBridge.php
@@ -4,7 +4,7 @@ class MixCloudBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'Alexis CHEMEL';
 	const NAME = 'MixCloud';
-	const URI = 'https://www.mixcloud.com/';
+	const URI = 'https://www.mixcloud.com';
 	const CACHE_TIMEOUT = 3600; // 1h
 	const DESCRIPTION = 'Returns latest musics on user stream';
 
@@ -26,7 +26,7 @@ class MixCloudBridge extends BridgeAbstract {
 	public function collectData(){
 		ini_set('user_agent', 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0');
 		
-		$html = getSimpleHTMLDOM(self::URI . $this->getInput('u'))
+		$html = getSimpleHTMLDOM(self::URI . '/' . $this->getInput('u'))
 			or returnServerError('Could not request MixCloud.');
 
 		foreach($html->find('section.card') as $element) {


### PR DESCRIPTION
Returned post URL before:

    https://www.mixcloud.com//raskayleb/roots-yard-studio-radio-04122017-with-ras-kayleb-outta-channel-one

Returned post URL after:

    https://www.mixcloud.com/raskayleb/roots-yard-studio-radio-04122017-with-ras-kayleb-outta-channel-one