### PR TITLE
Add recuperation of the current version from git if available.

### DIFF
--- a/index.php
+++ b/index.php
@@ -253,7 +253,8 @@ EOD;
 		echo $inactiveBridges;
 	?>
 	<section class="footer">
-		<a href="https://github.com/RSS-Bridge/rss-bridge">RSS-Bridge 2018-06-10 ~ Public Domain</a><br />
+		<a href="https://github.com/RSS-Bridge/rss-bridge">RSS-Bridge ~ Public Domain</a><br />
+		<p class="version"> <?= Configuration::getVersion() ?> </p>
 		<?= $activeFoundBridgeCount; ?>/<?= count($bridgeList) ?> active bridges. <br />
 		<?php
 			if($activeFoundBridgeCount !== count($bridgeList)) {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -115,8 +115,9 @@ class Configuration {
 			if(file_exists($revisionHashFile)) {
 				return 'git.' . $branchName . '.' . substr(file_get_contents($revisionHashFile), 0, 7);
 			}
+		}
 
-		} else return Configuration::$VERSION;
+		return Configuration::$VERSION;
 
 	}
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -1,6 +1,8 @@
 <?php
 class Configuration {
 
+	public static $VERSION = "2018-06-10";
+
 	public static $config = null;
 
 	public static function verifyInstallation() {
@@ -99,6 +101,18 @@ class Configuration {
 		}
 
 		return null;
+
+	}
+
+	public static function getVersion() {
+
+		$revisionHashFile = '.git/refs/heads/master';
+
+		if(file_exists($revisionHashFile)) {
+
+			return 'git.' . trim(file_get_contents($revisionHashFile));
+
+		} else return Configuration::$VERSION;
 
 	}
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -106,11 +106,15 @@ class Configuration {
 
 	public static function getVersion() {
 
-		$revisionHashFile = '.git/refs/heads/master';
+		$headFile = '.git/HEAD';
 
-		if(file_exists($revisionHashFile)) {
+		if(file_exists($headFile)) {
 
-			return 'git.' . trim(file_get_contents($revisionHashFile));
+			$revisionHashFile = '.git/' . substr(file_get_contents($headFile), 5, -1);
+			$branchName = explode('/', $revisionHashFile)[3];
+			if(file_exists($revisionHashFile)) {
+				return 'git.' . $branchName . '.' . substr(file_get_contents($revisionHashFile), 0, 7);
+			}
 
 		} else return Configuration::$VERSION;
 

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -64,7 +64,10 @@ function buildBridgeException($e, $bridge){
 	$body = 'Error message: `'
 	. $e->getMessage()
 	. "`\nQuery string: `"
-	. $_SERVER['QUERY_STRING'] . '`';
+	. $_SERVER['QUERY_STRING']
+	. "`\nVersion: `"
+	. Configuration::getVersion()
+	. '`';
 
 	$link = buildGitHubIssueQuery($title, $body, 'bug report', $bridge->getMaintainer());
 

--- a/static/style.css
+++ b/static/style.css
@@ -143,6 +143,11 @@ section.footer:hover {
 
 }
 
+section.footer .version {
+	
+	font-size: 80%;
+	
+}
 
 section > h2 {
 


### PR DESCRIPTION
Include the version when auto-reporting an error.
When creating a new release, we can just update the version in the configuration class.

![capturerssb1](https://user-images.githubusercontent.com/7746332/41993396-3d664cc2-7a43-11e8-8216-ea4f32a480be.PNG)
![capturerssb2](https://user-images.githubusercontent.com/7746332/41993397-3d8ad786-7a43-11e8-8c34-4f35eee150a3.PNG)
![capturerssb3](https://user-images.githubusercontent.com/7746332/41993398-3db133e0-7a43-11e8-8033-affbee753c80.PNG)
