### PR TITLE
[index.php] Abort on parse error of config.default.ini.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,8 @@ if(!file_exists('config.default.ini.php'))
 	die('The default configuration file "config.default.ini.php" is missing!');
 
 $config = parse_ini_file('config.default.ini.php', true, INI_SCANNER_TYPED);
+if(!$config)
+	die('Error parsing config.default.ini.php');
 
 if(file_exists('config.ini.php')) {
 	// Replace default configuration with custom settings


### PR DESCRIPTION
If there is an error parsing the default config file, then abort.

I found this while using PHP 5.4 on RSS-Bridge version 2018-06-10. (PHP 5.4 doesn't support INI_SCANNER_TYPED so php converted it to a string then failed to parse the file.) I have updated the wiki to reflect the changes necessary for PHP 5.4:
https://github.com/RSS-Bridge/rss-bridge/wiki/RSS-Bridge-on-PHP-5.4