### PR TITLE
[VkBridge] Rewrited bridge code

### DIFF
--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -209,7 +209,7 @@ class VkBridge extends BridgeAbstract
 		} else if ($last_post_id < $pinned_post_item['post_id']) {
 			$this->items[] = $pinned_post_item;
 			usort($this->items, function ($item1, $item2) {
-				return $item1['post_id'] - $item2['post_id'];
+				return $item2['post_id'] - $item1['post_id'];
 			});
 		}
 	}

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -43,6 +43,8 @@ class VkBridge extends BridgeAbstract
 		or returnServerError('No results for group or user name "' . $this->getInput('u') . '".');
 
 		$text_html = iconv('windows-1251', 'utf-8', $text_html);
+		// makes album link generating work correctly
+		$text_html = str_replace('"class="page_album_link">', '" class="page_album_link">', $text_html);
 		$html = str_get_html($text_html);
 		$pageName = $html->find('.page_name', 0)->plaintext;
 		$this->pageName = htmlspecialchars_decode($pageName);
@@ -116,6 +118,15 @@ class VkBridge extends BridgeAbstract
 				if ($result == null) continue;
 				$a->outertext = '';
 				$content_suffix .= "<br>$result";
+			}
+
+			// get albums
+			foreach($post->find('.page_album_wrap') as $el) {
+				$a = $el->find('.page_album_link', 0);
+				$album_title = $a->find('.page_album_title_text', 0)->getAttribute('title');
+				$album_link = self::URI . ltrim($a->getAttribute('href'), '/');
+				$el->outertext = '';
+				$content_suffix .= "<br>Album: <a href='$album_link'>$album_title</a>";
 			}
 
 			if (is_object($post->find('div.copy_quote', 0))) {

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -137,7 +137,7 @@ class VkBridge extends BridgeAbstract
 				$content_suffix .= "<br>Album: <a href='$album_link'>$album_title</a>";
 			}
 
-			// get documents
+			// get photo documents
 			foreach($post->find('a.page_doc_photo_href') as $a) {
 				$doc_link = self::URI . ltrim($a->getAttribute('href'), '/');
 				$doc_gif_label_element = $a->find(".page_gif_label", 0);
@@ -158,6 +158,24 @@ class VkBridge extends BridgeAbstract
 
 				$a->outertext = '';
 			}
+
+			// get other documents
+			foreach($post->find('div.page_doc_row') as $div) {
+				$doc_title_element = $div->find("a.page_doc_title", 0);
+
+				if (is_object($doc_title_element)) {
+					$doc_title = $doc_title_element->innertext;
+					$doc_link = $doc_title_element->getAttribute('href');
+					$content_suffix .= "<br>Doc: <a href='$doc_link'>$doc_title</a>";
+
+				} else {
+					continue;
+
+				}
+
+				$div->outertext = '';
+			}
+
 
 			// get sign
 			foreach($post->find('a.wall_signed_by') as $a) {

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -168,7 +168,7 @@ class VkBridge extends BridgeAbstract
 
 				if (is_object($doc_title_element)) {
 					$doc_title = $doc_title_element->innertext;
-					$doc_link = $doc_title_element->getAttribute('href');
+					$doc_link = self::URI . ltrim($doc_title_element->getAttribute('href'), '/');
 					$content_suffix .= "<br>Doc: <a href='$doc_link'>$doc_title</a>";
 
 				} else {

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -159,6 +159,14 @@ class VkBridge extends BridgeAbstract
 				$a->outertext = '';
 			}
 
+			// get sign
+			foreach($post->find('a.wall_signed_by') as $a) {
+				$link = self::URI . ltrim($a->getAttribute('href'), '/');
+				$title = $a->innertext;
+				$content_suffix .= "<br>Sign: <a href='$link'>$title</a>";
+				$a->outertext = '';
+			}
+
 			if (is_object($post->find('div.copy_quote', 0))) {
 				$copy_quote = $post->find('div.copy_quote', 0);
 				if ($copy_post_header = $copy_quote->find('div.copy_post_header', 0)) {

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -86,6 +86,21 @@ class VkBridge extends BridgeAbstract
 				$el_to_remove->outertext = '';
 			};
 
+			// looking for article
+			$article = $post->find("a.article_snippet", 0);
+			if (is_object($article)) {
+				$article_title = $article->find("div.article_snippet__title", 0)->innertext;
+				$article_author = $article->find("div.article_snippet__author", 0)->innertext;
+				$article_link = self::URI . ltrim($article->getAttribute('href'), '/');
+				$article_img_element_style = $article->find("div.article_snippet__image", 0)->getAttribute('style');
+				preg_match('/background-image: url\((.*)\)/', $article_img_element_style, $matches);
+				if (count($matches) > 0) {
+					$content_suffix .= "<br><img src='" . $matches[1] . "'>";
+				}
+				$content_suffix .= "<br>Article: <a href='$article_link'>$article_title ($article_author)</a>";
+				$article->outertext = '';
+			}
+
 			if (is_object($post->find('div.copy_quote', 0))) {
 				$copy_quote = $post->find('div.copy_quote', 0);
 				if ($copy_post_header = $copy_quote->find('div.copy_post_header', 0)) {

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -71,7 +71,13 @@ class VkBridge extends BridgeAbstract
 			}
 
 			// get post link
-			$item['uri'] = self::URI . $post->find('a.post_link', 0)->getAttribute('href');
+			$post_link = $post->find('a.post_link', 0)->getAttribute('href');
+			if (substr(self::URI, -1) == '/') {
+				$post_link = self::URI . ltrim($post_link, "/");
+			} else {
+				$post_link = self::URI . $post_link;
+			}
+			$item['uri'] = $post_link;
 			$item['timestamp'] = $this->getTime($post);
 			$item['title'] = $this->getTitle($item['content']);
 			$item['author'] = $pageName;

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -137,6 +137,28 @@ class VkBridge extends BridgeAbstract
 				$content_suffix .= "<br>Album: <a href='$album_link'>$album_title</a>";
 			}
 
+			// get documents
+			foreach($post->find('a.page_doc_photo_href') as $a) {
+				$doc_link = self::URI . ltrim($a->getAttribute('href'), '/');
+				$doc_gif_label_element = $a->find(".page_gif_label", 0);
+				$doc_title_element = $a->find(".doc_label", 0);
+
+				if (is_object($doc_gif_label_element)) {
+					$gif_preview_img = backgroundToImg($a->find('.page_doc_photo', 0));
+					$content_suffix .= "<br>Gif: <a href='$doc_link'>$gif_preview_img</a>";
+
+				} else if (is_object($doc_title_element)) {
+					$doc_title = $doc_title_element->innertext;
+					$content_suffix .= "<br>Doc: <a href='$doc_link'>$doc_title</a>";
+
+				} else {
+					continue;
+
+				}
+
+				$a->outertext = '';
+			}
+
 			if (is_object($post->find('div.copy_quote', 0))) {
 				$copy_quote = $post->find('div.copy_quote', 0);
 				if ($copy_post_header = $copy_quote->find('div.copy_post_header', 0)) {

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -69,6 +69,7 @@ class VkBridge extends BridgeAbstract
 			$external_link_selectors = array(
 				'a.page_media_link_title',
 				'div.page_media_link_title > a',
+				'div.media_desc > a.lnk',
 			);
 
 			foreach($external_link_selectors as $sel) {

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -73,10 +73,18 @@ class VkBridge extends BridgeAbstract
 			// get post link
 			$item['uri'] = self::URI . $post->find('a.post_link', 0)->getAttribute('href');
 			$item['timestamp'] = $this->getTime($post);
+			$item['title'] = $this->getTitle($item['content']);
 			$item['author'] = $pageName;
 			$this->items[] = $item;
 
 		}
+	}
+
+	private function getTitle($content)
+	{
+		preg_match('/^["\w\ \p{Cyrillic}\(\)\?#«»-]+/mu', htmlspecialchars_decode($content), $result);
+		if (count($result) == 0) return "untitled";
+		return $result[0];
 	}
 
 	private function getTime($post)

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -101,6 +101,15 @@ class VkBridge extends BridgeAbstract
 				$article->outertext = '';
 			}
 
+			// get video on post
+			$video = $post->find('div.post_video_desc', 0);
+			if (is_object($video)) {
+				$video_title = $video->find('div.post_video_title', 0)->plaintext;
+				$video_link = self::URI . ltrim( $video->find('a.lnk', 0)->getAttribute('href'), '/' );
+				$content_suffix .= "<br>Video: <a href='$video_link'>$video_title</a>";
+				$video->outertext = '';
+			}
+
 			if (is_object($post->find('div.copy_quote', 0))) {
 				$copy_quote = $post->find('div.copy_quote', 0);
 				if ($copy_post_header = $copy_quote->find('div.copy_post_header', 0)) {
@@ -112,13 +121,6 @@ class VkBridge extends BridgeAbstract
 
 			$item = array();
 			$item['content'] = strip_tags(backgroundToImg($post->find('div.wall_text', 0)->innertext), '<br><img>') . $content_suffix;
-
-			//get video on post
-			if (is_object($post->find('span.post_video_title_content', 0))) {
-				$titleVideo = $post->find('span.post_video_title_content', 0)->plaintext;
-				$linkToVideo = self::URI . $post->find('a.page_post_thumb_video', 0)->getAttribute('href');
-				$item['content'] .= "\n\r {$titleVideo}: {$linkToVideo}";
-			}
 
 			// get post link
 			$post_link = $post->find('a.post_link', 0)->getAttribute('href');

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -45,7 +45,7 @@ class VkBridge extends BridgeAbstract
 		$text_html = iconv('windows-1251', 'utf-8', $text_html);
 		$html = str_get_html($text_html);
 		$pageName = $html->find('.page_name', 0)->plaintext;
-		$this->pageName = $pageName;
+		$this->pageName = htmlspecialchars_decode($pageName);
 
 		foreach ($html->find('.post') as $post) {
 

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -179,7 +179,6 @@ class VkBridge extends BridgeAbstract
 				$div->outertext = '';
 			}
 
-
 			// get sign
 			$post_author = $pageName;
 			foreach($post->find('a.wall_signed_by') as $a) {
@@ -197,7 +196,8 @@ class VkBridge extends BridgeAbstract
 			}
 
 			$item = array();
-			$item['content'] = strip_tags(backgroundToImg($post->find('div.wall_text', 0)->innertext), '<br><img>') . $content_suffix;
+			$item['content'] = strip_tags(backgroundToImg($post->find('div.wall_text', 0)->innertext), '<br><img>');
+			$item['content'] .= $content_suffix;
 
 			// get post link
 			$post_link = $post->find('a.post_link', 0)->getAttribute('href');

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -181,10 +181,9 @@ class VkBridge extends BridgeAbstract
 
 
 			// get sign
+			$post_author = $pageName;
 			foreach($post->find('a.wall_signed_by') as $a) {
-				$link = self::URI . ltrim($a->getAttribute('href'), '/');
-				$title = $a->innertext;
-				$content_suffix .= "<br>Sign: <a href='$link'>$title</a>";
+				$post_author = $a->innertext;
 				$a->outertext = '';
 			}
 
@@ -212,7 +211,7 @@ class VkBridge extends BridgeAbstract
 			$item['uri'] = $post_link;
 			$item['timestamp'] = $this->getTime($post);
 			$item['title'] = $this->getTitle($item['content']);
-			$item['author'] = $pageName;
+			$item['author'] = $post_author;
 			if ($is_pinned_post) {
 				// do not append it now
 				$pinned_post_item = $item;

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -46,8 +46,11 @@ class VkBridge extends BridgeAbstract
 		// makes album link generating work correctly
 		$text_html = str_replace('"class="page_album_link">', '" class="page_album_link">', $text_html);
 		$html = str_get_html($text_html);
-		$pageName = $html->find('.page_name', 0)->plaintext;
-		$this->pageName = htmlspecialchars_decode($pageName);
+		$pageName = $html->find('.page_name', 0);
+		if (is_object($pageName)) {
+			$pageName = $pageName->plaintext;
+			$this->pageName = htmlspecialchars_decode($pageName);
+		}
 		$pinned_post_item = null;
 		$last_post_id = 0;
 

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -84,10 +84,17 @@ class VkBridge extends BridgeAbstract
 			}
 
 			// remove external link from content
-			$el_to_remove = $post->find('div.page_media_link_desc_wrap', 0);
-			if (is_object($el_to_remove)) {
-				$el_to_remove->outertext = '';
-			};
+			$external_link_selectors_to_remove = array(
+				'div.page_media_thumbed_link',
+				'div.page_media_link_desc_wrap',
+				'div.media_desc > a.lnk',
+			);
+
+			foreach($external_link_selectors_to_remove as $sel) {
+				if (is_object($post->find($sel, 0))) {
+					$post->find($sel, 0)->outertext = '';
+				}
+			}
 
 			// looking for article
 			$article = $post->find("a.article_snippet", 0);

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -60,6 +60,16 @@ class VkBridge extends BridgeAbstract
 				//delete link "show full" in content
 				$post->find('a.wall_post_more', 0)->outertext = '';
 			}
+
+			if (is_object($post->find('div.copy_quote', 0))) {
+				$copy_quote = $post->find('div.copy_quote', 0);
+				if ($copy_post_header = $copy_quote->find('div.copy_post_header', 0)) {
+					$copy_post_header->outertext = '';
+				}
+				$copy_quote_content = $copy_quote->innertext;
+				$copy_quote->outertext = "<br>Reposted: <br>$copy_quote_content";
+			}
+
 			$item = array();
 			$item['content'] = strip_tags(backgroundToImg($post->find('div.wall_text', 0)->innertext), '<br><img>');
 


### PR DESCRIPTION
First link - before, second link - after. If "u" param starts with "wall", it shows only one post (undocumented feature).

What has been done?

- Added titles to feed items
- Unpin pinned posts (see date of first posts)
https://feed.eugenemolotov.ru/?action=display&bridge=Vk&u=socarmenia&format=Html
https://feed.eugenemolotov.ru/vkdev/?action=display&bridge=Vk&u=socarmenia&format=Html

- Corrected video link parsing
https://feed.eugenemolotov.ru/?action=display&bridge=Vk&u=wall27530993_1378&format=Html
https://feed.eugenemolotov.ru/vkdev/?action=display&bridge=Vk&u=wall27530993_1378&format=Html

- Article link parsing
https://feed.eugenemolotov.ru/?action=display&bridge=Vk&u=wall-72028042_602&format=Html
https://feed.eugenemolotov.ru/vkdev/?action=display&bridge=Vk&u=wall-72028042_602&format=Html

- Photo and albums parsing
https://feed.eugenemolotov.ru/?action=display&bridge=Vk&u=wall-63239555_158959&format=Html
https://feed.eugenemolotov.ru/vkdev/?action=display&bridge=Vk&u=wall-63239555_158959&format=Html

- Using post signer as feed item author (by default - page name as item author)
https://feed.eugenemolotov.ru/?action=display&bridge=Vk&u=wall-72028042_754&format=Html
https://feed.eugenemolotov.ru/vkdev/?action=display&bridge=Vk&u=wall-72028042_754&format=Html

- Some other fixes