### PR TITLE
README - sort lists alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ rss-bridge is a PHP project capable of generating ATOM feeds for websites which 
 Supported sites/pages (main)
 ===
 
- * `FlickrExplore` : [Latest interesting images](http://www.flickr.com/explore) from Flickr
- * `GoogleSearch` : Most recent results from Google Search
- * `GooglePlus` : Most recent posts of user timeline
- * `Twitter` : Return keyword/hashtag search or user timeline
- * `Identi.ca` : Identica user timeline (Should be compatible with other Pump.io instances)
- * `YouTube` : YouTube user channel, playlist or search
- * `Cryptome` : Returns the most recent documents from [Cryptome.org](http://cryptome.org/)
- * `DansTonChat`: Most recent quotes from [danstonchat.com](http://danstonchat.com/)
- * `DuckDuckGo`: Most recent results from [DuckDuckGo.com](https://duckduckgo.com/)
- * `Instagram`: Most recent photos from an Instagram user
- * `OpenClassrooms`: Lastest tutorials from [fr.openclassrooms.com](http://fr.openclassrooms.com/)
- * `Pinterest`: Most recent photos from user or search
- * `ScmbBridge`: Newest stories from [secouchermoinsbete.fr](http://secouchermoinsbete.fr/)
- * `Wikipedia`: highlighted articles from [Wikipedia](https://wikipedia.org/) in English, German, French or Esperanto
- * `Bandcamp` : Returns last release from [bandcamp](https://bandcamp.com/) for a tag
- * `ThePirateBay` : Returns the newest indexed torrents from [The Pirate Bay](https://thepiratebay.se/) with keywords
- * `Facebook` : Returns the latest posts on a page or profile on [Facebook](https://facebook.com/)
+* `Bandcamp` : Returns last release from [bandcamp](https://bandcamp.com/) for a tag
+* `Cryptome` : Returns the most recent documents from [Cryptome.org](http://cryptome.org/)
+* `DansTonChat`: Most recent quotes from [danstonchat.com](http://danstonchat.com/)
+* `DuckDuckGo`: Most recent results from [DuckDuckGo.com](https://duckduckgo.com/)
+* `Facebook` : Returns the latest posts on a page or profile on [Facebook](https://facebook.com/)
+* `FlickrExplore` : [Latest interesting images](http://www.flickr.com/explore) from Flickr
+* `GooglePlus` : Most recent posts of user timeline
+* `GoogleSearch` : Most recent results from Google Search
+* `Identi.ca` : Identica user timeline (Should be compatible with other Pump.io instances)
+* `Instagram`: Most recent photos from an Instagram user
+* `OpenClassrooms`: Lastest tutorials from [fr.openclassrooms.com](http://fr.openclassrooms.com/)
+* `Pinterest`: Most recent photos from user or search
+* `ScmbBridge`: Newest stories from [secouchermoinsbete.fr](http://secouchermoinsbete.fr/)
+* `ThePirateBay` : Returns the newest indexed torrents from [The Pirate Bay](https://thepiratebay.se/) with keywords
+* `Twitter` : Return keyword/hashtag search or user timeline
+* `Wikipedia`: highlighted articles from [Wikipedia](https://wikipedia.org/) in English, German, French or Esperanto
+* `YouTube` : YouTube user channel, playlist or search
 
 Plus [many other bridges](bridges/) to enable, thanks to the community
 
@@ -31,11 +31,11 @@ Output format
 ===
 Output format can take several forms:
 
- * `Atom` : ATOM Feed, for use in RSS/Feed readers
- * `Mrss` : MRSS Feed, for use in RSS/Feed readers
- * `Json` : Json, for consumption by other applications.
- * `Html` : Simple html page.
- * `Plaintext` : raw text (php object, as returned by print_r)
+* `Atom` : ATOM Feed, for use in RSS/Feed readers
+* `Html` : Simple html page.
+* `Json` : Json, for consumption by other applications.
+* `Mrss` : MRSS Feed, for use in RSS/Feed readers
+* `Plaintext` : raw text (php object, as returned by print_r)
    
 Screenshot
 ===


### PR DESCRIPTION
This makes them easier to scan and check "does rss-bridge support service X I'm interested in?" :)