### PR TITLE
[YoutubeBridge] Removed query video info limit in playlist mode

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -110,8 +110,8 @@ class YoutubeBridge extends BridgeAbstract {
 		$this->feedName = $this->ytBridgeFixTitle($xml->find('feed > title', 0)->plaintext);  // feedName will be used by getName()
 	}
 
-	private function ytBridgeParseHtmlListing($html, $element_selector, $title_selector){
-		$limit = 10;
+	private function ytBridgeParseHtmlListing($html, $element_selector, $title_selector, $ignore_limit = false){
+		$limit = $ignore_limit ? INF : 10;
 		$count = 0;
 		foreach($html->find($element_selector) as $element) {
 			if($count < $limit) {
@@ -179,7 +179,7 @@ class YoutubeBridge extends BridgeAbstract {
 			$url_listing = self::URI . 'playlist?list=' . urlencode($this->request);
 			$html = $this->ytGetSimpleHTMLDOM($url_listing)
 				or returnServerError("Could not request YouTube. Tried:\n - $url_listing");
-			$this->ytBridgeParseHtmlListing($html, 'tr.pl-video', '.pl-video-title a');
+			$this->ytBridgeParseHtmlListing($html, 'tr.pl-video', '.pl-video-title a', true);
 			$this->feedName = 'Playlist: ' . str_replace(' - YouTube', '', $html->find('title', 0)->plaintext); // feedName will be used by getName()
 			usort($this->items, function ($item1, $item2) {
 				return $item2['timestamp'] - $item1['timestamp'];


### PR DESCRIPTION
Didn't pay attention before posting https://github.com/RSS-Bridge/rss-bridge/pull/643

For example, if latest video is last in playlist, it was not going to be added 'cos of $limit variable.

Before (with limit): https://feed.eugenemolotov.ru/?action=display&bridge=Youtube&p=PL0lo9MOBetEHBM4Z-lY7S3Lj7ifGQM42D&format=Html
After (without limit): https://feed.eugenemolotov.ru/dev/?action=display&bridge=Youtube&p=PL0lo9MOBetEHBM4Z-lY7S3Lj7ifGQM42D&format=Html

On both examples, items are sorted by publication date. Also this change makes playlist feed generating longer if cache is not used.