### PR TITLE
[WIP] Add user config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,7 @@ pip-log.txt
 /cache
 /whitelist.txt
 DEBUG
+config.ini.php
 
 ######################
 ## VisualStudioCode ##

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -1,24 +1,24 @@
 ; <?php exit; ?> DO NOT REMOVE THIS LINE
 
 ; This file contains the default settings for RSS-Bridge. Do not change this
-; file, it will be replaced on the next update of RSS-Bridge. You can specify
-; your own configuration in 'config.ini.php' (copy of this file).
+; file, it will be replaced on the next update of RSS-Bridge! You can specify
+; your own configuration in 'config.ini.php' (copy this file).
 
 [cache]
 
-; Allow users to specify a custom timeout for specific requests.
+; Allow users to specify custom timeout for specific requests.
 ; true  = enabled
 ; false = disabled (default)
 custom_timeout = false
 
 [proxy]
 
-; Sets the prox url (i.e. "tcp://192.168.0.0:32")
+; Sets the proxy url (i.e. "tcp://192.168.0.0:32")
 ; ""    = Proxy disabled (default)
 url = ""
 
 ; Sets the proxy name that is shown on the bridge instead of the proxy url.
-; ""    = Show prox url
+; ""    = Show proxy url
 name = "Hidden proxy name"
 
 ; Allow users to disable proxy usage for specific requests.

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -1,0 +1,27 @@
+; <?php exit; ?> DO NOT REMOVE THIS LINE
+
+; This file contains the default settings for RSS-Bridge. Do not change this
+; file, it will be replaced on the next update of RSS-Bridge. You can specify
+; your own configuration in 'config.ini.php' (copy of this file).
+
+[cache]
+
+; Allow users to specify a custom timeout for specific requests.
+; true  = enabled
+; false = disabled (default)
+custom_timeout = false
+
+[proxy]
+
+; Sets the prox url (i.e. "tcp://192.168.0.0:32")
+; ""    = Proxy disabled (default)
+url = ""
+
+; Sets the proxy name that is shown on the bridge instead of the proxy url.
+; ""    = Show prox url
+name = "Hidden proxy name"
+
+; Allow users to disable proxy usage for specific requests.
+; true  = enabled
+; false = disabled (default)
+by_bridge = false

--- a/index.php
+++ b/index.php
@@ -27,8 +27,6 @@ if(file_exists('config.ini.php')) {
 	}
 }
 
-var_dump($config);
-
 if(!empty($config['proxy']['url']))
 	define('PROXY_URL', $config['proxy']['url']);
 

--- a/index.php
+++ b/index.php
@@ -10,18 +10,34 @@ TODO :
 - implement header('X-Cached-Version: '.date(DATE_ATOM, filemtime($cachefile)));
 */
 
+if(!file_exists('config.default.ini.php'))
+	die('The default configuration file "config.default.ini.php" is missing!');
+
+$config = parse_ini_file('config.default.ini.php', true, INI_SCANNER_TYPED);
+
+if(file_exists('config.ini.php')) {
+	// Replace default configuration with custom settings
+	foreach(parse_ini_file('config.ini.php', true, INI_SCANNER_TYPED) as $header => $section) {
+		foreach($section as $key => $value) {
+			// Skip unknown sections and keys
+			if(array_key_exists($header, $config) && array_key_exists($key, $config[$header])) {
+				$config[$header][$key] = $value;
+			}
+		}
+	}
+}
+
+var_dump($config);
+
+if(!empty($config['proxy']['url']))
+	define('PROXY_URL', $config['proxy']['url']);
+
+define('PROXY_BYBRIDGE', $config['proxy']['by_bridge']);
+define('PROXY_NAME', $config['proxy']['name']);
+define('CUSTOM_CACHE_TIMEOUT', $config['cache']['custom_timeout']);
+
 // Defines the minimum required PHP version for RSS-Bridge
 define('PHP_VERSION_REQUIRED', '5.6.0');
-
-//define('PROXY_URL', 'tcp://192.168.0.0:28');
-// Set to true if you allow users to disable proxy usage for specific bridges
-define('PROXY_BYBRIDGE', false);
-// Comment this line or keep PROXY_NAME empty to display PROXY_URL instead
-define('PROXY_NAME', 'Hidden Proxy Name');
-
-// Allows the operator to specify custom cache timeouts via '&_cache_timeout=3600'
-// true: enabled, false: disabled (default)
-define('CUSTOM_CACHE_TIMEOUT', false);
 
 date_default_timezone_set('UTC');
 error_reporting(0);

--- a/index.php
+++ b/index.php
@@ -27,11 +27,25 @@ if(file_exists('config.ini.php')) {
 	}
 }
 
+if(!is_string($config['proxy']['url']))
+	die('Parameter [proxy] => "url" is not a valid string! Please check "config.ini.php"!');
+
 if(!empty($config['proxy']['url']))
 	define('PROXY_URL', $config['proxy']['url']);
 
+if(!is_bool($config['proxy']['by_bridge']))
+	die('Parameter [proxy] => "by_bridge" is not a valid Boolean! Please check "config.ini.php"!');
+
 define('PROXY_BYBRIDGE', $config['proxy']['by_bridge']);
+
+if(!is_string($config['proxy']['name']))
+	die('Parameter [proxy] => "name" is not a valid string! Please check "config.ini.php"!');
+
 define('PROXY_NAME', $config['proxy']['name']);
+
+if(!is_bool($config['cache']['custom_timeout']))
+	die('Parameter [cache] => "custom_timeout" is not a valid Boolean! Please check "config.ini.php"!');
+
 define('CUSTOM_CACHE_TIMEOUT', $config['cache']['custom_timeout']);
 
 // Defines the minimum required PHP version for RSS-Bridge


### PR DESCRIPTION
This PR adds user configurations, using the INI file syntax suggested by @mitsukarenai (https://github.com/RSS-Bridge/rss-bridge/issues/650#issuecomment-374798643)

The default settings are specified in 'config.default.ini.php'. User settings are specified in 'config.ini.php' (must be created manually). The user settings file may contain all or a subset of the default settings. Parameters in the user settings file replace default parameters. Additional (unknown) parameters are ignored.

The user settings file 'config.ini.php' is ignored by git and will not be replaced when upgrading RSS-Bridge.

References #650 

Todo:
- [x] Add type checks (user settings must have same types as default settings)
- [x] Update Wiki