### PR TITLE
[YoutubeBridge] Playlist mode: faster feed generating if item count is less or equal to 15

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -110,10 +110,6 @@ class YoutubeBridge extends BridgeAbstract {
 		$this->feedName = $this->ytBridgeFixTitle($xml->find('feed > title', 0)->plaintext);  // feedName will be used by getName()
 	}
 
-	private function ytCountItemsFromHtmlListing($html, $element_selector, $title_selector) {
-		return $this->ytBridgeParseHtmlListing($html, $element_selector, $title_selector, false);
-	}
-
 	private function ytBridgeParseHtmlListing($html, $element_selector, $title_selector, $add_parsed_items = true) {
 		$limit = $add_parsed_items ? 10 : INF;
 		$count = 0;
@@ -187,7 +183,7 @@ class YoutubeBridge extends BridgeAbstract {
 			$url_listing = self::URI . 'playlist?list=' . urlencode($this->request);
 			$html = $this->ytGetSimpleHTMLDOM($url_listing)
 				or returnServerError("Could not request YouTube. Tried:\n - $url_listing");
-			$item_count = $this->ytCountItemsFromHtmlListing($html, 'tr.pl-video', '.pl-video-title a');
+			$item_count = $this->ytBridgeParseHtmlListing($html, 'tr.pl-video', '.pl-video-title a', false);
 			if ($item_count <= 15 && ($xml = $this->ytGetSimpleHTMLDOM($url_feed))) {
 				$this->ytBridgeParseXmlFeed($xml);
 			} else {


### PR DESCRIPTION
If playlist item count is less or equal than 15 - all required item info is grabbed from xml feed. So we don't need to request every youtube video page from playlist.

Before: https://feed.eugenemolotov.ru/?action=display&bridge=Youtube&p=PL0lo9MOBetEF5A-1VtR-0pwMfznFa9hoW&format=Html
After: https://feed.eugenemolotov.ru/dev/?action=display&bridge=Youtube&p=PL0lo9MOBetEF5A-1VtR-0pwMfznFa9hoW&format=Html

Partially fixes https://github.com/RSS-Bridge/rss-bridge/issues/647