### PR TITLE
[WIP] Cloudflare bypass

### DIFF
--- a/bridges/CpasbienBridge.php
+++ b/bridges/CpasbienBridge.php
@@ -3,7 +3,7 @@ class CpasbienBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'lagaisse';
 	const NAME = 'Cpasbien Bridge';
-	const URI = 'http://www.cpasbien.cm';
+	const URI = 'http://www.torrent9.ec';
 	const CACHE_TIMEOUT = 86400; // 24h
 	const DESCRIPTION = 'Returns latest torrents from a request query';
 
@@ -16,36 +16,28 @@ class CpasbienBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$request = str_replace(" ", "-", trim($this->getInput('q')));
-		$html = getSimpleHTMLDOM(self::URI . '/recherche/' . urlencode($request) . '.html')
+		$request = str_replace(' ', '-', trim($this->getInput('q')));
+		$html = getSimpleHTMLDOM(self::URI . '/search_torrent/' . urlencode($request) . '.html')
 			or returnServerError('No results for this query.');
 
-		foreach($html->find('#gauche', 0)->find('div') as $episode) {
-			if($episode->getAttribute('class') == 'ligne0'
-			|| $episode->getAttribute('class') == 'ligne1') {
+		foreach($html->find('table tr') as $episode) {
+			$urlepisode = static::URI . $episode->find('a', 0)->getAttribute('href');
+			$htmlepisode = getSimpleHTMLDOMCached($urlepisode, 86400 * 366 * 30);
 
-				$urlepisode = $episode->find('a', 0)->getAttribute('href');
-				$htmlepisode = getSimpleHTMLDOMCached($urlepisode, 86400 * 366 * 30);
+			$item = array();
+			$item['author'] = $episode->find('a', 0)->text();
+			$item['title'] = $episode->find('a', 0)->text();
+			$item['pubdate'] = $this->getCachedDate($urlepisode);
 
-				$item = array();
-				$item['author'] = $episode->find('a', 0)->text();
-				$item['title'] = $episode->find('a', 0)->text();
-				$item['pubdate'] = $this->getCachedDate($urlepisode);
-				$textefiche = $htmlepisode->find('#textefiche', 0)->find('p', 1);
+			$textefiche = $htmlepisode->find('.description_torrent', 0)->next_sibling();
 
-				if(isset($textefiche)) {
-					$item['content'] = $textefiche->text();
-				} else {
-					$p = $htmlepisode->find('#textefiche', 0)->find('p');
-					if(!empty($p)) {
-						$item['content'] = $htmlepisode->find('#textefiche', 0)->find('p', 0)->text();
-					}
-				}
-
-				$item['id'] = $episode->find('a', 0)->getAttribute('href');
-				$item['uri'] = self::URI . $htmlepisode->find('#telecharger', 0)->getAttribute('href');
-				$this->items[] = $item;
+			if(isset($textefiche)) {
+				$item['content'] = $textefiche->innertext();
 			}
+
+			$item['id'] = $episode->find('a', 0)->getAttribute('href');
+			$item['uri'] = self::URI . $htmlepisode->find('.download-btn', 0)->find('a', 0)->getAttribute('href');
+			$this->items[] = $item;
 		}
 	}
 

--- a/bridges/Torrent9Bridge.php
+++ b/bridges/Torrent9Bridge.php
@@ -3,7 +3,7 @@ class Torrent9Bridge extends BridgeAbstract {
 
 	const MAINTAINER = 'lagaisse';
 	const NAME = 'Torrent9 Bridge';
-	const URI = 'http://www.torrent9.pe';
+	const URI = 'http://www.t9.pe';
 	const CACHE_TIMEOUT = 86400; // 24h = 86400s
 	const DESCRIPTION = 'Returns latest torrents';
 
@@ -63,7 +63,7 @@ class Torrent9Bridge extends BridgeAbstract {
 
 				$textefiche = $htmlepisode->find('.movie-information', 0)->find('p', 1);
 				if(isset($textefiche)) {
-					$item['content'] = $textefiche->text();
+					$item['content'] = $textefiche->innertext();
 				} else {
 					$p = $htmlepisode->find('.movie-information', 0)->find('p');
 					if(!empty($p)) {

--- a/lib/RssBridge.php
+++ b/lib/RssBridge.php
@@ -30,6 +30,8 @@ if(!file_exists($vendorLibSimpleHtmlDom)) {
 }
 require_once $vendorLibSimpleHtmlDom;
 
+require_once __DIR__ . PATH_VENDOR . '/cloudflare-bypass/autoload.php';
+
 /* Example use
 
 	require_once __DIR__ . '/lib/RssBridge.php';

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -1,5 +1,12 @@
 <?php
+use CloudflareBypass\RequestMethod\CFCurl;
 function getContents($url, $header = array(), $opts = array()){
+	$curl_cf_wrapper = new CFCurl(array(
+		'cache'         => true,   // Stores clearance tokens in Cache folder
+		'cache_path'	=> __DIR__ . '/../cache/cf',
+		'max_retries'   => 5       // Max attempts to try and get CF clearance
+	));
+
 	$ch = curl_init($url);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
@@ -21,7 +28,7 @@ function getContents($url, $header = array(), $opts = array()){
 		curl_setopt($ch, CURLOPT_PROXY, PROXY_URL);
 	}
 
-	$content = curl_exec($ch);
+	$content = $curl_cf_wrapper->exec($ch); // NOTE: HEAD requests not supported!
 	$curlError = curl_error($ch);
 	$curlErrno = curl_errno($ch);
 	curl_close($ch);

--- a/vendor/cloudflare-bypass/CloudflareBypass/CFBypass.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/CFBypass.php
@@ -1,0 +1,144 @@
+<?php
+namespace CloudflareBypass;
+
+class CFBypass
+{
+    /**
+     * Check if page is a IUAM page. Given page content and headers, will check if page is
+     * protected by CloudFlare (to my best of judgment).
+     *
+     * Response Headers Properties
+     *
+     * Name                 Description
+     * -------------------------------------------
+     * http_code            Response http code
+     *
+     * @access protected
+     * @param string $content Response body
+     * @param array $headers Response headers
+     * @return bool 
+     */
+    protected function isProtected($content, $headers)
+    {
+        /*
+         * 1. Cloudflare UAM page always throw a 503
+         */
+        if ((int)$headers['http_code'] !== 503) {
+            return false;
+        }
+
+        /*
+         * 2. Cloudflare UAM page contains the following strings:
+         * - jschl_vc
+         * - pass
+         * - jschl_answer
+         * - /cdn-cgi/l/chk_jschl
+         */
+        if (!(
+            strpos($content, "jschl_vc")                !== false &&
+            strpos($content, "pass")                    !== false &&
+            strpos($content, "jschl_answer")            !== false &&
+            strpos($content, "/cdn-cgi/l/chk_jschl")    !== false
+        )) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get clearance link. Given IUAM page contents, will solve JS challenge and return clearance link
+     * e.g. http://test/cdn-cgi/l/chk_jschl?jschl_vc=X&pass=X&jschl_answer=X
+     *
+     * @access protected
+     * @param string $content Response body
+     * @param string $url Request URL
+     * @throws \ErrorException if values for the "jschl_vc" / "pass" inputs CAN NOT be found
+     * @throws \ErrorException if JavaScript arithmetic code CAN NOT be extracted
+     * @throws \ErrorException if PHP evaluation of JavaScript arithmetic code FAILS
+     * @return string Clearance link
+     */
+    protected function getClearanceLink($content, $url)
+    {
+        /*
+         * 1. Mimic waiting process
+         */
+        sleep(4);
+        
+        /*
+         * 2. Extract "jschl_vc" and "pass" params
+         */
+        preg_match_all('/name="\w+" value="(.+?)"/', $content, $matches);
+        
+        if (!isset($matches[1]) || !isset($matches[1][1])) {
+            throw new \ErrorException('Unable to fetch jschl_vc and pass values; maybe not protected?');
+        }
+        
+        $params = array();
+        list($params['jschl_vc'], $params['pass']) = $matches[1];
+
+        // Extract CF script tag portion from content.
+        $cf_script_start_pos    = strpos($content, 's,t,o,p,b,r,e,a,k,i,n,g,f,');
+        $cf_script_end_pos      = strpos($content, '</script>', $cf_script_start_pos);
+        $cf_script              = substr($content, $cf_script_start_pos, $cf_script_end_pos-$cf_script_start_pos);
+
+        /*
+         * 3. Extract JavaScript challenge logic
+         */
+        preg_match_all('/:[\/!\[\]+()]+|[-*+\/]?=[\/!\[\]+()]+/', $cf_script, $matches);
+        
+        if (!isset($matches[0]) || !isset($matches[0][0])) {
+            throw new \ErrorException('Unable to find javascript challenge logic; maybe not protected?');
+        }
+        
+        try {
+            /*
+             * 4. Convert challenge logic to PHP
+             */
+            $php_code = "";
+            foreach ($matches[0] as $js_code) {
+                // [] causes "invalid operator" errors; convert to integer equivalents
+                $js_code = str_replace(array(
+                    ")+(",  
+                    "![]",
+                    "!+[]", 
+                    "[]"
+                ), array(
+                    ").(", 
+                    "(!1)", 
+                    "(!0)", 
+                    "(0)"
+                ), $js_code);
+
+                $php_code .= '$params[\'jschl_answer\']' . ($js_code[0] == ':' ? '=' . substr($js_code, 1) : $js_code) . ';';
+            }
+            
+            /*
+             * 5. Eval PHP and get solution
+             */
+            eval($php_code);
+
+            // toFixed(10).
+            $params['jschl_answer'] = round($params['jschl_answer'], 10);
+
+            // Split url into components.
+            $uri = parse_url($url);
+
+            // Add host length to get final answer.
+            $params['jschl_answer'] += strlen($uri['host']);
+
+            /*
+             * 6. Generate clearance link
+             */
+            return sprintf("%s://%s/cdn-cgi/l/chk_jschl?%s", 
+                $uri['scheme'], 
+                $uri['host'], 
+                http_build_query($params)
+            );
+        }
+        catch (Exception $ex) {
+            // PHP evaluation bug; inform user to report bug
+            throw new \ErrorException(sprintf('Something went wrong! Please report an issue: %s', $ex->getMessage()));
+        }
+    }
+}

--- a/vendor/cloudflare-bypass/CloudflareBypass/CFCore.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/CFCore.php
@@ -1,0 +1,49 @@
+<?php
+namespace CloudflareBypass;
+
+class CFCore extends CFBypass
+{
+    /**
+     * Maximum retries allowed.
+     * @var integer
+     */ 
+    protected $max_retries = 5;
+
+    /**
+     * Use caching mechanism.
+     * @var bool
+     */
+    protected $cache = false;
+
+    /**
+     * Configuration properties:
+     *
+     * Key                  Sets
+     * -------------------------------------------
+     * "cache"              $this->cache (to Storage class)
+     * "max_retries"        $this->max_retries (to value given)
+     *
+     * @access public
+     * @param array $config Config containing any of the properties above.
+     * @throws \ErrorException if "max_retries" IS NOT an integer
+     */
+    public function __construct($config = array())
+    {
+
+        $cache = isset($config['cache']) ? $config['cache'] : true;
+        $cache_path = isset($config['cache_path']) ? $config['cache_path'] : sys_get_temp_dir()."/cf-bypass";
+
+        if ($cache === true) {
+            $this->cache = new Storage($cache_path);
+        }
+
+        // Set $this->max_retries
+        if (isset($config['max_retries'])) {
+            if (!is_numeric($config['max_retries'])) {
+                throw new \ErrorException('"max_retries" should be an integer!');
+            }
+
+            $this->max_retries = $config['max_retries'];
+        }
+    }
+}

--- a/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/CFCurl.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/CFCurl.php
@@ -1,0 +1,131 @@
+<?php
+namespace CloudflareBypass\RequestMethod;
+
+class CFCurl extends \CloudflareBypass\CFCore
+{
+    /**
+     * Bypasses cloudflare using a curl handle. Given a curl handle this method will behave 
+     * like "curl_exec" however it will take care of the IUAM page if it pops up. This method 
+     * creates a copy of the curl handle passed through for the CF process.
+     *
+     * @access public
+     * @param resource $ch cURL handle
+     * @param bool $root_scope Used in retry process (DON'T MODIFY)
+     * @param integer $retry   Used in retry process (DON'T MODIFY)
+     * @throws \ErrorException if "CURLOPT_USERAGENT" IS NOT set
+     * @throws \ErrorException if retry process FAILS more than 4 times consecutively
+     * @return string Response body
+     */
+    public function exec($ch, $root_scope = true, $retry = 1)
+    {
+        if ($root_scope) {
+            $ch = new Curl($ch);
+            
+            // Check if clearance tokens exists in a cache file. 
+            if (isset($this->cache) && $this->cache) {
+                $info = $ch->getinfo();
+                $components = parse_url($info['url']);
+
+                // Set clearance tokens.
+                if (($cached = $this->cache->fetch($components['host'])) !== false) {
+                    foreach ($cached as $cookie => $val) {
+                        $ch->setopt(CURLOPT_COOKIELIST, 'Set-Cookie: ' . $val);
+                    }
+                }
+            }
+
+            // Request original page.
+            $response = $ch->exec();
+            $response_info = $ch->getinfo();
+
+            // Check if page is protected by Cloudflare.
+            if (!$this->isProtected($response, $response_info)) {
+                return $response;
+            }
+
+            // Clone curl object handle.
+            $ch_copy = $ch->copyHandle();
+
+            // Enable response header and cookie storage.
+            $ch_copy->enableResponseStorage();
+
+            // Assign neccessary options.
+            $ch_copy->setopt(CURLINFO_HEADER_OUT, true);
+        } else {
+            // Not in root scope so $ch is a clone.
+            $ch_copy = $ch;
+        }
+
+        // Request UAM page with necessary settings.
+        $uam_response = $ch_copy->exec();
+        $uam_response_info = $ch_copy->getinfo();
+
+        if ($root_scope) {
+            /*
+             * 1. Check if user agent is set in cURL handle
+             */
+            if (!$ch_copy->getRequestHeader('User-Agent')) {
+                throw new \ErrorException('CURLOPT_USERAGENT is a mandatory field!');
+            }
+
+            /*
+             * 2. Extract "__cfuid" cookie
+             */
+            if (!($cfduid_cookie = $ch_copy->getCookie('__cfduid'))) {
+                return $response;
+            }
+            
+            $ch_copy->setopt(CURLOPT_COOKIELIST, $cfduid_cookie);
+        }
+
+        /*
+         * 3. Solve challenge and request clearance link
+         */
+        if (!($cfclearance_cookie = $ch_copy->getCookie('cf_clearance'))) {
+            $ch_copy->setopt(CURLOPT_URL, $this->getClearanceLink($uam_response, $uam_response_info['url']));
+            $ch_copy->setopt(CURLOPT_FOLLOWLOCATION, true);
+
+            // GET clearance link.
+            $ch_copy->setopt(CURLOPT_CUSTOMREQUEST, 'GET');
+            $ch_copy->setopt(CURLOPT_HTTPGET, true);
+            $ch_copy->exec();
+
+            /*
+             * 4. Extract "cf_clearance" cookie
+             */
+            if (!($cfclearance_cookie = $ch_copy->getCookie('cf_clearance'))) {
+                if ($retry > $this->max_retries) {
+                    throw new \ErrorException("Exceeded maximum retries trying to get CF clearance!");
+                }
+
+                $cfclearance_cookie = $this->exec($ch, false, $retry+1);
+            }
+        }
+
+        // Not in root scope, return clearance cookie.
+        if ($cfclearance_cookie && !$root_scope) {
+            return $cfclearance_cookie;
+        }
+
+        if (isset($this->cache) && $this->cache) {
+            $cookies = array();
+            $components = parse_url($uam_response_info['url']);
+
+            foreach ($ch_copy->getCookies() as $cookie => $val) {
+                $cookies[$cookie] = $val;
+            }
+
+            // Store clearance tokens in cache.
+            $this->cache->store($components['host'], $cookies);
+        }
+       
+        /*
+         * 5. Set "__cfduid" and "cf_clearance" in original cURL handle
+         */
+        foreach ($ch_copy->getCookies() as $cookie => $val) {
+            $ch->setopt(CURLOPT_COOKIELIST, 'Set-Cookie: ' . $val);
+        }
+
+        return $ch->exec();
+    }
+}

--- a/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/CFStream.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/CFStream.php
@@ -1,0 +1,126 @@
+<?php
+namespace CloudflareBypass\RequestMethod;
+
+class CFStream extends \CloudflareBypass\CFCore
+{
+    /**
+     * Given a URL and a context (stream / array), if URL is protected by the Cloudflare,
+     * this method will add the "__cfduid" and "cf_clearance" cookies to the "Cookie" header 
+     * (or update them if they exist).
+     *
+     * @access public
+     * @param string $url Request URL
+     * @param mixed $context Stream / array of context options
+     * @param resource $stream Stream context; used in retry process (DONT MODIFY)
+     * @param bool $root_scope Used in retry process (DON'T MODIFY)
+     * @param integer $retry   Used in retry process (DON'T MODIFY)
+     * @throws \ErrorException if $url is not a valid URL
+     * @throws \ErrorException if $context if not valid context
+     * @return resource $context
+     */
+    public function create($url, $context, $stream = null, $root_scope = true, $retry = 1)
+    {
+        if ($root_scope) {
+            // Extract array if context is a resource.
+            if (is_resource($context)) {
+                $context = stream_context_get_options($context);
+            }
+
+            $stream = new StreamContext($url, $context);
+
+            // Check if clearance tokens exists in a cache file.
+            if (isset($this->cache) && $this->cache) {
+                $components = parse_url($url);
+
+                if (($cached = $this->cache->fetch($components['host'])) !== false) {
+                    // Set clearance tokens.
+                    foreach ($cached as $cookie => $val) {
+                        $stream->setCookie($cookie, $val);
+                    }
+                }
+            }
+        }
+
+        // Request original page.
+        $response = $stream->fileGetContents();
+        $response_info = array(
+            'http_code'     => $stream->getResponseHeader('http_code')
+        );
+
+        if ($root_scope) {
+            // Check if page is protected by Cloudflare.
+            if (!$this->isProtected($response, $response_info)) {
+                return $stream;
+            }
+
+            /*
+             * 1. Check if user agent is set in context
+             */
+            if (!$stream->getRequestHeader('User-Agent')) {
+                throw new \ErrorException('User agent needs to be set in context!');
+            }
+
+            /*
+             * 2. Extract "__cfuid" cookie
+             */
+            if (!($cfduid_cookie = $stream->getCookie('__cfduid'))) {
+                return $stream;
+            }
+
+            // Clone streamcontext object handle.
+            $stream_copy = $stream->copyHandle();
+            $stream_copy->setCookie('__cfduid', $cfduid_cookie);
+        } else {
+            // Not in root scope so $stream is a clone.
+            $stream_copy = $stream;
+        }
+
+        /*
+         * 3. Solve challenge and request clearance link
+         */
+        if (!($cfclearance_cookie = $stream_copy->getCookie('cf_clearance'))) {
+            $stream_copy->setURL($this->getClearanceLink($response, $url));
+            $stream_copy->setHttpContextOption('follow_location', 1);
+
+            // GET clearance link.
+            $stream_copy->setHttpContextOption('method', 'GET');
+            $stream_copy->fileGetContents();
+
+            /*
+             * 4. Extract "cf_clearance" cookie
+             */
+            if (!($cfclearance_cookie = $stream_copy->getCookie('cf_clearance'))) {
+                if ($retry > $this->max_retries) {
+                    throw new \ErrorException("Exceeded maximum retries trying to get CF clearance!");
+                }
+
+                $cfclearance_cookie = $this->create($url, false, $stream_copy, false, $retry+1);
+            }
+        }
+
+        if (!$root_scope) {
+            return $cfclearance_cookie;
+        }
+
+        if (isset($this->cache) && $this->cache) {
+            $cookies = array();
+            $components = parse_url($url);
+
+            foreach ($stream_copy->getCookies() as $cookie => $val) {
+                $cookies[$cookie] = $val;
+            }
+
+            // Store clearance tokens in cache.
+            $this->cache->store($components['host'], $cookies);
+        }
+
+        /*
+         * 5. Set "__cfduid" and "cf_clearance" in original stream
+         */
+        $stream->setCookie('__cfduid', $cfduid_cookie);
+        $stream->setCookie('cf_clearance', $cfclearance_cookie);
+        $stream->updateContext();
+
+        return $stream;
+    }
+}

--- a/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/CFStreamContext.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/CFStreamContext.php
@@ -1,0 +1,32 @@
+<?php
+namespace CloudflareBypass\RequestMethod;
+
+class CFStreamContext extends \CloudflareBypass\CFCore
+{
+    /**
+     * Given a URL and a context (stream / array), if URL is protected by the Cloudflare,
+     * this method will add the "__cfduid" and "cf_clearance" cookies to the "Cookie" header 
+     * (or update them if they exist).
+     *
+     * @access public
+     * @param string $url Request URL
+     * @param mixed $context Stream / array of context options
+     * @param resource $stream Stream context; used in retry process (DONT MODIFY)
+     * @param bool $root_scope Used in retry process (DON'T MODIFY)
+     * @param integer $retry   Used in retry process (DON'T MODIFY)
+     * @throws \ErrorException if $url is not a valid URL
+     * @throws \ErrorException if $context if not valid context
+     * @return resource $context
+     */
+    public function create($url, $context, $stream = null, $root_scope = true, $retry = 1)
+    {
+        $stream_cf_wrapper = new CFStream(array(
+            'cache'         => $this->cache,
+            'max_retries'   => $this->max_retries
+        ));
+
+        $stream = $stream_cf_wrapper->create($url, $context, $stream, $root_scope, $retry);
+
+        return $stream->getContext();
+    }
+}

--- a/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/Curl.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/Curl.php
@@ -1,0 +1,230 @@
+<?php
+namespace CloudflareBypass\RequestMethod;
+
+class Curl
+{
+    /**
+     * Cookies set per request.
+     * @var array
+     */
+    private $cookies = array();
+
+    /**
+     * Request headers per request.
+     * @var array
+     */
+    private $request_headers = array();
+
+    /**
+     * cURL handle.
+     * @var resource
+     */
+    private $ch;
+
+    /**
+     * Sets $this->ch to specified cURL handle.
+     *
+     * @access public
+     * @param resource $curl cURL handle
+     * @throws \ErrorException if $ch IS NOT a cURL handle
+     */
+    public function __construct($ch = null)
+    {
+        if (!is_resource($ch)) {
+            throw new \ErrorException('Curl handle is required!');
+        }
+
+        $this->ch = $ch;
+    }
+
+    /**
+     * Get request headers set for current request.
+     *
+     * @access public
+     */
+    public function getRequestHeaders()
+    {
+        return $this->request_headers;
+    }
+
+    /**
+     * Get cookies set for current request.
+     *
+     * @access public
+     */
+    public function getCookies()
+    {
+        return $this->cookies;
+    }
+
+    /**
+     * Enables cURL object handle to fetch and store response headers and cookies.
+     * WARNING: Overrides "CURLOPT_HEADERFUNCTION".
+     *
+     * @access public
+     * @return bool
+     */
+    public function enableResponseStorage()
+    {
+        return $this->setopt(CURLOPT_HEADERFUNCTION, array($this, 'storeResponseHeader'));
+    }
+
+    /**
+     * Clones cURL object handle.
+     *
+     * @access public
+     * @see http://php.net/curl-copy-handle
+     * @return object cURL object
+     */
+    public function copyHandle()
+    {
+        return new Curl(curl_copy_handle($this->ch));
+    }
+
+    /**
+     * @access public
+     * @see http://php.net/curl_setopt
+     * @param integer $opt
+     * @param mixed $val
+     * @return bool
+     */
+    public function setopt($opt, $val)
+    {
+        return curl_setopt($this->ch, $opt, $val);
+    }
+
+    /**
+     * @access public
+     * @see http://php.net/curl-getinfo
+     * @param integer $opt (optional)
+     * @return mixed $val
+     */
+    public function getInfo($opt = null)
+    {
+        $args = array($this->ch);
+
+        if (func_num_args()) {
+            $args[] = $opt;
+        }
+        
+        return call_user_func_array('curl_getinfo', $args);
+    }
+
+    /**
+     * Truncates cookie feed.
+     * Truncates request headers.
+     *
+     * @access public
+     * @see http://php.net/curl_exec
+     * @return mixed
+     */
+    public function exec()
+    {
+        $this->cookies = array();
+        $this->request_headers = array();
+
+        $res = curl_exec($this->ch);
+        $info = curl_getinfo($this->ch);
+
+        if (isset($info['request_header'])) {
+            // Store request headers and cookies.
+            $headers = explode("\n", $info['request_header']);
+            $headers_count = count($headers);
+
+            for ($i=0; $i<$headers_count; $i++) {
+                $this->storeRequestHeader($this->ch, $headers[$i]);
+            }
+        }
+
+        return $res;
+    }
+
+    /**
+     * @access public
+     * @see http://php.net/curl_close
+     */
+    public function close()
+    {
+        curl_close($this->ch);
+    }
+
+    /**
+     * Returns full config for specified cookie name.
+     *
+     * @access public
+     * @param string $cookie Cookie name
+     * @return string Cookie value or NULL
+     */
+    public function getCookie($cookie)
+    {
+        if (isset($this->cookies[$cookie])) {
+            return $this->cookies[$cookie];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns value of specified request header.
+     *
+     * @access public
+     * @param string $header Request header
+     * @return string Request header or NULL
+     */
+    public function getRequestHeader($header)
+    {
+        if (isset($this->request_headers[$header])) {
+            return $this->request_headers[$header];
+        }
+
+        return null;
+    }
+
+    /**
+     * Populates request headers into $this->request_headers (header name -> value).
+     * Populates cookies into $this->cookies (cookie name -> cookie value).
+     *
+     * @access private 
+     * @param resource $ch cURL handle
+     * @param string $header Request header
+     */
+    private function storeRequestHeader($ch, $header)
+    {
+        if (strpos($header, ':') !== false) {
+            // Match request header and value.
+            list($name, $val) = explode(':', $header);
+            $this->request_headers[$name] = $val;
+        }
+
+        if (strpos($header, 'Cookie') !== false) {
+            // Convert string into array of cookies.
+            $cookies = explode(';', substr($header, strpos($header, ':')+1));
+            $cookies_count = count($cookies);
+
+            // Store cookies.
+            for ($i=0; $i<$cookies_count; $i++) {
+                list($cookie, $val) = explode('=', trim($cookies[$i]));
+                $this->cookies[$cookie] = $cookie . '=' . $val . ';';                   
+            }
+        }
+    }
+
+    /**
+     * Populates cookies set into $this->cookies (cookie name -> full cookie).
+     *
+     * @access private
+     * @param resource $ch cURL handle
+     * @param string $header Request header
+     * @return integer Byte-length of request header
+     */
+    private function storeResponseHeader($ch, $header)
+    {
+        if (strpos($header, 'Set-Cookie') !== false) {
+            // Match cookie name and value.
+            preg_match('/Set\-Cookie: ([^=]+)(.+)/', $header, $matches);
+            $this->cookies[$matches[1]] = $matches[1] . $matches[2];
+        }
+
+        return strlen($header);
+    }
+}

--- a/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/StreamContext.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/RequestMethod/StreamContext.php
@@ -1,0 +1,465 @@
+<?php
+namespace CloudflareBypass\RequestMethod;
+
+class StreamContext
+{
+    /**
+     * Cookies set per request.
+     * @var array
+     */
+    private $cookies = array();
+
+    /**
+     * Cookies set per request.
+     * @var array
+     */
+    private $cookies_original = array();
+
+    /**
+     * Request headers per request.
+     * @var array
+     */
+    private $request_headers = array();
+
+    /**
+     * Response headers per request.
+     * @var array
+     */
+    private $response_headers = array();
+
+    /**
+     * Context options.
+     * @var array
+     */
+    private $context = array();
+
+    /**
+     * Stream context.
+     * @var resource
+     */
+    private $stream_context = array();
+
+    /**
+     * Follow location.
+     * @var bool
+     */
+    private $follow_location = false;
+
+    /**
+     * Request URL.
+     * @var string
+     */
+    private $url;
+
+    /**
+     * Sets $this->URL to request URL.
+     * Sets $this->context to given context options array.
+     * Populates cookies in context options array into $this->cookies.
+     * 
+     * @access public
+     * @param string $url Request URL
+     * @param array $context Array of context options
+     * @throws \ErrorException if $url is not a valid URL
+     * @throws \ErrorException if $context is not a valid context
+     */
+    public function __construct($url, $context)
+    {
+        if (!is_string($url) || !parse_url($url)) {
+            throw new \ErrorException('Url is not valid!');
+        }
+
+        if (!is_array($context) || !isset($context['http'])) {
+            throw new \ErrorException('Context is not valid!');
+        }
+
+        $this->url = $url;
+        $this->context = $context;
+
+        $this->updateRequestHeaders();
+        $this->updateCookies();
+    }
+
+    /**
+     * Clones StreamContext object handle.
+     *
+     * @access public
+     * @return object StreamContext object
+     */
+    public function copyHandle()
+    {
+        return new StreamContext($this->url, $this->context);
+    }
+
+    /**
+     * Returns stream context.
+     *
+     * @access public
+     * @return resource
+     */
+    public function getContext()
+    {
+        return $this->stream_context;
+    }
+
+    /**
+     * Updates stream context
+     *
+     * @access public
+     */
+    public function updateContext()
+    {
+        $this->stream_context = stream_context_create($this->context);
+    }
+
+    /**
+     * Get cookies set for current request.
+     *
+     * @access public
+     * @return array
+     */
+    public function getCookies()
+    {
+        return $this->cookies;
+    }
+
+    /**
+     * Get request headers set for current request.
+     *
+     * @access public
+     * @return array
+     */
+    public function getRequestHeaders()
+    {
+        return $this->request_headers;
+    }
+
+    /**
+     * Get response headers set for current request.
+     *
+     * @access public
+     */
+    public function getResponseHeaders()
+    {
+        return $this->response_headers;
+    }
+ 
+    /**
+     * Returns full config for specified cookie name.
+     *
+     * @access public
+     * @param string $cookie Cookie name
+     * @return string Cookie value or NULL
+     */
+    public function getCookie($cookie)
+    {
+        if (isset($this->cookies[$cookie])) {
+            return $this->cookies[$cookie];
+        }
+
+        return null;
+    }
+
+    /**
+     * Populates response headers into $this->response_headers.
+     * Populates cookies set in response headers into $this->cookies.
+     *
+     * @access public
+     * @see http://php.net/file-get-contents
+     * @return string
+     */
+    public function fileGetContents()
+    {
+        $this->updateContext();
+
+        // cURL response header collection.
+        $curl_http_response_header = [];
+
+        $follow_location = isset($this->context['http']['follow_location']) ? $this->context['http']['follow_location'] : 1;
+        $method = isset($this->context['http']['method']) ? $this->context['http']['method'] : 'GET';
+
+        // Unfortunately file_get_contents doesn't return contents of a 503 page.
+        // Please advise if there is a better way to do this.
+        $ch = curl_init($this->url);
+
+        // Set options to match context.
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getCurlHttpHeaders());
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, 
+            function    ($ch, $header) 
+            use         (&$curl_http_response_header) {
+            
+            // Trim response header.
+            $trimmed_header = str_replace("\r\n", "", $header);
+            
+            // If not empty, add response header to header collection.
+            if (!empty($trimmed_header)) { 
+                $curl_http_response_header[] = $trimmed_header;
+            }
+            
+            return strlen($header);
+        });
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, $follow_location);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+
+        // Get request body.
+        $content = curl_exec($ch);
+        curl_close($ch);
+
+        // Get response headers.
+        if ($path = $this->updateResponseHeaders($curl_http_response_header)) {
+            // Follow location...
+            if (strpos($path, '/') === 0) {
+                $parsed_url = parse_url($this->url);
+                
+                $scheme     = isset($parsed_url['scheme'])   ? $parsed_url['scheme'] . '://' : '';
+                $host       = isset($parsed_url['host'])     ? $parsed_url['host'] : '';
+                $port       = isset($parsed_url['port'])     ? ':' . $parsed_url['port'] : '';
+                $user       = isset($parsed_url['user'])     ? $parsed_url['user'] : '';
+                $pass       = isset($parsed_url['pass'])     ? ':' . $parsed_url['pass'] : '';
+                $pass       = ($user || $pass)               ? $pass . '@' : '';
+                
+                $this->url = $scheme . $user . $pass . $host . $port . $path;
+            } else {
+                $this->url .= $path;
+            }
+
+            $content = $this->fileGetContents();
+        }
+
+        return $content;
+    }
+
+    /**
+     * Returns value of specified request header.
+     *
+     * @access public
+     * @param string $header Request header
+     * @return string Request header or NULL
+     */
+    public function getRequestHeader($header)
+    {
+        if (isset($this->request_headers[$header])) {
+            return $this->request_headers[$header];
+        }
+
+        if ($header == 'User-Agent' && isset($this->context['http']['user_agent'])) {
+            return $this->context['http']['user_agent'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns value of specified response header.
+     *
+     * @access public
+     * @param string $header Response header
+     * @return string Response header or NULL
+     */
+    public function getResponseHeader($header)
+    {
+        if (isset($this->response_headers[$header])) {
+            return $this->response_headers[$header];
+        }
+    }
+
+    /**
+     * Set Request URL.
+     *
+     * @access public
+     * @param string $url Request URL
+     * @throws \ErrorException if $url is not a valid URL
+     */
+    public function setURL($url)
+    {
+        if (!is_string($url) || !parse_url($url)) {
+            throw new \ErrorException('Url is not valid!');
+        }
+
+        $this->url = $url;
+    }
+
+    /**
+     * Sets option in HTTP context array.
+     *
+     * @access public
+     * @param string $name Option name
+     * @param string $val Option value
+     */
+    public function setHttpContextOption($name, $val)
+    {
+        if ($name === 'follow_location') {
+            $this->follow_location = $val;
+            $this->context['http']['follow_location'] = 0;
+        } else {
+            $this->context['http'][$name] = $val;
+        }
+    }
+
+    /**
+     * Set Cookie in context array.
+     *
+     * @access public
+     * @param string $name Cookie name
+     * @param string $val Cookie value
+     */
+    public function setCookie($name, $val)
+    {   
+        // Extract value from cookie string.
+        $pos = strpos($val, '=');
+  
+        if ($pos !== false) {
+            $val = substr($val, strpos($val, '=')+1);
+        }
+
+        $settings = explode(';', $val);
+
+        if (isset($this->request_headers['Cookie'])) {
+            // Add cookie to cookie list.
+            $match = "/(Cookie:.+?)\r\n/";
+            $replace = '$1' . $name . '=' . $settings[0] . ";\r\n";
+
+            if (strpos($this->request_headers['Cookie'], $name . '=') !== false) {
+                // Update value for specified cookie.
+                $match = "/(Cookie:.+?)$name=(.+?);/";
+                $replace = '$1' . $name . '=' . $settings[0] . ';';
+            }
+
+            $this->context['http']['header'] = preg_replace($match, $replace, $this->context['http']['header']);
+        } else {
+            if (empty($this->request_headers)) {
+                $this->context['http']['header'] = "";
+            } elseif (substr($this->context['http']['header'], -2) !== "\r\n") {
+                $this->context['http']['header'] .= "\r\n";
+            }
+
+            // Add cookie header with new cookie.
+            $this->context['http']['header'] .= 'Cookie:' . $name . '=' . $settings[0] . ";\r\n";
+        }
+
+        $this->updateRequestHeaders();
+        $this->updateCookies();
+    }
+
+    /**
+     * Converts context headers into format compatible with "CURLOPT_HTTPHEADER".
+     *
+     * @access private
+     * @return array
+     */
+    public function getCurlHttpHeaders()
+    {
+        // Convert headers into format compatible with cURL
+        $http_headers = explode("\r\n", $this->context['http']['header']);
+
+        // User agent can be set in 2 places, "header" and "user_agent".
+        if (strpos($this->context['http']['header'], 'User-Agent') === false) {
+            if (isset($this->context['http']['user_agent'])) {
+                $http_headers[] = 'User-Agent: ' . $this->context['http']['user_agent'];
+            }
+        }
+
+        return $http_headers;
+    }
+
+    /**
+     * Updates $this->request_headers to match with context array. 
+     *
+     * @access private
+     */
+    private function updateRequestHeaders()
+    {
+        // Extract request headers.
+        $headers = explode("\r\n", $this->context['http']['header']);
+        $headers_count = count($headers);
+
+        // Set request headers.
+        for ($i=0; $i<$headers_count; $i++) {
+            if (strpos($headers[$i], ':') !== false) {
+                list($name, $val) = explode(':', $headers[$i]);
+                $this->request_headers[$name] = $val;
+            }
+        }
+    }
+
+    /**
+     * Updates $this->response_headers to match response headers from current request.
+     *
+     * @access private
+     * @param array $http_response_header
+     * @return string URI to follow
+     */
+    private function updateResponseHeaders($headers)
+    {
+        $this->response_headers = array();
+        $follow_uri = "";
+
+        foreach ($headers as $header) {
+            if (strpos($header, 'HTTP') === 0) {
+                // Store HTTP code as its own response header.
+                $matches = explode(' ', $header);
+                $this->response_headers['http_code'] = $matches[1];
+            } elseif (strpos($header, 'Set-Cookie') !== false) {
+                // Extract response cookie.
+                list($_, $fullval) = explode(':', $header);
+                list($cookie, $val) = explode('=', trim($fullval));
+                // Ignore other config options.
+                $val = substr($val, 0, strpos($val, ';'));
+                // Store cookie.
+                $this->setCookie($cookie, $val);
+            } elseif (strpos($header, ':') !== false) {
+                // Store response header.
+                list($name, $val) = explode(':', $header);
+                $this->response_headers[$name] = $val;
+                // Store location to follow.
+                if ($name === "Location") {
+                    $follow_uri = $val;
+                }
+            }
+        }
+
+        // Update cookies.
+        $this->updateRequestHeaders();
+        $this->updateCookies();
+        
+        // Follow location if location is set and follow location is enabled
+        if ($this->follow_location && $follow_uri) {
+            return trim($follow_uri);
+        }
+
+        return "";
+    }
+
+    /**
+     * Updates $this->cookies to match with context array.
+     *
+     * @access private
+     */
+    private function updateCookies()
+    {
+        // Extract cookies.        
+        if (isset($this->request_headers['Cookie'])) {
+            $cookies = explode(';', $this->request_headers['Cookie']);
+            $cookies_count = count($cookies);
+
+            // Set cookies.
+            for ($i=0; $i<$cookies_count; $i++) {
+                if (strpos($cookies[$i], '=') !== false) {
+                    list($name, $val) = explode('=', trim($cookies[$i]));
+                    $this->cookies[$name] = $name . '=' . $val . ';';
+                    $this->cookies_original[$name] = $val;
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieve cookies raw
+     *
+     * @return array
+     */
+    public function getCookiesOriginal()
+    {
+        return $this->cookies_original;
+    }
+}

--- a/vendor/cloudflare-bypass/CloudflareBypass/Storage.php
+++ b/vendor/cloudflare-bypass/CloudflareBypass/Storage.php
@@ -1,0 +1,139 @@
+<?php
+namespace CloudflareBypass;
+
+class Storage
+{
+
+    /**
+     * Path storage
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * Creates Cache directory if it does NOT exist
+     *
+     * @access public
+     * @throws \ErrorException if cache directory CAN NOT be created
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+
+        // Suffix path with forward-slash if not done already.
+        if (substr($this->path, -1) !== "/") {
+            $this->path .= "/";
+        }
+
+        $this->createBaseFolder();
+    }
+
+    /**
+     * Create base folder path
+     *
+     * @return void
+     */
+    public function createBaseFolder()
+    {
+        if (!is_dir($this->path)) {
+            if (!mkdir($this->path, 0755, true)) {
+                throw new \ErrorException('Unable to create Cache directory!');
+            }
+        }
+    }
+
+    /**
+     * Returns clearance tokens from the specified cache file.
+     *
+     * @access public
+     * @param $site_host Site host
+     * @throws \ErrorException if $site_host IS empty
+     * @return array Clearance tokens or FALSE
+     */
+    public function fetch($site_host)
+    {
+        if (trim($site_host) === "") {
+            throw new \ErrorException("Site host should not be empty!");
+        }
+
+        // Construct cache file endpoint.
+        $file = md5($site_host);
+
+        if (!file_exists($this->path . $file)) {
+            if (preg_match('/^www./', $site_host)) {
+                $file = md5(substr($site_host, 4));
+            }
+        }
+
+        if (file_exists($this->path . $file)) {
+            return json_decode(file_get_contents($this->path . $file), true);
+        }
+
+        return false;
+    }
+
+    /**
+     * Stores clearance tokens into a cache file in cache folder.
+     *
+     * File name:           Data:
+     * -------------------------------------------
+     * md5( file name )     {"__cfduid":"<cfduid>", "cf_clearance":"<cf_clearance>"}
+     *
+     * @access public
+     * @param string $site_host site host name
+     * @param array $clearance_tokens Associative array containing "__cfduid" and "cf_clearance" cookies
+     * @throws \ErrorException if $site_host IS empty
+     * @throws \ErrorException if $clearance_tokens IS missing token fields, OR contains rubbish
+     * @throws \ErrorException if file_put_contents FAILS to write to file
+     */
+    public function store($site_host, $clearance_tokens)
+    {
+        if (trim($site_host) === "") {
+            throw new \ErrorException("Site host should not be empty!");
+        }
+
+        if (!(
+            is_array($clearance_tokens) && 
+            isset($clearance_tokens['__cfduid']) &&
+            isset($clearance_tokens['cf_clearance'])
+        )) {
+            throw new \ErrorException("Clearance tokens not in a valid format!");
+        }
+
+        // Construct cache file endpoint.
+        $filename = $this->path . md5($site_host);
+
+        // Perform data retention duties.
+        $this->retention();
+
+        if (!file_put_contents($filename, json_encode($clearance_tokens))) {
+            // Remove file if it exists.
+            if (file_exists($filename)) {
+                unlink($filename);
+            }
+        }
+    }
+
+    /**
+     * Deletes files from cache folder which are older than 24 hours.
+     *
+     * @access private
+     */
+    private function retention()
+    {
+        if ($handle = opendir($this->path)) {
+            while (false !== ($file = readdir($handle))) {
+                // Skip special directories.
+                if ('.' === $file || '..' === $file || strpos($file, '.') === 0) {
+                    continue;
+                }
+        
+                // Delete file if last modified over 24 hours ago.
+                if (time()-filemtime($this->path . "/" . $file) > 86400) {
+                    unlink($this->path . "/". $file);
+                }
+            }
+        }
+    }
+}

--- a/vendor/cloudflare-bypass/autoload.php
+++ b/vendor/cloudflare-bypass/autoload.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * For users who do NOT want to install composer.
+ * This file should take care of loading the right class.
+ */
+spl_autoload_register(function ($class) {
+    // Not interested in class if its not a child of CloudflareBypass
+    if (substr($class, 0, 17) !== 'CloudflareBypass\\') {
+      return;
+    }
+    
+    $class = str_replace('\\', '/', $class);
+    
+    $path = dirname(__FILE__).'/'.$class.'.php';
+    if (is_readable($path)) {
+        require_once $path;
+    }
+});


### PR DESCRIPTION
This PR implements `cloudflare-bypass` from https://github.com/KyranRana/cloudflare-bypass

Please do not merge yet, there are a few things to discuss first!

Sites with Cloudflare protection generally prevent services like RSS-Bridge from accessing contents by putting the site in UAM (Under Attack Mode). Regular browsers will go through a process to enter the site by executing some JavaScript that stores cookies on the machine for subsequent requests. In general this procedure takes a few seconds during which the user is presented a waiting page.

cloudflare-bypass basically goes through the same procedure via PHP. That way the contents are made available again for RSS-Bridge to collect. 

Notice: The way cloudflare-bypass is implemented, it will have no effect on "regular" connections without Cloudflare protection.

With this PR I have fixed two bridges (Cpasbien and Torrent9) which were previously blocked by Cloudflare. They now work fine on my machine, so if you want to try it yourself, those bridges are prepared.

`cloudflare-bypass` currently doesn't provide a license, even though it's being discussed (possibly Unlicense). So this is another point to consider. Additionally the library is currenly copied manually into the 'vendors' folder but could also be installed automatically via composer (which I'm not sure how this would work to be honest).

Please let me know what you think about this PR

- Do we want this to be part of RSS-Bridge?
- Is there any reason to keep this from being part of master? (too far into gray zone?)
- Should this feature be made optional (via settings or based on the bridge)?
- Further ideas or suggestions?