### PR TITLE
Fix twitter list filter test #613, fix and change getName() for lists.

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -82,7 +82,7 @@ class TwitterBridge extends BridgeAbstract {
 			break;
 		default: return parent::getName();
 		}
-		return 'Twitter List ' . $this->getInput($param) . ' by ' $specific;
+		return 'Twitter List ' . $this->getInput($param) . ' by ' . $specific;
 	}
 
 	public function getURI(){
@@ -161,7 +161,8 @@ class TwitterBridge extends BridgeAbstract {
 			$item['timestamp'] = $tweet->find('span.js-short-timestamp', 0)->getAttribute('data-time');
 			// generate the title
 			$item['title'] = strip_tags($this->fixAnchorSpacing($tweet->find('p.js-tweet-text', 0), '<a>'));
-
+      
+			
 			switch($this->queriedContext) {
 				case 'By list':
 					// Check if filter applies to list (using raw content)
@@ -173,6 +174,7 @@ class TwitterBridge extends BridgeAbstract {
 					break;
 				default:
 			}
+			
 
 			$this->processContentLinks($tweet);
 			$this->processEmojis($tweet);

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -82,7 +82,7 @@ class TwitterBridge extends BridgeAbstract {
 			break;
 		default: return parent::getName();
 		}
-		return 'Twitter ' . $specific . $this->getInput($param);
+		return 'Twitter ' . $specific . ' / ' .  $this->getInput($param);
 	}
 
 	public function getURI(){

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -77,12 +77,10 @@ class TwitterBridge extends BridgeAbstract {
 			$param = 'u';
 			break;
 		case 'By list':
-			$specific = $this->getInput('user');
-			$param = 'list';
-			break;
+			return $this->getInput('list') . ' - Twitter list by ' . $this->getInput('user');
 		default: return parent::getName();
 		}
-		return $this->getInput($param) . ' - Twitter list by ' . $specific;
+		return 'Twitter ' . $specific . $this->getInput($param);
 	}
 
 	public function getURI(){

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -159,8 +159,7 @@ class TwitterBridge extends BridgeAbstract {
 			$item['timestamp'] = $tweet->find('span.js-short-timestamp', 0)->getAttribute('data-time');
 			// generate the title
 			$item['title'] = strip_tags($this->fixAnchorSpacing($tweet->find('p.js-tweet-text', 0), '<a>'));
-      
-			
+
 			switch($this->queriedContext) {
 				case 'By list':
 					// Check if filter applies to list (using raw content)
@@ -172,7 +171,6 @@ class TwitterBridge extends BridgeAbstract {
 					break;
 				default:
 			}
-			
 
 			$this->processContentLinks($tweet);
 			$this->processEmojis($tweet);

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -166,7 +166,7 @@ class TwitterBridge extends BridgeAbstract {
 			switch($this->queriedContext) {
 				case 'By list':
 					// Check if filter applies to list (using raw content)
-					if(!is_null($this->getInput('filter'))) {
+					if($this->getInput('filter')) {
 						if(stripos($tweet->find('p.js-tweet-text', 0)->plaintext, $this->getInput('filter')) === false) {
 							continue 2; // switch + for-loop!
 						}

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -82,7 +82,7 @@ class TwitterBridge extends BridgeAbstract {
 			break;
 		default: return parent::getName();
 		}
-		return 'Twitter List ' . $this->getInput($param) . ' by ' . $specific;
+		return $this->getInput($param) . ' - Twitter list by ' . $specific;
 	}
 
 	public function getURI(){

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -82,7 +82,7 @@ class TwitterBridge extends BridgeAbstract {
 			break;
 		default: return parent::getName();
 		}
-		return 'Twitter ' . $specific . ' / ' .  $this->getInput($param);
+		return 'Twitter List ' . $this->getInput($param) . ' by ' $specific;
 	}
 
 	public function getURI(){


### PR DESCRIPTION
Fix for #613

Change the `getName()` for lists, previously the list name and user name had no separator. Now the list name is up front, because the name is a bit long for lists.