### PR TITLE
Adds markdown support to Container Linux Feed

### DIFF
--- a/bridges/ContainerLinuxReleasesBridge.php
+++ b/bridges/ContainerLinuxReleasesBridge.php
@@ -40,17 +40,28 @@ class ContainerLinuxReleasesBridge extends BridgeAbstract {
 
 			$item['uri'] = "https://coreos.com/releases/#$releaseVersion";
 			$item['title'] = $releaseVersion;
-			$item['content'] = nl2br($release['release_notes']);
 
-			$item['content'] .= <<<EOT
-<br/>
+			$content = $release['release_notes'];
+			$content .= <<<EOT
+
 Major Software:
-<br/>
-- Kernel: {$release['major_software']['kernel'][0]}<br/>
-- Docker: {$release['major_software']['docker'][0]}<br/>
-- etcd: {$release['major_software']['etcd'][0]}<br/>
+* Kernel: <tt>{$release['major_software']['kernel'][0]}</tt>
+* Docker: <tt>{$release['major_software']['docker'][0]}</tt>
+* etcd: <tt>{$release['major_software']['etcd'][0]}</tt>
 EOT;
 			$item['timestamp'] = strtotime($release['release_date']);
+
+			// Based on https://gist.github.com/jbroadway/2836900
+			$regex = '/\[([^\[]+)\]\(([^\)]+)\)/';
+			$replacement = '<a href=\'\2\'>\1</a>';
+
+			$item['content'] = preg_replace($regex, $replacement, nl2br($content));
+
+			$regex = '/\n[\*|\-](.*)/';
+			$item['content'] = preg_replace_callback ($regex, function($regs) {
+				$item = $regs[1];
+				return sprintf ("\n<ul>\n\t<li>%s</li>\n</ul>", trim ($item));
+			}, $item['content']);
 
 			$this->items[] = $item;
 		}

--- a/bridges/ContainerLinuxReleasesBridge.php
+++ b/bridges/ContainerLinuxReleasesBridge.php
@@ -45,22 +45,28 @@ class ContainerLinuxReleasesBridge extends BridgeAbstract {
 			$content .= <<<EOT
 
 Major Software:
-* Kernel: <tt>{$release['major_software']['kernel'][0]}</tt>
-* Docker: <tt>{$release['major_software']['docker'][0]}</tt>
-* etcd: <tt>{$release['major_software']['etcd'][0]}</tt>
+* Kernel: {$release['major_software']['kernel'][0]}
+* Docker: {$release['major_software']['docker'][0]}
+* etcd: {$release['major_software']['etcd'][0]}
 EOT;
 			$item['timestamp'] = strtotime($release['release_date']);
 
 			// Based on https://gist.github.com/jbroadway/2836900
+			// Links
 			$regex = '/\[([^\[]+)\]\(([^\)]+)\)/';
 			$replacement = '<a href=\'\2\'>\1</a>';
+			$item['content'] = preg_replace($regex, $replacement, $content);
 
-			$item['content'] = preg_replace($regex, $replacement, nl2br($content));
+			// Headings
+			$regex = '/^(.*)\:\s?$/m';
+			$replacement = '<h3>\1</h3>';
+			$item['content'] = preg_replace($regex, $replacement, $item['content']);
 
-			$regex = '/\n[\*|\-](.*)/';
+			// Lists
+			$regex = '/\n\s*[\*|\-](.*)/';
 			$item['content'] = preg_replace_callback ($regex, function($regs) {
 				$item = $regs[1];
-				return sprintf ("\n<ul>\n\t<li>%s</li>\n</ul>", trim ($item));
+				return sprintf ("<ul><li>%s</li></ul>", trim ($item));
 			}, $item['content']);
 
 			$this->items[] = $item;


### PR DESCRIPTION
- The earlier feed was serving plain markdown inside HTML
- This adds some basic Markdown parsing to make it look better

Results:

![image](https://user-images.githubusercontent.com/584253/41954516-3c68f8d2-79f9-11e8-8f56-375b26bb5f48.png)

The dumb parser is based on https://gist.github.com/jbroadway/2836900, but doesn't seem to parse all the lists properly. But seems to work for most of them, and the feed degrades gracefully so seems fine.