### PR TITLE
Automated Style Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+; Use 2 spaces for indentation in all files
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+
+[*.php]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,6 @@ config.ini.php
 
 #Builder
 .buildconfig
+
+# PHP CS Fixer
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -16,7 +16,7 @@ return PhpCsFixer\Config::create()
     ->setRules([
         'blank_line_after_namespace' => true,
         'strict_param' => true,
-        'array_syntax' => ['syntax' => 'long'],
+        'array_syntax' => ['syntax' => 'short'],
         // 'braces' => [
         //   'position_after_anonymous_constructs' => 'same',
         //   'position_after_control_structures'   => 'same',

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,50 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->in(__DIR__)
+;
+
+/**
+ * This is same as PSR2 with 3 changes:
+ * 1. Use tabs instead of spaces
+ * 2. function_declaration is turned off
+ * 3. braces rule is turned off
+ */
+// 1.
+return PhpCsFixer\Config::create()
+    ->setIndent("\t")
+    ->setRules([
+        'blank_line_after_namespace' => true,
+        'strict_param' => true,
+        'array_syntax' => ['syntax' => 'long'],
+        // 'braces' => [
+        //   'position_after_anonymous_constructs' => 'same',
+        //   'position_after_control_structures'   => 'same',
+        //   // Put braces on same line as functions and classes
+        //   'position_after_functions_and_oop_constructs' => 'same'
+        // ],
+        'elseif' => true,
+        'encoding' => true,
+        'full_opening_tag' => true,
+        'full_opening_tag' => true,
+        'indentation_type' => true,
+        'line_ending' => true,
+        'lowercase_constants' => true,
+        'lowercase_keywords' => true,
+        'method_argument_space' => true,
+        'no_break_comment' => true,
+        'no_closing_tag' => true,
+        'no_spaces_after_function_name' => true,
+        'no_spaces_inside_parenthesis' => true,
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'single_blank_line_at_eof' => true,
+        'single_class_element_per_statement' => true,
+        'single_import_per_statement' => true,
+        'single_line_after_imports' => true,
+        'switch_case_semicolon_to_colon' => true,
+        'switch_case_space' => true,
+        'visibility_required' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/bridges/ABCTabsBridge.php
+++ b/bridges/ABCTabsBridge.php
@@ -14,7 +14,7 @@ class ABCTabsBridge extends BridgeAbstract {
 		$table = $html->find('table#myTable', 0)->children(1);
 
 		foreach ($table->find('tr') as $tab) {
-			$item = array();
+			$item = [];
 			$item['author'] = $tab->find('td', 1)->plaintext
 			. ' - '
 			. $tab->find('td', 2)->plaintext;

--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -6,20 +6,20 @@ class AllocineFRBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 25200; // 7h
 	const URI = 'http://www.allocine.fr/';
 	const DESCRIPTION = 'Bridge for allocine.fr';
-	const PARAMETERS = array( array(
-		'category' => array(
+	const PARAMETERS = [ [
+		'category' => [
 			'name' => 'category',
 			'type' => 'list',
 			'required' => true,
 			'exampleValue' => 'Faux Raccord',
 			'title' => 'Select your category',
-			'values' => array(
+			'values' => [
 				'Faux Raccord' => 'faux-raccord',
 				'Top 5' => 'top-5',
 				'Tueurs en Séries' => 'tueurs-en-serie'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	public function getURI(){
 		if(!is_null($this->getInput('category'))) {
@@ -47,7 +47,7 @@ class AllocineFRBridge extends BridgeAbstract {
 			return self::NAME . ' : '
 				.array_search(
 					$this->getInput('category'),
-					self::PARAMETERS[$this->queriedContext]['category']['values']
+					self::PARAMETERS[$this->queriedContext]['category']['values'], true
 				);
 		}
 
@@ -61,11 +61,11 @@ class AllocineFRBridge extends BridgeAbstract {
 
 		$category = array_search(
 				$this->getInput('category'),
-				self::PARAMETERS[$this->queriedContext]['category']['values']
+				self::PARAMETERS[$this->queriedContext]['category']['values'], true
 			);
 
 		foreach($html->find('.media-meta-list figure.media-meta-fig') as $element) {
-			$item = array();
+			$item = [];
 
 			$title = $element->find('div.titlebar h3.title a', 0);
 			$content = trim($element->innertext);

--- a/bridges/AmazonBridge.php
+++ b/bridges/AmazonBridge.php
@@ -8,29 +8,29 @@ class AmazonBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 3600; // 1h
 	const DESCRIPTION = 'Returns products from Amazon search';
 
-	const PARAMETERS = array(array(
-		'q' => array(
+	const PARAMETERS = [[
+		'q' => [
 			'name' => 'Keyword',
 			'required' => true,
-		),
-		'sort' => array(
+		],
+		'sort' => [
 			'name' => 'Sort by',
 			'type' => 'list',
 			'required' => false,
-			'values' => array(
+			'values' => [
 				'Relevance' => 'relevanceblender',
 				'Price: Low to High' => 'price-asc-rank',
 				'Price: High to Low' => 'price-desc-rank',
 				'Average Customer Review' => 'review-rank',
 				'Newest Arrivals' => 'date-desc-rank',
-			),
+			],
 			'defaultValue' => 'relevanceblender',
-		),
-		'tld' => array(
+		],
+		'tld' => [
 			'name' => 'Country',
 			'type' => 'list',
 			'required' => true,
-			'values' => array(
+			'values' => [
 				'Australia' => 'com.au',
 				'Brazil' => 'com.br',
 				'Canada' => 'ca',
@@ -45,10 +45,10 @@ class AmazonBridge extends BridgeAbstract {
 				'Spain' => 'es',
 				'United Kingdom' => 'co.uk',
 				'United States' => 'com',
-			),
+			],
 			'defaultValue' => 'com',
-		),
-	));
+		],
+	]];
 
 	public function getName(){
 		if(!is_null($this->getInput('tld')) && !is_null($this->getInput('q'))) {
@@ -68,7 +68,7 @@ class AmazonBridge extends BridgeAbstract {
 
 		foreach($html->find('li.s-result-item') as $element) {
 
-			$item = array();
+			$item = [];
 
 			// Title
 			$title = $element->find('h2', 0);

--- a/bridges/AnimeUltimeBridge.php
+++ b/bridges/AnimeUltimeBridge.php
@@ -6,18 +6,18 @@ class AnimeUltimeBridge extends BridgeAbstract {
 	const URI = 'http://www.anime-ultime.net/';
 	const CACHE_TIMEOUT = 10800; // 3h
 	const DESCRIPTION = 'Returns the 10 newest releases posted on Anime-Ultime';
-	const PARAMETERS = array( array(
-		'type' => array(
+	const PARAMETERS = [ [
+		'type' => [
 		'name' => 'Type',
 		'type' => 'list',
-		'values' => array(
+		'values' => [
 			'Everything' => '',
 			'Anime' => 'A',
 			'Drama' => 'D',
 			'Tokusatsu' => 'T'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	private $filter = 'Releases';
 
@@ -26,7 +26,7 @@ class AnimeUltimeBridge extends BridgeAbstract {
 		//Add type filter if provided
 		$typeFilter = array_search(
 			$this->getInput('type'),
-			self::PARAMETERS[$this->queriedContext]['type']['values']
+			self::PARAMETERS[$this->queriedContext]['type']['values'], true
 		);
 
 		//Build date and filters for making requests
@@ -35,7 +35,7 @@ class AnimeUltimeBridge extends BridgeAbstract {
 
 		//Process each HTML page until having 10 releases
 		$processedOK = 0;
-		foreach (array($thismonth, $lastmonth) as $requestFilter) {
+		foreach ([$thismonth, $lastmonth] as $requestFilter) {
 
 			//Retrive page contents
 			$url = self::URI . 'history-0-1/' . $requestFilter;
@@ -100,7 +100,7 @@ class AnimeUltimeBridge extends BridgeAbstract {
 							$item_description = utf8_encode($item_description);
 
 							//Build and add final item
-							$item = array();
+							$item = [];
 							$item['uri'] = $item_uri;
 							$item['title'] = $item_name . ' ' . $item_type . ' ' . $item_episode;
 							$item['author'] = $item_fansub;
@@ -123,7 +123,7 @@ class AnimeUltimeBridge extends BridgeAbstract {
 		if(!is_null($this->getInput('type'))) {
 			$typeFilter = array_search(
 				$this->getInput('type'),
-				self::PARAMETERS[$this->queriedContext]['type']['values']
+				self::PARAMETERS[$this->queriedContext]['type']['values'], true
 			);
 
 			return 'Latest ' . $typeFilter . ' - Anime-Ultime Bridge';

--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -9,12 +9,12 @@ class Arte7Bridge extends BridgeAbstract {
 
 	const API_TOKEN = 'Nzc1Yjc1ZjJkYjk1NWFhN2I2MWEwMmRlMzAzNjI5NmU3NWU3ODg4ODJjOWMxNTMxYzEzZGRjYjg2ZGE4MmIwOA';
 
-	const PARAMETERS = array(
-		'Catégorie (Français)' => array(
-			'catfr' => array(
+	const PARAMETERS = [
+		'Catégorie (Français)' => [
+			'catfr' => [
 				'type' => 'list',
 				'name' => 'Catégorie',
-				'values' => array(
+				'values' => [
 					'Toutes les vidéos (français)' => null,
 					'Actu & société' => 'ACT',
 					'Séries & fiction' => 'SER',
@@ -25,14 +25,14 @@ class Arte7Bridge extends BridgeAbstract {
 					'Histoire' => 'HIST',
 					'Science' => 'SCI',
 					'Autre' => 'AUT'
-				)
-			)
-		),
-		'Catégorie (Allemand)' => array(
-			'catde' => array(
+				]
+			]
+		],
+		'Catégorie (Allemand)' => [
+			'catde' => [
 				'type' => 'list',
 				'name' => 'Catégorie',
-				'values' => array(
+				'values' => [
 					'Alle Videos (deutsch)' => null,
 					'Aktuelles & Gesellschaft' => 'ACT',
 					'Fernsehfilme & Serien' => 'SER',
@@ -43,10 +43,10 @@ class Arte7Bridge extends BridgeAbstract {
 					'Geschichte' => 'HIST',
 					'Wissenschaft' => 'SCI',
 					'Sonstiges' => 'AUT'
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	public function collectData(){
 		switch($this->queriedContext) {
@@ -64,16 +64,16 @@ class Arte7Bridge extends BridgeAbstract {
 			. $lang
 			. ($category != null ? '&category.code=' . $category : '');
 
-		$header = array(
+		$header = [
 			'Authorization: Bearer ' . self::API_TOKEN
-		);
+		];
 
 		$input = getContents($url, $header) or die('Could not request ARTE.');
 		$input_json = json_decode($input, true);
 
 		foreach($input_json['videos'] as $element) {
 
-			$item = array();
+			$item = [];
 			$item['uri'] = $element['url'];
 			$item['id'] = $element['id'];
 

--- a/bridges/AskfmBridge.php
+++ b/bridges/AskfmBridge.php
@@ -6,21 +6,21 @@ class AskfmBridge extends BridgeAbstract {
 	const URI = 'https://ask.fm/';
 	const CACHE_TIMEOUT = 300; //5 min
 	const DESCRIPTION = 'Returns answers from an Ask.fm user';
-	const PARAMETERS = array(
-		'Ask.fm username' => array(
-			'u' => array(
+	const PARAMETERS = [
+		'Ask.fm username' => [
+			'u' => [
 				'name' => 'Username',
 				'required' => true
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM($this->getURI())
 			or returnServerError('Requested username can\'t be found.');
 
 		foreach($html->find('div.streamItem-answer') as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = self::URI . $element->find('a.streamItemsAge', 0)->href;
 			$question = trim($element->find('h1.streamItemContent-question', 0)->innertext);
 

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -6,13 +6,13 @@ class BandcampBridge extends BridgeAbstract {
 	const URI = 'https://bandcamp.com/';
 	const CACHE_TIMEOUT = 600; // 10min
 	const DESCRIPTION = 'New bandcamp release by tag';
-	const PARAMETERS = array( array(
-		'tag' => array(
+	const PARAMETERS = [ [
+		'tag' => [
 			'name' => 'tag',
 			'type' => 'text',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM($this->getURI())
@@ -23,7 +23,7 @@ class BandcampBridge extends BridgeAbstract {
 			$uri = ltrim($script, "return 'url(");
 			$uri = rtrim($uri, "')");
 
-			$item = array();
+			$item = [];
 			$item['author'] = $release->find('div.itemsubtext', 0)->plaintext
 			. ' - '
 			. $release->find('div.itemtext', 0)->plaintext;

--- a/bridges/BastaBridge.php
+++ b/bridges/BastaBridge.php
@@ -21,7 +21,7 @@ class BastaBridge extends BridgeAbstract {
 
 		foreach($html->find('item') as $element) {
 			if($limit < 10) {
-				$item = array();
+				$item = [];
 				$item['title'] = $element->find('title', 0)->innertext;
 				$item['uri'] = $element->find('guid', 0)->plaintext;
 				$item['timestamp'] = strtotime($element->find('dc:date', 0)->plaintext);

--- a/bridges/BlaguesDeMerdeBridge.php
+++ b/bridges/BlaguesDeMerdeBridge.php
@@ -12,7 +12,7 @@ class BlaguesDeMerdeBridge extends BridgeAbstract {
 			or returnServerError('Could not request BDM.');
 
 		foreach($html->find('article.joke_contener') as $element) {
-			$item = array();
+			$item = [];
 			$temp = $element->find('a');
 
 			if(isset($temp[2])) {

--- a/bridges/BloombergBridge.php
+++ b/bridges/BloombergBridge.php
@@ -6,15 +6,15 @@ class BloombergBridge extends BridgeAbstract
 	const DESCRIPTION = 'Trending stories from Bloomberg';
 	const MAINTAINER = 'mdemoss';
 
-	const PARAMETERS = array(
-	'Trending Stories' => array(),
-	'From Search' => array(
-	'q' => array(
+	const PARAMETERS = [
+	'Trending Stories' => [],
+	'From Search' => [
+	'q' => [
 				'name' => 'Keyword',
 				'required' => true
-	)
-	)
-	);
+	]
+	]
+	];
 
 	public function getName()
 	{

--- a/bridges/BooruprojectBridge.php
+++ b/bridges/BooruprojectBridge.php
@@ -7,23 +7,23 @@ class BooruprojectBridge extends GelbooruBridge {
 	const NAME = 'Booruproject';
 	const URI = 'http://booru.org/';
 	const DESCRIPTION = 'Returns images from given page of booruproject';
-	const PARAMETERS = array(
-		'global' => array(
-			'p' => array(
+	const PARAMETERS = [
+		'global' => [
+			'p' => [
 				'name' => 'page',
 				'type' => 'number'
-			),
-			't' => array(
+			],
+			't' => [
 				'name' => 'tags'
-			)
-		),
-		'Booru subdomain (subdomain.booru.org)' => array(
-			'i' => array(
+			]
+		],
+		'Booru subdomain (subdomain.booru.org)' => [
+			'i' => [
 				'name' => 'Subdomain',
 				'required' => true
-			)
-		)
-	);
+			]
+		]
+	];
 
 	const PIDBYPAGE = 20;
 

--- a/bridges/CNETBridge.php
+++ b/bridges/CNETBridge.php
@@ -8,11 +8,11 @@ class CNETBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the newest articles. <br /> You may specify a
 topic found in some section URLs, else all topics are selected.';
 
-	const PARAMETERS = array( array(
-		'topic' => array(
+	const PARAMETERS = [ [
+		'topic' => [
 			'name' => 'Topic name'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 
@@ -69,7 +69,7 @@ topic found in some section URLs, else all topics are selected.';
 						)
 					);
 
-					$item = array();
+					$item = [];
 					$item['uri'] = $article_uri;
 					$item['title'] = $article_title;
 					$item['author'] = $article_author;

--- a/bridges/CastorusBridge.php
+++ b/bridges/CastorusBridge.php
@@ -6,27 +6,27 @@ class CastorusBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 600; // 10min
 	const DESCRIPTION = 'Returns the latest changes';
 
-	const PARAMETERS = array(
-		'Get latest changes' => array(),
-		'Get latest changes via ZIP code' => array(
-			'zip' => array(
+	const PARAMETERS = [
+		'Get latest changes' => [],
+		'Get latest changes via ZIP code' => [
+			'zip' => [
 				'name' => 'ZIP code',
 				'type' => 'text',
 				'required' => true,
 				'exampleValue' => '74910, 74',
 				'title' => 'Insert ZIP code (complete or partial)'
-			)
-		),
-		'Get latest changes via city name' => array(
-			'city' => array(
+			]
+		],
+		'Get latest changes via city name' => [
+			'city' => [
 				'name' => 'City name',
 				'type' => 'text',
 				'required' => true,
 				'exampleValue' => 'Seyssel, Seys',
 				'title' => 'Insert city name (complete or partial)'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	// Extracts the title from an actitiy
 	private function extractActivityTitle($activity){
@@ -89,7 +89,7 @@ class CastorusBridge extends BridgeAbstract {
 			returnServerError('Failed to find activities!');
 
 		foreach($activities as $activity) {
-			$item = array();
+			$item = [];
 
 			$item['title'] = $this->extractActivityTitle($activity);
 			$item['uri'] = $this->extractActivityUrl($activity);

--- a/bridges/ChristianDailyReporterBridge.php
+++ b/bridges/ChristianDailyReporterBridge.php
@@ -14,7 +14,7 @@ class ChristianDailyReporterBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM($uri)
 			or returnServerError('Could not request Christian Daily Reporter.');
 		foreach($html->find('div.top p a,div.column p a') as $element) {
-			$item = array();
+			$item = [];
 			// Title
 			$item['title'] = $element->innertext;
 			// URL

--- a/bridges/CollegeDeFranceBridge.php
+++ b/bridges/CollegeDeFranceBridge.php
@@ -8,7 +8,7 @@ class CollegeDeFranceBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the latest audio and video from CollegeDeFrance';
 
 	public function collectData(){
-		$months = array(
+		$months = [
 			'01' => 'janv.',
 			'02' => 'févr.',
 			'03' => 'mars',
@@ -21,7 +21,7 @@ class CollegeDeFranceBridge extends BridgeAbstract {
 			'10' => 'oct.',
 			'11' => 'nov.',
 			'12' => 'déc.'
-		);
+		];
 
 		// The "API" used by the site returns a list of partial HTML in this form
 		/* <li>
@@ -38,7 +38,7 @@ class CollegeDeFranceBridge extends BridgeAbstract {
 			or returnServerError('Could not request CollegeDeFrance.');
 
 		foreach($html->find('a[data-target]') as $element) {
-			$item = array();
+			$item = [];
 			$item['title'] = $element->find('.title', 0)->plaintext;
 
 			// Most relative URLs contains an hour in addition to the date, so let's use it

--- a/bridges/CommonDreamsBridge.php
+++ b/bridges/CommonDreamsBridge.php
@@ -20,7 +20,7 @@ class CommonDreamsBridge extends FeedExpander {
 		$html3 = getSimpleHTMLDOMCached($url);
 		$text = $html3->find('div[class=field--type-text-with-summary]', 0)->innertext;
 		$html3->clear();
-		unset ($html3);
+		unset($html3);
 		return $text;
 	}
 }

--- a/bridges/CopieDoubleBridge.php
+++ b/bridges/CopieDoubleBridge.php
@@ -17,7 +17,7 @@ class CopieDoubleBridge extends BridgeAbstract {
 			$td = $element->find('td', 0);
 
 			if($td->class === 'couleur_1') {
-				$item = array();
+				$item = [];
 				$title = $td->innertext;
 				$pos = strpos($title, '<a');
 				$title = substr($title, 0, $pos);

--- a/bridges/CourrierInternationalBridge.php
+++ b/bridges/CourrierInternationalBridge.php
@@ -15,7 +15,7 @@ class CourrierInternationalBridge extends BridgeAbstract {
 		$article_count = 1;
 
 		foreach($element as $article) {
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $article->parent->getAttribute('href');
 

--- a/bridges/CpasbienBridge.php
+++ b/bridges/CpasbienBridge.php
@@ -7,13 +7,13 @@ class CpasbienBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 86400; // 24h
 	const DESCRIPTION = 'Returns latest torrents from a request query';
 
-	const PARAMETERS = array( array(
-		'q' => array(
+	const PARAMETERS = [ [
+		'q' => [
 			'name' => 'Search',
 			'required' => true,
 			'title' => 'Type your search'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$request = str_replace(" ", "-", trim($this->getInput('q')));
@@ -27,7 +27,7 @@ class CpasbienBridge extends BridgeAbstract {
 				$urlepisode = $episode->find('a', 0)->getAttribute('href');
 				$htmlepisode = getSimpleHTMLDOMCached($urlepisode, 86400 * 366 * 30);
 
-				$item = array();
+				$item = [];
 				$item['author'] = $episode->find('a', 0)->text();
 				$item['title'] = $episode->find('a', 0)->text();
 				$item['pubdate'] = $this->getCachedDate($urlepisode);

--- a/bridges/CryptomeBridge.php
+++ b/bridges/CryptomeBridge.php
@@ -7,14 +7,14 @@ class CryptomeBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 21600; //6h
 	const DESCRIPTION = 'Returns the N most recent documents.';
 
-	const PARAMETERS = array( array(
-		'n' => array(
+	const PARAMETERS = [ [
+		'n' => [
 			'name' => 'number of elements',
 			'type' => 'number',
 			'defaultValue' => 20,
 			'exampleValue' => 10
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM(self::URI)
@@ -29,7 +29,7 @@ class CryptomeBridge extends BridgeAbstract {
 
 		foreach($html->find('pre') as $element) {
 			for($i = 0; $i < $num; ++$i) {
-				$item = array();
+				$item = [];
 				$item['uri'] = self::URI . substr($element->find('a', $i)->href, 20);
 				$item['title'] = substr($element->find('b', $i)->plaintext, 22);
 				$item['content'] = preg_replace(

--- a/bridges/DailymotionBridge.php
+++ b/bridges/DailymotionBridge.php
@@ -7,33 +7,33 @@ class DailymotionBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 10800; // 3h
 	const DESCRIPTION = 'Returns the 5 newest videos by username/playlist or search';
 
-	const PARAMETERS = array (
-		'By username' => array(
-			'u' => array(
+	const PARAMETERS = [
+		'By username' => [
+			'u' => [
 				'name' => 'username',
 				'required' => true
-			)
-		),
-		'By playlist id' => array(
-			'p' => array(
+			]
+		],
+		'By playlist id' => [
+			'p' => [
 				'name' => 'playlist id',
 				'required' => true
-			)
-		),
-		'From search results' => array(
-			's' => array(
+			]
+		],
+		'From search results' => [
+			's' => [
 				'name' => 'Search keyword',
 				'required' => true
-			),
-			'pa' => array(
+			],
+			'pa' => [
 				'name' => 'Page',
 				'type' => 'number'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	protected function getMetadata($id){
-		$metadata = array();
+		$metadata = [];
 		$html2 = getSimpleHTMLDOM(self::URI . 'video/' . $id);
 		if(!$html2) {
 			return $metadata;
@@ -58,7 +58,7 @@ class DailymotionBridge extends BridgeAbstract {
 
 		foreach($html->find('div.media a.preview_link') as $element) {
 			if($count < $limit) {
-				$item = array();
+				$item = [];
 				$item['id'] = str_replace('/video/', '', strtok($element->href, '_'));
 				$metadata = $this->getMetadata($item['id']);
 				if(empty($metadata)) {

--- a/bridges/DanbooruBridge.php
+++ b/bridges/DanbooruBridge.php
@@ -7,19 +7,19 @@ class DanbooruBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 1800; // 30min
 	const DESCRIPTION = 'Returns images from given page';
 
-	const PARAMETERS = array(
-		'global' => array(
-			'p' => array(
+	const PARAMETERS = [
+		'global' => [
+			'p' => [
 				'name' => 'page',
 				'defaultValue' => 1,
 				'type' => 'number'
-			),
-			't' => array(
+			],
+			't' => [
 				'name' => 'tags'
-			)
-		),
-		0 => array()
-	);
+			]
+		],
+		0 => []
+	];
 
 	const PATHTODATA = 'article';
 	const IDATTRIBUTE = 'data-id';
@@ -39,7 +39,7 @@ class DanbooruBridge extends BridgeAbstract {
 		// Fix links
 		defaultLinkTo($element, $this->getURI());
 
-		$item = array();
+		$item = [];
 		$item['uri'] = $element->find('a', 0)->href;
 		$item['postid'] = (int)preg_replace("/[^0-9]/", '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();

--- a/bridges/DansTonChatBridge.php
+++ b/bridges/DansTonChatBridge.php
@@ -13,7 +13,7 @@ class DansTonChatBridge extends BridgeAbstract {
 			or returnServerError('Could not request DansTonChat.');
 
 		foreach($html->find('div.item') as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $element->find('a', 0)->href;
 			$titleContent = $element->find('h3 a', 0);
 			if($titleContent) {

--- a/bridges/DauphineLibereBridge.php
+++ b/bridges/DauphineLibereBridge.php
@@ -7,11 +7,11 @@ class DauphineLibereBridge extends FeedExpander {
 	const CACHE_TIMEOUT = 7200; // 2h
 	const DESCRIPTION = 'Returns the newest articles.';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'Catégorie de l\'article',
 			'type' => 'list',
-			'values' => array(
+			'values' => [
 				'À la une' => '',
 				'France Monde' => 'france-monde',
 				'Faits Divers' => 'faits-divers',
@@ -27,9 +27,9 @@ class DauphineLibereBridge extends FeedExpander {
 				'Savoie' => 'savoie',
 				'Haute-Savoie' => 'haute-savoie',
 				'Vaucluse' => 'vaucluse'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	public function collectData(){
 		$url = self::URI . 'rss';

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -4,47 +4,47 @@ class DealabsBridge extends BridgeAbstract {
 	const URI = 'https://www.dealabs.com/';
 	const DESCRIPTION = 'Return the Dealabs search result using keywords';
 	const MAINTAINER = 'sysadminstory';
-	const PARAMETERS = array(
-		'Recherche par Mot(s) clé(s)' => array (
-			'q' => array(
+	const PARAMETERS = [
+		'Recherche par Mot(s) clé(s)' => [
+			'q' => [
 				'name' => 'Mot(s) clé(s)',
 				'type' => 'text',
 				'required' => true
-			),
-			'hide_expired' => array(
+			],
+			'hide_expired' => [
 				'name' => 'Masquer les éléments expirés',
 				'type' => 'checkbox',
 				'required' => 'true'
-			),
-			'hide_local' => array(
+			],
+			'hide_local' => [
 				'name' => 'Masquer les deals locaux',
 				'type' => 'checkbox',
 				'title' => 'Masquer les deals en magasins physiques',
 				'required' => 'true'
-			),
-			'priceFrom' => array(
+			],
+			'priceFrom' => [
 				'name' => 'Prix minimum',
 				'type' => 'text',
 				'title' => 'Prix mnimum en euros',
 				'required' => 'false',
 				'defaultValue' => ''
-			),
-			'priceTo' => array(
+			],
+			'priceTo' => [
 				'name' => 'Prix maximum',
 				'type' => 'text',
 				'title' => 'Prix maximum en euros',
 				'required' => 'false',
 				'defaultValue' => ''
-			),
-		),
+			],
+		],
 
-		'Deals par groupe' => array(
-			'groupe' => array(
+		'Deals par groupe' => [
+			'groupe' => [
 				'name' => 'Groupe',
 				'type' => 'list',
 				'required' => 'true',
 				'title' => 'Groupe dont il faut afficher les deals',
-				'values' => array(
+				'values' => [
 					'Accessoires & gadgets' => 'accessoires-gadgets',
 					'Alimentation & boissons' => 'alimentation-boissons',
 					'Animaux' => 'animaux',
@@ -62,21 +62,21 @@ class DealabsBridge extends BridgeAbstract {
 					'Sports & plein air' => 'sports-plein-air',
 					'Téléphonie' => 'telephonie',
 					'Voyages & sorties' => 'voyages-sorties-restaurants'
-				)
-			),
-			'ordre' => array(
+				]
+			],
+			'ordre' => [
 				'name' => 'Trier par',
 				'type' => 'list',
 				'required' => 'true',
 				'title' => 'Ordre de tri des deals',
-				'values' => array(
+				'values' => [
 					'Du deal le plus Hot au moins Hot' => '',
 					'Du deal le plus récent au plus ancien' => '-nouveaux',
 					'Du deal le plus commentés au moins commentés' => '-commentes'
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	const CACHE_TIMEOUT = 3600;
 
@@ -144,66 +144,66 @@ class DealabsBridge extends BridgeAbstract {
 		// Deal Image Link CSS Selector
 		$selectorImageLink = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'cept-thread-image-link',
 				'imgFrame',
 				'imgFrame--noBorder',
 				'thread-listImgCell',
-			)
+			]
 		);
 
 		// Deal Link CSS Selector
 		$selectorLink = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'cept-tt',
 				'thread-link',
 				'linkPlain',
-			)
+			]
 		);
 
 		// Deal Hotness CSS Selector
 		$selectorHot = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'flex',
 				'flex--align-c',
 				'flex--justify-space-between',
 				'space--b-2',
-			)
+			]
 		);
 
 		// Deal Description CSS Selector
 		$selectorDescription = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'cept-description-container',
 				'userHtml',
 				'overflow--wrap-break',
 				'size--all-s',
 				'size--fromW3-m',
-			)
+			]
 		);
 
 		// Deal Date CSS Selector
 		$selectorDate = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'size--all-s',
 				'flex',
 				'flex--wrap',
 				'flex--justify-e',
 				'flex--grow-1',
-			)
+			]
 		);
 
 		// If there is no results, we don't parse the content because it display some random deals
 		$noresult = $html->find('h3[class=size--all-l size--fromW2-xl size--fromW3-xxl]', 0);
 		if($noresult != null && $noresult->plaintext == 'Il n&#039;y a rien à afficher pour le moment :(') {
-			$this->items = array();
+			$this->items = [];
 		} else {
 			foreach($list as $deal) {
-				$item = array();
+				$item = [];
 				$item['uri'] = $deal->find('div[class=threadGrid-title]', 0)->find('a', 0)->href;
 				$item['title'] = $deal->find('a[class*='. $selectorLink .']', 0
 					)->plaintext;
@@ -230,7 +230,7 @@ class DealabsBridge extends BridgeAbstract {
 				$dealDateDiv = $deal->find('div[class='. $selectorDate .']', 0)
 					->find('span[class=hide--toW3]');
 				$itemDate = end($dealDateDiv)->plaintext;
-				if(substr( $itemDate, 0, 6 ) === 'il y a') {
+				if(substr($itemDate, 0, 6) === 'il y a') {
 					$item['timestamp'] = $this->relativeDateToTimestamp($itemDate);
 				} else 	{
 					$item['timestamp'] = $this->parseDate($itemDate);
@@ -329,7 +329,7 @@ class DealabsBridge extends BridgeAbstract {
 
 		$selectorLazy = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'thread-image',
 				'width--all-auto',
 				'height--all-auto',
@@ -337,18 +337,18 @@ class DealabsBridge extends BridgeAbstract {
 				'cept-thread-img',
 				'img--dummy',
 				'js-lazy-img'
-			)
+			]
 		);
 
 			$selectorPlain = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'thread-image',
 				'width--all-auto',
 				'height--all-auto',
 				'imgFrame-img',
 				'cept-thread-img'
-			)
+			]
 		);
 		if($deal->find('img[class='. $selectorLazy .']', 0) != null) {
 			return json_decode(
@@ -356,7 +356,7 @@ class DealabsBridge extends BridgeAbstract {
 					$deal->find('img[class='. $selectorLazy .']', 0)
 						->getAttribute('data-lazy-img')))->{'src'};
 		} else {
-			return $deal->find('img[class='. $selectorPlain .']', 0	)->src;
+			return $deal->find('img[class='. $selectorPlain .']', 0)->src;
 		}
 	}
 
@@ -368,12 +368,12 @@ class DealabsBridge extends BridgeAbstract {
 	{
 		$selector = implode(
 			' ', /* Notice this is a space! */
-			array(
+			[
 				'meta-ribbon',
 				'overflow--wrap-off',
 				'space--l-3',
 				'text--color-greyShade'
-			)
+			]
 		);
 		if($deal->find('span[class='. $selector .']', 0) != null) {
 			return '<div>'
@@ -390,7 +390,7 @@ class DealabsBridge extends BridgeAbstract {
 	 */
 	private function parseDate($string)
 	{
-		$month_fr = array(
+		$month_fr = [
 			'janvier',
 			'février',
 			'mars',
@@ -403,8 +403,8 @@ class DealabsBridge extends BridgeAbstract {
 			'octobre',
 			'novembre',
 			'décembre'
-		);
-		$month_en = array(
+		];
+		$month_en = [
 			'January',
 			'February',
 			'March',
@@ -417,7 +417,7 @@ class DealabsBridge extends BridgeAbstract {
 			'October',
 			'November',
 			'December'
-		);
+		];
 		$string = str_replace('Actualisé ', '', $string);
 		$date_str = trim(str_replace($month_fr, $month_en, $string));
 
@@ -436,7 +436,7 @@ class DealabsBridge extends BridgeAbstract {
 	 */
 	private function relativeDateToTimestamp($str) {
 		$date = new DateTime();
-		$search = array(
+		$search = [
 			'il y a ',
 			'min',
 			'h',
@@ -445,8 +445,8 @@ class DealabsBridge extends BridgeAbstract {
 			'mois',
 			'ans',
 			'et '
-		);
-		$replace = array(
+		];
+		$replace = [
 			'-',
 			'minute',
 			'hour',
@@ -454,7 +454,7 @@ class DealabsBridge extends BridgeAbstract {
 			'month',
 			'year',
 			''
-		);
+		];
 
 		$date->modify(str_replace($search, $replace, $str));
 		return $date->getTimestamp();
@@ -467,7 +467,7 @@ class DealabsBridge extends BridgeAbstract {
 				break;
 			case 'Deals par groupe':
 				$values = self::PARAMETERS['Deals par groupe']['groupe']['values'];
-				$groupe = array_search($this->getInput('groupe'), $values);
+				$groupe = array_search($this->getInput('groupe'), $values, true);
 				return self::NAME . ' - Groupe : '. $groupe;
 				break;
 			default: // Return default value

--- a/bridges/DemoBridge.php
+++ b/bridges/DemoBridge.php
@@ -6,35 +6,35 @@ class DemoBridge extends BridgeAbstract {
 	const URI = 'http://github.com/rss-bridge/rss-bridge';
 	const DESCRIPTION = 'Bridge used for demos';
 
-	const PARAMETERS = array(
-		'testCheckbox' => array(
-			'testCheckbox' => array(
+	const PARAMETERS = [
+		'testCheckbox' => [
+			'testCheckbox' => [
 				'type' => 'checkbox',
 				'name' => 'test des checkbox'
-			)
-		),
-		'testList' => array(
-			'testList' => array(
+			]
+		],
+		'testList' => [
+			'testList' => [
 				'type' => 'list',
 				'name' => 'test des listes',
-				'values' => array(
+				'values' => [
 					'Test' => 'test',
 					'Test 2' => 'test2'
-				)
-			)
-		),
-		'testNumber' => array(
-			'testNumber' => array(
+				]
+			]
+		],
+		'testNumber' => [
+			'testNumber' => [
 				'type' => 'number',
 				'name' => 'test des numéros',
 				'exampleValue' => '1515632'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 
-		$item = array();
+		$item = [];
 		$item['author'] = "Me!";
 		$item['title'] = "Test";
 		$item['content'] = "Awesome content !";

--- a/bridges/DemonoidBridge.php
+++ b/bridges/DemonoidBridge.php
@@ -6,16 +6,16 @@ class DemonoidBridge extends BridgeAbstract {
 	const URI = 'https://www.demonoid.pw/';
 	const DESCRIPTION = 'Returns results from search';
 
-	const PARAMETERS = array(array(
-		'q' => array(
+	const PARAMETERS = [[
+		'q' => [
 			'name' => 'keywords',
 			'exampleValue' => 'keyword1 keyword2…',
 			'required' => true,
-			),
-		'category' => array(
+			],
+		'category' => [
 			'name' => 'Category',
 			'type' => 'list',
-			'values' => array(
+			'values' => [
 				'All' => 0,
 				'Movies' => 1,
 				'Music' => 2,
@@ -27,13 +27,13 @@ class DemonoidBridge extends BridgeAbstract {
 				'Comics' => 10,
 				'Books' => 11,
 				'Audiobooks' => 17
-				)
-			)
-		), array(
-		'catOnly' => array(
+				]
+			]
+		], [
+		'catOnly' => [
 			'name' => 'Category',
 			'type' => 'list',
-			'values' => array(
+			'values' => [
 				'All' => 0,
 				'Movies' => 1,
 				'Music' => 2,
@@ -45,19 +45,19 @@ class DemonoidBridge extends BridgeAbstract {
 				'Comics' => 10,
 				'Books' => 11,
 				'Audiobooks' => 17
-				)
-			)
-		), array(
-		'userid' => array(
+				]
+			]
+		], [
+		'userid' => [
 			'name' => 'user id',
 			'exampleValue' => '00000',
 			'required' => true,
 			'type' => 'number'
-			),
-		'category' => array(
+			],
+		'category' => [
 			'name' => 'Category',
 			'type' => 'list',
-			'values' => array(
+			'values' => [
 				'All' => 0,
 				'Movies' => 1,
 				'Music' => 2,
@@ -69,10 +69,10 @@ class DemonoidBridge extends BridgeAbstract {
 				'Comics' => 10,
 				'Books' => 11,
 				'Audiobooks' => 17
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	public function collectData() {
 
@@ -122,7 +122,7 @@ class DemonoidBridge extends BridgeAbstract {
 			if(preg_match('~items total~', $currentElement)) {
 				break;
 			}
-			$item = array();
+			$item = [];
 			//Do we have a date ?
 			if(preg_match('~Added.*?(.*)~', $currentElement->plaintext, $dateStr)) {
 				if(preg_match('~today~', $dateStr[0])) {

--- a/bridges/DeveloppezDotComBridge.php
+++ b/bridges/DeveloppezDotComBridge.php
@@ -21,19 +21,19 @@ class DeveloppezDotComBridge extends FeedExpander {
 	// http://stackoverflow.com/questions/1262038/how-to-replace-microsoft-encoded-quotes-in-php
 	private function convertSmartQuotes($string)
 	{
-		$search = array(chr(145),
+		$search = [chr(145),
 						chr(146),
 						chr(147),
 						chr(148),
-						chr(151));
+						chr(151)];
 
-		$replace = array(
+		$replace = [
 			"'",
 			"'",
 			'"',
 			'"',
 			'-'
-		);
+		];
 
 		return str_replace($search, $replace, $string);
 	}

--- a/bridges/DiceBridge.php
+++ b/bridges/DiceBridge.php
@@ -7,40 +7,40 @@ class DiceBridge extends BridgeAbstract {
 	const DESCRIPTION = 'The Unofficial Dice RSS';
 	// const CACHE_TIMEOUT = 86400; // 1 day
 
-	const PARAMETERS = array(array(
-		'for_one' => array(
+	const PARAMETERS = [[
+		'for_one' => [
 			'name' => 'With at least one of the words',
 			'required' => false,
-		),
-		'for_all' => array(
+		],
+		'for_all' => [
 			'name' => 'With all of the words',
 			'required' => false,
-		),
-		'for_exact' => array(
+		],
+		'for_exact' => [
 			'name' => 'With the exact phrase',
 			'required' => false,
-		),
-		'for_none' => array(
+		],
+		'for_none' => [
 			'name' => 'With none of these words',
 			'required' => false,
-		),
-		'for_jt' => array(
+		],
+		'for_jt' => [
 			'name' => 'Within job title',
 			'required' => false,
-		),
-		'for_com' => array(
+		],
+		'for_com' => [
 			'name' => 'Within company name',
 			'required' => false,
-		),
-		'for_loc' => array(
+		],
+		'for_loc' => [
 			'name' => 'City, State, or ZIP code',
 			'required' => false,
-		),
-		'radius' => array(
+		],
+		'radius' => [
 			'name' => 'Radius in miles',
 			'type' => 'list',
 			'required' => false,
-			'values' => array(
+			'values' => [
 				'Exact Location' => 'El',
 				'Within 5 miles' => '5',
 				'Within 10 miles' => '10',
@@ -50,14 +50,14 @@ class DiceBridge extends BridgeAbstract {
 				'Within 50 miles' => '50',
 				'Within 75 miles' => '75',
 				'Within 100 miles' => '100',
-			),
+			],
 			'defaultValue' => '0',
-		),
-		'jtype' => array(
+		],
+		'jtype' => [
 			'name' => 'Job type',
 			'type' => 'list',
 			'required' => false,
-			'values' => array(
+			'values' => [
 				'Full-Time' => 'Full Time',
 				'Part-Time' => 'Part Time',
 				'Contract - Independent' => 'Contract Independent',
@@ -66,14 +66,14 @@ class DiceBridge extends BridgeAbstract {
 				'Contract to Hire - W2' => 'C2H W2',
 				'Third Party - Contract - Corp-to-Corp' => 'Contract Corp-To-Corp',
 				'Third Party - Contract to Hire - Corp-to-Corp' => 'C2H Corp-To-Corp',
-			),
+			],
 			'defaultValue' => 'Full Time',
-		),
-		'telecommute' => array(
+		],
+		'telecommute' => [
 			'name' => 'Telecommute',
 			'type' => 'checkbox',
-		),
-	));
+		],
+	]];
 
 	public function collectData() {
 		$uri = 'https://www.dice.com/jobs/advancedResult.html';
@@ -96,7 +96,7 @@ class DiceBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM($uri)
 			or returnServerError('Could not request Dice.');
 		foreach($html->find('div.complete-serp-result-div') as $element) {
-			$item = array();
+			$item = [];
 			// Title
 			$masterLink = $element->find('a[id^=position]', 0);
 			$item['title'] = $masterLink->title;

--- a/bridges/DilbertBridge.php
+++ b/bridges/DilbertBridge.php
@@ -24,7 +24,7 @@ class DilbertBridge extends BridgeAbstract {
 				$title = 'Dilbert Comic Strip on ' . $date;
 			$date = strtotime($date);
 
-			$item = array();
+			$item = [];
 			$item['uri'] = $url;
 			$item['title'] = $title;
 			$item['author'] = 'Scott Adams';

--- a/bridges/DiscogsBridge.php
+++ b/bridges/DiscogsBridge.php
@@ -6,36 +6,36 @@ class DiscogsBridge extends BridgeAbstract {
 	const NAME = 'DiscogsBridge';
 	const URI = 'https://www.discogs.com/';
 	const DESCRIPTION = 'Returns releases from discogs';
-	const PARAMETERS = array(
-		'Artist Releases' => array(
-			'artistid' => array(
+	const PARAMETERS = [
+		'Artist Releases' => [
+			'artistid' => [
 				'name' => 'Artist ID',
 				'type' => 'number',
-			)
-		),
-		'Label Releases' => array(
-			'labelid' => array(
+			]
+		],
+		'Label Releases' => [
+			'labelid' => [
 				'name' => 'Label ID',
 				'type' => 'number',
-			)
-		),
-		'User Wantlist' => array(
-			'username_wantlist' => array(
+			]
+		],
+		'User Wantlist' => [
+			'username_wantlist' => [
 				'name' => 'Username',
 				'type' => 'text',
-			)
-		),
-		'User Folder' => array(
-			'username_folder' => array(
+			]
+		],
+		'User Folder' => [
+			'username_folder' => [
 				'name' => 'Username',
 				'type' => 'text',
-			),
-			'folderid' => array(
+			],
+			'folderid' => [
 				'name' => 'Folder ID',
 				'type' => 'number',
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData() {
 
@@ -56,7 +56,7 @@ class DiscogsBridge extends BridgeAbstract {
 			$jsonData = json_decode($data, true);
 			foreach($jsonData["releases"] as $release) {
 
-				$item = array();
+				$item = [];
 				$item["author"] = $release["artist"];
 				$item["title"] = $release["title"];
 				$item["id"] = $release["id"];
@@ -88,7 +88,7 @@ class DiscogsBridge extends BridgeAbstract {
 			foreach($jsonData as $element) {
 
 				$infos = $element["basic_information"];
-				$item = array();
+				$item = [];
 				$item["title"] = $infos["title"];
 				$item["author"] = $infos["artists"][0]["name"];
 				$item["id"] = $infos["artists"][0]["id"];

--- a/bridges/DuckDuckGoBridge.php
+++ b/bridges/DuckDuckGoBridge.php
@@ -10,29 +10,29 @@ class DuckDuckGoBridge extends BridgeAbstract {
 	const SORT_DATE = '+sort:date';
 	const SORT_RELEVANCE = '';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'keyword',
 			'required' => true
-		),
-		'sort' => array(
+		],
+		'sort' => [
 			'name' => 'sort by',
 			'type' => 'list',
 			'required' => false,
-			'values' => array(
+			'values' => [
 				'date' => self::SORT_DATE,
 				'relevance' => self::SORT_RELEVANCE
-			),
+			],
 			'defaultValue' => self::SORT_DATE
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM(self::URI . 'html/?kd=-1&q=' . $this->getInput('u') . $this->getInput('sort'))
 			or returnServerError('Could not request DuckDuckGo.');
 
 		foreach($html->find('div.results_links') as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $element->find('a', 0)->href;
 			$item['title'] = $element->find('a', 1)->innertext;
 			$item['content'] = $element->find('div.snippet', 0)->plaintext;

--- a/bridges/ETTVBridge.php
+++ b/bridges/ETTVBridge.php
@@ -7,15 +7,15 @@ class ETTVBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns list of 20 latest torrents for a specific search.';
 	const CACHE_TIMEOUT = 14400; // 4 hours
 
-	const PARAMETERS = array( array(
-		'query' => array(
+	const PARAMETERS = [ [
+		'query' => [
 			'name' => 'Keywords',
 			'required' => true
-		),
-		'cat' => array(
+		],
+		'cat' => [
 			'type' => 'list',
 			'name' => 'Category',
-			'values' => array(
+			'values' => [
 				'(ALL TYPES)' => '0',
 				'Anime: Movies' => '73',
 				'Anime: Dubbed/Subbed' => '74',
@@ -54,23 +54,23 @@ class ETTVBridge extends BridgeAbstract {
 				'TV: Sport' => '72',
 				'TV: HEVC/x265' => '77',
 				'Unsorted: Unsorted' => '78'
-			),
+			],
 			'defaultValue' => '(ALL TYPES)'
-		),
-		'status' => array(
+		],
+		'status' => [
 			'type' => 'list',
 			'name' => 'Status',
-			'values' => array(
+			'values' => [
 				'Active Transfers' => '0',
 				'Included Dead' => '1',
 				'Only Dead' => '2'
-			),
+			],
 			'defaultValue' => 'Included Dead'
-		),
-		'lang' => array(
+		],
+		'lang' => [
 			'type' => 'list',
 			'name' => 'Lang',
-			'values' => array(
+			'values' => [
 				'(ALL)' => '0',
 				'Arabic' => '17',
 				'Chinese ' => '10',
@@ -89,10 +89,10 @@ class ETTVBridge extends BridgeAbstract {
 				'Russian' => '7',
 				'Spanish' => '6',
 				'Turkish' => '16'
-			),
+			],
 			'defaultValue' => '(ALL)'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		// No control on inputs, because all have defaultValue set
@@ -122,7 +122,7 @@ class ETTVBridge extends BridgeAbstract {
 			$dllinks = $page->find('div#downloadbox table', 0);
 
 			// fill item
-			$item = array();
+			$item = [];
 			$item['author'] = $details->children(6)->children(1)->plaintext;
 			$item['title'] = $entry->title;
 			$item['uri'] = $dllinks->children(0)->children(0)->children(0)->href;

--- a/bridges/EZTVBridge.php
+++ b/bridges/EZTVBridge.php
@@ -7,13 +7,13 @@ class EZTVBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns list of *recent* torrents for a specific show
 on EZTV. Get showID from URLs in https://eztv.ch/shows/showID/show-full-name.';
 
-	const PARAMETERS = array( array(
-		'i' => array(
+	const PARAMETERS = [ [
+		'i' => [
 			'name' => 'Show ids',
 			'exampleValue' => 'showID1,showID2,…',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 
@@ -53,7 +53,7 @@ on EZTV. Get showID from URLs in https://eztv.ch/shows/showID/show-full-name.';
 				if($released->plaintext == '&gt;1 week') continue;
 
 				// Fill item
-				$item = array();
+				$item = [];
 				$item['uri'] = self::URI . $epinfo->href;
 				$item['id'] = $item['uri'];
 				$item['timestamp'] = makeTimestamp($released->plaintext);

--- a/bridges/EliteDangerousGalnetBridge.php
+++ b/bridges/EliteDangerousGalnetBridge.php
@@ -12,7 +12,7 @@ class EliteDangerousGalnetBridge extends BridgeAbstract {
 			or returnServerError('Error while downloading the website content');
 
 		foreach($html->find('div.article') as $element) {
-			$item = array();
+			$item = [];
 
 			$uri = $element->find('h3 a', 0)->href;
 			$uri = self::URI . substr($uri, strlen('/galnet/'));

--- a/bridges/ElloBridge.php
+++ b/bridges/ElloBridge.php
@@ -7,28 +7,28 @@ class ElloBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 4800; //2hours
 	const DESCRIPTION = 'Returns the newest posts for Ello';
 
-	const PARAMETERS = array(
-		'By User' => array(
-			'u' => array(
+	const PARAMETERS = [
+		'By User' => [
+			'u' => [
 				'name' => 'Username',
 				'required' => true,
 				'title' => 'Username'
-			)
-		),
-		'Search' => array(
-			's' => array(
+			]
+		],
+		'Search' => [
+			's' => [
 				'name' => 'Search',
 				'required' => true,
 				'title' => 'Search'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData() {
 
-		$header = array(
+		$header = [
 			'Authorization: Bearer ' . $this->getAPIKey()
-		);
+		];
 
 		if(!empty($this->getInput('u'))) {
 			$postData = getContents(self::URI . 'api/v2/users/~' . urlencode($this->getInput('u')) . '/posts', $header) or
@@ -42,7 +42,7 @@ class ElloBridge extends BridgeAbstract {
 		$count = 0;
 		foreach($postData->posts as $post) {
 
-			$item = array();
+			$item = [];
 			$item['author'] = $this->getUsername($post, $postData);
 			$item['timestamp'] = strtotime($post->created_at);
 			$item['title'] = $this->findText($post->summary);

--- a/bridges/ElsevierBridge.php
+++ b/bridges/ElsevierBridge.php
@@ -7,14 +7,14 @@ class ElsevierBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 43200; //12h
 	const DESCRIPTION = 'Returns the recent articles published in Elsevier journals';
 
-	const PARAMETERS = array( array(
-		'j' => array(
+	const PARAMETERS = [ [
+		'j' => [
 			'name' => 'Journal name',
 			'required' => true,
 			'exampleValue' => 'academic-pediactrics',
 			'title' => 'Insert html-part of your journal'
-		)
-	));
+		]
+	]];
 
 	// Extracts the list of names from an article as string
 	private function extractArticleName($article){
@@ -63,7 +63,7 @@ class ElsevierBridge extends BridgeAbstract {
 			or returnServerError('No results for Elsevier journal ' . $this->getInput('j'));
 
 		foreach($html->find('.pod-listing') as $article) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $article->find('.pod-listing-header>a', 0)->getAttribute('href') . '?np=y';
 			$item['title'] = $article->find('.pod-listing-header>a', 0)->plaintext;
 			$item['author'] = $this->extractArticleName($article);

--- a/bridges/EstCeQuonMetEnProdBridge.php
+++ b/bridges/EstCeQuonMetEnProdBridge.php
@@ -21,7 +21,7 @@ class EstCeQuonMetEnProdBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM($this->getURI())
 			or returnServerError('Could not request EstCeQuonMetEnProd: ' . $this->getURI());
 
-		$item = array();
+		$item = [];
 		$item['uri'] = $this->getURI() . '#' . date('Y-m-d');
 		$item['title'] = $this->getName();
 		$item['author'] = 'Nicolas Hoffmann';

--- a/bridges/EtsyBridge.php
+++ b/bridges/EtsyBridge.php
@@ -5,32 +5,32 @@ class EtsyBridge extends BridgeAbstract {
 	const URI = 'https://www.etsy.com';
 	const DESCRIPTION = 'Returns feeds for search results';
 	const MAINTAINER = 'logmanoriginal';
-	const PARAMETERS = array(
-		array(
-			'query' => array(
+	const PARAMETERS = [
+		[
+			'query' => [
 				'name' => 'Search query',
 				'type' => 'text',
 				'required' => true,
 				'title' => 'Insert your search term here',
 				'exampleValue' => 'Enter your search term'
-			),
-			'queryextension' => array(
+			],
+			'queryextension' => [
 				'name' => 'Query extension',
 				'type' => 'text',
 				'requied' => false,
 				'title' => 'Insert additional query parts here
 (anything after ?search=<your search query>)',
 				'exampleValue' => '&explicit=1&locationQuery=2921044'
-			),
-			'showimage' => array(
+			],
+			'showimage' => [
 				'name' => 'Show image in content',
 				'type' => 'checkbox',
 				'requrired' => false,
 				'title' => 'Activate to show the image in the content',
 				'defaultValue' => false
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM($this->getURI())
@@ -43,7 +43,7 @@ class EtsyBridge extends BridgeAbstract {
 			if($result->find('a.banner-card'))
 				continue;
 
-			$item = array();
+			$item = [];
 
 			$item['title'] = $result->find('a', 0)->title;
 			$item['uri'] = $result->find('a', 0)->href;
@@ -61,7 +61,7 @@ class EtsyBridge extends BridgeAbstract {
 				$item['content'] .= '<img src="' . $image . '">';
 			}
 
-			$item['enclosures'] = array($image);
+			$item['enclosures'] = [$image];
 
 			$this->items[] = $item;
 		}

--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -8,12 +8,12 @@ class FB2Bridge extends BridgeAbstract {
 	const DESCRIPTION = 'Input a page title or a profile log. For a profile log,
  please insert the parameter as follow : myExamplePage/132621766841117';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'Username',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 
@@ -41,7 +41,7 @@ class FB2Bridge extends BridgeAbstract {
 
 		//Utility function for converting facebook emoticons
 		$unescape_fb_emote = function($matches){
-			static $facebook_emoticons = array(
+			static $facebook_emoticons = [
 				'smile' => ':)',
 				'frown' => ':(',
 				'tongue' => ':P',
@@ -62,7 +62,7 @@ class FB2Bridge extends BridgeAbstract {
 				'confused' => 'o_O',
 				'upset' => 'xD',
 				'colonthree' => ':3',
-				'like' => '&#x1F44D;');
+				'like' => '&#x1F44D;'];
 			$len = count($matches);
 			if ($len > 1)
 				for ($i = 1; $i < $len; $i++)
@@ -105,7 +105,7 @@ EOD;
 
 		foreach($html->find("article") as $content) {
 
-			$item = array();
+			$item = [];
 
 			$item['uri'] = "http://touch.facebook.com"
 			. $content->find("div[class='_52jc _5qc4 _24u0 _36xo']", 0)->find("a", 0)->getAttribute("href");
@@ -125,7 +125,7 @@ EOD;
 			$content = preg_replace_callback('/ href=\"([^"]+)\"/i', $unescape_fb_link, $content);
 
 			//Clean useless html tag properties and fix link closing tags
-			foreach (array(
+			foreach ([
 				'onmouseover',
 				'onclick',
 				'target',
@@ -137,7 +137,7 @@ EOD;
 				'aria-[^=]*',
 				'role',
 				'rel',
-				'id') as $property_name)
+				'id'] as $property_name)
 					$content = preg_replace('/ ' . $property_name . '=\"[^"]*\"/i', '', $content);
 			$content = preg_replace('/<\/a [^>]+>/i', '</a>', $content);
 
@@ -167,21 +167,21 @@ EOD;
 
 		$regex = implode(
 			'',
-			array(
+			[
 				"/timeline_unit",
 				"\\\\\\\\u00253A1",
 				"\\\\\\\\u00253A([0-9]*)",
 				"\\\\\\\\u00253A([0-9]*)",
 				"\\\\\\\\u00253A([0-9]*)",
 				"\\\\\\\\u00253A([0-9]*)/"
-			)
+			]
 		);
 
 		preg_match($regex, $string, $result);
 
 		return implode(
 			'',
-			array(
+			[
 				"https://touch.facebook.com/pages_reaction_units/more/?page_id=",
 				$pageID,
 				"&cursor=%7B%22timeline_cursor%22%3A%22timeline_unit%3A1%3A",
@@ -194,7 +194,7 @@ EOD;
 				$result[4],
 				"%22%2C%22timeline_section_cursor%22%3A%7B%7D%2C%22",
 				"has_next_page%22%3Atrue%7D&surface=mobile_page_home&unit_count=3"
-			)
+			]
 		);
 	}
 
@@ -212,12 +212,12 @@ EOD;
 	//the page if no cookie is provided.
 	private function getCookies($pageURL){
 
-		$ctx = stream_context_create(array(
-			'http' => array(
+		$ctx = stream_context_create([
+			'http' => [
 				'user_agent' => "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0",
 				'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
-				)
-			)
+				]
+			]
 		);
 		$a = file_get_contents($pageURL, 0, $ctx);
 
@@ -237,12 +237,12 @@ EOD;
 	//Get the page ID from the Facebook page.
 	private function getPageID($page, $cookies){
 
-		$context = stream_context_create(array(
-			'http' => array(
+		$context = stream_context_create([
+			'http' => [
 				'user_agent' => "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0",
 				'header' => 'Cookie: ' . $cookies
-				)
-			)
+				]
+			]
 		);
 
 		$pageContent = file_get_contents($page, 0, $context);

--- a/bridges/FDroidBridge.php
+++ b/bridges/FDroidBridge.php
@@ -7,17 +7,17 @@ class FDroidBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 60 * 60 * 2; // 2 hours
 	const DESCRIPTION = 'Returns latest added/updated apps on the open-source Android apps repository F-Droid';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'Widget selection',
 			'type' => 'list',
 			'required' => true,
-			'values' => array(
+			'values' => [
 				'Latest added apps' => 'added',
 				'Latest updated apps' => 'updated'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	public function collectData(){
 		$url = self::URI;
@@ -39,7 +39,7 @@ class FDroidBridge extends BridgeAbstract {
 		// and now extracting app info from the selected widget (and yeah turns out icons are of heterogeneous sizes)
 
 		foreach($html_widget->find('a') as $element) {
-				$item = array();
+				$item = [];
 				$item['uri'] = self::URI . $element->href;
 				$item['title'] = $element->find('h4', 0)->plaintext;
 				$item['icon'] = $element->find('img', 0)->src;

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -8,23 +8,23 @@ class FacebookBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Input a page title or a profile log. For a profile log,
  please insert the parameter as follow : myExamplePage/132621766841117';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'Username',
 			'required' => true
-		),
-		'media_type' => array(
+		],
+		'media_type' => [
 			'name' => 'Media type',
 			'type' => 'list',
 			'required' => false,
-			'values' => array(
+			'values' => [
 				'All' => 'all',
 				'Video' => 'video',
 				'No Video' => 'novideo'
-			),
+			],
 			'defaultValue' => 'all'
-		)
-	));
+		]
+	]];
 
 	private $authorName = '';
 
@@ -55,7 +55,7 @@ class FacebookBridge extends BridgeAbstract {
 
 		//Utility function for converting facebook emoticons
 		$unescape_fb_emote = function($matches){
-			static $facebook_emoticons = array(
+			static $facebook_emoticons = [
 				'smile' => ':)',
 				'frown' => ':(',
 				'tongue' => ':P',
@@ -76,7 +76,7 @@ class FacebookBridge extends BridgeAbstract {
 				'confused' => 'o_O',
 				'upset' => 'xD',
 				'colonthree' => ':3',
-				'like' => '&#x1F44D;');
+				'like' => '&#x1F44D;'];
 			$len = count($matches);
 			if ($len > 1)
 				for ($i = 1; $i < $len; $i++)
@@ -97,12 +97,12 @@ class FacebookBridge extends BridgeAbstract {
 				$captcha_fields = $_SESSION['captcha_fields'];
 				$captcha_fields['captcha_response'] = preg_replace("/[^a-zA-Z0-9]+/", "", $_POST['captcha_response']);
 
-				$header = array("Content-type:
-application/x-www-form-urlencoded\r\nReferer: $captcha_action\r\nCookie: noscript=1\r\n");
-				$opts = array(
+				$header = ["Content-type:
+application/x-www-form-urlencoded\r\nReferer: $captcha_action\r\nCookie: noscript=1\r\n"];
+				$opts = [
 					CURLOPT_POST => 1,
 					CURLOPT_POSTFIELDS => http_build_query($captcha_fields)
-				);
+				];
 
 				$html = getContents($captcha_action, $header, $opts);
 
@@ -118,7 +118,7 @@ application/x-www-form-urlencoded\r\nReferer: $captcha_action\r\nCookie: noscrip
 
 		//Retrieve page contents
 		if(is_null($html)) {
-			$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE') . "\r\n");
+			$header = ['Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE') . "\r\n"];
 
 			// First character cannot be a forward slash
 			if(strpos($this->getInput('u'), "/") === 0) {
@@ -140,7 +140,7 @@ application/x-www-form-urlencoded\r\nReferer: $captcha_action\r\nCookie: noscrip
 			//Save form for submitting after getting captcha response
 			if (session_status() == PHP_SESSION_NONE)
 				session_start();
-			$captcha_fields = array();
+			$captcha_fields = [];
 			foreach ($captcha->find('input, button') as $input)
 				$captcha_fields[$input->name] = $input->value;
 			$_SESSION['captcha_fields'] = $captcha_fields;
@@ -192,7 +192,7 @@ EOD;
 				if(strpos($cell->class, '_3xaf') !== false) {
 					$posts = $cell->children();
 				} else {
-					$posts = array($cell);
+					$posts = [$cell];
 				}
 
 				foreach($posts as $post) {
@@ -208,7 +208,7 @@ EOD;
 						default: break;
 					}
 
-					$item = array();
+					$item = [];
 
 					if(count($post->find('abbr')) > 0) {
 
@@ -240,7 +240,7 @@ EOD;
 						$content = preg_replace_callback('/ href=\"([^"]+)\"/i', $unescape_fb_link, $content);
 
 						//Clean useless html tag properties and fix link closing tags
-						foreach (array(
+						foreach ([
 							'onmouseover',
 							'onclick',
 							'target',
@@ -252,7 +252,7 @@ EOD;
 							'aria-[^=]*',
 							'role',
 							'rel',
-							'id') as $property_name)
+							'id'] as $property_name)
 								$content = preg_replace('/ ' . $property_name . '=\"[^"]*\"/i', '', $content);
 						$content = preg_replace('/<\/a [^>]+>/i', '</a>', $content);
 

--- a/bridges/FeedExpanderExampleBridge.php
+++ b/bridges/FeedExpanderExampleBridge.php
@@ -6,23 +6,23 @@ class FeedExpanderExampleBridge extends FeedExpander {
 	const URI = '#';
 	const DESCRIPTION = 'Example bridge to test FeedExpander';
 
-	const PARAMETERS = array(
-		'Feed' => array(
-			'version' => array(
+	const PARAMETERS = [
+		'Feed' => [
+			'version' => [
 				'name' => 'Version',
 				'type' => 'list',
 				'required' => true,
 				'title' => 'Select your feed format/version',
 				'defaultValue' => 'RSS 2.0',
-				'values' => array(
+				'values' => [
 					'RSS 0.91' => 'rss_0_9_1',
 					'RSS 1.0' => 'rss_1_0',
 					'RSS 2.0' => 'rss_2_0',
 					'ATOM 1.0' => 'atom_1_0'
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	public function collectData(){
 		switch($this->getInput('version')) {

--- a/bridges/FierPandaBridge.php
+++ b/bridges/FierPandaBridge.php
@@ -12,7 +12,7 @@ class FierPandaBridge extends BridgeAbstract {
 			or returnServerError('Could not request Fier Panda.');
 
 		foreach($html->find('div.container-content article') as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $this->getURI() . $element->find('a', 0)->href;
 			$item['title'] = trim($element->find('h1 a', 0)->innertext);
 			// Remove the link at the end of the article

--- a/bridges/FilterBridge.php
+++ b/bridges/FilterBridge.php
@@ -7,26 +7,26 @@ class FilterBridge extends FeedExpander {
 	const CACHE_TIMEOUT = 3600; // 1h
 	const DESCRIPTION = 'Filters a feed of your choice';
 
-	const PARAMETERS = array(array(
-		'url' => array(
+	const PARAMETERS = [[
+		'url' => [
 			'name' => 'Feed URL',
 			'required' => true,
-		),
-		'filter' => array(
+		],
+		'filter' => [
 			'name' => 'Filter item title (regular expression)',
 			'required' => false,
-		),
-		'filter_type' => array(
+		],
+		'filter_type' => [
 			'name' => 'Filter type',
 			'type' => 'list',
 			'required' => false,
-			'values' => array(
+			'values' => [
 				'Permit' => 'permit',
 				'Block' => 'block',
-			),
+			],
 			'defaultValue' => 'permit',
-		),
-	));
+		],
+	]];
 
 	protected function parseItem($newItem){
 		$item = parent::parseItem($newItem);

--- a/bridges/FlickrBridge.php
+++ b/bridges/FlickrBridge.php
@@ -11,27 +11,27 @@ class FlickrBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 21600; // 6 hours
 	const DESCRIPTION = 'Returns images from Flickr';
 
-	const PARAMETERS = array(
-		'Explore' => array(),
-		'By keyword' => array(
-			'q' => array(
+	const PARAMETERS = [
+		'Explore' => [],
+		'By keyword' => [
+			'q' => [
 				'name' => 'Keyword',
 				'type' => 'text',
 				'required' => true,
 				'title' => 'Insert keyword',
 				'exampleValue' => 'bird'
-			)
-		),
-		'By username' => array(
-			'u' => array(
+			]
+		],
+		'By username' => [
+			'u' => [
 				'name' => 'Username',
 				'type' => 'text',
 				'required' => true,
 				'title' => 'Insert username (as shown in the address bar)',
 				'exampleValue' => 'flickr'
-			)
-		),
-	);
+			]
+		],
+	];
 
 	public function collectData(){
 		switch($this->queriedContext) {
@@ -85,7 +85,7 @@ class FlickrBridge extends BridgeAbstract {
 			// Use JSON data to build items
 			foreach(reset($model_json)[0][$key]['_data'] as $element) {
 				if($element['id'] === $imageID) {
-					$item = array();
+					$item = [];
 
 					/* Author name depends on scope. On a keyword search the
 					 * author is part of the picture data. On a username search

--- a/bridges/FootitoBridge.php
+++ b/bridges/FootitoBridge.php
@@ -11,53 +11,53 @@ class FootitoBridge extends BridgeAbstract {
 			or returnServerError('Could not request Footito.');
 
 		foreach($html->find('div.post') as $element) {
-			$item = array();
+			$item = [];
 
 			$content = trim($element->innertext);
 			$content = str_replace(
 				"<img",
 				"<img style='float : left;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"logo\"",
 				"style='float : left;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"contenu\"",
 				"style='margin-left : 60px;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"responsive-comment\"",
 				"style='border-top : 1px #DDD solid; background-color : white; padding : 10px;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"jaime\"",
 				"style='display : none;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"auteur-event responsive\"",
 				"style='display : none;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"report-abuse-button\"",
 				"style='display : none;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"reaction clearfix\"",
 				"style='margin : 10px 0px; padding : 5px; border-bottom : 1px #DDD solid;'",
-				$content );
+				$content);
 
 			$content = str_replace(
 				"class=\"infos\"",
 				"style='font-size : 0.7em;'",
-				$content );
+				$content);
 
 			$item['content'] = $content;
 

--- a/bridges/FourchanBridge.php
+++ b/bridges/FourchanBridge.php
@@ -7,17 +7,17 @@ class FourchanBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 300; // 5min
 	const DESCRIPTION = 'Returns posts from the specified thread';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'Thread category',
 			'required' => true
-		),
-		't' => array(
+		],
+		't' => [
 			'name' => 'Thread number',
 			'type' => 'number',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function getURI(){
 		if(!is_null($this->getInput('c')) && !is_null($this->getInput('t'))) {
@@ -33,7 +33,7 @@ class FourchanBridge extends BridgeAbstract {
 			or returnServerError("Could not request 4chan, thread not found");
 
 		foreach($html->find('div.postContainer') as $element) {
-			$item = array();
+			$item = [];
 			$item['id'] = $element->find('.post', 0)->getAttribute('id');
 			$item['uri'] = $this->getURI() . '#' . $item['id'];
 			$item['timestamp'] = $element->find('span.dateTime', 0)->getAttribute('data-utc');

--- a/bridges/FuturaSciencesBridge.php
+++ b/bridges/FuturaSciencesBridge.php
@@ -6,77 +6,77 @@ class FuturaSciencesBridge extends FeedExpander {
 	const URI = 'http://www.futura-sciences.com/';
 	const DESCRIPTION = 'Returns the newest articles.';
 
-	const PARAMETERS = array( array(
-		'feed' => array(
+	const PARAMETERS = [ [
+		'feed' => [
 			'name' => 'Feed',
 			'type' => 'list',
-			'values' => array(
-				'Les flux multi-magazines' => array(
+			'values' => [
+				'Les flux multi-magazines' => [
 					'Les dernières actualités de Futura-Sciences' => 'actualites',
 					'Les dernières définitions de Futura-Sciences' => 'definitions',
 					'Les dernières photos de Futura-Sciences' => 'photos',
 					'Les dernières questions - réponses de Futura-Sciences' => 'questions-reponses',
 					'Les derniers dossiers de Futura-Sciences' => 'dossiers'
-				),
-				'Les flux Services' => array(
+				],
+				'Les flux Services' => [
 					'Les cartes virtuelles de Futura-Sciences' => 'services/cartes-virtuelles',
 					'Les fonds d\'écran de Futura-Sciences' => 'services/fonds-ecran'
-				),
-				'Les flux Santé' => array(
+				],
+				'Les flux Santé' => [
 					'Les dernières actualités de Futura-Santé' => 'sante/actualites',
 					'Les dernières définitions de Futura-Santé' => 'sante/definitions',
 					'Les dernières questions-réponses de Futura-Santé' => 'sante/question-reponses',
 					'Les derniers dossiers de Futura-Santé' => 'sante/dossiers'
-				),
-				'Les flux High-Tech' => array(
+				],
+				'Les flux High-Tech' => [
 					'Les dernières actualités de Futura-High-Tech' => 'high-tech/actualites',
 					'Les dernières astuces de Futura-High-Tech' => 'high-tech/question-reponses',
 					'Les dernières définitions de Futura-High-Tech' => 'high-tech/definitions',
 					'Les derniers dossiers de Futura-High-Tech' => 'high-tech/dossiers'
-				),
-				'Les flux Espace' => array(
+				],
+				'Les flux Espace' => [
 					'Les dernières actualités de Futura-Espace' => 'espace/actualites',
 					'Les dernières définitions de Futura-Espace' => 'espace/definitions',
 					'Les dernières questions-réponses de Futura-Espace' => 'espace/question-reponses',
 					'Les derniers dossiers de Futura-Espace' => 'espace/dossiers'
-				),
-				'Les flux Environnement' => array(
+				],
+				'Les flux Environnement' => [
 					'Les dernières actualités de Futura-Environnement' => 'environnement/actualites',
 					'Les dernières définitions de Futura-Environnement' => 'environnement/definitions',
 					'Les dernières questions-réponses de Futura-Environnement' => 'environnement/question-reponses',
 					'Les derniers dossiers de Futura-Environnement' => 'environnement/dossiers'
-				),
-				'Les flux Maison' => array(
+				],
+				'Les flux Maison' => [
 					'Les dernières actualités de Futura-Maison' => 'maison/actualites',
 					'Les dernières astuces de Futura-Maison' => 'maison/question-reponses',
 					'Les dernières définitions de Futura-Maison' => 'maison/definitions',
 					'Les derniers dossiers de Futura-Maison' => 'maison/dossiers'
-				),
-				'Les flux Nature' => array(
+				],
+				'Les flux Nature' => [
 					'Les dernières actualités de Futura-Nature' => 'nature/actualites',
 					'Les dernières définitions de Futura-Nature' => 'nature/definitions',
 					'Les dernières questions-réponses de Futura-Nature' => 'nature/question-reponses',
 					'Les derniers dossiers de Futura-Nature' => 'nature/dossiers'
-				),
-				'Les flux Terre' => array(
+				],
+				'Les flux Terre' => [
 					'Les dernières actualités de Futura-Terre' => 'terre/actualites',
 					'Les dernières définitions de Futura-Terre' => 'terre/definitions',
 					'Les dernières questions-réponses de Futura-Terre' => 'terre/question-reponses',
 					'Les derniers dossiers de Futura-Terre' => 'terre/dossiers'
-				),
-				'Les flux Matière' => array(
+				],
+				'Les flux Matière' => [
 					'Les dernières actualités de Futura-Matière' => 'matiere/actualites',
 					'Les dernières définitions de Futura-Matière' => 'matiere/definitions',
 					'Les dernières questions-réponses de Futura-Matière' => 'matiere/question-reponses',
 					'Les derniers dossiers de Futura-Matière' => 'matiere/dossiers'
-				),
-				'Les flux Mathématiques' => array(
+				],
+				'Les flux Mathématiques' => [
 					'Les dernières actualités de Futura-Mathématiques' => 'mathematiques/actualites',
 					'Les derniers dossiers de Futura-Mathématiques' => 'mathematiques/dossiers'
-				)
-			)
-		)
-	));
+				]
+			]
+		]
+	]];
 
 	public function collectData(){
 		$url = self::URI . 'rss/' . $this->getInput('feed') . '.xml';
@@ -132,7 +132,7 @@ class FuturaSciencesBridge extends FeedExpander {
 		if(!empty($headline))
 			$headline = '<p><b>' . $headline . '</b></p>';
 
-		foreach (array(
+		foreach ([
 			'<div class="clear',
 			'<div class="sharebar2',
 			'<div class="diaporamafullscreen"',
@@ -147,7 +147,7 @@ class FuturaSciencesBridge extends FeedExpander {
 			'<div class="httplogbar-wrapper noprint',
 			'<div id="forumcomments',
 			'<div ng-if="active"'
-		) as $div_start) {
+		] as $div_start) {
 			$contents = $this->stripRecursiveHTMLSection($contents, 'div', $div_start);
 		}
 

--- a/bridges/GBAtempBridge.php
+++ b/bridges/GBAtempBridge.php
@@ -6,19 +6,19 @@ class GBAtempBridge extends BridgeAbstract {
 	const URI = 'https://gbatemp.net/';
 	const DESCRIPTION = 'GBAtemp is a user friendly underground video game community.';
 
-	const PARAMETERS = array( array(
-		'type' => array(
+	const PARAMETERS = [ [
+		'type' => [
 			'name' => 'Type',
 			'type' => 'list',
 			'required' => true,
-			'values' => array(
+			'values' => [
 				'News' => 'N',
 				'Reviews' => 'R',
 				'Tutorials' => 'T',
 				'Forum' => 'F'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	private function extractFromDelimiters($string, $start, $end){
 		if(strpos($string, $start) !== false) {
@@ -41,7 +41,7 @@ class GBAtempBridge extends BridgeAbstract {
 	}
 
 	private function buildItem($uri, $title, $author, $timestamp, $content){
-		$item = array();
+		$item = [];
 		$item['uri'] = $uri;
 		$item['title'] = $title;
 		$item['author'] = $author;
@@ -88,6 +88,7 @@ class GBAtempBridge extends BridgeAbstract {
 				$content = $this->fetchPostContent($url, self::URI);
 				$this->items[] = $this->buildItem($url, $title, $author, $time, $content);
 			}
+			// no break
 		case 'R':
 			foreach($html->find('li.portal_review') as $reviewItem) {
 				$url = self::URI . $reviewItem->find('a', 0)->href;
@@ -110,6 +111,7 @@ class GBAtempBridge extends BridgeAbstract {
 				$content = $this->cleanupPostContent($intro . $review . $subheader . $procons . $scores, self::URI);
 				$this->items[] = $this->buildItem($url, $title, $author, $time, $content);
 			}
+			// no break
 		case 'T':
 			foreach($html->find('li.portal-tutorial') as $tutorialItem) {
 				$url = self::URI . $tutorialItem->find('a', 0)->href;
@@ -125,6 +127,7 @@ class GBAtempBridge extends BridgeAbstract {
 				$content = $this->fetchPostContent($url, self::URI);
 				$this->items[] = $this->buildItem($url, $title, $author, $time, $content);
 			}
+			// no break
 		case 'F':
 			foreach($html->find('li.rc_item') as $postItem) {
 				$url = self::URI . $postItem->find('a', 1)->href;
@@ -147,7 +150,7 @@ class GBAtempBridge extends BridgeAbstract {
 		if(!is_null($this->getInput('type'))) {
 			$type = array_search(
 				$this->getInput('type'),
-				self::PARAMETERS[$this->queriedContext]['type']['values']
+				self::PARAMETERS[$this->queriedContext]['type']['values'], true
 			);
 			return 'GBAtemp ' . $type . ' Bridge';
 		}

--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -9,16 +9,16 @@ class GiphyBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 300; //5min
 	const DESCRIPTION = 'Bridge for giphy.com';
 
-	const PARAMETERS = array( array(
-		's' => array(
+	const PARAMETERS = [ [
+		's' => [
 			'name' => 'search tag',
 			'required' => true
-		),
-		'n' => array(
+		],
+		'n' => [
 			'name' => 'max number of returned items',
 			'type' => 'number'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = '';
@@ -44,7 +44,7 @@ class GiphyBridge extends BridgeAbstract {
 				$img = $figure->firstChild();
 				$caption = $figure->lastChild();
 
-				$item = array();
+				$item = [];
 				$item['id'] = $img->getAttribute('data-gif_id');
 				$item['uri'] = $img->getAttribute('data-bitly_gif_url');
 				$item['username'] = 'Giphy - ' . ucfirst($kw);

--- a/bridges/GithubIssueBridge.php
+++ b/bridges/GithubIssueBridge.php
@@ -7,31 +7,31 @@ class GithubIssueBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 600; // 10min
 	const DESCRIPTION = 'Returns the issues or comments of an issue of a github project';
 
-	const PARAMETERS = array(
-		'global' => array(
-			'u' => array(
+	const PARAMETERS = [
+		'global' => [
+			'u' => [
 				'name' => 'User name',
 				'required' => true
-			),
-			'p' => array(
+			],
+			'p' => [
 				'name' => 'Project name',
 				'required' => true
-			)
-		),
-		'Project Issues' => array(
-			'c' => array(
+			]
+		],
+		'Project Issues' => [
+			'c' => [
 				'name' => 'Show Issues Comments',
 				'type' => 'checkbox'
-			)
-		),
-		'Issue comments' => array(
-			'i' => array(
+			]
+		],
+		'Issue comments' => [
+			'i' => [
 				'name' => 'Issue number',
 				'type' => 'number',
 				'required' => 'true'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function getName(){
 		$name = $this->getInput('u') . '/' . $this->getInput('p');
@@ -70,7 +70,7 @@ class GithubIssueBridge extends BridgeAbstract {
 		$class = $comment->getAttribute('class');
 		$classes = explode(' ', $class);
 		$event = false;
-		if(in_array('discussion-item', $classes)) {
+		if(in_array('discussion-item', $classes, true)) {
 			$event = true;
 		}
 
@@ -89,11 +89,11 @@ class GithubIssueBridge extends BridgeAbstract {
 		if($event) {
 			$title .= ' / ' . substr($class, strpos($class, 'discussion-item-') + strlen('discussion-item-'));
 			if(!$comment->hasAttribute('id')) {
-				$items = array();
+				$items = [];
 				$timestamp = strtotime($comment->find('relative-time', 0)->getAttribute('datetime'));
 				$content = $comment->innertext;
 				while($comment = $comment->nextSibling()) {
-					$item = array();
+					$item = [];
 					$item['author'] = $author;
 					$item['title'] = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
 					$item['timestamp'] = $timestamp;
@@ -109,7 +109,7 @@ class GithubIssueBridge extends BridgeAbstract {
 			$content = "<pre>" . $comment->find('.comment-body', 0)->innertext . "</pre>";
 		}
 
-		$item = array();
+		$item = [];
 		$item['author'] = $author;
 		$item['uri'] = $uri . '#' . $comment->getAttribute('id');
 		$item['title'] = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
@@ -119,17 +119,17 @@ class GithubIssueBridge extends BridgeAbstract {
 	}
 
 	protected function extractIssueComments($issue){
-		$items = array();
+		$items = [];
 		$title = $issue->find('.gh-header-title', 0)->plaintext;
 		$issueNbr = trim(substr($issue->find('.gh-header-number', 0)->plaintext, 1));
 		$comments = $issue->find('.js-discussion', 0);
 		foreach($comments->children() as $comment) {
 			$classes = explode(' ', $comment->getAttribute('class'));
-			if(in_array('discussion-item', $classes)
-			|| in_array('timeline-comment-wrapper', $classes)) {
+			if(in_array('discussion-item', $classes, true)
+			|| in_array('timeline-comment-wrapper', $classes, true)) {
 				$item = $this->extractIssueComment($issueNbr, $title, $comment);
 				if(array_keys($item) !== range(0, count($item) - 1)) {
-					$item = array($item);
+					$item = [$item];
 				}
 				$items = array_merge($items, $item);
 			}
@@ -150,7 +150,7 @@ class GithubIssueBridge extends BridgeAbstract {
 				$info = $issue->find('.opened-by', 0);
 				$issueNbr = substr(trim($info->plaintext), 1, strpos(trim($info->plaintext), ' '));
 
-				$item = array();
+				$item = [];
 				$item['content'] = '';
 
 				if($this->getInput('c')) {

--- a/bridges/GithubSearchBridge.php
+++ b/bridges/GithubSearchBridge.php
@@ -6,26 +6,26 @@ class GithubSearchBridge extends BridgeAbstract {
 	const URI = 'https://github.com/';
 	const CACHE_TIMEOUT = 600; // 10min
 	const DESCRIPTION = 'Returns a specified repositories search (sorted by recently updated)';
-	const PARAMETERS = array( array(
-		's' => array(
+	const PARAMETERS = [ [
+		's' => [
 			'type' => 'text',
 			'name' => 'Search query'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
-		$params = array('utf8' => '✓',
+		$params = ['utf8' => '✓',
 										'q' => urlencode($this->getInput('s')),
 										's' => 'updated',
 										'o' => 'desc',
-										'type' => 'Repositories');
+										'type' => 'Repositories'];
 		$url = self::URI . 'search?' . http_build_query($params);
 
 		$html = getSimpleHTMLDOM($url)
 			or returnServerError('Error while downloading the website content');
 
 		foreach($html->find('div.repo-list-item') as $element) {
-			$item = array();
+			$item = [];
 
 			$uri = $element->find('h3 a', 0)->href;
 			$uri = substr(self::URI, 0, -1) . $uri;

--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -6,13 +6,13 @@ class GoComicsBridge extends BridgeAbstract {
 	const URI = 'https://www.gocomics.com/';
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'The Unofficial GoComics RSS';
-	const PARAMETERS = array( array(
-		'comicname' => array(
+	const PARAMETERS = [ [
+		'comicname' => [
 			'name' => 'comicname',
 			'type' => 'text',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM($this->getURI())
@@ -24,7 +24,7 @@ class GoComicsBridge extends BridgeAbstract {
 		$link = self::URI . $html->find(".gc-deck--cta-0", 0)->find('a', 0)->href;
 		for($i = 0; $i < 5; $i++) {
 
-			$item = array();
+			$item = [];
 
 			$page = getSimpleHTMLDOM($link)
 				or returnServerError('Could not request GoComics: ' . $link);

--- a/bridges/GooglePlusPostBridge.php
+++ b/bridges/GooglePlusPostBridge.php
@@ -10,12 +10,12 @@ class GooglePlusPostBridge extends BridgeAbstract{
 	const CACHE_TIMEOUT = 600; //10min
 	const DESCRIPTION = 'Returns user public post (without API).';
 
-	const PARAMETERS = array( array(
-		'username' => array(
+	const PARAMETERS = [ [
+		'username' => [
 			'name' => 'username or Id',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$username = $this->getInput('username');
@@ -35,7 +35,7 @@ class GooglePlusPostBridge extends BridgeAbstract{
 
 		// I don't even know where to start with this discusting html...
 		foreach($html->find('div[jsname=WsjYwc]') as $post) {
-			$item = array();
+			$item = [];
 
 			$item['author'] = $item['fullname'] = $post->find('div div div div a', 0)->innertext;
 			$item['id'] = $post->find('div div div', 0)->getAttribute('id');

--- a/bridges/GoogleSearchBridge.php
+++ b/bridges/GoogleSearchBridge.php
@@ -15,12 +15,12 @@ class GoogleSearchBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 1800; // 30min
 	const DESCRIPTION = 'Returns most recent results from Google search.';
 
-	const PARAMETERS = array(array(
-		'q' => array(
+	const PARAMETERS = [[
+		'q' => [
 			'name' => "keyword",
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = '';
@@ -36,7 +36,7 @@ class GoogleSearchBridge extends BridgeAbstract {
 		if(!is_null($emIsRes)) {
 			foreach($emIsRes->find('div[class=g]') as $element) {
 
-				$item = array();
+				$item = [];
 
 				// Extract direct URL from google href (eg. /url?q=...)
 				$t = $element->find('a[href]', 0)->href;

--- a/bridges/GrandComicsDatabaseBridge.php
+++ b/bridges/GrandComicsDatabaseBridge.php
@@ -6,13 +6,13 @@ class GrandComicsDatabaseBridge extends BridgeAbstract {
 	const URI = 'https://www.comics.org/';
 	const CACHE_TIMEOUT = 7200; // 2h
 	const DESCRIPTION = 'Returns the latest comics added to a series timeline';
-	const PARAMETERS = array( array(
-		'series' => array(
+	const PARAMETERS = [ [
+		'series' => [
 			'name' => 'Series id (from the timeline URL)',
 			'required' => true,
 			'exampleValue' => '63051',
-		),
-	));
+		],
+	]];
 
 	public function collectData(){
 
@@ -49,7 +49,7 @@ class GrandComicsDatabaseBridge extends BridgeAbstract {
 			}
 
 			// Build final item
-			$item = array();
+			$item = [];
 			$item['title'] = $seriesName . ' - ' . $key_date;
 			$item['timestamp'] = strtotime($key_date);
 			$item['content'] = str_get_html($content);

--- a/bridges/HDWallpapersBridge.php
+++ b/bridges/HDWallpapersBridge.php
@@ -6,20 +6,20 @@ class HDWallpapersBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 43200; //12h
 	const DESCRIPTION = 'Returns the latests wallpapers from HDWallpapers';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'category',
 			'defaultValue' => 'latest_wallpapers'
-		),
-		'm' => array(
+		],
+		'm' => [
 			'name' => 'max number of wallpapers'
-		),
-		'r' => array(
+		],
+		'r' => [
 			'name' => 'resolution',
 			'defaultValue' => '1920x1200',
 			'exampleValue' => '1920x1200, 1680x1050,…'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$category = $this->category;
@@ -44,7 +44,7 @@ class HDWallpapersBridge extends BridgeAbstract {
 			foreach($html->find('.wallpapers .wall a') as $element) {
 				$thumbnail = $element->find('img', 0);
 
-				$item = array();
+				$item = [];
 				// http://www.hdwallpapers.in/download/yosemite_reflections-1680x1050.jpg
 				$item['uri'] = self::URI
 				. '/download'

--- a/bridges/HentaiHavenBridge.php
+++ b/bridges/HentaiHavenBridge.php
@@ -12,7 +12,7 @@ class HentaiHavenBridge extends BridgeAbstract {
 			or returnServerError('Could not request Hentai Haven.');
 
 		foreach($html->find('div.zoe-grid') as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $element->find('div.brick-content h3 a', 0)->href;
 			$thumbnailUri = $element->find('a.thumbnail-image img', 0)->getAttribute('data-src');
 			$item['title'] = mb_convert_encoding(

--- a/bridges/IPBBridge.php
+++ b/bridges/IPBBridge.php
@@ -5,24 +5,24 @@ class IPBBridge extends FeedExpander {
 	const URI = 'https://www.invisionpower.com';
 	const DESCRIPTION = 'Returns feeds for forums powered by IPB';
 	const MAINTAINER = 'logmanoriginal';
-	const PARAMETERS = array(
-		array(
-			'uri' => array(
+	const PARAMETERS = [
+		[
+			'uri' => [
 				'name' => 'URI',
 				'type' => 'text',
 				'required' => true,
 				'title' => 'Insert forum, subforum or topic URI',
 				'exampleValue' => 'https://invisioncommunity.com/forums/forum/499-feedback-and-ideas/'
-			),
-			'limit' => array(
+			],
+			'limit' => [
 				'name' => 'Limit',
 				'type' => 'number',
 				'required' => false,
 				'title' => 'Specifies the number of items to return on each request (-1: all)',
 				'defaultValue' => 10
-			)
-		)
-	);
+			]
+		]
+	];
 	const CACHE_TIMEOUT = 3600;
 
 	// Constants for internal use
@@ -69,7 +69,7 @@ class IPBBridge extends FeedExpander {
 			case $this->isTopic($html):
 				$this->collectTopic($html, $limit);
 				break;
-			case $this->isForum($html);
+			case $this->isForum($html):
 				$this->collectForum($html);
 				break;
 			default:
@@ -109,7 +109,7 @@ class IPBBridge extends FeedExpander {
 	private function collectForumList($html){
 		foreach($html->find(static::FORUM_TYPE_LIST_FILTER, 0)->children() as $row) {
 			// Columns: Title, Statistics, Last modified
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $row->find('a', 0)->href;
 			$item['title'] = $row->find('a', 0)->title;
@@ -123,7 +123,7 @@ class IPBBridge extends FeedExpander {
 	private function collectForumTable($html){
 		foreach($html->find(static::FORUM_TYPE_TABLE_FILTER, 0)->children() as $row) {
 			// Columns: Icon, Content, Preview, Statistics, Last modified
-			$item = array();
+			$item = [];
 
 			// Skip header row
 			if(!is_null($row->find('th', 0))) continue;
@@ -190,7 +190,7 @@ class IPBBridge extends FeedExpander {
 		}
 
 		foreach(array_reverse($html->find(static::TOPIC_TYPE_ARTICLE)) as $article) {
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $article->find('time', 0)->parent()->href;
 			$item['author'] = $article->find('aside a', 0)->plaintext;
@@ -240,7 +240,7 @@ class IPBBridge extends FeedExpander {
 		}
 
 		foreach(array_reverse($html->find(static::TOPIC_TYPE_DIV)) as $article) {
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $article->find('a[rel=bookmark]', 0)->href;
 			$item['author'] = $article->find('.author', 0)->plaintext;
@@ -267,7 +267,7 @@ class IPBBridge extends FeedExpander {
 
 	/** Returns all images from the provide HTML DOM */
 	private function findImages($html){
-		$images = array();
+		$images = [];
 
 		foreach($html->find('img') as $img) {
 			$images[] = $img->src;

--- a/bridges/IdenticaBridge.php
+++ b/bridges/IdenticaBridge.php
@@ -7,19 +7,19 @@ class IdenticaBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 300; // 5min
 	const DESCRIPTION = 'Returns user timelines';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'username',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM($this->getURI())
 			or returnServerError('Requested username can\'t be found.');
 
 		foreach($html->find('li.major') as $dent) {
-			$item = array();
+			$item = [];
 
 			// get dent link
 			$item['uri'] = html_entity_decode($dent->find('a', 0)->href);

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -6,35 +6,35 @@ class InstagramBridge extends BridgeAbstract {
 	const URI = 'https://instagram.com/';
 	const DESCRIPTION = 'Returns the newest images';
 
-	const PARAMETERS = array(
-		array(
-			'u' => array(
+	const PARAMETERS = [
+		[
+			'u' => [
 				'name' => 'username',
 				'required' => true
-			)
-		),
-		array(
-			'h' => array(
+			]
+		],
+		[
+			'h' => [
 				'name' => 'hashtag',
 				'required' => true
-			)
-		),
-		'global' => array(
-			'media_type' => array(
+			]
+		],
+		'global' => [
+			'media_type' => [
 				'name' => 'Media type',
 				'type' => 'list',
 				'required' => false,
-				'values' => array(
+				'values' => [
 					'All' => 'all',
 					'Story' => 'story',
 					'Video' => 'video',
 					'Picture' => 'picture',
-				),
+				],
 				'defaultValue' => 'all'
-			)
-		)
+			]
+		]
 
-	);
+	];
 
 	public function collectData(){
 
@@ -71,7 +71,7 @@ class InstagramBridge extends BridgeAbstract {
 				if($this->getInput('media_type') == 'video' && !$media->is_video) continue;
 			}
 
-			$item = array();
+			$item = [];
 			$item['uri'] = self::URI . 'p/' . $media->shortcode . '/';
 
 			if (isset($media->edge_media_to_caption->edges[0]->node->text)) {
@@ -86,7 +86,7 @@ class InstagramBridge extends BridgeAbstract {
 				$item['enclosures'] = $data[1];
 			} else {
 				$item['content'] = '<img src="' . htmlentities($media->display_url) . '" alt="'. $item["title"] . '" />';
-				$item['enclosures'] = array($media->display_url);
+				$item['enclosures'] = [$media->display_url];
 			}
 
 			$item['timestamp'] = $media->taken_at_timestamp;

--- a/bridges/IsoHuntBridge.php
+++ b/bridges/IsoHuntBridge.php
@@ -6,41 +6,41 @@ class IsoHuntBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 300; //5min
 	const DESCRIPTION = 'Returns the latest results by category or search result';
 
-	const PARAMETERS = array(
+	const PARAMETERS = [
 		/*
 		 * Get feeds for one of the "latest" categories
 		 * Notice: The categories "News" and "Top Searches" are received from the main page
 		 * Elements are sorted by name ascending!
 		 */
-		'By "Latest" category' => array(
-			'latest_category' => array(
+		'By "Latest" category' => [
+			'latest_category' => [
 				'name' => 'Latest category',
 				'type' => 'list',
 				'required' => true,
 				'title' => 'Select your category',
 				'defaultValue' => 'news',
-				'values' => array(
+				'values' => [
 					'Hot Torrents' => 'hot_torrents',
 					'News' => 'news',
 					'Releases' => 'releases',
 					'Torrents' => 'torrents'
-				)
-			)
-		),
+				]
+			]
+		],
 
 		/*
 		 * Get feeds for one of the "torrent" categories
 		 * Make sure to add new categories also to get_torrent_category_index($)!
 		 * Elements are sorted by name ascending!
 		 */
-		'By "Torrent" category' => array(
-			'torrent_category' => array(
+		'By "Torrent" category' => [
+			'torrent_category' => [
 				'name' => 'Torrent category',
 				'type' => 'list',
 				'required' => true,
 				'title' => 'Select your category',
 				'defaultValue' => 'anime',
-				'values' => array(
+				'values' => [
 					'Adult' => 'adult',
 					'Anime' => 'anime',
 					'Books' => 'books',
@@ -50,31 +50,31 @@ class IsoHuntBridge extends BridgeAbstract {
 					'Other' => 'other',
 					'Series & TV' => 'series_tv',
 					'Software' => 'software'
-				)
-			),
-			'torrent_popularity' => array(
+				]
+			],
+			'torrent_popularity' => [
 				'name' => 'Sort by popularity',
 				'type' => 'checkbox',
 				'title' => 'Activate to receive results by popularity'
-			)
-		),
+			]
+		],
 
 		/*
 		 * Get feeds for a specific search request
 		 */
-		'Search torrent by name' => array(
-			'search_name' => array(
+		'Search torrent by name' => [
+			'search_name' => [
 				'name' => 'Name',
 				'required' => true,
 				'title' => 'Insert your search query',
 				'exampleValue' => 'Bridge'
-			),
-			'search_category' => array(
+			],
+			'search_category' => [
 				'name' => 'Category',
 				'type' => 'list',
 				'title' => 'Select your category',
 				'defaultValue' => 'all',
-				'values' => array(
+				'values' => [
 					'Adult' => 'adult',
 					'All' => 'all',
 					'Anime' => 'anime',
@@ -85,10 +85,10 @@ class IsoHuntBridge extends BridgeAbstract {
 					'Other' => 'other',
 					'Series & TV' => 'series_tv',
 					'Software' => 'software'
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	public function getURI(){
 		$uri = self::URI;
@@ -132,21 +132,21 @@ class IsoHuntBridge extends BridgeAbstract {
 		case 'By "Latest" category':
 			$categoryName = array_search(
 					$this->getInput('latest_category'),
-					self::PARAMETERS['By "Latest" category']['latest_category']['values']
+					self::PARAMETERS['By "Latest" category']['latest_category']['values'], true
 				);
 			$name = 'Latest ' . $categoryName . ' - ' . self::NAME;
 			break;
 		case 'By "Torrent" category':
 			$categoryName = array_search(
 					$this->getInput('torrent_category'),
-					self::PARAMETERS['By "Torrent" category']['torrent_category']['values']
+					self::PARAMETERS['By "Torrent" category']['torrent_category']['values'], true
 				);
 			$name = 'Category: ' . $categoryName . ' - ' . self::NAME;
 			break;
 		case 'Search torrent by name':
 			$categoryName = array_search(
 					$this->getInput('search_category'),
-					self::PARAMETERS['Search torrent by name']['search_category']['values']
+					self::PARAMETERS['Search torrent by name']['search_category']['values'], true
 				);
 			$name = 'Search: "'
 			. $this->getInput('search_name')
@@ -218,7 +218,7 @@ class IsoHuntBridge extends BridgeAbstract {
 			if(!$date)
 				returnServerError('Unable to find date!');
 
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $this->fixRelativeUri($anchor->href);
 			$item['title'] = $anchor->title;
@@ -256,7 +256,7 @@ class IsoHuntBridge extends BridgeAbstract {
 			if(!$element)
 				returnServerError('Unable to find element!');
 
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $element->href;
 			$item['title'] = $element->plaintext;
@@ -282,7 +282,7 @@ class IsoHuntBridge extends BridgeAbstract {
 			returnServerError('Unable to find posts!');
 
 		foreach($posts as $post) {
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $this->latestNewsExtractUri($post);
 			$item['title'] = $this->latestNewsExtractTitle($post);
@@ -371,7 +371,7 @@ class IsoHuntBridge extends BridgeAbstract {
 			returnServerError('Unable to find torrents!');
 
 		foreach($torrents as $torrent) {
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $this->latestTorrentsExtractUri($torrent);
 			$item['title'] = $this->latestTorrentsExtractTitle($torrent);
@@ -446,13 +446,13 @@ class IsoHuntBridge extends BridgeAbstract {
 	private function buildCategoryUri($category, $order_popularity = false){
 		switch($category) {
 		case 'anime': $index = 1; break;
-		case 'software' : $index = 2; break;
-		case 'games' : $index = 3; break;
-		case 'adult' : $index = 4; break;
-		case 'movies' : $index = 5; break;
-		case 'music' : $index = 6; break;
-		case 'other' : $index = 7; break;
-		case 'series_tv' : $index = 8; break;
+		case 'software': $index = 2; break;
+		case 'games': $index = 3; break;
+		case 'adult': $index = 4; break;
+		case 'movies': $index = 5; break;
+		case 'music': $index = 6; break;
+		case 'other': $index = 7; break;
+		case 'series_tv': $index = 8; break;
 		case 'books': $index = 9; break;
 		case 'all':
 		default: $index = 0; break;

--- a/bridges/JapanExpoBridge.php
+++ b/bridges/JapanExpoBridge.php
@@ -6,12 +6,12 @@ class JapanExpoBridge extends BridgeAbstract {
 	const URI = 'http://www.japan-expo-paris.com/fr/actualites';
 	const CACHE_TIMEOUT = 14400; // 4h
 	const DESCRIPTION = 'Returns most recent entries from Japan Expo actualités.';
-	const PARAMETERS = array( array(
-		'mode' => array(
+	const PARAMETERS = [ [
+		'mode' => [
 			'name' => 'Show full contents',
 			'type' => 'checkbox',
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 
@@ -19,7 +19,7 @@ class JapanExpoBridge extends BridgeAbstract {
 			return strtotime(
 				strtr(
 					strtolower(str_replace('Publié le ', '', $date_to_parse)),
-					array(
+					[
 						'janvier' => 'jan',
 						'février' => 'feb',
 						'mars' => 'march',
@@ -32,7 +32,7 @@ class JapanExpoBridge extends BridgeAbstract {
 						'octobre' => 'oct',
 						'novembre' => 'nov',
 						'décembre' => 'dec'
-					)
+					]
 				)
 			);
 		}
@@ -88,7 +88,7 @@ class JapanExpoBridge extends BridgeAbstract {
 				. '">Lire l\'article</a>';
 			}
 
-			$item = array();
+			$item = [];
 			$item['uri'] = $url;
 			$item['title'] = $title;
 			$item['timestamp'] = $timestamp;

--- a/bridges/KATBridge.php
+++ b/bridges/KATBridge.php
@@ -8,34 +8,34 @@ class KATBridge extends BridgeAbstract {
  show"). Category based search needs the category number as input. User based
  search takes the Uploader ID: see KAT URL for user feed. Search can be done in a specified category';
 
-	const PARAMETERS = array( array(
-		'q' => array(
+	const PARAMETERS = [ [
+		'q' => [
 			'name' => 'keywords, separated by semicolons',
 			'exampleValue' => 'first list;second list;…',
 			'required' => true
-		),
-		'crit' => array(
+		],
+		'crit' => [
 			'type' => 'list',
 			'name' => 'Search type',
-			'values' => array(
+			'values' => [
 				'search' => 'search',
 				'category' => 'cat',
 				'user' => 'usr'
-			)
-		),
-		'cat_check' => array(
+			]
+		],
+		'cat_check' => [
 			'type' => 'checkbox',
 			'name' => 'Specify category for normal search ?',
-		),
-		'cat' => array(
+		],
+		'cat' => [
 			'name' => 'Category number',
 			'exampleValue' => '100, 200… See KAT for category number'
-		),
-		'trusted' => array(
+		],
+		'trusted' => [
 			'type' => 'checkbox',
 			'name' => 'Only get results from Elite or Verified uploaders ?',
-		),
-	));
+		],
+	]];
 	public function collectData(){
 		function parseDateTimestamp($element){
 				$guessedDate = strptime($element, '%d-%m-%Y %H:%M:%S');
@@ -95,7 +95,7 @@ class KATBridge extends BridgeAbstract {
 				if(!$trustedBool
 				|| !is_null($element->find('i[title="Elite Uploader"]', 0))
 				|| !is_null($element->find('i[title="Verified Uploader"]', 0))) {
-					$item = array();
+					$item = [];
 					$item['uri'] = self::URI . $element->find('a', 2)->href;
 					$item['id'] = self::URI . $element->find('a.cellMainLink', 0)->href;
 					$item['timestamp'] = parseDateTimestamp($element->find('td', 2)->plaintext);

--- a/bridges/KernelBugTrackerBridge.php
+++ b/bridges/KernelBugTrackerBridge.php
@@ -5,35 +5,35 @@ class KernelBugTrackerBridge extends BridgeAbstract {
 	const URI = 'https://bugzilla.kernel.org';
 	const DESCRIPTION = 'Returns feeds for bug comments';
 	const MAINTAINER = 'logmanoriginal';
-	const PARAMETERS = array(
-		'Bug comments' => array(
-			'id' => array(
+	const PARAMETERS = [
+		'Bug comments' => [
+			'id' => [
 				'name' => 'Bug tracking ID',
 				'type' => 'number',
 				'required' => true,
 				'title' => 'Insert bug tracking ID',
 				'exampleValue' => 121241
-			),
-			'limit' => array(
+			],
+			'limit' => [
 				'name' => 'Number of comments to return',
 				'type' => 'number',
 				'required' => false,
 				'title' => 'Specify number of comments to return',
 				'defaultValue' => -1
-			),
-			'sorting' => array(
+			],
+			'sorting' => [
 				'name' => 'Sorting',
 				'type' => 'list',
 				'required' => false,
 				'title' => 'Defines the sorting order of the comments returned',
 				'defaultValue' => 'of',
-				'values' => array(
+				'values' => [
 					'Oldest first' => 'of',
 					'Latest first' => 'lf'
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	private $bugid = '';
 	private $bugdesc = '';
@@ -71,6 +71,7 @@ class KernelBugTrackerBridge extends BridgeAbstract {
 		// Order comments
 		switch($sorting) {
 			case 'lf': $comments = array_reverse($comments, true);
+			// no break
 			case 'of':
 			default: // Nothing to do, keep original order
 		}
@@ -78,7 +79,7 @@ class KernelBugTrackerBridge extends BridgeAbstract {
 		foreach($comments as $comment) {
 			$comment = $this->inlineStyles($comment);
 
-			$item = array();
+			$item = [];
 			$item['uri'] = $this->getURI() . '#' . $comment->id;
 			$item['author'] = $comment->find('span.bz_comment_user', 0)->innertext;
 			$item['title'] = $comment->find('span.bz_comment_number', 0)->find('a', 0)->innertext;

--- a/bridges/KununuBridge.php
+++ b/bridges/KununuBridge.php
@@ -6,37 +6,37 @@ class KununuBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 86400; // 24h
 	const DESCRIPTION = 'Returns the latest reviews for a company and site of your choice.';
 
-	const PARAMETERS = array(
-		'global' => array(
-			'site' => array(
+	const PARAMETERS = [
+		'global' => [
+			'site' => [
 				'name' => 'Site',
 				'type' => 'list',
 				'required' => true,
 				'title' => 'Select your site',
-				'values' => array(
+				'values' => [
 					'Austria' => 'at',
 					'Germany' => 'de',
 					'Switzerland' => 'ch',
 					'United States' => 'us'
-				)
-			),
-			'full' => array(
+				]
+			],
+			'full' => [
 				'name' => 'Load full article',
 				'type' => 'checkbox',
 				'required' => false,
 				'exampleValue' => 'checked',
 				'title' => 'Activate to load full article'
-			)
-		),
-		array(
-			'company' => array(
+			]
+		],
+		[
+			'company' => [
 				'name' => 'Company',
 				'required' => true,
 				'exampleValue' => 'kununu-us',
 				'title' => 'Insert company name (i.e. Kununu US) or URI path (i.e. kununu-us)'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	private $companyName = '';
 
@@ -64,7 +64,7 @@ class KununuBridge extends BridgeAbstract {
 		return parent::getURI();
 	}
 
-	function getName(){
+	public function getName(){
 		if(!is_null($this->getInput('company'))) {
 			$company = $this->fixCompanyName($this->getInput('company'));
 			return ($this->companyName ?: $company) . ' - ' . self::NAME;
@@ -95,7 +95,7 @@ class KununuBridge extends BridgeAbstract {
 
 		// Go through all articles
 		foreach($articles as $article) {
-			$item = array();
+			$item = [];
 
 			$item['author'] = $this->extractArticleAuthorPosition($article);
 			$item['timestamp'] = $this->extractArticleDate($article);
@@ -135,8 +135,8 @@ class KununuBridge extends BridgeAbstract {
 	* Encodes unmlauts in the given text
 	*/
 	private function encodeUmlauts($text){
-		$umlauts = Array("/ä/","/ö/","/ü/","/Ä/","/Ö/","/Ü/","/ß/");
-		$replace = Array("ae","oe","ue","Ae","Oe","Ue","ss");
+		$umlauts = ["/ä/","/ö/","/ü/","/Ä/","/Ö/","/Ü/","/ß/"];
+		$replace = ["ae","oe","ue","Ae","Oe","Ue","ss"];
 
 		return preg_replace($umlauts, $replace, $text);
 	}

--- a/bridges/LWNprevBridge.php
+++ b/bridges/LWNprevBridge.php
@@ -8,7 +8,7 @@ class LWNprevBridge extends BridgeAbstract{
 
 	private $editionTimeStamp;
 
-	function getURI(){
+	public function getURI(){
 		return self::URI.'free/bigpage';
 	}
 
@@ -95,7 +95,7 @@ EOD;
 					$node->nodeName === 'h2' || (
 						!is_null($node->attributes) &&
 						!is_null($class = $node->attributes->getNamedItem('class')) &&
-						in_array($class->nodeValue, array('Cat1HL','Cat2HL'))
+						in_array($class->nodeValue, ['Cat1HL','Cat2HL'], true)
 					)
 				)
 			) {
@@ -109,13 +109,13 @@ EOD;
 	}
 
 	private function getFeatureContents(&$html){
-		$items = array();
+		$items = [];
 		foreach($html->getElementsByTagName('h2') as $title) {
 			if($title->getAttribute('class') !== 'SummaryHL') {
 				continue;
 			}
 
-			$item = array();
+			$item = [];
 
 			$author = $title->nextSibling;
 			$this->jumpToNextTag($author);
@@ -145,6 +145,7 @@ EOD;
 			if($cat->getAttribute('class') !== 'Cat2HL') {
 				break;
 			}
+			// no break
 		case 'Cat2HL':
 			$cat2 = $cat->textContent;
 			$cat = $cat->previousSibling;
@@ -156,6 +157,7 @@ EOD;
 			if($cat->getAttribute('class') !== 'Cat1HL') {
 				break;
 			}
+			// no break
 		case 'Cat1HL':
 			$cat1 = $cat->textContent;
 			$cats[0] = $cat1;
@@ -178,15 +180,15 @@ EOD;
 	}
 
 	private function getAnnouncements(&$html){
-		$items = array();
-		$cats = array('','','');
+		$items = [];
+		$cats = ['','',''];
 
 		foreach($html->getElementsByTagName('p') as $newsletters) {
 			if($newsletters->getAttribute('class') !== 'Cat3HL') {
 				continue;
 			}
 
-			$item = array();
+			$item = [];
 
 			$item['uri'] = self::URI.'#'.count($items);
 
@@ -208,7 +210,7 @@ EOD;
 						$node->nodeType !== XML_TEXT_NODE && (
 							!is_null($node->attributes) &&
 							!is_null($class = $node->attributes->getNamedItem('class')) &&
-							in_array($class->nodeValue, array('Cat1HL','Cat2HL','Cat3HL'))
+							in_array($class->nodeValue, ['Cat1HL','Cat2HL','Cat3HL'], true)
 						)
 					)
 				) {
@@ -226,7 +228,7 @@ EOD;
 				continue;
 			}
 
-			$item = array();
+			$item = [];
 
 			$cat = $title->previousSibling;
 			$this->jumpToPreviousTag($cat);
@@ -241,14 +243,14 @@ EOD;
 	}
 
 	private function getBriefItems(&$html){
-		$items = array();
-		$cats = array('','','');
+		$items = [];
+		$cats = ['','',''];
 		foreach($html->getElementsByTagName('h2') as $title) {
 			if($title->getAttribute('class') !== 'SummaryHL') {
 				continue;
 			}
 
-			$item = array();
+			$item = [];
 
 			$cat = $title->previousSibling;
 			$this->jumpToPreviousTag($cat);
@@ -262,4 +264,3 @@ EOD;
 		return $items;
 	}
 }
-?>

--- a/bridges/LeBonCoinBridge.php
+++ b/bridges/LeBonCoinBridge.php
@@ -7,13 +7,13 @@ class LeBonCoinBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns most recent results from LeBonCoin for a
 region, and optionally a category and a keyword .';
 
-	const PARAMETERS = array(
-		array(
-			'k' => array('name' => 'Mot Clé'),
-			'r' => array(
+	const PARAMETERS = [
+		[
+			'k' => ['name' => 'Mot Clé'],
+			'r' => [
 				'name' => 'Région',
 				'type' => 'list',
-				'values' => array(
+				'values' => [
 					'Toute la France' => 'ile_de_france/occasions',
 					'Alsace' => 'alsace',
 					'Aquitaine' => 'aquitaine',
@@ -41,15 +41,15 @@ region, and optionally a category and a keyword .';
 					'Martinique' => 'martinique',
 					'Guyane' => 'guyane',
 					'Réunion' => 'reunion'
-				)
-			),
-			'c' => array(
+				]
+			],
+			'c' => [
 				'name' => 'Catégorie',
 				'type' => 'list',
-				'values' => array(
+				'values' => [
 					'TOUS' => '',
 					'EMPLOI' => '_emploi_',
-					'VEHICULES' => array(
+					'VEHICULES' => [
 						'Tous' => '_vehicules_',
 						'Voitures' => 'voitures',
 						'Motos' => 'motos',
@@ -60,30 +60,30 @@ region, and optionally a category and a keyword .';
 						'Équipement Caravaning' => 'equipement_caravaning',
 						'Nautisme' => 'nautisme',
 						'Équipement Nautisme' => 'equipement_nautisme'
-					),
-					'IMMOBILIER' => array(
+					],
+					'IMMOBILIER' => [
 						'Tous' => '_immobilier_',
 						'Ventes immobilières' => 'ventes_immobilieres',
 						'Locations' => 'locations',
 						'Colocations' => 'colocations',
 						'Bureaux & Commerces' => 'bureaux_commerces'
-					),
-					'VACANCES' => array(
+					],
+					'VACANCES' => [
 						'Tous' => '_vacances_',
 						'Location gîtes' => 'locations_gites',
 						'Chambres d\'hôtes' => 'chambres_d_hotes',
 						'Campings' => 'campings',
 						'Hôtels' => 'hotels',
 						'Hébergements insolites' => 'hebergements_insolites'
-					),
-					'MULTIMEDIA' => array(
+					],
+					'MULTIMEDIA' => [
 						'Tous' => '_multimedia_',
 						'Informatique' => 'informatique',
 						'Consoles & Jeux vidéo' => 'consoles_jeux_video',
 						'Image & Son' => 'image_son',
 						'Téléphonie' => 'telephonie'
-					),
-					'LOISIRS' => array(
+					],
+					'LOISIRS' => [
 						'Tous' => '_loisirs_',
 						'DVD / Films' => 'dvd_films',
 						'CD / Musique' => 'cd_musique',
@@ -95,8 +95,8 @@ region, and optionally a category and a keyword .';
 						'Collection' => 'collection',
 						'Jeux & Jouets' => 'jeux_jouets',
 						'Vins & Gastronomie' => 'vins_gastronomie'
-					),
-					'MATÉRIEL PROFESSIONNEL' => array(
+					],
+					'MATÉRIEL PROFESSIONNEL' => [
 						'Tous' => '_materiel_professionnel_',
 						'Matériel Agricole' => 'mateiel_agricole',
 						'Transport - Manutention' => 'transport_manutention',
@@ -107,16 +107,16 @@ region, and optionally a category and a keyword .';
 						'Fournitures de Bureau' => 'fournitures_de_bureau',
 						'Commerces & Marchés' => 'commerces_marches',
 						'Matériel médical' => 'materiel_medical'
-					),
-					'SERVICES' => array(
+					],
+					'SERVICES' => [
 						'Tous' => '_services_',
 						'Prestations de services' => 'prestations_de_services',
 						'Billetterie' => 'billetterie',
 						'Évènements' => 'evenements',
 						'Cours particuliers' => 'cours_particuliers',
 						'Covoiturage' => 'covoiturage'
-					),
-					'MAISON' => array(
+					],
+					'MAISON' => [
 						'Tous' => '_maison_',
 						'Ameublement' => 'ameublement',
 						'Électroménager' => 'electromenager',
@@ -131,12 +131,12 @@ region, and optionally a category and a keyword .';
 						'Montres & Bijoux' => 'montres_bijoux',
 						'Équipement bébé' => 'equipement_bebe',
 						'Vêtements bébé' => 'vetements_bebe'
-					),
+					],
 					'AUTRES' => 'autres'
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	public function collectData(){
 
@@ -164,7 +164,7 @@ region, and optionally a category and a keyword .';
 
 			$element = $element->find('a', 0);
 
-			$item = array();
+			$item = [];
 			$item['uri'] = $element->href;
 			$title = html_entity_decode($element->getAttribute('title'));
 			$content_image = $element->find('div.item_image', 0)->find('.lazyload', 0);

--- a/bridges/LegifranceJOBridge.php
+++ b/bridges/LegifranceJOBridge.php
@@ -6,14 +6,14 @@ class LegifranceJOBridge extends BridgeAbstract {
 	const URI = 'https://www.legifrance.gouv.fr/affichJO.do';
 	const DESCRIPTION = 'Returns the laws and decrees officially registered daily in France';
 
-	const PARAMETERS = array();
+	const PARAMETERS = [];
 
 	private $author;
 	private $timestamp;
 	private $uri;
 
 	private function extractItem($section, $subsection = null, $origin = null){
-		$item = array();
+		$item = [];
 		$item['author'] = $this->author;
 		$item['timestamp'] = $this->timestamp;
 		$item['uri'] = $this->uri . '#' . count($this->items);

--- a/bridges/LesJoiesDuCodeBridge.php
+++ b/bridges/LesJoiesDuCodeBridge.php
@@ -12,7 +12,7 @@ class LesJoiesDuCodeBridge extends BridgeAbstract {
 			or returnServerError('Could not request LesJoiesDuCode.');
 
 		foreach($html->find('div.blog-post') as $element) {
-			$item = array();
+			$item = [];
 			$temp = $element->find('h1 a', 0);
 			$titre = html_entity_decode($temp->innertext);
 			$url = $temp->href;

--- a/bridges/LinkedInCompanyBridge.php
+++ b/bridges/LinkedInCompanyBridge.php
@@ -8,12 +8,12 @@ class LinkedInCompanyBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns most recent actus from Company on LinkedIn.
  (https://www.linkedin.com/company/<strong style=\"font-weight:bold;\">apple</strong>)';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'Company name',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = '';
@@ -25,7 +25,7 @@ class LinkedInCompanyBridge extends BridgeAbstract {
 		foreach($html->find('//*[@id="my-feed-post"]/li') as $element) {
 			$title = $element->find('span.share-body', 0)->innertext;
 			if($title) {
-				$item = array();
+				$item = [];
 				$item['uri'] = $link;
 				$item['title'] = mb_substr(strip_tags($element->find('span.share-body', 0)->innertext), 0, 100);
 				$item['content'] = strip_tags($element->find('span.share-body', 0)->innertext);

--- a/bridges/MangareaderBridge.php
+++ b/bridges/MangareaderBridge.php
@@ -7,14 +7,14 @@ class MangareaderBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 10800; // 3h
 	const DESCRIPTION = 'Returns the latest updates, popular mangas or manga updates (new chapters)';
 
-	const PARAMETERS = array(
-		'Get latest updates' => array(),
-		'Get popular mangas' => array(
-			'category' => array(
+	const PARAMETERS = [
+		'Get latest updates' => [],
+		'Get popular mangas' => [
+			'category' => [
 				'name' => 'Category',
 				'type' => 'list',
 				'required' => true,
-				'values' => array(
+				'values' => [
 					'All' => 'all',
 					'Action' => 'action',
 					'Adventure' => 'adventure',
@@ -53,27 +53,27 @@ class MangareaderBridge extends BridgeAbstract {
 					'Vampire' => 'vampire',
 					'Yaoi' => 'yaoi',
 					'Yuri' => 'yuri'
-				),
+				],
 			'exampleValue' => 'All',
 			'title' => 'Select your category'
-			)
-		),
-		'Get manga updates' => array(
-			'path' => array(
+			]
+		],
+		'Get manga updates' => [
+			'path' => [
 				'name' => 'Path',
 				'required' => true,
 				'pattern' => '[a-zA-Z0-9-_]*',
 				'exampleValue' => 'bleach, umi-no-kishidan',
 				'title' => 'URL part of desired manga'
-			),
-			'limit' => array(
+			],
+			'limit' => [
 				'name' => 'Limit',
 				'type' => 'number',
 				'defaultValue' => 10,
 				'title' => 'Number of items to return [-1 returns all]'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	private $request = '';
 
@@ -119,7 +119,7 @@ class MangareaderBridge extends BridgeAbstract {
 
 		// Return some dummy-data if no content available
 		if(empty($this->items)) {
-			$item = array();
+			$item = [];
 			$item['content'] = "<p>No updates available</p>";
 
 			$this->items[] = $item;
@@ -138,7 +138,7 @@ class MangareaderBridge extends BridgeAbstract {
 			$chapters = $xpath->query("a[@class='chaptersrec']", $node);
 
 			if (isset($manga) && $chapters->length >= 1) {
-				$item = array();
+				$item = [];
 				$item['uri'] = self::URI . htmlspecialchars($manga->getAttribute('href'));
 				$item['title'] = htmlspecialchars($manga->nodeValue);
 
@@ -175,7 +175,7 @@ class MangareaderBridge extends BridgeAbstract {
 				->getAttribute('style');
 			$thumbnail = substr($mangaimgelement, 22, strlen($mangaimgelement) - 24);
 
-			$item = array();
+			$item = [];
 			$item['title'] = htmlspecialchars($xpath->query(".//*[@class='manga_name']//a", $manga)
 				->item(0)
 				->nodeValue);
@@ -210,7 +210,7 @@ EOD;
 		$chapters = $xpath->query($query);
 
 		foreach ($chapters as $chapter) {
-			$item = array();
+			$item = [];
 			$item['title'] = htmlspecialchars($xpath->query("td[1]", $chapter)
 				->item(0)
 				->nodeValue);

--- a/bridges/MixCloudBridge.php
+++ b/bridges/MixCloudBridge.php
@@ -8,12 +8,12 @@ class MixCloudBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 3600; // 1h
 	const DESCRIPTION = 'Returns latest musics on user stream';
 
-	const PARAMETERS = array(array(
-		'u' => array(
+	const PARAMETERS = [[
+		'u' => [
 			'name' => 'username',
 			'required' => true,
-		)
-	));
+		]
+	]];
 
 	public function getName(){
 		if(!is_null($this->getInput('u'))) {
@@ -31,7 +31,7 @@ class MixCloudBridge extends BridgeAbstract {
 
 		foreach($html->find('section.card') as $element) {
 
-			$item = array();
+			$item = [];
 
 			$item['uri'] = self::URI . $element->find('hgroup.card-title h1 a', 0)->getAttribute('href');
 			$item['title'] = html_entity_decode(

--- a/bridges/MoebooruBridge.php
+++ b/bridges/MoebooruBridge.php
@@ -7,16 +7,16 @@ class MoebooruBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns images from given page';
 	const MAINTAINER = 'pmaziere';
 
-	const PARAMETERS = array( array(
-		'p' => array(
+	const PARAMETERS = [ [
+		'p' => [
 			'name' => 'page',
 			'defaultValue' => 1,
 			'type' => 'number'
-		),
-		't' => array(
+		],
+		't' => [
 			'name' => 'tags'
-		)
-	));
+		]
+	]];
 
 	protected function getFullURI(){
 		return $this->getURI()
@@ -37,7 +37,7 @@ class MoebooruBridge extends BridgeAbstract {
 
 		foreach($data as $datai) {
 			$json = json_decode($datai, true);
-			$item = array();
+			$item = [];
 			$item['uri'] = $this->getURI() . '/post/show/' . $json['id'];
 			$item['postid'] = $json['id'];
 			$item['timestamp'] = $json['created_at'];

--- a/bridges/MoinMoinBridge.php
+++ b/bridges/MoinMoinBridge.php
@@ -5,50 +5,50 @@ class MoinMoinBridge extends BridgeAbstract {
 	const NAME = 'MoinMoin Bridge';
 	const URI = 'https://moinmo.in';
 	const DESCRIPTION = 'Generates feeds for pages of a MoinMoin (compatible) wiki';
-	const PARAMETERS = array(
-		array(
-			'source' => array(
+	const PARAMETERS = [
+		[
+			'source' => [
 				'name' => 'Source',
 				'type' => 'text',
 				'required' => true,
 				'title' => 'Insert wiki page URI (e.g.: https://moinmo.in/MoinMoin)',
 				'exampleValue' => 'https://moinmo.in/MoinMoin'
-			),
-			'separator' => array(
+			],
+			'separator' => [
 				'name' => 'Separator',
 				'type' => 'list',
 				'requied' => true,
 				'title' => 'Defines the separtor for splitting content into feeds',
 				'defaultValue' => 'h2',
-				'values' => array(
+				'values' => [
 					'Header (h1)' => 'h1',
 					'Header (h2)' => 'h2',
 					'Header (h3)' => 'h3',
 					'List element (li)' => 'li',
 					'Anchor (a)' => 'a'
-				)
-			),
-			'limit' => array(
+				]
+			],
+			'limit' => [
 				'name' => 'Limit',
 				'type' => 'number',
 				'required' => false,
 				'title' => 'Number of items to return (from top)',
 				'defaultValue' => -1
-			),
-			'content' => array(
+			],
+			'content' => [
 				'name' => 'Content',
 				'type' => 'list',
 				'required' => false,
 				'title' => 'Defines how feed contents are build',
 				'defaultValue' => 'separator',
-				'values' => array(
+				'values' => [
 					'By separator' => 'separator',
 					'Follow link (only for anchor)' => 'follow',
 					'None' => 'none'
-				)
-			)
-		)
-	);
+				]
+			]
+		]
+	];
 
 	private $title = '';
 
@@ -93,7 +93,7 @@ class MoinMoinBridge extends BridgeAbstract {
 		$sections = $this->splitSections($html);
 
 		foreach($sections as $section) {
-			$item = array();
+			$item = [];
 
 			$item['uri'] = $this->findSectionAnchor($section[0]);
 
@@ -114,6 +114,7 @@ class MoinMoinBridge extends BridgeAbstract {
 
 						break;
 					}
+					// no break
 				case 'separator':
 				default: // Use contents from the current page
 					$item['content'] = $this->cleanArticle($section[2]);
@@ -157,16 +158,16 @@ class MoinMoinBridge extends BridgeAbstract {
 		$content = $html->find('div#page', 0)->innertext
 			or returnServerError('Unable to find <div id="page"/>!');
 
-		$sections = array();
+		$sections = [];
 
 		$regex = implode(
 			'',
-			array(
+			[
 				"\<{$this->getInput('separator')}.+?(?=\>)\>",
 				"(.+?)(?=\<\/{$this->getInput('separator')}\>)",
 				"\<\/{$this->getInput('separator')}\>",
 				"(.+?)((?=\<{$this->getInput('separator')})|(?=\<div\sid=\"pagebottom\")){1}"
-			)
+			]
 		);
 
 		preg_match_all(
@@ -178,13 +179,13 @@ class MoinMoinBridge extends BridgeAbstract {
 
 		// Some pages don't use headers, return page as one feed
 		if(count($sections) === 0) {
-			return array(
-				array(
+			return [
+				[
 					$content,
 					$html->find('title', 0)->innertext,
 					$content
-				)
-			);
+				]
+			];
 		}
 
 		return $sections;
@@ -250,7 +251,7 @@ class MoinMoinBridge extends BridgeAbstract {
 			return null;
 		} else {
 			$timestamp = $pageinfo->innertext;
-			$matches = array();
+			$matches = [];
 			preg_match('/.+?(?=\().+?(?=\d)([0-9\-\s\:]+)/m', $pageinfo, $matches);
 			return strtotime($matches[1]);
 		}
@@ -303,7 +304,7 @@ class MoinMoinBridge extends BridgeAbstract {
 	 * Finds the domain for a given URI
 	 */
 	private function findDomain($uri){
-		$matches = array();
+		$matches = [];
 		preg_match('/(http[s]{0,1}:\/\/.+?(?=\/))/', $uri, $matches);
 		return $matches[1];
 	}

--- a/bridges/MondeDiploBridge.php
+++ b/bridges/MondeDiploBridge.php
@@ -13,7 +13,7 @@ class MondeDiploBridge extends BridgeAbstract {
 
 		foreach($html->find('div.unarticle') as $article) {
 			$element = $article->parent();
-			$item = array();
+			$item = [];
 			$item['uri'] = self::URI . $element->href;
 			$item['title'] = $element->find('h3', 0)->plaintext;
 			$item['content'] = $element->find('div.dates_auteurs', 0)->plaintext

--- a/bridges/MsnMondeBridge.php
+++ b/bridges/MsnMondeBridge.php
@@ -23,7 +23,7 @@ class MsnMondeBridge extends BridgeAbstract {
 		$limit = 0;
 		foreach($html->find('.smalla') as $article) {
 			if($limit < 10) {
-				$item = array();
+				$item = [];
 				$item['title'] = utf8_decode($article->find('h4', 0)->innertext);
 				$item['uri'] = self::URI . utf8_decode($article->find('a', 0)->href);
 				$this->msnMondeExtractContent($item['uri'], $item);

--- a/bridges/NasaApodBridge.php
+++ b/bridges/NasaApodBridge.php
@@ -16,7 +16,7 @@ class NasaApodBridge extends BridgeAbstract {
 
 		for($i = 0; $i < 3; $i++) {
 			$line = $list[$i];
-			$item = array();
+			$item = [];
 
 			$uri_page = $html->find('a', $i + 3)->href;
 			$uri = self::URI . $uri_page;

--- a/bridges/NextgovBridge.php
+++ b/bridges/NextgovBridge.php
@@ -6,11 +6,11 @@ class NextgovBridge extends FeedExpander {
 	const URI = 'https://www.nextgov.com/';
 	const DESCRIPTION = 'USA Federal technology news, best practices, and web 2.0 tools.';
 
-	const PARAMETERS = array( array(
-		'category' => array(
+	const PARAMETERS = [ [
+		'category' => [
 			'name' => 'Category',
 			'type' => 'list',
-			'values' => array(
+			'values' => [
 				'All' => 'all',
 				'Technology News' => 'technology-news',
 				'CIO Briefing' => 'cio-briefing',
@@ -21,9 +21,9 @@ class NextgovBridge extends FeedExpander {
 				'Health' => 'health',
 				'Defense' => 'defense',
 				'Big Data' => 'big-data'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	public function collectData(){
 		$this->collectExpandableDatas(self::URI . 'rss/' . $this->getInput('category') . '/', 10);

--- a/bridges/NotAlwaysBridge.php
+++ b/bridges/NotAlwaysBridge.php
@@ -7,11 +7,11 @@ class NotAlwaysBridge extends BridgeAbstract {
 		const DESCRIPTION = 'Returns the latest stories';
 		const CACHE_TIMEOUT = 1800; // 30 minutes
 
-		const PARAMETERS = array( array(
-				'filter' => array(
+		const PARAMETERS = [ [
+				'filter' => [
 						'type' => 'list',
 						'name' => 'Filter',
-						'values' => array(
+						'values' => [
 								'All' => 'all',
 								'Right' => 'right',
 								'Working' => 'working',
@@ -21,17 +21,17 @@ class NotAlwaysBridge extends BridgeAbstract {
 								'Friendly' => 'friendly',
 								'Hopeless' => 'hopeless',
 								'Unfiltered' => 'unfiltered'
-						),
+						],
 						'required' => true
-				)
-		));
+				]
+		]];
 
 		public function collectData(){
 				$html = getSimpleHTMLDOM($this->getURI())
 						or returnServerError('Could not request NotAlways.');
 				foreach($html->find('.post') as $post) {
 						#print_r($post);
-						$item = array();
+						$item = [];
 						$item['uri'] = $post->find('h1', 0)->find('a', 0)->href;
 						$item['content'] = $post;
 						$item['title'] = $post->find('h1', 0)->find('a', 0)->innertext;

--- a/bridges/NovelUpdatesBridge.php
+++ b/bridges/NovelUpdatesBridge.php
@@ -6,13 +6,13 @@ class NovelUpdatesBridge extends BridgeAbstract {
 	const URI = 'http://www.novelupdates.com/';
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'Returns releases from Novel Updates';
-	const PARAMETERS = array( array(
-		'n' => array(
+	const PARAMETERS = [ [
+		'n' => [
 			'name' => 'Novel name as found in the url',
 			'exampleValue' => 'spirit-realm',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	private $seriesTitle = '';
 
@@ -36,7 +36,7 @@ class NovelUpdatesBridge extends BridgeAbstract {
 		$html = stristr($html, '<tr>'); //remove tbody
 		$html = str_get_html(stristr($html, '</tbody>', true)); //remove last tbody and get back as an array
 		foreach($html->find('tr') as $element) {
-				$item = array();
+				$item = [];
 				$item['uri'] = $element->find('td', 2)->find('a', 0)->href;
 				$item['title'] = $element->find('td', 2)->find('a', 0)->plaintext;
 				$item['team'] = $element->find('td', 1)->innertext;

--- a/bridges/OpenClassroomsBridge.php
+++ b/bridges/OpenClassroomsBridge.php
@@ -7,12 +7,12 @@ class OpenClassroomsBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'Returns latest tutorials from OpenClassrooms.';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'Catégorie',
 			'type' => 'list',
 			'required' => true,
-			'values' => array(
+			'values' => [
 				'Arts & Culture' => 'arts',
 				'Code' => 'code',
 				'Design' => 'design',
@@ -22,9 +22,9 @@ class OpenClassroomsBridge extends BridgeAbstract {
 				'Sciences Humaines' => 'humainities',
 				'Systèmes d\'information' => 'it',
 				'Autres' => 'others'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	public function getURI(){
 		if(!is_null($this->getInput('u'))) {
@@ -39,7 +39,7 @@ class OpenClassroomsBridge extends BridgeAbstract {
 			or returnServerError('Could not request OpenClassrooms.');
 
 		foreach($html->find('.courseListItem') as $element) {
-				$item = array();
+				$item = [];
 				$item['uri'] = self::URI . $element->find('a', 0)->href;
 				$item['title'] = $element->find('h3', 0)->plaintext;
 				$item['content'] = $element->find('slidingItem__descriptionContent', 0)->plaintext;

--- a/bridges/ParuVenduImmoBridge.php
+++ b/bridges/ParuVenduImmoBridge.php
@@ -7,23 +7,23 @@ class ParuVenduImmoBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 10800; // 3h
 	const DESCRIPTION = 'Returns the ads from the first page of search result.';
 
-	const PARAMETERS = array( array(
-		'minarea' => array(
+	const PARAMETERS = [ [
+		'minarea' => [
 			'name' => 'Minimal surface m²',
 			'type' => 'number'
-		),
-		'maxprice' => array(
+		],
+		'maxprice' => [
 			'name' => 'Max price',
 			'type' => 'number'
-		),
-		'pa' => array(
+		],
+		'pa' => [
 			'name' => 'Country code',
 			'exampleValue' => 'FR'
-		),
-		'lo' => array(
+		],
+		'lo' => [
 			'name' => 'department numbers or postal codes, comma-separated'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM($this->getURI())
@@ -49,7 +49,7 @@ class ParuVenduImmoBridge extends BridgeAbstract {
 
 			list($href) = explode('#', $element->href);
 
-			$item = array();
+			$item = [];
 			$item['uri'] = self::URI . $href;
 			$item['title'] = $element->title;
 			$item['content'] = $img . $desc . $price;

--- a/bridges/PickyWallpapersBridge.php
+++ b/bridges/PickyWallpapersBridge.php
@@ -7,26 +7,26 @@ class PickyWallpapersBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 43200; // 12h
 	const DESCRIPTION = 'Returns the latests wallpapers from PickyWallpapers';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'category',
 			'required' => true
-		),
-		's' => array(
+		],
+		's' => [
 			'name' => 'subcategory'
-		),
-		'm' => array(
+		],
+		'm' => [
 			'name' => 'Max number of wallpapers',
 			'defaultValue' => 12,
 			'type' => 'number'
-		),
-		'r' => array(
+		],
+		'r' => [
 			'name' => 'resolution',
 			'exampleValue' => '1920x1200, 1680x1050,…',
 			'defaultValue' => '1920x1200',
 			'pattern' => '[0-9]{3,4}x[0-9]{3,4}'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$lastpage = 1;
@@ -44,7 +44,7 @@ class PickyWallpapersBridge extends BridgeAbstract {
 			}
 
 			foreach($html->find('.items li img') as $element) {
-				$item = array();
+				$item = [];
 				$item['uri'] = str_replace('www', 'wallpaper', self::URI)
 				. '/'
 				. $resolution

--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -6,24 +6,24 @@ class PinterestBridge extends FeedExpander {
 	const URI = 'https://www.pinterest.com';
 	const DESCRIPTION = 'Returns the newest images on a board';
 
-	const PARAMETERS = array(
-		'By username and board' => array(
-			'u' => array(
+	const PARAMETERS = [
+		'By username and board' => [
+			'u' => [
 				'name' => 'username',
 				'required' => true
-			),
-			'b' => array(
+			],
+			'b' => [
 				'name' => 'board',
 				'required' => true
-			)
-		),
-		'From search' => array(
-			'q' => array(
+			]
+		],
+		'From search' => [
+			'q' => [
 				'name' => 'Keyword',
 				'required' => true
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 		switch($this->queriedContext) {
@@ -56,7 +56,7 @@ class PinterestBridge extends FeedExpander {
 		$results = $json['resourceDataCache'][0]['data']['results'];
 
 		foreach($results as $result) {
-			$item = array();
+			$item = [];
 
 			$item['uri'] = self::URI . $result['board']['url'];
 
@@ -87,7 +87,7 @@ class PinterestBridge extends FeedExpander {
 				. $result['description']
 				. '</p>';
 
-			$item['enclosures'] = array($result['images']['orig']['url']);
+			$item['enclosures'] = [$result['images']['orig']['url']];
 
 			$this->items[] = $item;
 		}

--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -7,13 +7,13 @@ class PixivBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the tag search from pixiv.net';
 
 
-	const PARAMETERS = array( array(
-		'tag' => array(
+	const PARAMETERS = [ [
+		'tag' => [
 			'name' => 'Tag to search',
 			'exampleValue' => 'example',
 			'required' => true
-		),
-	));
+		],
+	]];
 
 
 	public function collectData(){
@@ -32,7 +32,7 @@ class PixivBridge extends BridgeAbstract {
 			if($count == 10) break;
 			$count++;
 
-			$item = array();
+			$item = [];
 			$item["id"] = $result["illustId"];
 			$item["uri"] = "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=" . $result["illustId"];
 			$item["title"] = $result["illustTitle"];
@@ -58,7 +58,7 @@ class PixivBridge extends BridgeAbstract {
 			mkdir($path, 0755, true);
 
 		if(!is_file($path . '/' . $illustId . '.jpeg')) {
-			$headers = array("Referer:  https://www.pixiv.net/member_illust.php?mode=medium&illust_id=" . $illustId);
+			$headers = ["Referer:  https://www.pixiv.net/member_illust.php?mode=medium&illust_id=" . $illustId];
 			$illust = getContents($url, $headers);
 			if(strpos($illust, "404 Not Found") !== false) {
 				$illust = getContents(str_replace("jpg", "png", $url), $headers);

--- a/bridges/RTBFBridge.php
+++ b/bridges/RTBFBridge.php
@@ -6,13 +6,13 @@ class RTBFBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the newest RTBF videos by series ID';
 	const MAINTAINER = 'Frenzie';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'series id',
 			'exampleValue' => 9500,
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = '';
@@ -27,7 +27,7 @@ class RTBFBridge extends BridgeAbstract {
 				break;
 			}
 
-			$item = array();
+			$item = [];
 			$item['id'] = $element->getAttribute('data-id');
 			$item['uri'] = self::URI . 'detail?id=' . $item['id'];
 			$thumbnailUriSrcSet = explode(

--- a/bridges/RadioMelodieBridge.php
+++ b/bridges/RadioMelodieBridge.php
@@ -10,7 +10,7 @@ class RadioMelodieBridge extends BridgeAbstract {
 			or returnServerError('Could not request Radio Melodie.');
 		$list = $html->find('div[class=actuitem]');
 		foreach($list as $element) {
-			$item = array();
+			$item = [];
 
 			// Get picture URL
 			$pictureHTML = $element->find('div[class=picture]');
@@ -20,7 +20,7 @@ class RadioMelodieBridge extends BridgeAbstract {
 				$pictures);
 			$pictureURL = $pictures[1];
 
-			$item['enclosures'] = array($pictureURL);
+			$item['enclosures'] = [$pictureURL];
 			$item['uri'] = self::URI . $element->parent()->href;
 			$item['title'] = $element->find('h3', 0)->plaintext;
 			$item['content'] = $element->find('p', 0)->plaintext . '<br/><img src="'.$pictureURL.'"/>';

--- a/bridges/RainbowSixSiegeBridge.php
+++ b/bridges/RainbowSixSiegeBridge.php
@@ -21,7 +21,7 @@ class RainbowSixSiegeBridge extends BridgeAbstract {
 			$jsonItem = $json[$i]['Content'];
 			$article = str_get_html($jsonItem);
 
-			$item = array();
+			$item = [];
 
 			$uri = $article->find('h3 a', 0)->href;
 			$uri = 'https://rainbow6.ubisoft.com' . $uri;

--- a/bridges/ReadComicsBridge.php
+++ b/bridges/ReadComicsBridge.php
@@ -7,13 +7,13 @@ class ReadComicsBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Enter the comics as they appear in the website uri,
  separated by semicolons, ex: good-comic-1;good-comic-2; ...';
 
-	const PARAMETERS = array( array(
-		'q' => array(
+	const PARAMETERS = [ [
+		'q' => [
 			'name' => 'keywords, separated by semicolons',
 			'exampleValue' => 'first list;second list;...',
 			'required' => true
-		),
-	));
+		],
+	]];
 
 	public function collectData(){
 
@@ -31,7 +31,7 @@ class ReadComicsBridge extends BridgeAbstract {
 				or $this->returnServerError('Could not request readcomics.tv.');
 
 			foreach($html->find('li') as $element) {
-				$item = array();
+				$item = [];
 				$item['uri'] = $element->find('a.ch-name', 0)->href;
 				$item['id'] = $item['uri'];
 				$item['timestamp'] = parseDateTimestamp($element);

--- a/bridges/Releases3DSBridge.php
+++ b/bridges/Releases3DSBridge.php
@@ -123,7 +123,7 @@ class Releases3DSBridge extends BridgeAbstract {
 			. '">Search using Qwant</a></li></ul>';
 
 			//Build and add final item with the above three sections
-			$item = array();
+			$item = [];
 			$item['title'] = $name;
 			$item['author'] = $publisher;
 			$item['timestamp'] = $ignDate;

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -34,7 +34,7 @@ class ReporterreBridge extends BridgeAbstract {
 
 		foreach($html->find('item') as $element) {
 			if($limit < 5) {
-				$item = array();
+				$item = [];
 				$item['title'] = html_entity_decode($element->find('title', 0)->plaintext);
 				$item['timestamp'] = strtotime($element->find('dc:date', 0)->plaintext);
 				$item['uri'] = $element->find('guid', 0)->innertext;

--- a/bridges/ScmbBridge.php
+++ b/bridges/ScmbBridge.php
@@ -13,7 +13,7 @@ class ScmbBridge extends BridgeAbstract {
 			or returnServerError('Could not request Se Coucher Moins Bete.');
 
 		foreach($html->find('article') as $article) {
-			$item = array();
+			$item = [];
 			$item['uri'] = self::URI . $article->find('p.summary a', 0)->href;
 			$item['title'] = $article->find('header h1 a', 0)->innertext;
 

--- a/bridges/ScoopItBridge.php
+++ b/bridges/ScoopItBridge.php
@@ -7,12 +7,12 @@ class ScoopItBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'Returns most recent results from ScoopIt.';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'keyword',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$this->request = $this->getInput('u');
@@ -22,7 +22,7 @@ class ScoopItBridge extends BridgeAbstract {
 			or returnServerError('Could not request ScoopIt. for : ' . $link);
 
 		foreach($html->find('div.post-view') as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $element->find('a', 0)->href;
 			$item['title'] = preg_replace(
 				'~[[:cntrl:]]~',

--- a/bridges/SensCritiqueBridge.php
+++ b/bridges/SensCritiqueBridge.php
@@ -7,35 +7,35 @@ class SensCritiqueBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'Sens Critique news';
 
-	const PARAMETERS = array( array(
-		'm' => array(
+	const PARAMETERS = [ [
+		'm' => [
 			'name' => 'Movies',
 			'type' => 'checkbox'
-		),
-		's' => array(
+		],
+		's' => [
 			'name' => 'Series',
 			'type' => 'checkbox'
-		),
-		'g' => array(
+		],
+		'g' => [
 			'name' => 'Video Games',
 			'type' => 'checkbox'
-		),
-		'b' => array(
+		],
+		'b' => [
 			'name' => 'Books',
 			'type' => 'checkbox'
-		),
-		'bd' => array(
+		],
+		'bd' => [
 			'name' => 'BD',
 			'type' => 'checkbox'
-		),
-		'mu' => array(
+		],
+		'mu' => [
 			'name' => 'Music',
 			'type' => 'checkbox'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
-		$categories = array();
+		$categories = [];
 		foreach(self::PARAMETERS[$this->queriedContext] as $category => $properties) {
 			if($this->getInput($category)) {
 				$uri = self::URI;
@@ -68,7 +68,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 		}
 
 		foreach($list->find('li') as $movie) {
-			$item = array();
+			$item = [];
 			$item['author'] = htmlspecialchars_decode($movie->find('.elco-title a', 0)->plaintext, ENT_QUOTES)
 			. ' '
 			. $movie->find('.elco-date', 0)->plaintext;

--- a/bridges/SexactuBridge.php
+++ b/bridges/SexactuBridge.php
@@ -8,11 +8,11 @@ class SexactuBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 7200; // 2h
 	const DESCRIPTION = 'Sexactu via rss-bridge';
 
-	const REPLACED_ATTRIBUTES = array(
+	const REPLACED_ATTRIBUTES = [
 			'href' => 'href',
 			'src' => 'src',
 			'data-original' => 'src'
-	);
+	];
 
 	public function getURI(){
 		return self::URI . '/sexactu';
@@ -29,7 +29,7 @@ class SexactuBridge extends BridgeAbstract {
 
 			$title = $row->find('.title', 0);
 			if($title) {
-				$item = array();
+				$item = [];
 				$item['author'] = self::AUTHOR;
 				$item['title'] = $title->plaintext;
 				$urlAttribute = "data-href";
@@ -38,7 +38,7 @@ class SexactuBridge extends BridgeAbstract {
 					continue;
 				if(substr($uri, 0, 1) === 'h') { // absolute uri
 					$item['uri'] = $uri;
-				} else if(substr($uri, 0, 1) === '/') { // domain relative url
+				} elseif(substr($uri, 0, 1) === '/') { // domain relative url
 					$item['uri'] = self::URI . $uri;
 				} else {
 					$item['uri'] = $this->getURI() . $uri;

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -111,7 +111,7 @@ class ShanaprojectBridge extends BridgeAbstract {
 			returnServerError('Could not find anime headers!');
 
 		foreach($animes as $anime) {
-			$item = array();
+			$item = [];
 			$item['title'] = $this->extractAnimeTitle($anime);
 			$item['author'] = $this->extractAnimeAuthor($anime);
 			$item['uri'] = $this->extractAnimeUri($anime);

--- a/bridges/Shimmie2Bridge.php
+++ b/bridges/Shimmie2Bridge.php
@@ -19,7 +19,7 @@ class Shimmie2Bridge extends DanbooruBridge {
 	}
 
 	protected function getItemFromElement($element){
-		$item = array();
+		$item = [];
 		$item['uri'] = $this->getURI() . $element->href;
 		$item['id'] = (int)preg_replace("/[^0-9]/", '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -7,12 +7,12 @@ class SoundCloudBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 600; // 10min
 	const DESCRIPTION = 'Returns 10 newest music from user profile';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'username',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	const CLIENT_ID = '4jkoEFmZEDaqjwJ9Eih4ATNhcH3vMVfp';
 
@@ -33,7 +33,7 @@ class SoundCloudBridge extends BridgeAbstract {
 		)) or returnServerError('No results for this user');
 
 		for($i = 0; $i < 10; $i++) {
-			$item = array();
+			$item = [];
 			$item['author'] = $tracks[$i]->user->username . ' - ' . $tracks[$i]->title;
 			$item['title'] = $tracks[$i]->user->username . ' - ' . $tracks[$i]->title;
 			$item['content'] = '<audio src="'

--- a/bridges/SteamBridge.php
+++ b/bridges/SteamBridge.php
@@ -6,16 +6,16 @@ class SteamBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 3600; // 1h
 	const DESCRIPTION = 'Returns apps list';
 	const MAINTAINER = 'jacknumber';
-	const PARAMETERS = array(
-		'Wishlist' => array(
-			'username' => array(
+	const PARAMETERS = [
+		'Wishlist' => [
+			'username' => [
 				'name' => 'Username',
 				'required' => true,
-			),
-			'currency' => array(
+			],
+			'currency' => [
 				'name' => 'Currency',
 				'type' => 'list',
-				'values' => array(
+				'values' => [
 					// source: http://steam.steamlytics.xyz/currencies
 					'USD' => 'us',
 					'GBP' => 'gb',
@@ -45,26 +45,26 @@ class SteamBridge extends BridgeAbstract {
 					'TWD' => 'tw',
 					'SRD' => 'sr',
 					'AED' => 'ae',
-				),
-			),
-			'only_discount' => array(
+				],
+			],
+			'only_discount' => [
 				'name' => 'Only discount',
 				'type' => 'checkbox',
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 
 		$username = $this->getInput('username');
-		$params = array(
+		$params = [
 			'cc' => $this->getInput('currency')
-		);
+		];
 
 		$url = self::URI . 'wishlist/id/' . $username . '?' . http_build_query($params);
 
 		$targetVariable = 'g_rgAppInfo';
-		$sort = array();
+		$sort = [];
 
 		$html = '';
 		$html = getSimpleHTMLDOM($url)
@@ -117,7 +117,7 @@ class SteamBridge extends BridgeAbstract {
 				}
 			}
 
-			$item = array();
+			$item = [];
 			$item['uri'] = "http://store.steampowered.com/app/$id/";
 			$item['title'] = $element->name;
 			$item['type'] = $appType;
@@ -140,7 +140,7 @@ class SteamBridge extends BridgeAbstract {
 
 			}
 
-			$item['enclosures'] = array();
+			$item['enclosures'] = [];
 			$item['enclosures'][] = str_replace('_292x136', '', $element->capsule);
 
 			foreach($element->screenshots as $screenshot) {

--- a/bridges/StripeAPIChangeLogBridge.php
+++ b/bridges/StripeAPIChangeLogBridge.php
@@ -11,7 +11,7 @@ class StripeAPIChangeLogBridge extends BridgeAbstract {
 			or returnServerError('No results for Stripe API Changelog');
 
 		foreach($html->find('h3') as $change) {
-			$item = array();
+			$item = [];
 			$item['title'] = trim($change->plaintext);
 			$item['uri'] = self::URI . '#' . $item['title'];
 			$item['author'] = 'stripe';

--- a/bridges/SupInfoBridge.php
+++ b/bridges/SupInfoBridge.php
@@ -6,12 +6,12 @@ class SupInfoBridge extends BridgeAbstract {
 	const URI = 'https://www.supinfo.com';
 	const DESCRIPTION = 'Returns the newest articles.';
 
-	const PARAMETERS = array(array(
-		'tag' => array(
+	const PARAMETERS = [[
+		'tag' => [
 			'name' => 'Category (not mandatory)',
 			'type' => 'text',
-		)
-	));
+		]
+	]];
 
 	public function collectData() {
 
@@ -37,7 +37,7 @@ class SupInfoBridge extends BridgeAbstract {
 			or returnServerError('Unable to fetch article !');
 
 		$article = $articleHTML->find('div[id=courseDocZero]', 0);
-		$item = array();
+		$item = [];
 		$item['author'] = $article->find('#courseMetas', 0)->find('a', 0)->plaintext;
 		$item['id'] = $link;
 		$item['uri'] = self::URI . $link;

--- a/bridges/SuperSmashBlogBridge.php
+++ b/bridges/SuperSmashBlogBridge.php
@@ -33,7 +33,7 @@ class SuperSmashBlogBridge extends BridgeAbstract {
 			$content = $picture . $video . $text;
 
 			// Build final item
-			$item = array();
+			$item = [];
 			$item['title'] = $article['title']['rendered'];
 			$item['timestamp'] = strtotime($article['date']);
 			$item['content'] = $content;

--- a/bridges/SuperbWallpapersBridge.php
+++ b/bridges/SuperbWallpapersBridge.php
@@ -7,21 +7,21 @@ class SuperbWallpapersBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 43200; // 12h
 	const DESCRIPTION = 'Returns the latests wallpapers from SuperbWallpapers';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'category',
 			'required' => true
-		),
-		'm' => array(
+		],
+		'm' => [
 			'name' => 'Max number of wallpapers',
 			'type' => 'number'
-		),
-		'r' => array(
+		],
+		'r' => [
 			'name' => 'resolution',
 			'exampleValue' => '1920x1200, 1680x1050,…',
 			'defaultValue' => '1920x1200'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$category = $this->getInput('c');
@@ -46,7 +46,7 @@ class SuperbWallpapersBridge extends BridgeAbstract {
 			foreach($html->find('.wpl .i a') as $element) {
 				$thumbnail = $element->find('img', 0);
 
-				$item = array();
+				$item = [];
 				$item['uri'] = str_replace('200x125', $this->resolution, $thumbnail->src);
 				$item['timestamp'] = time();
 				$item['title'] = $element->title;

--- a/bridges/TagBoardBridge.php
+++ b/bridges/TagBoardBridge.php
@@ -7,12 +7,12 @@ class TagBoardBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'Returns most recent results from TagBoard.';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'keyword',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$link = 'https://post-cache.tagboard.com/search/' . $this->getInput('u');
@@ -22,7 +22,7 @@ class TagBoardBridge extends BridgeAbstract {
 		$parsed_json = json_decode($html);
 
 		foreach($parsed_json->{'posts'} as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $element->{'permalink'};
 			$item['title'] = $element->{'text'};
 			$thumbnailUri = $element->{'photos'}[0]->{'m'};

--- a/bridges/TebeoBridge.php
+++ b/bridges/TebeoBridge.php
@@ -6,20 +6,20 @@ class TebeoBridge extends FeedExpander {
 	const DESCRIPTION = 'Returns the newest Tébéo videos by category';
 	const MAINTAINER = 'Mitsukarenai';
 
-	const PARAMETERS = array( array(
-		'cat' => array(
+	const PARAMETERS = [ [
+		'cat' => [
 			'name' => 'Catégorie',
 			'type' => 'list',
-			'values' => array(
+			'values' => [
 				'Toutes les vidéos' => '/',
 				'Actualité' => '/14-actualite',
 				'Sport' => '/3-sport',
 				'Culture-Loisirs' => '/5-culture-loisirs',
 				'Société' => '/15-societe',
 				'Langue Bretonne' => '/9-langue-bretonne'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	public function collectData(){
 		$url = self::URI . '/le-replay/' . $this->getInput('cat');
@@ -27,7 +27,7 @@ class TebeoBridge extends FeedExpander {
 			or returnServerError('Could not request Tébéo.');
 
 		foreach($html->find('div[id=items_replay] div.replay') as $element) {
-			$item = array();
+			$item = [];
 			$item['uri'] = $element->find('a', 0)->href;
 			$item['title'] = $element->find('h3', 0)->plaintext;
 			$item['timestamp'] = strtotime($element->find('p.moment-format-day', 0)->plaintext);

--- a/bridges/TheCodingLoveBridge.php
+++ b/bridges/TheCodingLoveBridge.php
@@ -12,7 +12,7 @@ class TheCodingLoveBridge extends BridgeAbstract {
 			or returnServerError('Could not request The Coding Love.');
 
 		foreach($html->find('div.post') as $element) {
-			$item = array();
+			$item = [];
 			$temp = $element->find('h3 a', 0);
 
 			$titre = $temp->innertext;

--- a/bridges/TheHackerNewsBridge.php
+++ b/bridges/TheHackerNewsBridge.php
@@ -65,7 +65,7 @@ class TheHackerNewsBridge extends BridgeAbstract {
 				$contents = stripRecursiveHtmlSection($contents, 'div', '<div class=\'clear\'');
 				$contents = stripWithDelimiters($contents, '<script', '</script>');
 
-				$item = array();
+				$item = [];
 				$item['uri'] = $article_url;
 				$item['title'] = $article_title;
 				$item['author'] = $article_author;

--- a/bridges/ThePirateBayBridge.php
+++ b/bridges/ThePirateBayBridge.php
@@ -9,34 +9,34 @@ class ThePirateBayBridge extends BridgeAbstract {
  show"). Category based search needs the category number as input. User based
  search takes the Uploader name. Search can be done in a specified category';
 
-	const PARAMETERS = array( array(
-		'q' => array(
+	const PARAMETERS = [ [
+		'q' => [
 			'name' => 'keywords/username/category, separated by semicolons',
 			'exampleValue' => 'first list;second list;…',
 			'required' => true
-		),
-		'crit' => array(
+		],
+		'crit' => [
 			'type' => 'list',
 			'name' => 'Search type',
-			'values' => array(
+			'values' => [
 				'search' => 'search',
 				'category' => 'cat',
 				'user' => 'usr'
-			)
-		),
-		'catCheck' => array(
+			]
+		],
+		'catCheck' => [
 			'type' => 'checkbox',
 			'name' => 'Specify category for keyword search ?',
-		),
-		'cat' => array(
+		],
+		'cat' => [
 			'name' => 'Category number',
 			'exampleValue' => '100, 200… See TPB for category number'
-		),
-		'trusted' => array(
+		],
+		'trusted' => [
 			'type' => 'checkbox',
 			'name' => 'Only get results from Trusted or VIP users ?',
-		),
-	));
+		],
+	]];
 
 	public function collectData(){
 
@@ -148,7 +148,7 @@ class ThePirateBayBridge extends BridgeAbstract {
 				if(!$trustedBool
 				|| !is_null($element->find('img[alt=VIP]', 0))
 				|| !is_null($element->find('img[alt=Trusted]', 0))) {
-					$item = array();
+					$item = [];
 					$item['uri'] = $element->find('a', 3)->href;
 					$item['id'] = self::URI . $element->find('a.detLink', 0)->href;
 					$item['timestamp'] = parseDateTimestamp($element);

--- a/bridges/TheTVDBBridge.php
+++ b/bridges/TheTVDBBridge.php
@@ -8,21 +8,21 @@ class TheTVDBBridge extends BridgeAbstract {
 	const APIURI = 'https://api.thetvdb.com/';
 	const CACHE_TIMEOUT = 43200; // 12h
 	const DESCRIPTION = 'Returns latest episodes of a serie with theTVDB api. You can contribute to theTVDB.';
-	const PARAMETERS = array(
-		array(
-			'serie_id' => array(
+	const PARAMETERS = [
+		[
+			'serie_id' => [
 				'type' => 'number',
 				'name' => 'ID',
 				'required' => true,
-			),
-			'nb_episode' => array(
+			],
+			'nb_episode' => [
 				'type' => 'number',
 				'name' => 'Number of episodes',
 				'defaultValue' => 10,
 				'required' => true,
-			),
-		)
-	);
+			],
+		]
+	];
 	const APIACCOUNT = 'RSSBridge';
 	const APIKEY = '76DE1887EA401C9A';
 	const APIUSERKEY = 'B52869AC6005330F';
@@ -33,21 +33,21 @@ class TheTVDBBridge extends BridgeAbstract {
 
 	private function getToken(){
 		//login and get token, don't use curlJob to do less adaptations
-		$login_array = array(
+		$login_array = [
 			'apikey' => self::APIKEY,
 			'username' => self::APIACCOUNT,
 			'userkey' => self::APIUSERKEY
-		);
+		];
 
 		$login_json = json_encode($login_array);
 		$ch = curl_init($this->getApiUri() . 'login');
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $login_json);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+		curl_setopt($ch, CURLOPT_HTTPHEADER, [
 				'Content-Type: application/json',
 				'Accept: application/json'
-			)
+			]
 		);
 
 		curl_setopt($ch, CURLOPT_TIMEOUT, 5);
@@ -68,10 +68,10 @@ class TheTVDBBridge extends BridgeAbstract {
 		$ch = curl_init($url);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+		curl_setopt($ch, CURLOPT_HTTPHEADER, [
 				'Accept: application/json',
 				$token_header
-			)
+			]
 		);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
@@ -119,7 +119,7 @@ class TheTVDBBridge extends BridgeAbstract {
 		$episodes = (array)$episodes['data'];
 		$episodes = array_slice($episodes, -$nbepisodemin, $nbepisodemin);
 		foreach($episodes as $episode) {
-			$episodedata = array();
+			$episodedata = [];
 			$episodedata['uri'] = $this->getURI()
 			. '?tab=episode&seriesid='
 			. $serie_id
@@ -161,7 +161,7 @@ class TheTVDBBridge extends BridgeAbstract {
 	public function collectData(){
 		$serie_id = $this->getInput('serie_id');
 		$nbepisode = $this->getInput('nb_episode');
-		$episodelist = array();
+		$episodelist = [];
 		$token = $this->getToken();
 		$maxseason = $this->getLatestSeasonNumber($token, $serie_id);
 		$seriename = $this->getSerieName($token, $serie_id);

--- a/bridges/Torrent9Bridge.php
+++ b/bridges/Torrent9Bridge.php
@@ -11,28 +11,28 @@ class Torrent9Bridge extends BridgeAbstract {
 	const PAGE_SERIES_VOSTFR = 'torrents_series_vostfr';
 	const PAGE_SERIES_FR = 'torrents_series_french';
 
-	const PARAMETERS = array(
-		'From search' => array(
-			'q' => array(
+	const PARAMETERS = [
+		'From search' => [
+			'q' => [
 				'name' => 'Search',
 				'required' => true,
 				'title' => 'Type your search'
-			)
-		),
-		'By page' => array(
-			'page' => array(
+			]
+		],
+		'By page' => [
+			'page' => [
 				'name' => 'Page',
 				'type' => 'list',
 				'required' => false,
-				'values' => array(
+				'values' => [
 					'Series' => self::PAGE_SERIES,
 					'Series VOST' => self::PAGE_SERIES_VOSTFR,
 					'Series FR' => self::PAGE_SERIES_FR,
-				),
+				],
 				'defaultValue' => self::PAGE_SERIES
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 
@@ -55,7 +55,7 @@ class Torrent9Bridge extends BridgeAbstract {
 				 //30 years = forever
 				$htmlepisode = getSimpleHTMLDOMCached($urlepisode, 86400 * 366 * 30);
 
-				$item = array();
+				$item = [];
 				$item['author'] = $episode->find('a', 0)->text();
 				$item['title'] = $episode->find('a', 0)->text();
 				$item['id'] = $episode->find('a', 0)->getAttribute('href');

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -5,66 +5,66 @@ class TwitterBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 300; // 5min
 	const DESCRIPTION = 'returns tweets';
 	const MAINTAINER = 'pmaziere';
-	const PARAMETERS = array(
-		'global' => array(
-			'nopic' => array(
+	const PARAMETERS = [
+		'global' => [
+			'nopic' => [
 				'name' => 'Hide profile pictures',
 				'type' => 'checkbox',
 				'title' => 'Activate to hide profile pictures in content'
-			),
-			'noimg' => array(
+			],
+			'noimg' => [
 				'name' => 'Hide images in tweets',
 				'type' => 'checkbox',
 				'title' => 'Activate to hide images in tweets'
-			)
-		),
-		'By keyword or hashtag' => array(
-			'q' => array(
+			]
+		],
+		'By keyword or hashtag' => [
+			'q' => [
 				'name' => 'Keyword or #hashtag',
 				'required' => true,
 				'exampleValue' => 'rss-bridge, #rss-bridge',
 				'title' => 'Insert a keyword or hashtag'
-			)
-		),
-		'By username' => array(
-			'u' => array(
+			]
+		],
+		'By username' => [
+			'u' => [
 				'name' => 'username',
 				'required' => true,
 				'exampleValue' => 'sebsauvage',
 				'title' => 'Insert a user name'
-			),
-			'norep' => array(
+			],
+			'norep' => [
 				'name' => 'Without replies',
 				'type' => 'checkbox',
 				'title' => 'Only return initial tweets'
-			),
-			'noretweet' => array(
+			],
+			'noretweet' => [
 				'name' => 'Without retweets',
 				'required' => false,
 				'type' => 'checkbox',
 				'title' => 'Hide retweets'
-			)
-		),
-		'By list' => array(
-			'user' => array(
+			]
+		],
+		'By list' => [
+			'user' => [
 				'name' => 'User',
 				'required' => true,
 				'exampleValue' => 'sebsauvage',
 				'title' => 'Insert a user name'
-			),
-			'list' => array(
+			],
+			'list' => [
 				'name' => 'List',
 				'required' => true,
 				'title' => 'Insert the list name'
-			),
-			'filter' => array(
+			],
+			'filter' => [
 				'name' => 'Filter',
 				'exampleValue' => '#rss-bridge',
 				'required' => false,
 				'title' => 'Specify term to search for'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function getName(){
 		switch($this->queriedContext) {
@@ -112,8 +112,10 @@ class TwitterBridge extends BridgeAbstract {
 			switch($this->queriedContext) {
 			case 'By keyword or hashtag':
 				returnServerError('No results for this query.');
+				// no break
 			case 'By username':
 				returnServerError('Requested username can\'t be found.');
+				// no break
 			case 'By list':
 				returnServerError('Requested username or list can\'t be found');
 			}
@@ -142,7 +144,7 @@ class TwitterBridge extends BridgeAbstract {
 				continue;
 			}
 
-			$item = array();
+			$item = [];
 			// extract username and sanitize
 			$item['username'] = $tweet->getAttribute('data-screen-name');
 			// extract fullname (pseudonym)
@@ -204,7 +206,7 @@ EOD;
 			$image = $this->getImageURI($tweet);
 			if(!$this->getInput('noimg') && !is_null($image)) {
 				// add enclosures
-				$item['enclosures'] = array($image . ':orig');
+				$item['enclosures'] = [$image . ':orig'];
 
 				$image_html = <<<EOD
 <a href="{$image}:orig">
@@ -246,7 +248,7 @@ EOD;
 				$quotedImage = $this->getQuotedImageURI($tweet);
 				if(!$this->getInput('noimg') && !is_null($quotedImage)) {
 					// add enclosures
-					$item['enclosures'] = array($quotedImage . ':orig');
+					$item['enclosures'] = [$quotedImage . ':orig'];
 
 					$quotedImage_html = <<<EOD
 <a href="{$quotedImage}:orig">

--- a/bridges/UnsplashBridge.php
+++ b/bridges/UnsplashBridge.php
@@ -7,23 +7,23 @@ class UnsplashBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 43200; // 12h
 	const DESCRIPTION = 'Returns the latests photos from Unsplash';
 
-	const PARAMETERS = array( array(
-		'm' => array(
+	const PARAMETERS = [ [
+		'm' => [
 			'name' => 'Max number of photos',
 			'type' => 'number',
 			'defaultValue' => 20
-		),
-		'w' => array(
+		],
+		'w' => [
 			'name' => 'Width',
 			'exampleValue' => '1920, 1680, …',
 			'defaultValue' => '1920'
-		),
-		'q' => array(
+		],
+		'q' => [
 			'name' => 'JPEG quality',
 			'type' => 'number',
 			'defaultValue' => 75
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$width = $this->getInput('w');
@@ -51,10 +51,10 @@ class UnsplashBridge extends BridgeAbstract {
 				$thumbnail = $element->find('img', 0);
 				$thumbnail->src = str_replace('https://', 'http://', $thumbnail->src);
 
-				$item = array();
+				$item = [];
 				$item['uri'] = str_replace(
-					array('q=75', 'w=400'),
-					array("q=$quality", "w=$width"),
+					['q=75', 'w=400'],
+					["q=$quality", "w=$width"],
 					$thumbnail->src).'.jpg'; // '.jpg' only for format hint
 
 				$item['timestamp'] = time();

--- a/bridges/UsbekEtRicaBridge.php
+++ b/bridges/UsbekEtRicaBridge.php
@@ -6,23 +6,23 @@ class UsbekEtRicaBridge extends BridgeAbstract {
 	const URI = 'https://usbeketrica.com';
 	const DESCRIPTION = 'Returns latest articles from the front page';
 
-	const PARAMETERS = array(
-		array(
-			'limit' => array(
+	const PARAMETERS = [
+		[
+			'limit' => [
 				'name' => 'Number of articles to return',
 				'type' => 'number',
 				'required' => false,
 				'title' => 'Specifies the maximum number of articles to return',
 				'defaultValue' => -1
-			),
-			'fullarticle' => array(
+			],
+			'fullarticle' => [
 				'name' => 'Load full article',
 				'type' => 'checkbox',
 				'required' => false,
 				'title' => 'Activate to load full articles',
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 		$limit = $this->getInput('limit');
@@ -32,7 +32,7 @@ class UsbekEtRicaBridge extends BridgeAbstract {
 		$articles = $html->find('div.details');
 
 		foreach($articles as $article) {
-			$item = array();
+			$item = [];
 
 			$title = $article->find('div.card-title', 0);
 			if($title) {
@@ -69,9 +69,9 @@ class UsbekEtRicaBridge extends BridgeAbstract {
 
 			$image = $article->find('div.card-img img', 0);
 			if($image) {
-				$item['enclosures'] = array(
+				$item['enclosures'] = [
 					$image->src
-				);
+				];
 			}
 
 			$this->items[] = $item;

--- a/bridges/ViadeoCompanyBridge.php
+++ b/bridges/ViadeoCompanyBridge.php
@@ -8,12 +8,12 @@ class ViadeoCompanyBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns most recent actus from Company on Viadeo.
  (http://www.viadeo.com/fr/company/<strong style="font-weight:bold;">apple</strong>)';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'Company name',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$html = '';
@@ -25,7 +25,7 @@ class ViadeoCompanyBridge extends BridgeAbstract {
 		foreach($html->find('//*[@id="company-newsfeed"]/ul/li') as $element) {
 			$title = $element->find('p', 0)->innertext;
 			if($title) {
-				$item = array();
+				$item = [];
 				$item['uri'] = $link;
 				$item['title'] = mb_substr($element->find('p', 0)->innertext, 0, 100);
 				$item['content'] = $element->find('p', 0)->innertext;;

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -8,14 +8,14 @@ class VkBridge extends BridgeAbstract
 	const URI = 'https://vk.com/';
 	const CACHE_TIMEOUT = 300; // 5min
 	const DESCRIPTION = 'Working with open pages';
-	const PARAMETERS = array(
-		array(
-			'u' => array(
+	const PARAMETERS = [
+		[
+			'u' => [
 				'name' => 'Group or user name',
 				'required' => true
-			)
-		)
-	);
+			]
+		]
+	];
 
 	protected $pageName;
 
@@ -69,11 +69,11 @@ class VkBridge extends BridgeAbstract
 			$content_suffix = "";
 
 			// looking for external links
-			$external_link_selectors = array(
+			$external_link_selectors = [
 				'a.page_media_link_title',
 				'div.page_media_link_title > a',
 				'div.media_desc > a.lnk',
-			);
+			];
 
 			foreach($external_link_selectors as $sel) {
 				if (is_object($post->find($sel, 0))) {
@@ -87,11 +87,11 @@ class VkBridge extends BridgeAbstract
 			}
 
 			// remove external link from content
-			$external_link_selectors_to_remove = array(
+			$external_link_selectors_to_remove = [
 				'div.page_media_thumbed_link',
 				'div.page_media_link_desc_wrap',
 				'div.media_desc > a.lnk',
-			);
+			];
 
 			foreach($external_link_selectors_to_remove as $sel) {
 				if (is_object($post->find($sel, 0))) {
@@ -128,7 +128,7 @@ class VkBridge extends BridgeAbstract
 			$video = $post->find('div.post_video_desc', 0);
 			if (is_object($video)) {
 				$video_title = $video->find('div.post_video_title', 0)->plaintext;
-				$video_link = self::URI . ltrim( $video->find('a.lnk', 0)->getAttribute('href'), '/' );
+				$video_link = self::URI . ltrim($video->find('a.lnk', 0)->getAttribute('href'), '/');
 				$content_suffix .= "<br>Video: <a href='$video_link'>$video_title</a>";
 				$video->outertext = '';
 			}
@@ -138,7 +138,7 @@ class VkBridge extends BridgeAbstract
 				$video_title = $a->getAttribute('aria-label');
 				$temp = explode(" ", $video_title, 2);
 				if (count($temp) > 1) $video_title = $temp[1];
-				$video_link = self::URI . ltrim( $a->getAttribute('href'), '/' );
+				$video_link = self::URI . ltrim($a->getAttribute('href'), '/');
 				$content_suffix .= "<br>Video: <a href='$video_link'>$video_title</a>";
 				$a->outertext = '';
 			}
@@ -170,7 +170,7 @@ class VkBridge extends BridgeAbstract
 					$gif_preview_img = backgroundToImg($a->find('.page_doc_photo', 0));
 					$content_suffix .= "<br>Gif: <a href='$doc_link'>$gif_preview_img</a>";
 
-				} else if (is_object($doc_title_element)) {
+				} elseif (is_object($doc_title_element)) {
 					$doc_title = $doc_title_element->innertext;
 					$content_suffix .= "<br>Doc: <a href='$doc_link'>$doc_title</a>";
 
@@ -225,7 +225,7 @@ class VkBridge extends BridgeAbstract
 				$copy_quote->outertext = "<br>Reposted: <br>$copy_quote_content";
 			}
 
-			$item = array();
+			$item = [];
 			$item['content'] = strip_tags(backgroundToImg($post->find('div.wall_text', 0)->innertext), '<br><img>');
 			$item['content'] .= $content_suffix;
 
@@ -254,9 +254,9 @@ class VkBridge extends BridgeAbstract
 
 		if (is_null($pinned_post_item)) {
 			return;
-		} else if (count($this->items) == 0) {
+		} elseif (count($this->items) == 0) {
 			$this->items[] = $pinned_post_item;
-		} else if ($last_post_id < $pinned_post_item['post_id']) {
+		} elseif ($last_post_id < $pinned_post_item['post_id']) {
 			$this->items[] = $pinned_post_item;
 			usort($this->items, function ($item1, $item2) {
 				return $item2['post_id'] - $item1['post_id'];
@@ -269,13 +269,13 @@ class VkBridge extends BridgeAbstract
 		preg_match('/return showPhoto\(.+?({.*})/', $onclick, $preg_match_result);
 		if (count($preg_match_result) == 0) return;
 
-		$arg = htmlspecialchars_decode( str_replace('queue:1', '"queue":1', $preg_match_result[1]) );
+		$arg = htmlspecialchars_decode(str_replace('queue:1', '"queue":1', $preg_match_result[1]));
 		$data = json_decode($arg, true);
 		if ($data == null) return;
 
 		$thumb = $data['temp']['base'] . $data['temp']['x_'][0] . ".jpg";
 		$original = '';
-		foreach(array('y_', 'z_', 'w_') as $key) {
+		foreach(['y_', 'z_', 'w_'] as $key) {
 			if (!isset($data['temp'][$key])) continue;
 			if (!isset($data['temp'][$key][0])) continue;
 			if (substr($data['temp'][$key][0], 0, 4) == "http") {
@@ -330,7 +330,7 @@ class VkBridge extends BridgeAbstract
 	{
 		ini_set('user-agent', 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0');
 
-		$header = array('Accept-language: en', 'Cookie: remixlang=3');
+		$header = ['Accept-language: en', 'Cookie: remixlang=3'];
 
 		return getContents($this->getURI(), $header);
 	}

--- a/bridges/WallpaperStopBridge.php
+++ b/bridges/WallpaperStopBridge.php
@@ -7,24 +7,24 @@ class WallpaperStopBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 43200; // 12h
 	const DESCRIPTION = 'Returns the latests wallpapers from WallpaperStop';
 
-	const PARAMETERS = array( array(
-		'c' => array(
+	const PARAMETERS = [ [
+		'c' => [
 			'name' => 'Category'
-		),
-		's' => array(
+		],
+		's' => [
 			'name' => 'subcategory'
-		),
-		'm' => array(
+		],
+		'm' => [
 			'name' => 'Max number of wallpapers',
 			'type' => 'number',
 			'defaultValue' => 20
-		),
-		'r' => array(
+		],
+		'r' => [
 			'name' => 'resolution',
 			'exampleValue' => '1920x1200, 1680x1050,…',
 			'defaultValue' => '1920x1200'
-		)
-	));
+		]
+	]];
 
 	public function collectData(){
 		$category = $this->getInput('c');
@@ -58,7 +58,7 @@ class WallpaperStopBridge extends BridgeAbstract {
 				if(preg_match('%^' . self::URI . '/(.+)/([^/]+)-(\d+)\.html$%', $wplink, $matches)) {
 					$thumbnail = $element->find('img', 0);
 
-					$item = array();
+					$item = [];
 					$item['uri'] = self::URI
 					. '/wallpapers/'
 					. str_replace('wallpaper', 'wallpapers', $matches[1])

--- a/bridges/WebfailBridge.php
+++ b/bridges/WebfailBridge.php
@@ -4,33 +4,33 @@ class WebfailBridge extends BridgeAbstract {
 	const URI = 'https://webfail.com';
 	const NAME = 'Webfail';
 	const DESCRIPTION = 'Returns the latest fails';
-	const PARAMETERS = array(
-		'By content type' => array(
-			'language' => array(
+	const PARAMETERS = [
+		'By content type' => [
+			'language' => [
 				'name' => 'Language',
 				'type' => 'list',
 				'title' => 'Select your language',
-				'values' => array(
+				'values' => [
 					'English' => 'en',
 					'German' => 'de'
-				),
+				],
 				'defaultValue' => 'English'
-			),
-			'type' => array(
+			],
+			'type' => [
 				'name' => 'Type',
 				'type' => 'list',
 				'title' => 'Select your content type',
-				'values' => array(
+				'values' => [
 					'None' => '/',
 					'Facebook' => '/ffdts',
 					'Images' => '/images',
 					'Videos' => '/videos',
 					'Gifs' => '/gifs'
-				),
+				],
 				'defaultValue' => 'None'
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function getURI(){
 		if(is_null($this->getInput('language')))
@@ -47,7 +47,7 @@ class WebfailBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM($this->getURI() . $this->getInput('type'));
 
 		$type = array_search($this->getInput('type'),
-			self::PARAMETERS[$this->queriedContext]['type']['values']);
+			self::PARAMETERS[$this->queriedContext]['type']['values'], true);
 
 		switch(strtolower($type)) {
 		case 'facebook':
@@ -66,7 +66,7 @@ class WebfailBridge extends BridgeAbstract {
 	private function extractNews($html, $type){
 		$news = $html->find('#main', 0)->find('a.wf-list-news');
 		foreach($news as $element) {
-			$item = array();
+			$item = [];
 			$item['title'] = $this->fixTitle($element->find('div.wf-news-title', 0)->innertext);
 			$item['uri'] = $this->getURI() . $element->href;
 
@@ -99,7 +99,7 @@ class WebfailBridge extends BridgeAbstract {
 	private function extractArticle($html){
 		$articles = $html->find('article');
 		foreach($articles as $article) {
-			$item = array();
+			$item = [];
 			$item['title'] = $this->fixTitle($article->find('a', 1)->innertext);
 
 			// Images, videos and gifs are provided in their own unique way

--- a/bridges/WhydBridge.php
+++ b/bridges/WhydBridge.php
@@ -7,12 +7,12 @@ class WhydBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 600; // 10min
 	const DESCRIPTION = 'Returns 10 newest music from user profile';
 
-	const PARAMETERS = array( array(
-		'u' => array(
+	const PARAMETERS = [ [
+		'u' => [
 			'name' => 'username/id',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	private $userName = '';
 
@@ -41,7 +41,7 @@ class WhydBridge extends BridgeAbstract {
 
 		for($i = 0; $i < 10; $i++) {
 			$track = $html->find('div.post', $i);
-			$item = array();
+			$item = [];
 			$item['author'] = $track->find('h2', 0)->plaintext;
 			$item['title'] = $track->find('h2', 0)->plaintext;
 			$item['content'] = $track->find('a.thumb', 0) . '<br/>' . $track->find('h2', 0)->plaintext;

--- a/bridges/WikiLeaksBridge.php
+++ b/bridges/WikiLeaksBridge.php
@@ -4,16 +4,16 @@ class WikiLeaksBridge extends BridgeAbstract {
 	const URI = 'https://wikileaks.org';
 	const DESCRIPTION = 'Returns the latest news or articles from WikiLeaks';
 	const MAINTAINER = 'logmanoriginal';
-	const PARAMETERS = array(
-		array(
-			'category' => array(
+	const PARAMETERS = [
+		[
+			'category' => [
 				'name' => 'Category',
 				'type' => 'list',
 				'required' => true,
 				'title' => 'Select your category',
-				'values' => array(
+				'values' => [
 					'News' => '-News-',
-					'Leaks' => array(
+					'Leaks' => [
 						'All' => '-Leaks-',
 						'Intelligence' => '+-Intelligence-+',
 						'Global Economy' => '+-Global-Economy-+',
@@ -21,19 +21,19 @@ class WikiLeaksBridge extends BridgeAbstract {
 						'Corporations' => '+-Corporations-+',
 						'Government' => '+-Government-+',
 						'War & Military' => '+-War-Military-+'
-					)
-				),
+					]
+				],
 				'defaultValue' => 'news'
-			),
-			'teaser' => array(
+			],
+			'teaser' => [
 				'name' => 'Show teaser',
 				'type' => 'checkbox',
 				'required' => false,
 				'title' => 'If checked feeds will display the teaser',
 				'defaultValue' => true
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 		$html = getSimpleHTMLDOM($this->getURI());
@@ -60,13 +60,13 @@ class WikiLeaksBridge extends BridgeAbstract {
 		if(!is_null($this->getInput('category'))) {
 			$category = array_search(
 				$this->getInput('category'),
-				static::PARAMETERS[0]['category']['values']
+				static::PARAMETERS[0]['category']['values'], true
 			);
 
 			if($category === false) {
 				$category = array_search(
 					$this->getInput('category'),
-					static::PARAMETERS[0]['category']['values']['Leaks']
+					static::PARAMETERS[0]['category']['values']['Leaks'], true
 				);
 			}
 
@@ -84,7 +84,7 @@ class WikiLeaksBridge extends BridgeAbstract {
 		}
 
 		foreach($articles as $article) {
-			$item = array();
+			$item = [];
 
 			$item['title'] = $article->find('h3', 0)->plaintext;
 			$item['uri'] = static::URI . $article->find('h3 a', 0)->href;
@@ -103,7 +103,7 @@ class WikiLeaksBridge extends BridgeAbstract {
 		}
 
 		foreach($articles as $article) {
-			$item = array();
+			$item = [];
 
 			$item['title'] = $article->find('h2', 0)->plaintext;
 			$item['uri'] = static::URI . $article->find('a', 0)->href;
@@ -121,7 +121,7 @@ class WikiLeaksBridge extends BridgeAbstract {
 			}
 
 			$item['timestamp'] = strtotime($article->find('div.timestamp', 0)->plaintext);
-			$item['enclosures'] = array($teaser);
+			$item['enclosures'] = [$teaser];
 
 			$this->items[] = $item;
 		}

--- a/bridges/WikipediaBridge.php
+++ b/bridges/WikipediaBridge.php
@@ -9,38 +9,38 @@ class WikipediaBridge extends BridgeAbstract {
 	const URI = 'https://www.wikipedia.org/';
 	const DESCRIPTION = 'Returns articles for a language of your choice';
 
-	const PARAMETERS = array( array(
-		'language' => array(
+	const PARAMETERS = [ [
+		'language' => [
 			'name' => 'Language',
 			'type' => 'list',
 			'required' => true,
 			'title' => 'Select your language',
 			'exampleValue' => 'English',
-			'values' => array(
+			'values' => [
 				'English' => 'en',
 				'Dutch' => 'nl',
 				'Esperanto' => 'eo',
 				'French' => 'fr',
 				'German' => 'de',
-			)
-		),
-		'subject' => array(
+			]
+		],
+		'subject' => [
 			'name' => 'Subject',
 			'type' => 'list',
 			'required' => true,
 			'title' => 'What subject are you interested in?',
 			'exampleValue' => 'Today\'s featured article',
-			'values' => array(
+			'values' => [
 				'Today\'s featured article' => 'tfa',
 				'Did you know…' => 'dyk'
-			)
-		),
-		'fullarticle' => array(
+			]
+		],
+		'fullarticle' => [
 			'name' => 'Load full article',
 			'type' => 'checkbox',
 			'title' => 'Activate to always load the full article'
-		)
-	));
+		]
+	]];
 
 	public function getURI(){
 		if(!is_null($this->getInput('language'))) {
@@ -155,7 +155,7 @@ class WikipediaBridge extends BridgeAbstract {
 			}
 		}
 
-		$item = array();
+		$item = [];
 		$item['uri'] = $this->getURI() . $target->href;
 		$item['title'] = $target->title;
 
@@ -172,7 +172,7 @@ class WikipediaBridge extends BridgeAbstract {
 	*/
 	private function addDidYouKnowGeneric($element, $fullArticle){
 		foreach($element->find('ul', 0)->find('li') as $entry) {
-			$item = array();
+			$item = [];
 
 			// We can only use the first anchor, there is no way of finding the 'correct' one if there are multiple
 			$item['uri'] = $this->getURI() . $entry->find('a', 0)->href;

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -6,12 +6,12 @@ class WordPressBridge extends FeedExpander {
 	const CACHE_TIMEOUT = 10800; // 3h
 	const DESCRIPTION = 'Returns the newest full posts of a Wordpress powered website';
 
-	const PARAMETERS = array( array(
-		'url' => array(
+	const PARAMETERS = [ [
+		'url' => [
 			'name' => 'Blog URL',
 			'required' => true
-		)
-	));
+		]
+	]];
 
 	private function clearContent($content){
 		$content = preg_replace('/<script[^>]*>[^<]*<\/script>/', '', $content);

--- a/bridges/WordPressPluginUpdateBridge.php
+++ b/bridges/WordPressPluginUpdateBridge.php
@@ -7,14 +7,14 @@ class WordPressPluginUpdateBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 86400; // 24h = 86400s
 	const DESCRIPTION = 'Returns latest updates of WordPress.com plugins.';
 
-	const PARAMETERS = array(
-		array(
-			'pluginUrl' => array(
+	const PARAMETERS = [
+		[
+			'pluginUrl' => [
 				'name' => 'URL to the plugin',
 				'required' => true
-			)
-		)
-	);
+			]
+		]
+	];
 
 	public function collectData(){
 
@@ -26,7 +26,7 @@ class WordPressPluginUpdateBridge extends BridgeAbstract {
 
 		$content = $html->find('.block-content', 0);
 
-		$item = array();
+		$item = [];
 		$item['content'] = '';
 		$version = null;
 
@@ -49,7 +49,7 @@ class WordPressPluginUpdateBridge extends BridgeAbstract {
 					$this->items[] = $item;
 
 					$version = $element;
-					$item = array();
+					$item = [];
 					$item['content'] = '';
 
 				}

--- a/bridges/WorldOfTanksBridge.php
+++ b/bridges/WorldOfTanksBridge.php
@@ -6,11 +6,11 @@ class WorldOfTanksBridge extends FeedExpander {
 	const URI = 'http://worldoftanks.eu/';
 	const DESCRIPTION = 'News about the tank slaughter game.';
 
-	const PARAMETERS = array( array(
-		'lang' => array(
+	const PARAMETERS = [ [
+		'lang' => [
 			'name' => 'Langue',
 			'type' => 'list',
-			'values' => array(
+			'values' => [
 				'Français' => 'fr',
 				'English' => 'en',
 				'Español' => 'es',
@@ -18,9 +18,9 @@ class WorldOfTanksBridge extends FeedExpander {
 				'Čeština' => 'cs',
 				'Polski' => 'pl',
 				'Türkçe' => 'tr'
-			)
-		)
-	));
+			]
+		]
+	]];
 
 	public function collectData() {
 		$this->collectExpandableDatas(sprintf('https://worldoftanks.eu/%s/rss/news/', $this->getInput('lang')));

--- a/bridges/YGGTorrentBridge.php
+++ b/bridges/YGGTorrentBridge.php
@@ -10,12 +10,12 @@ class YGGTorrentBridge extends BridgeAbstract {
 	const URI = 'https://yggtorrent.is';
 	const DESCRIPTION = 'Returns torrent search from Yggtorrent';
 
-	const PARAMETERS = array(
-		array(
-			"cat" => array(
+	const PARAMETERS = [
+		[
+			"cat" => [
 				"name" => "category",
 				"type" => "list",
-				"values" => array(
+				"values" => [
 					"Toute les catégories" => "all.all",
 					"Film/Vidéo - Toutes les sous-catégories" => "2145.all",
 					"Film/Vidéo - Animation" => "2145.2178",
@@ -57,31 +57,31 @@ class YGGTorrentBridge extends BridgeAbstract {
 					"GPS - Applications" => "2141.2168",
 					"GPS - Cartes" => "2141.2169",
 					"GPS - Divers" => "2141.2170"
-				)
-			),
-			"nom" => array(
+				]
+			],
+			"nom" => [
 				"name" => "Nom",
 				"description" => "Nom du torrent",
 				"type" => "text"
-			),
-			"description" => array(
+			],
+			"description" => [
 				"name" => "Description",
 				"description" => "Description du torrent",
 				"type" => "text"
-			),
-			"fichier" => array(
+			],
+			"fichier" => [
 				"name" => "Fichier",
 				"description" => "Fichier du torrent",
 				"type" => "text"
-			),
-			"uploader" => array(
+			],
+			"uploader" => [
 				"name" => "Uploader",
 				"description" => "Uploader du torrent",
 				"type" => "text"
-			),
+			],
 
-		)
-	);
+		]
+	];
 
 	public function collectData() {
 
@@ -112,7 +112,7 @@ class YGGTorrentBridge extends BridgeAbstract {
 			$count++;
 			if($count == 1) continue;
 			if($count == 12) break;
-			$item = array();
+			$item = [];
 			$item["timestamp"] = $row->find(".hidden", 1)->plaintext;
 			$item["title"] = $row->find("a", 1)->plaintext;
 			$torrentData = $this->collectTorrentData($row->find("a", 1)->href);
@@ -138,6 +138,6 @@ class YGGTorrentBridge extends BridgeAbstract {
 		$page = getSimpleHTMLDOM($url) or returnServerError("Unable to query Yggtorrent page !");
 		$author = $page->find(".informations", 0)->find("a", 4)->plaintext;
 		$content = $page->find(".default", 1);
-		return array("author" => $author, "content" => $content);
+		return ["author" => $author, "content" => $content];
 	}
 }

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -14,39 +14,39 @@ class YoutubeBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the 10 newest videos by username/channel/playlist or search';
 	const MAINTAINER = 'mitsukarenai';
 
-	const PARAMETERS = array(
-		'By username' => array(
-			'u' => array(
+	const PARAMETERS = [
+		'By username' => [
+			'u' => [
 				'name' => 'username',
 				'exampleValue' => 'test',
 				'required' => true
-			)
-		),
-		'By channel id' => array(
-			'c' => array(
+			]
+		],
+		'By channel id' => [
+			'c' => [
 				'name' => 'channel id',
 				'exampleValue' => "15",
 				'required' => true
-			)
-		),
-		'By playlist Id' => array(
-			'p' => array(
+			]
+		],
+		'By playlist Id' => [
+			'p' => [
 				'name' => 'playlist id',
 				'exampleValue' => "15"
-			)
-		),
-		'Search result' => array(
-			's' => array(
+			]
+		],
+		'Search result' => [
+			's' => [
 				'name' => 'search keyword',
 				'exampleValue' => 'test'
-			),
-			'pa' => array(
+			],
+			'pa' => [
 				'name' => 'page',
 				'type' => 'number',
 				'exampleValue' => 1
-			)
-		)
-	);
+			]
+		]
+	];
 
 	private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time){
 		$html = $this->ytGetSimpleHTMLDOM(self::URI . "watch?v=$vid");
@@ -78,7 +78,7 @@ class YoutubeBridge extends BridgeAbstract {
 	}
 
 	private function ytBridgeAddItem($vid, $title, $author, $desc, $time){
-		$item = array();
+		$item = [];
 		$item['id'] = $vid;
 		$item['title'] = $title;
 		$item['author'] = $author;
@@ -140,8 +140,8 @@ class YoutubeBridge extends BridgeAbstract {
 
 	private function ytGetSimpleHTMLDOM($url){
 		return getSimpleHTMLDOM($url,
-			$header = array(),
-			$opts = array(),
+			$header = [],
+			$opts = [],
 			$lowercase = true,
 			$forceTagsClosed = true,
 			$target_charset = DEFAULT_TARGET_CHARSET,

--- a/bridges/ZDNetBridge.php
+++ b/bridges/ZDNetBridge.php
@@ -7,12 +7,12 @@ class ZDNetBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Technology News, Analysis, Comments and Product Reviews for IT Professionals.';
 
 	//http://www.zdnet.com/zdnet.opml
-	const PARAMETERS = array( array(
-		'feed' => array(
+	const PARAMETERS = [ [
+		'feed' => [
 			'name' => 'Feed',
 			'type' => 'list',
-			'values' => array(
-				'Subscribe to ZDNet RSS Feeds' => array(
+			'values' => [
+				'Subscribe to ZDNet RSS Feeds' => [
 					'All Blogs' => 'blog',
 					'Just News' => 'news',
 					'All Reviews' => 'topic/reviews',
@@ -22,8 +22,8 @@ class ZDNetBridge extends BridgeAbstract {
 					'Latest UK Articles' => 'uk',
 					'Latest US Articles' => 'us',
 					'Latest Asia Articles' => 'as'
-				),
-				'Keep up with ZDNet Blogs RSS:' => array(
+				],
+				'Keep up with ZDNet Blogs RSS:' => [
 					'Transforming the Datacenter' => 'blog/transforming-datacenter',
 					'SMB India' => 'blog/smb-india',
 					'Indonesia BizTech' => 'blog/indonesia-biztech',
@@ -116,8 +116,8 @@ class ZDNetBridge extends BridgeAbstract {
 					'ZDNet UK Book Reviews' => 'blog/zdnet-uk-book-reviews',
 					'ZDNet UK First Take' => 'blog/zdnet-uk-first-take',
 					'Zero Day' => 'blog/security'
-				),
-				'ZDNet Hot Topics RSS:' => array(
+				],
+				'ZDNet Hot Topics RSS:' => [
 					'Apple' => 'topic/apple',
 					'Collaboration' => 'topic/collaboration',
 					'Enterprise Software' => 'topic/enterprise-software',
@@ -141,23 +141,23 @@ class ZDNetBridge extends BridgeAbstract {
 					'Samsung' => 'topic/samsung',
 					'Security' => 'topic/security',
 					'Small business: going big on mobility' => 'topic/small-business-going-big-on-mobility'
-				),
-				'Product Blogs:' => array(
+				],
+				'Product Blogs:' => [
 					'Digital Cameras & Camcorders' => 'blog/digitalcameras',
 					'Home Theater' => 'blog/home-theater',
 					'Laptops and Desktops' => 'blog/computers',
 					'The Mobile Gadgeteer' => 'blog/mobile-gadgeteer',
 					'Smartphones and Cell Phones' => 'blog/cell-phones',
 					'The ToyBox' => 'blog/gadgetreviews'
-				),
-				'Vertical Blogs:' => array(
+				],
+				'Vertical Blogs:' => [
 					'ZDNet Education' => 'blog/education',
 					'ZDNet Healthcare' => 'blog/healthcare',
 					'ZDNet Government' => 'blog/government'
-				)
-			)
-		)
-	));
+				]
+			]
+		]
+	]];
 
 	public function collectData(){
 
@@ -261,7 +261,7 @@ class ZDNetBridge extends BridgeAbstract {
 				}
 
 				$contents = $article->find('article', 0)->innertext;
-				foreach(array(
+				foreach([
 					'<div class="shareBar"',
 					'<div class="shortcodeGalleryWrapper"',
 					'<div class="relatedContent',
@@ -269,7 +269,7 @@ class ZDNetBridge extends BridgeAbstract {
 					'<div data-shortcode',
 					'<div id="sharethrough',
 					'<div id="inpage-video'
-				) as $div_start) {
+				] as $div_start) {
 					$contents = stripRecursiveHtmlSection($contents, 'div', $div_start);
 				}
 				$contents = stripWithDelimiters($contents, '<script', '</script>');
@@ -287,7 +287,7 @@ class ZDNetBridge extends BridgeAbstract {
 				. '</b></p>'
 				. $contents;
 
-				$item = array();
+				$item = [];
 				$item['author'] = $author;
 				$item['uri'] = $article_url;
 				$item['title'] = $article_title;

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -43,7 +43,7 @@ class FileCache implements CacheInterface {
 			);
 
 			foreach($cacheIterator as $cacheFile) {
-				if(in_array($cacheFile->getBasename(), array('.', '..', '.gitkeep')))
+				if(in_array($cacheFile->getBasename(), ['.', '..', '.gitkeep'], true))
 					continue;
 				elseif($cacheFile->isFile()) {
 					if(filemtime($cacheFile->getPathname()) < time() - $duration)

--- a/index.php
+++ b/index.php
@@ -82,7 +82,7 @@ if(file_exists('DEBUG')) {
 	$debug_whitelist = trim(file_get_contents('DEBUG'));
 
 	$debug_enabled = empty($debug_whitelist)
-	|| in_array($_SERVER['REMOTE_ADDR'], explode("\n", $debug_whitelist));
+	|| in_array($_SERVER['REMOTE_ADDR'], explode("\n", $debug_whitelist), true);
 
 	if($debug_enabled) {
 		ini_set('display_errors', '1');
@@ -134,7 +134,7 @@ $userAgent .= '+https://github.com/RSS-Bridge/rss-bridge)';
 ini_set('user_agent', $userAgent);
 
 // default whitelist
-$whitelist_default = array(
+$whitelist_default = [
 	'BandcampBridge',
 	'CryptomeBridge',
 	'DansTonChatBridge',
@@ -150,7 +150,7 @@ $whitelist_default = array(
 	'ScmbBridge',
 	'TwitterBridge',
 	'WikipediaBridge',
-	'YoutubeBridge');
+	'YoutubeBridge'];
 
 try {
 

--- a/lib/Bridge.php
+++ b/lib/Bridge.php
@@ -2,7 +2,7 @@
 require_once(__DIR__ . '/BridgeInterface.php');
 class Bridge {
 
-	static protected $dirBridge;
+	protected static $dirBridge;
 
 	public function __construct(){
 		throw new \LogicException('Please use ' . __CLASS__ . '::create for new object.');
@@ -13,7 +13,7 @@ class Bridge {
 	* @param string $nameBridge Defined bridge name you want use
 	* @return Bridge object dedicated
 	*/
-	static public function create($nameBridge){
+	public static function create($nameBridge){
 		if(!preg_match('@^[A-Z][a-zA-Z0-9-]*$@', $nameBridge)) {
 			$message = <<<EOD
 'nameBridge' must start with one uppercase character followed or not by
@@ -39,7 +39,7 @@ EOD;
 		return false;
 	}
 
-	static public function setDir($dirBridge){
+	public static function setDir($dirBridge){
 		if(!is_string($dirBridge)) {
 			throw new \InvalidArgumentException('Dir bridge must be a string.');
 		}
@@ -51,7 +51,7 @@ EOD;
 		self::$dirBridge = $dirBridge;
 	}
 
-	static public function getDir(){
+	public static function getDir(){
 		if(is_null(self::$dirBridge)) {
 			throw new \LogicException(__CLASS__ . ' class need to know bridge path !');
 		}
@@ -63,8 +63,8 @@ EOD;
 	* Lists the available bridges.
 	* @return array List of the bridges
 	*/
-	static public function listBridges(){
-		$listBridge = array();
+	public static function listBridges(){
+		$listBridge = [];
 		$dirFiles = scandir(self::getDir());
 
 		if($dirFiles !== false) {
@@ -78,11 +78,11 @@ EOD;
 		return $listBridge;
 	}
 
-	static public function isWhitelisted($whitelist, $name){
-		return in_array($name, $whitelist)
-		|| in_array($name . '.php', $whitelist)
-		|| in_array($name . 'bridge', $whitelist) // DEPRECATED
-		|| in_array($name . 'bridge.php', $whitelist) // DEPRECATED
+	public static function isWhitelisted($whitelist, $name){
+		return in_array($name, $whitelist, true)
+		|| in_array($name . '.php', $whitelist, true)
+		|| in_array($name . 'bridge', $whitelist, true) // DEPRECATED
+		|| in_array($name . 'bridge.php', $whitelist, true) // DEPRECATED
 		|| (count($whitelist) === 1 && trim($whitelist[0]) === '*');
 	}
 }

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -7,12 +7,12 @@ abstract class BridgeAbstract implements BridgeInterface {
 	const DESCRIPTION = 'No description provided';
 	const MAINTAINER = 'No maintainer';
 	const CACHE_TIMEOUT = 3600;
-	const PARAMETERS = array();
+	const PARAMETERS = [];
 
 	protected $cache;
 	protected $extraInfos;
-	protected $items = array();
-	protected $inputs = array();
+	protected $items = [];
+	protected $inputs = [];
 	protected $queriedContext = '';
 	protected $cacheTimeout;
 
@@ -21,10 +21,10 @@ abstract class BridgeAbstract implements BridgeInterface {
 	* @return mixed
 	*/
 	public function getCachable(){
-		return array(
+		return [
 			'items' => $this->getItems(),
 			'extraInfos' => $this->getExtraInfos()
-		);
+		];
 	}
 
 	/**
@@ -53,7 +53,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 		}
 
 		// Apply default values to missing data
-		$contexts = array($queriedContext);
+		$contexts = [$queriedContext];
 		if(array_key_exists('global', static::PARAMETERS)) {
 			$contexts[] = 'global';
 		}
@@ -110,9 +110,9 @@ abstract class BridgeAbstract implements BridgeInterface {
 
 		// Only keep guessed context parameters values
 		if(isset($this->inputs[$queriedContext])) {
-			$this->inputs = array($queriedContext => $this->inputs[$queriedContext]);
+			$this->inputs = [$queriedContext => $this->inputs[$queriedContext]];
 		} else {
-			$this->inputs = array();
+			$this->inputs = [];
 		}
 	}
 
@@ -123,7 +123,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 * @return mixed Returns the context name or null if no match was found
 	 */
 	protected function getQueriedContext(array $inputs){
-		$queriedContexts = array();
+		$queriedContexts = [];
 
 		// Detect matching context
 		foreach(static::PARAMETERS as $context => $set) {
@@ -158,7 +158,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 			}
 			return null;
 		case 1: // Found unique match
-			return array_search(true, $queriedContexts);
+			return array_search(true, $queriedContexts, true);
 		default: return false;
 		}
 	}
@@ -260,10 +260,10 @@ abstract class BridgeAbstract implements BridgeInterface {
 	}
 
 	public function getExtraInfos(){
-		return array(
+		return [
 			'name' => $this->getName(),
 			'uri' => $this->getURI()
-		);
+		];
 	}
 
 	public function setCache(\CacheInterface $cache){

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -2,13 +2,13 @@
 require_once(__DIR__ . '/CacheInterface.php');
 class Cache {
 
-	static protected $dirCache;
+	protected static $dirCache;
 
 	public function __construct(){
 		throw new \LogicException('Please use ' . __CLASS__ . '::create for new object.');
 	}
 
-	static public function create($nameCache){
+	public static function create($nameCache){
 		if(!static::isValidNameCache($nameCache)) {
 			throw new \InvalidArgumentException('Name cache must be at least one
  uppercase follow or not by alphanumeric or dash characters.');
@@ -25,7 +25,7 @@ class Cache {
 		return new $nameCache();
 	}
 
-	static public function setDir($dirCache){
+	public static function setDir($dirCache){
 		if(!is_string($dirCache)) {
 			throw new \InvalidArgumentException('Dir cache must be a string.');
 		}
@@ -37,7 +37,7 @@ class Cache {
 		self::$dirCache = $dirCache;
 	}
 
-	static public function getDir(){
+	public static function getDir(){
 		$dirCache = self::$dirCache;
 
 		if(is_null($dirCache)) {
@@ -47,7 +47,7 @@ class Cache {
 		return $dirCache;
 	}
 
-	static public function isValidNameCache($nameCache){
+	public static function isValidNameCache($nameCache){
 		return preg_match('@^[A-Z][a-zA-Z0-9-]*$@', $nameCache);
 	}
 }

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -54,7 +54,7 @@ function buildGitHubIssueQuery($title, $body, $labels = null, $maintainer = null
  * provided parameter are invalid
  */
 function buildBridgeException($e, $bridge){
-	if(( !($e instanceof \Exception) && !($e instanceof \Error)) || !($bridge instanceof \BridgeInterface)) {
+	if((!($e instanceof \Exception) && !($e instanceof \Error)) || !($bridge instanceof \BridgeInterface)) {
 		return null;
 	}
 
@@ -85,7 +85,7 @@ unable to receive or process the remote website's content!";
  * provided parameter are invalid
  */
 function buildTransformException($e, $bridge){
-	if(( !($e instanceof \Exception) && !($e instanceof \Error)) || !($bridge instanceof \BridgeInterface)) {
+	if((!($e instanceof \Exception) && !($e instanceof \Error)) || !($bridge instanceof \BridgeInterface)) {
 		return null;
 	}
 

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -115,7 +115,7 @@ abstract class FeedExpander extends BridgeAbstract {
 	}
 
 	protected function parseATOMItem($feedItem){
-		$item = array();
+		$item = [];
 		if(isset($feedItem->id)) $item['uri'] = (string)$feedItem->id;
 		if(isset($feedItem->title)) $item['title'] = (string)$feedItem->title;
 		if(isset($feedItem->updated)) $item['timestamp'] = strtotime((string)$feedItem->updated);
@@ -125,7 +125,7 @@ abstract class FeedExpander extends BridgeAbstract {
 	}
 
 	protected function parseRSS_0_9_1_Item($feedItem){
-		$item = array();
+		$item = [];
 		if(isset($feedItem->link)) $item['uri'] = (string)$feedItem->link;
 		if(isset($feedItem->title)) $item['title'] = (string)$feedItem->title;
 		// rss 0.91 doesn't support timestamps

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -2,13 +2,13 @@
 require_once(__DIR__ . '/FormatInterface.php');
 class Format {
 
-	static protected $dirFormat;
+	protected static $dirFormat;
 
 	public function __construct(){
 		throw new \LogicException('Please use ' . __CLASS__ . '::create for new object.');
 	}
 
-	static public function create($nameFormat){
+	public static function create($nameFormat){
 		if(!preg_match('@^[A-Z][a-zA-Z]*$@', $nameFormat)) {
 			throw new \InvalidArgumentException('Name format must be at least
  one uppercase follow or not by alphabetic characters.');
@@ -26,7 +26,7 @@ class Format {
 		return new $nameFormat();
 	}
 
-	static public function setDir($dirFormat){
+	public static function setDir($dirFormat){
 		if(!is_string($dirFormat)) {
 			throw new \InvalidArgumentException('Dir format must be a string.');
 		}
@@ -38,7 +38,7 @@ class Format {
 		self::$dirFormat = $dirFormat;
 	}
 
-	static public function getDir(){
+	public static function getDir(){
 		$dirFormat = self::$dirFormat;
 
 		if(is_null($dirFormat)) {
@@ -52,12 +52,12 @@ class Format {
 	* Read format dir and catch informations about each format depending annotation
 	* @return array Informations about each format
 	*/
-	static public function searchInformation(){
+	public static function searchInformation(){
 		$pathDirFormat = self::getDir();
 
-		$listFormat = array();
+		$listFormat = [];
 
-		$searchCommonPattern = array('name');
+		$searchCommonPattern = ['name'];
 
 		$dirFiles = scandir($pathDirFormat);
 		if($dirFiles !== false) {

--- a/lib/FormatAbstract.php
+++ b/lib/FormatAbstract.php
@@ -3,11 +3,10 @@ require_once(__DIR__ . '/FormatInterface.php');
 abstract class FormatAbstract implements FormatInterface {
 	const DEFAULT_CHARSET = 'UTF-8';
 
-	protected
-		$contentType,
-		$charset,
-		$items,
-		$extraInfos;
+	protected $contentType;
+	protected $charset;
+	protected $items;
+	protected $extraInfos;
 
 	public function setCharset($charset){
 		$this->charset = $charset;
@@ -38,7 +37,7 @@ abstract class FormatAbstract implements FormatInterface {
 	}
 
 	public function setItems(array $items){
-		$this->items = array_map(array($this, 'array_trim'), $items);
+		$this->items = array_map([$this, 'array_trim'], $items);
 
 		return $this;
 	}
@@ -55,8 +54,8 @@ abstract class FormatAbstract implements FormatInterface {
 	* @param array $extraInfos array with know informations (there isn't merge !!!)
 	* @return this
 	*/
-	public function setExtraInfos(array $extraInfos = array()){
-		foreach(array('name', 'uri') as $infoName) {
+	public function setExtraInfos(array $extraInfos = []){
+		foreach(['name', 'uri'] as $infoName) {
 			if(!isset($extraInfos[$infoName])) {
 				$extraInfos[$infoName] = '';
 			}

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -1,5 +1,5 @@
 <?php
-function getContents($url, $header = array(), $opts = array()){
+function getContents($url, $header = [], $opts = []){
 	$ch = curl_init($url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
@@ -33,8 +33,8 @@ function getContents($url, $header = array(), $opts = array()){
 }
 
 function getSimpleHTMLDOM($url,
-$header = array(),
-$opts = array(),
+$header = [],
+$opts = [],
 $lowercase = true,
 $forceTagsClosed = true,
 $target_charset = DEFAULT_TARGET_CHARSET,
@@ -59,8 +59,8 @@ $defaultSpanText = DEFAULT_SPAN_TEXT){
  */
 function getSimpleHTMLDOMCached($url,
 $duration = 86400,
-$header = array(),
-$opts = array(),
+$header = [],
+$opts = [],
 $lowercase = true,
 $forceTagsClosed = true,
 $target_charset = DEFAULT_TARGET_CHARSET,

--- a/lib/html.php
+++ b/lib/html.php
@@ -178,7 +178,7 @@ CARD;
 					. $id
 					. '" /><br />'
 					. PHP_EOL;
-			} else if($inputEntry['type'] == 'list') {
+			} elseif($inputEntry['type'] == 'list') {
 				$card .= '<select '
 					. $additionalInfoString
 					. ' id="'
@@ -300,19 +300,19 @@ CARD;
 }
 
 function sanitize($textToSanitize,
-$removedTags = array('script', 'iframe', 'input', 'form'),
-$keptAttributes = array('title', 'href', 'src'),
-$keptText = array()){
+$removedTags = ['script', 'iframe', 'input', 'form'],
+$keptAttributes = ['title', 'href', 'src'],
+$keptText = []){
 	$htmlContent = str_get_html($textToSanitize);
 
 	foreach($htmlContent->find('*[!b38fd2b1fe7f4747d6b1c1254ccd055e]') as $element) {
-		if(in_array($element->tag, $keptText)) {
+		if(in_array($element->tag, $keptText, true)) {
 			$element->outertext = $element->plaintext;
-		} elseif(in_array($element->tag, $removedTags)) {
+		} elseif(in_array($element->tag, $removedTags, true)) {
 			$element->outertext = '';
 		} else {
 			foreach($element->getAllAttributes() as $attributeName => $attribute) {
-				if(!in_array($attributeName, $keptAttributes))
+				if(!in_array($attributeName, $keptAttributes, true))
 					$element->removeAttribute($attributeName);
 			}
 		}

--- a/lib/validation.php
+++ b/lib/validation.php
@@ -4,10 +4,10 @@ function validateData(&$data, $parameters){
 		if(!is_null($pattern)) {
 			$filteredValue = filter_var($value,
 			FILTER_VALIDATE_REGEXP,
-			array('options' => array(
+			['options' => [
 					'regexp' => '/^' . $pattern . '$/'
-				)
-			));
+				]
+			]);
 		} else {
 			$filteredValue = filter_var($value);
 		}
@@ -37,9 +37,9 @@ function validateData(&$data, $parameters){
 		if($filteredValue === false)
 			return null;
 
-		if(!in_array($filteredValue, $expectedValues)) { // Check sub-values?
+		if(!in_array($filteredValue, $expectedValues, true)) { // Check sub-values?
 			foreach($expectedValues as $subName => $subValue) {
-				if(is_array($subValue) && in_array($filteredValue, $subValue))
+				if(is_array($subValue) && in_array($filteredValue, $subValue, true))
 					return $filteredValue;
 			}
 			return null;


### PR DESCRIPTION
- Adds a editorconfig file
- Runs php-cs-fixer with the given configuration

Since php min is set to 5.6.0, we can comfortably force short array syntax.

This is same as PSR2 with 3 changes:

1. Use tabs instead of spaces
2. function_declaration is turned off
3. braces rule is turned off