### PR TITLE
Customizable cache timeout

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,6 +19,10 @@ define('PROXY_BYBRIDGE', false);
 // Comment this line or keep PROXY_NAME empty to display PROXY_URL instead
 define('PROXY_NAME', 'Hidden Proxy Name');
 
+// Allows the operator to specify custom cache timeouts via '&_cache_timeout=3600'
+// true: enabled (default), false: disabled
+define('CUSTOM_CACHE_TIMEOUT', true);
+
 date_default_timezone_set('UTC');
 error_reporting(0);
 
@@ -168,6 +172,16 @@ try {
 			define('NOPROXY', true);
 		}
 
+		// Custom cache timeout
+		$cache_timeout = -1;
+		if(array_key_exists('_cache_timeout', $params)) {
+			if(!CUSTOM_CACHE_TIMEOUT) {
+				throw new \HttpException('This server doesn\'t support "_cache_timeout"!');
+			}
+
+			$cache_timeout = filter_var($params['_cache_timeout'], FILTER_VALIDATE_INT);
+		}
+
 		// Initialize cache
 		$cache = Cache::create('FileCache');
 		$cache->setPath(CACHE_DIR);
@@ -178,10 +192,12 @@ try {
 		unset($params['bridge']);
 		unset($params['format']);
 		unset($params['_noproxy']);
+		unset($params['_cache_timeout']);
 
 		// Load cache & data
 		try {
 			$bridge->setCache($cache);
+			$bridge->setCacheTimeout($cache_timeout);
 			$bridge->setDatas($params);
 		} catch(Exception $e) {
 			http_response_code($e->getCode());

--- a/index.php
+++ b/index.php
@@ -20,8 +20,8 @@ define('PROXY_BYBRIDGE', false);
 define('PROXY_NAME', 'Hidden Proxy Name');
 
 // Allows the operator to specify custom cache timeouts via '&_cache_timeout=3600'
-// true: enabled (default), false: disabled
-define('CUSTOM_CACHE_TIMEOUT', true);
+// true: enabled, false: disabled (default)
+define('CUSTOM_CACHE_TIMEOUT', false);
 
 date_default_timezone_set('UTC');
 error_reporting(0);

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -270,12 +270,6 @@ abstract class BridgeAbstract implements BridgeInterface {
 		$this->cache = $cache;
 	}
 
-	/**
-	 * Sets the cache timeout to the provided timeout value. The specified
-	 * timeout must be between 1..86400, otherwise the default timeout is used.
-	 *
-	 * @param int $timeout The timeout in seconds
-	 */
 	public function setCacheTimeout($timeout){
 		if(is_numeric($timeout) && ($timeout < 1 || $timeout > 86400)) {
 			$this->cacheTimeout = static::CACHE_TIMEOUT;
@@ -285,12 +279,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 		$this->cacheTimeout = $timeout;
 	}
 
-	/**
-	 * Returns the cache timeout
-	 *
-	 * @return int Returns the cache timeout
-	 */
-	protected function getCacheTimeout(){
+	public function getCacheTimeout(){
 		return isset($this->cacheTimeout) ? $this->cacheTimeout : static::CACHE_TIMEOUT;
 	}
 }

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -14,6 +14,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 	protected $items = array();
 	protected $inputs = array();
 	protected $queriedContext = '';
+	protected $cacheTimeout;
 
 	/**
 	* Return cachable datas (extrainfos and items) stored in the bridge
@@ -171,7 +172,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 		if(!is_null($this->cache)) {
 			$time = $this->cache->getTime();
 			if($time !== false
-			&& (time() - static::CACHE_TIMEOUT < $time)
+			&& (time() - $this->getCacheTimeout() < $time)
 			&& (!defined('DEBUG') || DEBUG !== true)) {
 				$cached = $this->cache->loadData();
 				if(isset($cached['items']) && isset($cached['extraInfos'])) {
@@ -267,5 +268,29 @@ abstract class BridgeAbstract implements BridgeInterface {
 
 	public function setCache(\CacheInterface $cache){
 		$this->cache = $cache;
+	}
+
+	/**
+	 * Sets the cache timeout to the provided timeout value. The specified
+	 * timeout must be between 1..86400, otherwise the default timeout is used.
+	 *
+	 * @param int $timeout The timeout in seconds
+	 */
+	public function setCacheTimeout($timeout){
+		if(is_numeric($timeout) && ($timeout < 1 || $timeout > 86400)) {
+			$this->cacheTimeout = static::CACHE_TIMEOUT;
+			return;
+		}
+
+		$this->cacheTimeout = $timeout;
+	}
+
+	/**
+	 * Returns the cache timeout
+	 *
+	 * @return int Returns the cache timeout
+	 */
+	protected function getCacheTimeout(){
+		return isset($this->cacheTimeout) ? $this->cacheTimeout : static::CACHE_TIMEOUT;
 	}
 }

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -68,4 +68,13 @@ interface BridgeInterface {
 	 * @param object CacheInterface The cache instance
 	 */
 	public function setCache(\CacheInterface $cache);
+
+	/**
+	 * Sets the timeout for clearing the cache files. The timeout must be
+	 * specified between 1..86400 seconds (max. 24 hours). The default timeout
+	 * (specified by the bridge maintainer) applies for invalid values.
+	 *
+	 * @param int $timeout The cache timeout in seconds
+	 */
+	public function setCacheTimeout($timeout);
 }

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -77,4 +77,11 @@ interface BridgeInterface {
 	 * @param int $timeout The cache timeout in seconds
 	 */
 	public function setCacheTimeout($timeout);
+
+	/**
+	 * Returns the cache timeout
+	 *
+	 * @return int Cache timeout
+	 */
+	public function getCacheTimeout();
 }

--- a/lib/html.php
+++ b/lib/html.php
@@ -75,8 +75,24 @@ CARD;
 					. ((defined('PROXY_NAME') && PROXY_NAME) ? PROXY_NAME : PROXY_URL)
 					. ')</label><br />'
 					. PHP_EOL;
-			}
+			} if(CUSTOM_CACHE_TIMEOUT) {
+				$idArg = 'arg-'
+					. urlencode($bridgeName)
+					. '-'
+					. urlencode('_cache_timeout');
 
+				$card .= '<label for="'
+					. $idArg
+					. '">Cache timeout in seconds : </label>'
+					. PHP_EOL;
+
+				$card .= '<input id="'
+					. $idArg
+					. '" type="number" value="'
+					. $bridge->getCacheTimeout()
+					. '" name="_cache_timeout" /><br />'
+					. PHP_EOL;
+			}
 			$card .= $getHelperButtonsFormat($formats);
 		} else {
 			$card .= '<span style="font-weight: bold;">Inactive</span>';
@@ -250,6 +266,23 @@ CARD;
 					. '">Disable proxy ('
 					. ((defined('PROXY_NAME') && PROXY_NAME) ? PROXY_NAME : PROXY_URL)
 					. ')</label><br />'
+					. PHP_EOL;
+			} if(CUSTOM_CACHE_TIMEOUT) {
+				$idArg = 'arg-'
+					. urlencode($bridgeName)
+					. '-'
+					. urlencode('_cache_timeout');
+
+				$card .= '<label for="'
+					. $idArg
+					. '">Cache timeout in seconds : </label>'
+					. PHP_EOL;
+
+				$card .= '<input id="'
+					. $idArg
+					. '" type="number" value="'
+					. $bridge->getCacheTimeout()
+					. '" name="_cache_timeout" /><br />'
 					. PHP_EOL;
 			}
 			$card .= $getHelperButtonsFormat($formats);


### PR DESCRIPTION
This PR is a possible solution for #631 

It adds a new parameter "_cache_timeout" to change the cache timeout on request. This is very useful in cases where the default timeout depends on the contents (see #631 for more info).

This option must be activated in index.php by setting the `CUSTOM_CACHE_TIMEOUT` to `true`. When enabled each bridge receives the "Cache timeout in seconds" parameter. RSS-Bridge returns an error message if the option is disabled and the parameter "_cache_timeout" is specified in the request.

Please let me know if and how this can be improved.

TODO:

- [x] Test if this is a valid solution for #631 
- [x] Update Wiki