### PR TITLE
DansTonChatBridge: Update to follow DTC website changes

### DIFF
--- a/bridges/DansTonChatBridge.php
+++ b/bridges/DansTonChatBridge.php
@@ -15,8 +15,8 @@ class DansTonChatBridge extends BridgeAbstract {
 		foreach($html->find('div.item') as $element) {
 			$item = array();
 			$item['uri'] = $element->find('a', 0)->href;
-			$item['title'] = 'DansTonChat ' . $element->find('a', 1)->plaintext;
-			$item['content'] = $element->find('a', 0)->innertext;
+			$item['title'] = 'DansTonChat ' . html_entity_decode($element->find('h3 a', 0)->plaintext, ENT_QUOTES);
+			$item['content'] = $element->find('div.item-content a', 0)->innertext;
 			$this->items[] = $item;
 		}
 	}


### PR DESCRIPTION
Now, entry title is optionnal and may be found in h3 HTML element.
Entry content is mandatory and may be found in div[class="item-content"] HTML element.

Moreover, the title may contain simple quotes (here, encoded) so the bridge have to decode first to apply format library function. In case we don't do that, the format function double encode the quote and something like &amp;#039; could appear.