### PR TITLE
Use cURL instead of file_get_contents

### DIFF
--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -64,13 +64,11 @@ class Arte7Bridge extends BridgeAbstract {
 			. $lang
 			. ($category != null ? '&category.code=' . $category : '');
 
-		$context = array(
-			'http' => array(
-				'header' => 'Authorization: Bearer '. self::API_TOKEN
-			)
+		$header = array(
+			'Authorization: Bearer ' . self::API_TOKEN
 		);
 
-		$input = getContents($url, false, stream_context_create($context)) or die('Could not request ARTE.');
+		$input = getContents($url, $header) or die('Could not request ARTE.');
 		$input_json = json_decode($input, true);
 
 		foreach($input_json['videos'] as $element) {

--- a/bridges/KernelBugTrackerBridge.php
+++ b/bridges/KernelBugTrackerBridge.php
@@ -45,9 +45,7 @@ class KernelBugTrackerBridge extends BridgeAbstract {
 		// We use the print preview page for simplicity
 		$html = getSimpleHTMLDOMCached($this->getURI() . '&format=multiple',
 		86400,
-		false,
 		null,
-		0,
 		null,
 		true,
 		true,

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -109,7 +109,7 @@ class VkBridge extends BridgeAbstract
 	{
 		ini_set('user-agent', 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0');
 
-		$header = array("Accept-language: en\r\nCookie: remixlang=3\r\n");
+		$header = array('Accept-language: en', 'Cookie: remixlang=3');
 
 		return getContents($this->getURI(), $header);
 	}

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -109,19 +109,9 @@ class VkBridge extends BridgeAbstract
 	{
 		ini_set('user-agent', 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0');
 
-		$opts = array(
-			'http' => array(
-				'method' => "GET",
-				'user_agent' => ini_get('user_agent'),
-				'accept_encoding' => 'gzip',
-				'header' => "Accept-language: en\r\n 
-					Cookie: remixlang=3\r\n"
-			)
-		);
+		$header = array("Accept-language: en\r\nCookie: remixlang=3\r\n");
 
-		$context = stream_context_create($opts);
-
-		return getContents($this->getURI(), false, $context);
+		return getContents($this->getURI(), $header);
 	}
 
 

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -140,10 +140,8 @@ class YoutubeBridge extends BridgeAbstract {
 
 	private function ytGetSimpleHTMLDOM($url){
 		return getSimpleHTMLDOM($url,
-			$use_include_path = false,
 			$header = array(),
 			$opts = array(),
-			$maxLen = null,
 			$lowercase = true,
 			$forceTagsClosed = true,
 			$target_charset = DEFAULT_TARGET_CHARSET,

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -141,8 +141,8 @@ class YoutubeBridge extends BridgeAbstract {
 	private function ytGetSimpleHTMLDOM($url){
 		return getSimpleHTMLDOM($url,
 			$use_include_path = false,
-			$context = null,
-			$offset = 0,
+			$header = array(),
+			$opts = array(),
 			$maxLen = null,
 			$lowercase = true,
 			$forceTagsClosed = true,

--- a/index.php
+++ b/index.php
@@ -80,6 +80,9 @@ if(!extension_loaded('mbstring'))
 if(!extension_loaded('simplexml'))
 	die('"simplexml" extension not loaded. Please check "php.ini"');
 
+if(!extension_loaded('curl'))
+	die('"curl" extension not loaded. Please check "php.ini"');
+
 // configuration checks
 if(ini_get('allow_url_fopen') !== "1")
 	die('"allow_url_fopen" is not set to "1". Please check "php.ini');

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -1,77 +1,41 @@
 <?php
-function getContents($url,
-$use_include_path = false,
-$context = null,
-$offset = 0,
-$maxlen = null){
-	$contextOptions = array(
-		'http' => array(
-			'user_agent' => ini_get('user_agent'),
-			'accept_encoding' => 'gzip'
-		)
-	);
+function getContents($url, $header = array(), $opts = array()){
+	$ch = curl_init($url);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+	curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+	curl_setopt($ch, CURLOPT_USERAGENT, ini_get('user_agent'));
+	curl_setopt($ch, CURLOPT_ENCODING, '');
 
-	if(defined('PROXY_URL') && !defined('NOPROXY')) {
-		$contextOptions['http']['proxy'] = PROXY_URL;
-		$contextOptions['http']['request_fulluri'] = true;
-
-		if(is_null($context)) {
-			$context = stream_context_create($contextOptions);
-		} else {
-			$prevContext = $context;
-			if(!stream_context_set_option($context, $contextOptions)) {
-				$context = $prevContext;
-			}
+	if(is_array($opts)) {
+		foreach($opts as $key => $value) {
+			curl_setopt($ch, $key, $value);
 		}
 	}
 
-	if(is_null($maxlen)) {
-		$content = file_get_contents($url, $use_include_path, $context, $offset);
-	} else {
-		$content = file_get_contents($url, $use_include_path, $context, $offset, $maxlen);
+	if(defined('PROXY_URL') && !defined('NOPROXY')) {
+		curl_setopt($ch, CURLOPT_PROXY, PROXY_URL);
 	}
+
+	$content = curl_exec($ch);
+	curl_close($ch);
 
 	if($content === false)
 		debugMessage('Cant\'t download ' . $url);
-
-	// handle compressed data
-	foreach($http_response_header as $header) {
-		if(stristr($header, 'content-encoding')) {
-			switch(true) {
-			case stristr($header, 'gzip'):
-				$content = gzinflate(substr($content, 10, -8));
-				break;
-			case stristr($header, 'compress'):
-				//TODO
-			case stristr($header, 'deflate'):
-				//TODO
-			case stristr($header, 'brotli'):
-				//TODO
-				returnServerError($header . '=> Not implemented yet');
-				break;
-			case stristr($header, 'identity'):
-				break;
-			default:
-				returnServerError($header . '=> Unknown compression');
-			}
-		}
-	}
 
 	return $content;
 }
 
 function getSimpleHTMLDOM($url,
-$use_include_path = false,
-$context = null,
-$offset = 0,
-$maxLen = null,
+$header = array(),
+$opts = array(),
 $lowercase = true,
 $forceTagsClosed = true,
 $target_charset = DEFAULT_TARGET_CHARSET,
 $stripRN = true,
 $defaultBRText = DEFAULT_BR_TEXT,
 $defaultSpanText = DEFAULT_SPAN_TEXT){
-	$content = getContents($url, $use_include_path, $context, $offset, $maxLen);
+	$content = getContents($url, $header, $opts);
 	return str_get_html($content,
 	$lowercase,
 	$forceTagsClosed,
@@ -89,10 +53,8 @@ $defaultSpanText = DEFAULT_SPAN_TEXT){
  */
 function getSimpleHTMLDOMCached($url,
 $duration = 86400,
-$use_include_path = false,
-$context = null,
-$offset = 0,
-$maxLen = null,
+$header = array(),
+$opts = array(),
 $lowercase = true,
 $forceTagsClosed = true,
 $target_charset = DEFAULT_TARGET_CHARSET,
@@ -116,7 +78,7 @@ $defaultSpanText = DEFAULT_SPAN_TEXT){
 	&& (!defined('DEBUG') || DEBUG !== true)) { // Contents within duration
 		$content = $cache->loadData();
 	} else { // Content not within duration
-		$content = getContents($url, $use_include_path, $context, $offset, $maxLen);
+		$content = getContents($url, $header, $opts);
 		if($content !== false) {
 			$cache->saveData($content);
 		}

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -3,7 +3,10 @@ function getContents($url, $header = array(), $opts = array()){
 	$ch = curl_init($url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-	curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+
+	if(is_array($header) && count($header) !== 0)
+		curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+
 	curl_setopt($ch, CURLOPT_USERAGENT, ini_get('user_agent'));
 	curl_setopt($ch, CURLOPT_ENCODING, '');
 	curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -6,6 +6,7 @@ function getContents($url, $header = array(), $opts = array()){
 	curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
 	curl_setopt($ch, CURLOPT_USERAGENT, ini_get('user_agent'));
 	curl_setopt($ch, CURLOPT_ENCODING, '');
+	curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
 	if(is_array($opts)) {
 		foreach($opts as $key => $value) {


### PR DESCRIPTION
Please test before merging!

This PR is in some sense similar to #531. However, it is not so much concerned about proxy integration. Instead it replaces the existing `file_get_contents` function by cURL functions and provides an interface for customization of the many cURL options.

Notice: It is not specifically necessary to switch to cURL, but it can/will prove useful in the future. Also, there is some debate regarding vulnerability of the `file_get_contents` function due to it's ability to read local files:
- https://stackoverflow.com/a/17653374
- https://security.stackexchange.com/questions/177645/php-file-get-contents-vulnerability

I've added a quite extensive log to https://github.com/RSS-Bridge/rss-bridge/commit/300eef95f47b17e72f31e1d3543c9044811095af which should explain how this change works:

<details>
<summary>Click to see commit log</summary>

```
cURL is a powerful library specifically designed to connect to many
different types of servers with different types of protocols. For
more detailed information refer to the PHP cURL manual:

- http://php.net/manual/en/book.curl.php

Due to this change some parameters for the getContents function were
necessary (also applies to getSimpleHTMLDOM and getSimpleHTMLDOMCached):

> $use_include_path removed

  This parameter has never been used and doesn't even make sense in
  this context; If set to true file_get_contents would also search
  for files in the include_path (specified in php.ini).

> $context replaced by $header and $opts

  The $context parameter allowed for customization of the request in
  order to change how file_get_contents would acquire the data (i.e.
  using POST instead of GET, sending custom header, etc...)

  cURL also provides facilities to specify custom headers and change
  how it communicates to severs. cURL, however, is much more advanced.

  - $header is an optional parameter (empty by default). It receives
    an array of strings to send in the HTTP request header.

    See 'CURLOPT_HTTPHEADER':

    "An array of HTTP header fields to set, in the format
    array('Content-type: text/plain', 'Content-length: 100')"

    - php.net/manual/en/function.curl-setopt.php

  - $opts is an optional parameter (empty by default). It receives
    an array of options, where each option is a key-value-pair of
    a cURL option (CURLOPT_*) and it's associated parameter. This
    parameter accepts any of the CURLOPT_* settings.

    Example (sending POST instead of GET):

    $opts = array(
      CURLOPT_POST => 1,
      CURLOPT_POSTFIELDS => '&action=none'
    );
    $html = getContents($url, array(), $opts);

    Refer to the cURL setopt manual for more information:
    - php.net/manual/en/function.curl-setopt.php

> $offset and $maxlen removed

  These options were supported by file_get_contents, but there doesn't
  seem to be an equivalent in cURL. Since no caller uses them they are
  safe to remove.

Compressed data / Encoding

  By using cURL instead of file_get_contents RSS-Bridge no longer has
  to handle compressed data manually.

  See 'CURLOPT_ENCODING':

  "[...] Supported encodings are "identity", "deflate", and "gzip".
  If an empty string, "", is set, a header containing all supported
  encoding types is sent."

  - http://php.net/manual/en/function.curl-setopt.php

  Notice: By default all encoding types are accepted (""). This can
  be changed by setting a custom option via $opts.

    Example:

    $opts = array(CURLOPT_ENCODING => 'gzip');
    $html = getContents($url, array(), $opts);

Proxy

The proxy implementation should still work, but there doesn't seem
to be an equivalent for 'request_fulluri = true'. To my understanding
this isn't an issue because cURL knows how to handle proxy communication.
```
</details><br />


Unfortunately some bridges use the `file_get_contents` function directly, so the requirement for `allow_url_fopen` remains until these bridges opt for cURL or one of the `getContents` functions. Of course cURL must be installed and active for this PR to work.

With all of these changes there is a high chance that it broke the proxy implementation and maybe some bridges. Most likely the ones I had to fix:

- Arte7Bridge
- FacebookBridge
- VkBridge
- YoutubeBridge

They seem to work on my machine (at least Arte7, Facebook and Youtube. Vk I don't know how to use). If someone actively uses them please let me know if they broke for you. The same applies to the proxy implementation.

Please let me know what you think. Suggestions for improvement are also very welcome.