### PR TITLE
Dockerfile to create an official docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+cache/*
+DEBUG
+Dockerfile
+whitelist.txt
+phpcs.xml
+CHANGELOG.md
+CONTRIBUTING.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.1-apache
+
+COPY * /var/www/html/
+RUN echo '*' > whitelist.txt && chown -R www-data:www-data *

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM ulsmith/alpine-apache-php7
 
-COPY --chown=apache:root ./ /app/public/
+COPY ./ /app/public/
+
+RUN chown -R apache:root /app/public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM php:7.1-apache
+FROM ulsmith/alpine-apache-php7
 
-COPY * /var/www/html/
-RUN echo '*' > whitelist.txt && chown -R www-data:www-data *
+COPY --chown=apache:root ./ /app/public/


### PR DESCRIPTION
The build is at: https://cloud.docker.com/swarm/captn3m0/repository/registry-1.docker.io/captn3m0/rss-bridge/builds/45447e14-23bc-4f35-9ff2-58aa5e7bd69a

Right now there are 2 Docker images on Docker Hub:

- https://hub.docker.com/r/anansii/rss-bridge/
- https://hub.docker.com/r/bara/rss-bridge/

The first has 10k+ pulls, and the second just 147. I based mine off Alpine, so it is less than <50MB in total size.

Usage is fairly simple as well:

`docker run -p 9090:80 captn3m0/rss-bridge:latest`

You can mount a whitelist.txt to configure it as well:

`docker run -v whitelist.txt:/app/public/whitelist.txt -p 9090:80 captn3m0/rss-bridge:latest`

I can add these details to the README if this is a good idea. This can be easily setup for auto-builds on Docker Cloud with `master->latest` and `$tag->$tag`:

![image](https://user-images.githubusercontent.com/584253/41641895-60677fee-7484-11e8-8e97-1c1b266919c7.png)