### PR TITLE
[phpcs] enforce single quotes

### DIFF
--- a/bridges/BlaguesDeMerdeBridge.php
+++ b/bridges/BlaguesDeMerdeBridge.php
@@ -19,7 +19,7 @@ class BlaguesDeMerdeBridge extends BridgeAbstract {
 				$item['content'] = trim($element->find('div.joke_text_contener', 0)->innertext);
 				$uri = $temp[2]->href;
 				$item['uri'] = $uri;
-				$item['title'] = substr($uri, (strrpos($uri, "/") + 1));
+				$item['title'] = substr($uri, (strrpos($uri, '/') + 1));
 				$date = $element->find('li.bdm_date', 0)->innertext;
 				$time = mktime(0, 0, 0, substr($date, 3, 2), substr($date, 0, 2), substr($date, 6, 4));
 				$item['timestamp'] = $time;

--- a/bridges/CADBridge.php
+++ b/bridges/CADBridge.php
@@ -23,14 +23,14 @@ class CADBridge extends FeedExpander {
 		if($html3 == false)
 			return 'Daily comic not released yet';
 
-		$htmlpart = explode("/", $url);
+		$htmlpart = explode('/', $url);
 
 		switch ($htmlpart[3]) {
 			case 'cad':
-				preg_match_all("/http:\/\/cdn2\.cad-comic\.com\/comics\/cad-\S*png/", $html3, $url2);
+				preg_match_all('/http:\/\/cdn2\.cad-comic\.com\/comics\/cad-\S*png/', $html3, $url2);
 				break;
 			case 'sillies':
-				preg_match_all("/http:\/\/cdn2\.cad-comic\.com\/comics\/sillies-\S*gif/", $html3, $url2);
+				preg_match_all('/http:\/\/cdn2\.cad-comic\.com\/comics\/sillies-\S*gif/', $html3, $url2);
 				break;
 			default:
 				return 'Daily comic not released yet';

--- a/bridges/CopieDoubleBridge.php
+++ b/bridges/CopieDoubleBridge.php
@@ -25,7 +25,7 @@ class CopieDoubleBridge extends BridgeAbstract {
 			} elseif(strpos($element->innertext, '/images/suivant.gif') === false) {
 				$a = $element->find('a', 0);
 				$item['uri'] = self::URI . $a->href;
-				$content = str_replace('src="/', 'src="/' . self::URI, $element->find("td", 0)->innertext);
+				$content = str_replace('src="/', 'src="/' . self::URI, $element->find('td', 0)->innertext);
 				$content = str_replace('href="/', 'href="' . self::URI, $content);
 				$item['content'] = $content;
 				$this->items[] = $item;

--- a/bridges/CourrierInternationalBridge.php
+++ b/bridges/CourrierInternationalBridge.php
@@ -11,7 +11,7 @@ class CourrierInternationalBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM(self::URI)
 			or returnServerError('Error.');
 
-		$element = $html->find("article");
+		$element = $html->find('article');
 		$article_count = 1;
 
 		foreach($element as $article) {

--- a/bridges/CpasbienBridge.php
+++ b/bridges/CpasbienBridge.php
@@ -16,7 +16,7 @@ class CpasbienBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$request = str_replace(" ", "-", trim($this->getInput('q')));
+		$request = str_replace(' ', '-', trim($this->getInput('q')));
 		$html = getSimpleHTMLDOM(self::URI . '/recherche/' . urlencode($request) . '.html')
 			or returnServerError('No results for this query.');
 

--- a/bridges/DanbooruBridge.php
+++ b/bridges/DanbooruBridge.php
@@ -41,7 +41,7 @@ class DanbooruBridge extends BridgeAbstract {
 
 		$item = array();
 		$item['uri'] = $element->find('a', 0)->href;
-		$item['postid'] = (int)preg_replace("/[^0-9]/", '', $element->getAttribute(static::IDATTRIBUTE));
+		$item['postid'] = (int)preg_replace('/[^0-9]/', '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();
 		$thumbnailUri = $element->find('img', 0)->src;
 		$item['tags'] = $this->getTags($element);

--- a/bridges/DemoBridge.php
+++ b/bridges/DemoBridge.php
@@ -35,11 +35,11 @@ class DemoBridge extends BridgeAbstract {
 	public function collectData(){
 
 		$item = array();
-		$item['author'] = "Me!";
-		$item['title'] = "Test";
-		$item['content'] = "Awesome content !";
-		$item['id'] = "Lalala";
-		$item['uri'] = "http://example.com/test";
+		$item['author'] = 'Me!';
+		$item['title'] = 'Test';
+		$item['content'] = 'Awesome content !';
+		$item['id'] = 'Lalala';
+		$item['uri'] = 'http://example.com/test';
 
 		$this->items[] = $item;
 	}

--- a/bridges/DiscogsBridge.php
+++ b/bridges/DiscogsBridge.php
@@ -42,59 +42,59 @@ class DiscogsBridge extends BridgeAbstract {
 		if(!empty($this->getInput('artistid')) || !empty($this->getInput('labelid'))) {
 
 			if(!empty($this->getInput('artistid'))) {
-				$data = getContents("https://api.discogs.com/artists/"
+				$data = getContents('https://api.discogs.com/artists/'
 						. $this->getInput('artistid')
-						. "/releases?sort=year&sort_order=desc")
-						or returnServerError("Unable to query discogs !");
+						. '/releases?sort=year&sort_order=desc')
+						or returnServerError('Unable to query discogs !');
 			} elseif(!empty($this->getInput('labelid'))) {
-				$data = getContents("https://api.discogs.com/labels/"
+				$data = getContents('https://api.discogs.com/labels/'
 						. $this->getInput('labelid')
-						. "/releases?sort=year&sort_order=desc")
-						or returnServerError("Unable to query discogs !");
+						. '/releases?sort=year&sort_order=desc')
+						or returnServerError('Unable to query discogs !');
 			}
 
 			$jsonData = json_decode($data, true);
-			foreach($jsonData["releases"] as $release) {
+			foreach($jsonData['releases'] as $release) {
 
 				$item = array();
-				$item["author"] = $release["artist"];
-				$item["title"] = $release["title"];
-				$item["id"] = $release["id"];
-				$resId = array_key_exists("main_release", $release) ? $release["main_release"] : $release["id"];
-				$item["uri"] = self::URI . $this->getInput('artistid') . "/release/" . $resId;
-				$item["timestamp"] = DateTime::createFromFormat("Y", $release["year"])->getTimestamp();
-				$item["content"] = $item["author"] . " - " . $item["title"];
+				$item['author'] = $release['artist'];
+				$item['title'] = $release['title'];
+				$item['id'] = $release['id'];
+				$resId = array_key_exists('main_release', $release) ? $release['main_release'] : $release['id'];
+				$item['uri'] = self::URI . $this->getInput('artistid') . '/release/' . $resId;
+				$item['timestamp'] = DateTime::createFromFormat('Y', $release['year'])->getTimestamp();
+				$item['content'] = $item['author'] . ' - ' . $item['title'];
 				$this->items[] = $item;
 			}
 
-		} elseif(!empty($this->getInput("username_wantlist")) || !empty($this->getInput("username_folder"))) {
+		} elseif(!empty($this->getInput('username_wantlist')) || !empty($this->getInput('username_folder'))) {
 
-			if(!empty($this->getInput("username_wantlist"))) {
-				$data = getContents("https://api.discogs.com/users/"
+			if(!empty($this->getInput('username_wantlist'))) {
+				$data = getContents('https://api.discogs.com/users/'
 						. $this->getInput('username_wantlist')
-						. "/wants?sort=added&sort_order=desc")
-						or returnServerError("Unable to query discogs !");
-				$jsonData = json_decode($data, true)["wants"];
+						. '/wants?sort=added&sort_order=desc')
+						or returnServerError('Unable to query discogs !');
+				$jsonData = json_decode($data, true)['wants'];
 
-			} elseif(!empty($this->getInput("username_folder"))) {
-				$data = getContents("https://api.discogs.com/users/"
+			} elseif(!empty($this->getInput('username_folder'))) {
+				$data = getContents('https://api.discogs.com/users/'
 						. $this->getInput('username_folder')
-						. "/collection/folders/"
-						. $this->getInput("folderid")
-						."/releases?sort=added&sort_order=desc")
-						or returnServerError("Unable to query discogs !");
-				$jsonData = json_decode($data, true)["releases"];
+						. '/collection/folders/'
+						. $this->getInput('folderid')
+						.'/releases?sort=added&sort_order=desc')
+						or returnServerError('Unable to query discogs !');
+				$jsonData = json_decode($data, true)['releases'];
 			}
 			foreach($jsonData as $element) {
 
-				$infos = $element["basic_information"];
+				$infos = $element['basic_information'];
 				$item = array();
-				$item["title"] = $infos["title"];
-				$item["author"] = $infos["artists"][0]["name"];
-				$item["id"] = $infos["artists"][0]["id"];
-				$item["uri"] = self::URI . $infos["artists"][0]["id"] . "/release/" . $infos["id"];
-				$item["timestamp"] = strtotime($element["date_added"]);
-				$item["content"] = $item["author"] . " - " . $item["title"];
+				$item['title'] = $infos['title'];
+				$item['author'] = $infos['artists'][0]['name'];
+				$item['id'] = $infos['artists'][0]['id'];
+				$item['uri'] = self::URI . $infos['artists'][0]['id'] . '/release/' . $infos['id'];
+				$item['timestamp'] = strtotime($element['date_added']);
+				$item['content'] = $item['author'] . ' - ' . $item['title'];
 				$this->items[] = $item;
 
 			}

--- a/bridges/ETTVBridge.php
+++ b/bridges/ETTVBridge.php
@@ -1,7 +1,7 @@
 <?php
 class ETTVBridge extends BridgeAbstract {
 
-	const MAINTAINER = "GregThib";
+	const MAINTAINER = 'GregThib';
 	const NAME = 'ETTV';
 	const URI = 'https://www.ettv.tv/';
 	const DESCRIPTION = 'Returns list of 20 latest torrents for a specific search.';
@@ -113,7 +113,7 @@ class ETTVBridge extends BridgeAbstract {
 			$entry = $element->find('td', 1)->find('a', 0);
 
 			// retrieve result page to get more details
-			$link = rtrim(self::URI, "/") . $entry->href;
+			$link = rtrim(self::URI, '/') . $entry->href;
 			$page = getSimpleHTMLDOM($link)
 				or returnServerError('Could not request page ' . $link);
 

--- a/bridges/EZTVBridge.php
+++ b/bridges/EZTVBridge.php
@@ -1,7 +1,7 @@
 <?php
 class EZTVBridge extends BridgeAbstract {
 
-	const MAINTAINER = "alexAubin";
+	const MAINTAINER = 'alexAubin';
 	const NAME = 'EZTV';
 	const URI = 'https://eztv.ch/';
 	const DESCRIPTION = 'Returns list of *recent* torrents for a specific show
@@ -23,15 +23,15 @@ on EZTV. Get showID from URLs in https://eztv.ch/shows/showID/show-full-name.';
 			$relativeDays = 0;
 			$relativeHours = 0;
 
-			foreach(explode(" ", $relativeReleaseTime) as $relativeTimeElement) {
-				if(substr($relativeTimeElement, -1) == "d") $relativeDays = substr($relativeTimeElement, 0, -1);
-				if(substr($relativeTimeElement, -1) == "h") $relativeHours = substr($relativeTimeElement, 0, -1);
+			foreach(explode(' ', $relativeReleaseTime) as $relativeTimeElement) {
+				if(substr($relativeTimeElement, -1) == 'd') $relativeDays = substr($relativeTimeElement, 0, -1);
+				if(substr($relativeTimeElement, -1) == 'h') $relativeHours = substr($relativeTimeElement, 0, -1);
 			}
 			return mktime(date('h') - $relativeHours, 0, 0, date('m'), date('d') - $relativeDays, date('Y'));
 		}
 
 		// Loop on show ids
-		$showList = explode(",", $this->getInput('i'));
+		$showList = explode(',', $this->getInput('i'));
 		foreach($showList as $showID) {
 
 			// Get show page

--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -103,19 +103,19 @@ EOD;
 		$html = $this->buildContent($fileContent);
 		$author = $this->getInput('u');
 
-		foreach($html->find("article") as $content) {
+		foreach($html->find('article') as $content) {
 
 			$item = array();
 
-			$item['uri'] = "http://touch.facebook.com"
-			. $content->find("div[class='_52jc _5qc4 _24u0 _36xo']", 0)->find("a", 0)->getAttribute("href");
+			$item['uri'] = 'http://touch.facebook.com'
+			. $content->find("div[class='_52jc _5qc4 _24u0 _36xo']", 0)->find('a', 0)->getAttribute('href');
 
-			if($content->find("header", 0) !== null) {
-				$content->find("header", 0)->innertext = "";
+			if($content->find('header', 0) !== null) {
+				$content->find('header', 0)->innertext = '';
 			}
 
-			if($content->find("footer", 0) !== null) {
-				$content->find("footer", 0)->innertext = "";
+			if($content->find('footer', 0) !== null) {
+				$content->find('footer', 0)->innertext = '';
 			}
 
 			//Remove html nodes, keep only img, links, basic formatting
@@ -168,7 +168,7 @@ EOD;
 		$regex = implode(
 			'',
 			array(
-				"/timeline_unit",
+				'/timeline_unit',
 				"\\\\\\\\u00253A1",
 				"\\\\\\\\u00253A([0-9]*)",
 				"\\\\\\\\u00253A([0-9]*)",
@@ -182,18 +182,18 @@ EOD;
 		return implode(
 			'',
 			array(
-				"https://touch.facebook.com/pages_reaction_units/more/?page_id=",
+				'https://touch.facebook.com/pages_reaction_units/more/?page_id=',
 				$pageID,
-				"&cursor=%7B%22timeline_cursor%22%3A%22timeline_unit%3A1%3A",
+				'&cursor=%7B%22timeline_cursor%22%3A%22timeline_unit%3A1%3A',
 				$result[1],
-				"%3A",
+				'%3A',
 				$result[2],
-				"%3A",
+				'%3A',
 				$result[3],
-				"%3A",
+				'%3A',
 				$result[4],
-				"%22%2C%22timeline_section_cursor%22%3A%7B%7D%2C%22",
-				"has_next_page%22%3Atrue%7D&surface=mobile_page_home&unit_count=3"
+				'%22%2C%22timeline_section_cursor%22%3A%7B%7D%2C%22',
+				'has_next_page%22%3Atrue%7D&surface=mobile_page_home&unit_count=3'
 			)
 		);
 	}
@@ -201,7 +201,7 @@ EOD;
 	//Builds the HTML from the encoded JS that Facebook provides.
 	private function buildContent($pageContent){
 
-		$regex = "/\\\"html\\\":\\\"(.*?)\\\",\\\"replace/";
+		$regex = '/\\"html\\":\\"(.*?)\\",\\"replace/';
 		preg_match($regex, $pageContent, $result);
 
 		return str_get_html(html_entity_decode(json_decode('"' . $result[1] . '"')));
@@ -214,7 +214,7 @@ EOD;
 
 		$ctx = stream_context_create(array(
 			'http' => array(
-				'user_agent' => "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0",
+				'user_agent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0',
 				'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
 				)
 			)
@@ -222,12 +222,12 @@ EOD;
 		$a = file_get_contents($pageURL, 0, $ctx);
 
 		//First request to get the cookie
-		$cookies = "";
+		$cookies = '';
 		foreach($http_response_header as $hdr) {
-			if(strpos($hdr, "Set-Cookie") !== false) {
-				$cLine = explode(":", $hdr)[1];
-				$cLine = explode(";", $cLine)[0];
-				$cookies .= ";" . $cLine;
+			if(strpos($hdr, 'Set-Cookie') !== false) {
+				$cLine = explode(':', $hdr)[1];
+				$cLine = explode(';', $cLine)[0];
+				$cookies .= ';' . $cLine;
 			}
 		}
 
@@ -239,7 +239,7 @@ EOD;
 
 		$context = stream_context_create(array(
 			'http' => array(
-				'user_agent' => "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0",
+				'user_agent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0',
 				'header' => 'Cookie: ' . $cookies
 				)
 			)
@@ -247,12 +247,12 @@ EOD;
 
 		$pageContent = file_get_contents($page, 0, $context);
 
-		if(strpos($pageContent, "signup-button") != false) {
+		if(strpos($pageContent, 'signup-button') != false) {
 			return -1;
 		}
 
 		//Get the page ID if we don't have a captcha
-		$regex = "/page_id=([0-9]*)&/";
+		$regex = '/page_id=([0-9]*)&/';
 		preg_match($regex, $pageContent, $matches);
 
 		if(count($matches) > 0) {
@@ -260,7 +260,7 @@ EOD;
 		}
 
 		//Get the page ID if we do have a captcha
-		$regex = "/\"pageID\":\"([0-9]*)\"/";
+		$regex = '/"pageID":"([0-9]*)"/';
 		preg_match($regex, $pageContent, $matches);
 
 		return $matches[1];

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -102,7 +102,7 @@ class FacebookBridge extends BridgeAbstract {
 			if (isset($_SESSION['captcha_fields'], $_SESSION['captcha_action'])) {
 				$captcha_action = $_SESSION['captcha_action'];
 				$captcha_fields = $_SESSION['captcha_fields'];
-				$captcha_fields['captcha_response'] = preg_replace("/[^a-zA-Z0-9]+/", "", $_POST['captcha_response']);
+				$captcha_fields['captcha_response'] = preg_replace('/[^a-zA-Z0-9]+/', '', $_POST['captcha_response']);
 
 				$header = array("Content-type:
 application/x-www-form-urlencoded\r\nReferer: $captcha_action\r\nCookie: noscript=1\r\n");
@@ -153,11 +153,11 @@ application/x-www-form-urlencoded\r\nReferer: $captcha_action\r\nCookie: noscrip
 			} else {
 
 				// First character cannot be a forward slash
-				if(strpos($this->getInput('u'), "/") === 0) {
+				if(strpos($this->getInput('u'), '/') === 0) {
 					returnClientError('Remove leading slash "/" from the username!');
 				}
 
-				if(!strpos($this->getInput('u'), "/")) {
+				if(!strpos($this->getInput('u'), '/')) {
 					$html = getSimpleHTMLDOM(self::URI . urlencode($this->getInput('u')) . '?_fb_noscript=1', $header)
 						or returnServerError('No results for this query.');
 				} else {
@@ -305,7 +305,7 @@ EOD;
 						);
 
 						//Retrieve date of the post
-						$date = $post->find("abbr")[0];
+						$date = $post->find('abbr')[0];
 						if(isset($date) && $date->hasAttribute('data-utime')) {
 							$date = $date->getAttribute('data-utime');
 						} else {

--- a/bridges/FootitoBridge.php
+++ b/bridges/FootitoBridge.php
@@ -15,47 +15,47 @@ class FootitoBridge extends BridgeAbstract {
 
 			$content = trim($element->innertext);
 			$content = str_replace(
-				"<img",
+				'<img',
 				"<img style='float : left;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"logo\"",
+				'class="logo"',
 				"style='float : left;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"contenu\"",
+				'class="contenu"',
 				"style='margin-left : 60px;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"responsive-comment\"",
+				'class="responsive-comment"',
 				"style='border-top : 1px #DDD solid; background-color : white; padding : 10px;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"jaime\"",
+				'class="jaime"',
 				"style='display : none;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"auteur-event responsive\"",
+				'class="auteur-event responsive"',
 				"style='display : none;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"report-abuse-button\"",
+				'class="report-abuse-button"',
 				"style='display : none;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"reaction clearfix\"",
+				'class="reaction clearfix"',
 				"style='margin : 10px 0px; padding : 5px; border-bottom : 1px #DDD solid;'",
 				$content );
 
 			$content = str_replace(
-				"class=\"infos\"",
+				'class="infos"',
 				"style='font-size : 0.7em;'",
 				$content );
 

--- a/bridges/FourchanBridge.php
+++ b/bridges/FourchanBridge.php
@@ -30,7 +30,7 @@ class FourchanBridge extends BridgeAbstract {
 	public function collectData(){
 
 		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError("Could not request 4chan, thread not found");
+			or returnServerError('Could not request 4chan, thread not found');
 
 		foreach($html->find('div.postContainer') as $element) {
 			$item = array();

--- a/bridges/GithubIssueBridge.php
+++ b/bridges/GithubIssueBridge.php
@@ -106,7 +106,7 @@ class GithubIssueBridge extends BridgeAbstract {
 			$content = $comment->parent()->innertext;
 		} else {
 			$title .= ' / ' . trim($comment->firstChild()->plaintext);
-			$content = "<pre>" . $comment->find('.comment-body', 0)->innertext . "</pre>";
+			$content = '<pre>' . $comment->find('.comment-body', 0)->innertext . '</pre>';
 		}
 
 		$item = array();

--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -19,26 +19,26 @@ class GoComicsBridge extends BridgeAbstract {
 			or returnServerError('Could not request GoComics: ' . $this->getURI());
 
 		//Get info from first page
-		$author = preg_replace('/By /', '', $html->find(".media-subheading", 0)->plaintext);
+		$author = preg_replace('/By /', '', $html->find('.media-subheading', 0)->plaintext);
 
-		$link = self::URI . $html->find(".gc-deck--cta-0", 0)->find('a', 0)->href;
+		$link = self::URI . $html->find('.gc-deck--cta-0', 0)->find('a', 0)->href;
 		for($i = 0; $i < 5; $i++) {
 
 			$item = array();
 
 			$page = getSimpleHTMLDOM($link)
 				or returnServerError('Could not request GoComics: ' . $link);
-			$imagelink = $page->find(".img-fluid", 1)->src;
-			$date = explode("/", $link);
+			$imagelink = $page->find('.img-fluid', 1)->src;
+			$date = explode('/', $link);
 
 			$item['id'] = $imagelink;
 			$item['uri'] = $link;
 			$item['author'] = $author;
 			$item['title'] = 'GoComics ' . $this->getInput('comicname');
-			$item['timestamp'] = DateTime::createFromFormat("Ymd", $date[5] . $date[6] . $date[7])->getTimestamp();
+			$item['timestamp'] = DateTime::createFromFormat('Ymd', $date[5] . $date[6] . $date[7])->getTimestamp();
 			$item['content'] = '<img src="' . $imagelink . '" />';
 
-			$link = self::URI . $page->find(".js-previous-comic", 0)->href;
+			$link = self::URI . $page->find('.js-previous-comic', 0)->href;
 			$this->items[] = $item;
 		}
 	}

--- a/bridges/GoogleSearchBridge.php
+++ b/bridges/GoogleSearchBridge.php
@@ -17,7 +17,7 @@ class GoogleSearchBridge extends BridgeAbstract {
 
 	const PARAMETERS = array(array(
 		'q' => array(
-			'name' => "keyword",
+			'name' => 'keyword',
 			'required' => true
 		)
 	));

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -85,7 +85,7 @@ class InstagramBridge extends BridgeAbstract {
 				$item['content'] = $data[0];
 				$item['enclosures'] = $data[1];
 			} else {
-				$item['content'] = '<img src="' . htmlentities($media->display_url) . '" alt="'. $item["title"] . '" />';
+				$item['content'] = '<img src="' . htmlentities($media->display_url) . '" alt="'. $item['title'] . '" />';
 				$item['enclosures'] = array($media->display_url);
 			}
 

--- a/bridges/KununuBridge.php
+++ b/bridges/KununuBridge.php
@@ -135,8 +135,8 @@ class KununuBridge extends BridgeAbstract {
 	* Encodes unmlauts in the given text
 	*/
 	private function encodeUmlauts($text){
-		$umlauts = Array("/ä/","/ö/","/ü/","/Ä/","/Ö/","/Ü/","/ß/");
-		$replace = Array("ae","oe","ue","Ae","Oe","Ue","ss");
+		$umlauts = Array('/ä/','/ö/','/ü/','/Ä/','/Ö/','/Ü/','/ß/');
+		$replace = Array('ae','oe','ue','Ae','Oe','Ue','ss');
 
 		return preg_replace($umlauts, $replace, $text);
 	}

--- a/bridges/LeBonCoinBridge.php
+++ b/bridges/LeBonCoinBridge.php
@@ -172,7 +172,7 @@ region, and optionally a category and a keyword .';
 			if($content_image !== null) {
 				$content = '<img src="' . $content_image->getAttribute('data-imgsrc') . '" alt="thumbnail">';
 			} else {
-				$content = "";
+				$content = '';
 			}
 			$date = $element->find('aside.item_absolute', 0)->find('p.item_sup', 0);
 

--- a/bridges/LesJoiesDuCodeBridge.php
+++ b/bridges/LesJoiesDuCodeBridge.php
@@ -22,16 +22,16 @@ class LesJoiesDuCodeBridge extends BridgeAbstract {
 			// retrieve .gif instead of static .jpg
 			$images = $temp->find('p img');
 			foreach($images as $image) {
-				$img_src = str_replace(".jpg", ".gif", $image->src);
+				$img_src = str_replace('.jpg', '.gif', $image->src);
 				$image->src = $img_src;
 			}
 			$content = $temp->innertext;
 
 			$auteur = $temp->find('i', 0);
-			$pos = strpos($auteur->innertext, "by");
+			$pos = strpos($auteur->innertext, 'by');
 
 			if($pos > 0) {
-				$auteur = trim(str_replace("*/", "", substr($auteur->innertext, ($pos + 2))));
+				$auteur = trim(str_replace('*/', '', substr($auteur->innertext, ($pos + 2))));
 				$item['author'] = $auteur;
 			}
 

--- a/bridges/MangareaderBridge.php
+++ b/bridges/MangareaderBridge.php
@@ -100,7 +100,7 @@ class MangareaderBridge extends BridgeAbstract {
 		case 'Get popular mangas':
 			// Find manga name within "Popular mangas for ..."
 			$pagetitle = $xpath->query(".//*[@id='bodyalt']/h1")->item(0)->nodeValue;
-			$this->request = substr($pagetitle, 0, strrpos($pagetitle, " -"));
+			$this->request = substr($pagetitle, 0, strrpos($pagetitle, ' -'));
 			$this->getPopularMangas($xpath);
 			break;
 		case 'Get manga updates':
@@ -120,7 +120,7 @@ class MangareaderBridge extends BridgeAbstract {
 		// Return some dummy-data if no content available
 		if(empty($this->items)) {
 			$item = array();
-			$item['content'] = "<p>No updates available</p>";
+			$item['content'] = '<p>No updates available</p>';
 
 			$this->items[] = $item;
 		}
@@ -143,18 +143,18 @@ class MangareaderBridge extends BridgeAbstract {
 				$item['title'] = htmlspecialchars($manga->nodeValue);
 
 				// Add each chapter to the feed
-				$item['content'] = "";
+				$item['content'] = '';
 
 				foreach ($chapters as $chapter) {
-					if($item['content'] <> "") {
-						$item['content'] .= "<br>";
+					if($item['content'] <> '') {
+						$item['content'] .= '<br>';
 					}
 					$item['content'] .= "<a href='"
 						. self::URI
 						. htmlspecialchars($chapter->getAttribute('href'))
 						. "'>"
 						. htmlspecialchars($chapter->nodeValue)
-						. "</a>";
+						. '</a>';
 				}
 
 				$this->items[] = $item;
@@ -211,13 +211,13 @@ EOD;
 
 		foreach ($chapters as $chapter) {
 			$item = array();
-			$item['title'] = htmlspecialchars($xpath->query("td[1]", $chapter)
+			$item['title'] = htmlspecialchars($xpath->query('td[1]', $chapter)
 				->item(0)
 				->nodeValue);
-			$item['uri'] = self::URI . $xpath->query("td[1]/a", $chapter)
+			$item['uri'] = self::URI . $xpath->query('td[1]/a', $chapter)
 				->item(0)
 				->getAttribute('href');
-			$item['timestamp'] = strtotime($xpath->query("td[2]", $chapter)
+			$item['timestamp'] = strtotime($xpath->query('td[2]', $chapter)
 				->item(0)
 				->nodeValue);
 			array_unshift($this->items, $item);
@@ -227,12 +227,12 @@ EOD;
 	public function getURI(){
 		switch($this->queriedContext) {
 		case 'Get latest updates':
-			$path = "latest";
+			$path = 'latest';
 			break;
 		case 'Get popular mangas':
-			$path = "popular";
-			if($this->getInput('category') !== "all") {
-				$path .= "/" . $this->getInput('category');
+			$path = 'popular';
+			if($this->getInput('category') !== 'all') {
+				$path .= '/' . $this->getInput('category');
 			}
 			break;
 		case 'Get manga updates':

--- a/bridges/NasaApodBridge.php
+++ b/bridges/NasaApodBridge.php
@@ -12,7 +12,7 @@ class NasaApodBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM(self::URI . 'archivepix.html')
 			or returnServerError('Error while downloading the website content');
 
-		$list = explode("<br>", $html->find('b', 0)->innertext);
+		$list = explode('<br>', $html->find('b', 0)->innertext);
 
 		for($i = 0; $i < 3; $i++) {
 			$line = $list[$i];
@@ -32,7 +32,7 @@ class NasaApodBridge extends BridgeAbstract {
 			$explanation = $picture_html->find('p', 2)->innertext;
 
 			//Extract date from the picture page
-			$date = explode(" ", $picture_html->find('p', 1)->innertext);
+			$date = explode(' ', $picture_html->find('p', 1)->innertext);
 			$item['timestamp'] = strtotime($date[4] . $date[3] . $date[2]);
 
 			//Other informations

--- a/bridges/NotAlwaysBridge.php
+++ b/bridges/NotAlwaysBridge.php
@@ -49,7 +49,7 @@ class NotAlwaysBridge extends BridgeAbstract {
 
 		public function getURI(){
 				if(!is_null($this->getInput('filter'))) {
-						return self::URI . $this->getInput('filter') . "/";
+						return self::URI . $this->getInput('filter') . '/';
 				}
 
 				return parent::getURI();

--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -44,7 +44,7 @@ class PinterestBridge extends FeedExpander {
 		$pattern = '/https\:\/\/i\.pinimg\.com\/[a-zA-Z0-9]*x\//';
 		foreach($this->items as $item) {
 
-			$item["content"] = preg_replace($pattern, 'https://i.pinimg.com/originals/', $item["content"]);
+			$item['content'] = preg_replace($pattern, 'https://i.pinimg.com/originals/', $item['content']);
 			$newitems[] = $item;
 		}
 		$this->items = $newitems;
@@ -64,10 +64,10 @@ class PinterestBridge extends FeedExpander {
 			// provide even less info. Thus we attempt multiple options.
 			$item['title'] = trim($result['title']);
 
-			if($item['title'] === "")
+			if($item['title'] === '')
 				$item['title'] = trim($result['rich_summary']['display_name']);
 
-			if($item['title'] === "")
+			if($item['title'] === '')
 				$item['title'] = trim($result['grid_description']);
 
 			$item['timestamp'] = strtotime($result['created_at']);

--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -33,40 +33,40 @@ class PixivBridge extends BridgeAbstract {
 			$count++;
 
 			$item = array();
-			$item["id"] = $result["illustId"];
-			$item["uri"] = "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=" . $result["illustId"];
-			$item["title"] = $result["illustTitle"];
-			$item["author"] = $result["userName"];
+			$item['id'] = $result['illustId'];
+			$item['uri'] = 'https://www.pixiv.net/member_illust.php?mode=medium&illust_id=' . $result['illustId'];
+			$item['title'] = $result['illustTitle'];
+			$item['author'] = $result['userName'];
 
-			preg_match_all($timeRegex, $result["url"], $dt, PREG_SET_ORDER, 0);
-			$elementDate = DateTime::createFromFormat("YmdHis",
+			preg_match_all($timeRegex, $result['url'], $dt, PREG_SET_ORDER, 0);
+			$elementDate = DateTime::createFromFormat('YmdHis',
 						$dt[0][1] . $dt[0][2] . $dt[0][3] . $dt[0][4] . $dt[0][5] . $dt[0][6]);
-			$item["timestamp"] = $elementDate->getTimestamp();
+			$item['timestamp'] = $elementDate->getTimestamp();
 
-			$item["content"] = "<img src='" . $this->cacheImage($result['url'], $item["id"]) . "' />";
+			$item['content'] = "<img src='" . $this->cacheImage($result['url'], $item['id']) . "' />";
 			$this->items[] = $item;
 		}
 	}
 
 	public function cacheImage($url, $illustId) {
 
-		$url = str_replace("_master1200", "", $url);
-		$url = str_replace("c/240x240/img-master/", "img-original/", $url);
+		$url = str_replace('_master1200', '', $url);
+		$url = str_replace('c/240x240/img-master/', 'img-original/', $url);
 		$path = CACHE_DIR . '/pixiv_img';
 
 		if(!is_dir($path))
 			mkdir($path, 0755, true);
 
 		if(!is_file($path . '/' . $illustId . '.jpeg')) {
-			$headers = array("Referer:  https://www.pixiv.net/member_illust.php?mode=medium&illust_id=" . $illustId);
+			$headers = array('Referer:  https://www.pixiv.net/member_illust.php?mode=medium&illust_id=' . $illustId);
 			$illust = getContents($url, $headers);
-			if(strpos($illust, "404 Not Found") !== false) {
-				$illust = getContents(str_replace("jpg", "png", $url), $headers);
+			if(strpos($illust, '404 Not Found') !== false) {
+				$illust = getContents(str_replace('jpg', 'png', $url), $headers);
 			}
 			file_put_contents($path . '/' . $illustId . '.jpeg', $illust);
 		}
 
-		return 'cache/pixiv_img/' . $illustId . ".jpeg";
+		return 'cache/pixiv_img/' . $illustId . '.jpeg';
 
 	}
 

--- a/bridges/RainbowSixSiegeBridge.php
+++ b/bridges/RainbowSixSiegeBridge.php
@@ -8,9 +8,9 @@ class RainbowSixSiegeBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Latest articles from the Rainbow Six Siege blog';
 
 	public function collectData(){
-		$dlUrl = "https://prod-tridionservice.ubisoft.com/live/v1/News/Latest?templateId=tcm%3A152-7677";
-		$dlUrl .= "8-32&pageIndex=0&pageSize=10&language=en-US&detailPageId=tcm%3A152-194572-64";
-		$dlUrl .= "&keywordList=175426&siteId=undefined&useSeoFriendlyUrl=true";
+		$dlUrl = 'https://prod-tridionservice.ubisoft.com/live/v1/News/Latest?templateId=tcm%3A152-7677';
+		$dlUrl .= '8-32&pageIndex=0&pageSize=10&language=en-US&detailPageId=tcm%3A152-194572-64';
+		$dlUrl .= '&keywordList=175426&siteId=undefined&useSeoFriendlyUrl=true';
 		$jsonString = getContents($dlUrl) or returnServerError('Error while downloading the website content');
 
 		$json = json_decode($jsonString, true);

--- a/bridges/ReadComicsBridge.php
+++ b/bridges/ReadComicsBridge.php
@@ -25,7 +25,7 @@ class ReadComicsBridge extends BridgeAbstract {
 			return $timestamp;
 		}
 
-		$keywordsList = explode(";", $this->getInput('q'));
+		$keywordsList = explode(';', $this->getInput('q'));
 		foreach($keywordsList as $keywords) {
 			$html = $this->getSimpleHTMLDOM(self::URI . 'comic/' . rawurlencode($keywords))
 				or $this->returnServerError('Could not request readcomics.tv.');

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -19,7 +19,7 @@ class ReporterreBridge extends BridgeAbstract {
 			// Replace all relative urls with absolute ones
 			$text = preg_replace(
 				'/(href|src)(\=[\"\'])(?!http)([^"\']+)/ims',
-				"$1$2" . self::URI . "$3",
+				'$1$2' . self::URI . '$3',
 				$text
 			);
 

--- a/bridges/Rue89Bridge.php
+++ b/bridges/Rue89Bridge.php
@@ -9,9 +9,9 @@ class Rue89Bridge extends FeedExpander {
 	protected function parseItem($item){
 		$item = parent::parseItem($item);
 
-		$url = "http://api.rue89.nouvelobs.com/export/mobile2/node/"
-		. str_replace(" ", "", substr($item['uri'], -8))
-		. "/full";
+		$url = 'http://api.rue89.nouvelobs.com/export/mobile2/node/'
+		. str_replace(' ', '', substr($item['uri'], -8))
+		. '/full';
 
 		$datas = json_decode(getContents($url), true);
 		$item['content'] = $datas['node']['body'];

--- a/bridges/SexactuBridge.php
+++ b/bridges/SexactuBridge.php
@@ -32,7 +32,7 @@ class SexactuBridge extends BridgeAbstract {
 				$item = array();
 				$item['author'] = self::AUTHOR;
 				$item['title'] = $title->plaintext;
-				$urlAttribute = "data-href";
+				$urlAttribute = 'data-href';
 				$uri = $title->$urlAttribute;
 				if($uri === false)
 					continue;

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -73,7 +73,7 @@ class ShanaprojectBridge extends BridgeAbstract {
 		// Getting the picture is a little bit tricky as it is part of the style.
 		// Luckily the style is part of the parent div :)
 
-		if(preg_match("/url\(\/\/([^\)]+)\)/i", $anime->parent->style, $matches))
+		if(preg_match('/url\(\/\/([^\)]+)\)/i', $anime->parent->style, $matches))
 			return $matches[1];
 
 		returnServerError('Could not extract background image!');

--- a/bridges/Shimmie2Bridge.php
+++ b/bridges/Shimmie2Bridge.php
@@ -21,7 +21,7 @@ class Shimmie2Bridge extends DanbooruBridge {
 	protected function getItemFromElement($element){
 		$item = array();
 		$item['uri'] = $this->getURI() . $element->href;
-		$item['id'] = (int)preg_replace("/[^0-9]/", '', $element->getAttribute(static::IDATTRIBUTE));
+		$item['id'] = (int)preg_replace('/[^0-9]/', '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();
 		$thumbnailUri = $this->getURI() . $element->find('img', 0)->src;
 		$item['tags'] = $element->getAttribute('data-tags');

--- a/bridges/SuperSmashBlogBridge.php
+++ b/bridges/SuperSmashBlogBridge.php
@@ -8,7 +8,7 @@ class SuperSmashBlogBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Latest articles from the Super Smash Blog blog';
 
 	public function collectData(){
-		$dlUrl = "https://www.smashbros.com/data/bs/en_US/json/en_US.json";
+		$dlUrl = 'https://www.smashbros.com/data/bs/en_US/json/en_US.json';
 
 		$jsonString = getContents($dlUrl) or returnServerError('Error while downloading the website content');
 		$json = json_decode($jsonString, true);

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -66,7 +66,7 @@ class VkBridge extends BridgeAbstract
 				$post->find('a.wall_post_more', 0)->outertext = '';
 			}
 
-			$content_suffix = "";
+			$content_suffix = '';
 
 			// looking for external links
 			$external_link_selectors = array(
@@ -81,8 +81,8 @@ class VkBridge extends BridgeAbstract
 					$innertext = $a->innertext;
 					$parsed_url = parse_url($a->getAttribute('href'));
 					if (strpos($parsed_url['path'], '/away.php') !== 0) continue;
-					parse_str($parsed_url["query"], $parsed_query);
-					$content_suffix .= "<br>External link: <a href='" . $parsed_query["to"] . "'>$innertext</a>";
+					parse_str($parsed_url['query'], $parsed_query);
+					$content_suffix .= "<br>External link: <a href='" . $parsed_query['to'] . "'>$innertext</a>";
 				}
 			}
 
@@ -100,17 +100,17 @@ class VkBridge extends BridgeAbstract
 			}
 
 			// looking for article
-			$article = $post->find("a.article_snippet", 0);
+			$article = $post->find('a.article_snippet', 0);
 			if (is_object($article)) {
-				if (strpos($article->getAttribute('class'), "article_snippet_mini") !== false) {
-					$article_title_selector = "div.article_snippet_mini_title";
-					$article_author_selector = "div.article_snippet_mini_info > .mem_link,
-						div.article_snippet_mini_info > .group_link";
-					$article_thumb_selector = "div.article_snippet_mini_thumb";
+				if (strpos($article->getAttribute('class'), 'article_snippet_mini') !== false) {
+					$article_title_selector = 'div.article_snippet_mini_title';
+					$article_author_selector = 'div.article_snippet_mini_info > .mem_link,
+						div.article_snippet_mini_info > .group_link';
+					$article_thumb_selector = 'div.article_snippet_mini_thumb';
 				} else {
-					$article_title_selector = "div.article_snippet__title";
-					$article_author_selector = "div.article_snippet__author";
-					$article_thumb_selector = "div.article_snippet__image";
+					$article_title_selector = 'div.article_snippet__title';
+					$article_author_selector = 'div.article_snippet__author';
+					$article_thumb_selector = 'div.article_snippet__image';
 				}
 				$article_title = $article->find($article_title_selector, 0)->innertext;
 				$article_author = $article->find($article_author_selector, 0)->innertext;
@@ -136,7 +136,7 @@ class VkBridge extends BridgeAbstract
 			// get all other videos
 			foreach($post->find('a.page_post_thumb_video') as $a) {
 				$video_title = $a->getAttribute('aria-label');
-				$temp = explode(" ", $video_title, 2);
+				$temp = explode(' ', $video_title, 2);
 				if (count($temp) > 1) $video_title = $temp[1];
 				$video_link = self::URI . ltrim( $a->getAttribute('href'), '/' );
 				$content_suffix .= "<br>Video: <a href='$video_link'>$video_title</a>";
@@ -163,8 +163,8 @@ class VkBridge extends BridgeAbstract
 			// get photo documents
 			foreach($post->find('a.page_doc_photo_href') as $a) {
 				$doc_link = self::URI . ltrim($a->getAttribute('href'), '/');
-				$doc_gif_label_element = $a->find(".page_gif_label", 0);
-				$doc_title_element = $a->find(".doc_label", 0);
+				$doc_gif_label_element = $a->find('.page_gif_label', 0);
+				$doc_title_element = $a->find('.doc_label', 0);
 
 				if (is_object($doc_gif_label_element)) {
 					$gif_preview_img = backgroundToImg($a->find('.page_doc_photo', 0));
@@ -184,7 +184,7 @@ class VkBridge extends BridgeAbstract
 
 			// get other documents
 			foreach($post->find('div.page_doc_row') as $div) {
-				$doc_title_element = $div->find("a.page_doc_title", 0);
+				$doc_title_element = $div->find('a.page_doc_title', 0);
 
 				if (is_object($doc_title_element)) {
 					$doc_title = $doc_title_element->innertext;
@@ -204,7 +204,7 @@ class VkBridge extends BridgeAbstract
 				$poll_title = $div->find('.page_media_poll_title', 0)->innertext;
 				$content_suffix .= "<br>Poll: $poll_title";
 				foreach($div->find('div.page_poll_text') as $poll_stat_title) {
-					$content_suffix .= "<br>- " . $poll_stat_title->innertext;
+					$content_suffix .= '<br>- ' . $poll_stat_title->innertext;
 				}
 				$div->outertext = '';
 			}
@@ -231,10 +231,10 @@ class VkBridge extends BridgeAbstract
 
 			// get post link
 			$post_link = $post->find('a.post_link', 0)->getAttribute('href');
-			preg_match("/wall-?\d+_(\d+)/", $post_link, $preg_match_result);
+			preg_match('/wall-?\d+_(\d+)/', $post_link, $preg_match_result);
 			$item['post_id'] = intval($preg_match_result[1]);
 			if (substr(self::URI, -1) == '/') {
-				$post_link = self::URI . ltrim($post_link, "/");
+				$post_link = self::URI . ltrim($post_link, '/');
 			} else {
 				$post_link = self::URI . $post_link;
 			}
@@ -273,17 +273,17 @@ class VkBridge extends BridgeAbstract
 		$data = json_decode($arg, true);
 		if ($data == null) return;
 
-		$thumb = $data['temp']['base'] . $data['temp']['x_'][0] . ".jpg";
+		$thumb = $data['temp']['base'] . $data['temp']['x_'][0] . '.jpg';
 		$original = '';
 		foreach(array('y_', 'z_', 'w_') as $key) {
 			if (!isset($data['temp'][$key])) continue;
 			if (!isset($data['temp'][$key][0])) continue;
-			if (substr($data['temp'][$key][0], 0, 4) == "http") {
-				$base = "";
+			if (substr($data['temp'][$key][0], 0, 4) == 'http') {
+				$base = '';
 			} else {
 				$base = $data['temp']['base'];
 			}
-			$original = $base . $data['temp'][$key][0] . ".jpg";
+			$original = $base . $data['temp'][$key][0] . '.jpg';
 		}
 
 		if ($original) {
@@ -296,7 +296,7 @@ class VkBridge extends BridgeAbstract
 	private function getTitle($content)
 	{
 		preg_match('/^["\w\ \p{Cyrillic}\(\)\?#«»-]+/mu', htmlspecialchars_decode($content), $result);
-		if (count($result) == 0) return "untitled";
+		if (count($result) == 0) return 'untitled';
 		return $result[0];
 	}
 

--- a/bridges/WhydBridge.php
+++ b/bridges/WhydBridge.php
@@ -18,10 +18,10 @@ class WhydBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$html = '';
-		if(strlen(preg_replace("/[^0-9a-f]/", '', $this->getInput('u'))) == 24) {
+		if(strlen(preg_replace('/[^0-9a-f]/', '', $this->getInput('u'))) == 24) {
 			// is input the userid ?
 			$html = getSimpleHTMLDOM(
-				self::URI . 'u/' . preg_replace("/[^0-9a-f]/", '', $this->getInput('u'))
+				self::URI . 'u/' . preg_replace('/[^0-9a-f]/', '', $this->getInput('u'))
 			) or returnServerError('No results for this query.');
 		} else { // input may be the username
 			$html = getSimpleHTMLDOM(

--- a/bridges/YGGTorrentBridge.php
+++ b/bridges/YGGTorrentBridge.php
@@ -12,72 +12,72 @@ class YGGTorrentBridge extends BridgeAbstract {
 
 	const PARAMETERS = array(
 		array(
-			"cat" => array(
-				"name" => "category",
-				"type" => "list",
-				"values" => array(
-					"Toute les catégories" => "all.all",
-					"Film/Vidéo - Toutes les sous-catégories" => "2145.all",
-					"Film/Vidéo - Animation" => "2145.2178",
-					"Film/Vidéo - Animation Série" => "2145.2179",
-					"Film/Vidéo - Concert" => "2145.2180",
-					"Film/Vidéo - Documentaire" => "2145.2181",
-					"Film/Vidéo - Émission TV" => "2145.2182",
-					"Film/Vidéo - Film" => "2145.2183",
-					"Film/Vidéo - Série TV" => "2145.2184",
-					"Film/Vidéo - Spectacle" => "2145.2185",
-					"Film/Vidéo - Sport" => "2145.2186",
-					"Film/Vidéo - Vidéo-clips" => "2145.2186",
-					"Audio - Toutes les sous-catégories" => "2139.all",
-					"Audio - Karaoké" => "2139.2147",
-					"Audio - Musique" => "2139.2148",
-					"Audio - Podcast Radio" => "2139.2150",
-					"Audio - Samples" => "2139.2149",
-					"Jeu vidéo - Toutes les sous-catégories" => "2142.all",
-					"Jeu vidéo - Autre" => "2142.2167",
-					"Jeu vidéo - Linux" => "2142.2159",
-					"Jeu vidéo - MacOS" => "2142.2160",
-					"Jeu vidéo - Microsoft" => "2142.2162",
-					"Jeu vidéo - Nintendo" => "2142.2163",
-					"Jeu vidéo - Smartphone" => "2142.2165",
-					"Jeu vidéo - Sony" => "2142.2164",
-					"Jeu vidéo - Tablette" => "2142.2166",
-					"Jeu vidéo - Windows" => "2142.2161",
-					"eBook - Toutes les sous-catégories" => "2140.all",
-					"eBook - Audio" => "2140.2151",
-					"eBook - Bds" => "2140.2152",
-					"eBook - Comics" => "2140.2153",
-					"eBook - Livres" => "2140.2154",
-					"eBook - Mangas" => "2140.2155",
-					"eBook - Presse" => "2140.2156",
-					"Emulation - Toutes les sous-catégories" => "2141.all",
-					"Emulation - Emulateurs" => "2141.2157",
-					"Emulation - Roms" => "2141.2158",
-					"GPS - Toutes les sous-catégories" => "2141.all",
-					"GPS - Applications" => "2141.2168",
-					"GPS - Cartes" => "2141.2169",
-					"GPS - Divers" => "2141.2170"
+			'cat' => array(
+				'name' => 'category',
+				'type' => 'list',
+				'values' => array(
+					'Toute les catégories' => 'all.all',
+					'Film/Vidéo - Toutes les sous-catégories' => '2145.all',
+					'Film/Vidéo - Animation' => '2145.2178',
+					'Film/Vidéo - Animation Série' => '2145.2179',
+					'Film/Vidéo - Concert' => '2145.2180',
+					'Film/Vidéo - Documentaire' => '2145.2181',
+					'Film/Vidéo - Émission TV' => '2145.2182',
+					'Film/Vidéo - Film' => '2145.2183',
+					'Film/Vidéo - Série TV' => '2145.2184',
+					'Film/Vidéo - Spectacle' => '2145.2185',
+					'Film/Vidéo - Sport' => '2145.2186',
+					'Film/Vidéo - Vidéo-clips' => '2145.2186',
+					'Audio - Toutes les sous-catégories' => '2139.all',
+					'Audio - Karaoké' => '2139.2147',
+					'Audio - Musique' => '2139.2148',
+					'Audio - Podcast Radio' => '2139.2150',
+					'Audio - Samples' => '2139.2149',
+					'Jeu vidéo - Toutes les sous-catégories' => '2142.all',
+					'Jeu vidéo - Autre' => '2142.2167',
+					'Jeu vidéo - Linux' => '2142.2159',
+					'Jeu vidéo - MacOS' => '2142.2160',
+					'Jeu vidéo - Microsoft' => '2142.2162',
+					'Jeu vidéo - Nintendo' => '2142.2163',
+					'Jeu vidéo - Smartphone' => '2142.2165',
+					'Jeu vidéo - Sony' => '2142.2164',
+					'Jeu vidéo - Tablette' => '2142.2166',
+					'Jeu vidéo - Windows' => '2142.2161',
+					'eBook - Toutes les sous-catégories' => '2140.all',
+					'eBook - Audio' => '2140.2151',
+					'eBook - Bds' => '2140.2152',
+					'eBook - Comics' => '2140.2153',
+					'eBook - Livres' => '2140.2154',
+					'eBook - Mangas' => '2140.2155',
+					'eBook - Presse' => '2140.2156',
+					'Emulation - Toutes les sous-catégories' => '2141.all',
+					'Emulation - Emulateurs' => '2141.2157',
+					'Emulation - Roms' => '2141.2158',
+					'GPS - Toutes les sous-catégories' => '2141.all',
+					'GPS - Applications' => '2141.2168',
+					'GPS - Cartes' => '2141.2169',
+					'GPS - Divers' => '2141.2170'
 				)
 			),
-			"nom" => array(
-				"name" => "Nom",
-				"description" => "Nom du torrent",
-				"type" => "text"
+			'nom' => array(
+				'name' => 'Nom',
+				'description' => 'Nom du torrent',
+				'type' => 'text'
 			),
-			"description" => array(
-				"name" => "Description",
-				"description" => "Description du torrent",
-				"type" => "text"
+			'description' => array(
+				'name' => 'Description',
+				'description' => 'Description du torrent',
+				'type' => 'text'
 			),
-			"fichier" => array(
-				"name" => "Fichier",
-				"description" => "Fichier du torrent",
-				"type" => "text"
+			'fichier' => array(
+				'name' => 'Fichier',
+				'description' => 'Fichier du torrent',
+				'type' => 'text'
 			),
-			"uploader" => array(
-				"name" => "Uploader",
-				"description" => "Uploader du torrent",
-				"type" => "text"
+			'uploader' => array(
+				'name' => 'Uploader',
+				'description' => 'Uploader du torrent',
+				'type' => 'text'
 			),
 
 		)
@@ -85,42 +85,42 @@ class YGGTorrentBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$catInfo = explode(".", $this->getInput("cat"));
+		$catInfo = explode('.', $this->getInput('cat'));
 		$category = $catInfo[0];
 		$subcategory = $catInfo[1];
 
-		$html = getSimpleHTMLDOM(self::URI . "/engine/search?name="
-					. $this->getInput("nom")
-					. "&description="
-					. $this->getInput("description")
-					. "&fichier="
-					. $this->getInput("fichier")
-					. "&file="
-					. $this->getInput("uploader")
-					. "&category="
+		$html = getSimpleHTMLDOM(self::URI . '/engine/search?name='
+					. $this->getInput('nom')
+					. '&description='
+					. $this->getInput('description')
+					. '&fichier='
+					. $this->getInput('fichier')
+					. '&file='
+					. $this->getInput('uploader')
+					. '&category='
 					. $category
-					. "&sub_category="
+					. '&sub_category='
 					. $subcategory
-					. "&do=search")
-					or returnServerError("Unable to query Yggtorrent !");
+					. '&do=search')
+					or returnServerError('Unable to query Yggtorrent !');
 
 		$count = 0;
-		$results = $html->find(".results", 0);
+		$results = $html->find('.results', 0);
 		if(!$results) return;
 
-		foreach($results->find("tr") as $row) {
+		foreach($results->find('tr') as $row) {
 			$count++;
 			if($count == 1) continue;
 			if($count == 12) break;
 			$item = array();
-			$item["timestamp"] = $row->find(".hidden", 1)->plaintext;
-			$item["title"] = $row->find("a", 1)->plaintext;
-			$torrentData = $this->collectTorrentData($row->find("a", 1)->href);
-			$item["author"] = $torrentData["author"];
-			$item["content"] = $torrentData["content"];
-			$item["seeders"] = $row->find("td", 7)->plaintext;
-			$item["leechers"] = $row->find("td", 8)->plaintext;
-			$item["size"] = $row->find("td", 5)->plaintext;
+			$item['timestamp'] = $row->find('.hidden', 1)->plaintext;
+			$item['title'] = $row->find('a', 1)->plaintext;
+			$torrentData = $this->collectTorrentData($row->find('a', 1)->href);
+			$item['author'] = $torrentData['author'];
+			$item['content'] = $torrentData['content'];
+			$item['seeders'] = $row->find('td', 7)->plaintext;
+			$item['leechers'] = $row->find('td', 8)->plaintext;
+			$item['size'] = $row->find('td', 5)->plaintext;
 
 			$this->items[] = $item;
 		}
@@ -130,14 +130,14 @@ class YGGTorrentBridge extends BridgeAbstract {
 	public function collectTorrentData($url) {
 
 		//For weird reason, the link we get can be invalid, we fix it.
-		$url_full = explode("/", $url);
+		$url_full = explode('/', $url);
 		$url_full[4] = urlencode($url_full[4]);
 		$url_full[5] = urlencode($url_full[5]);
 		$url_full[6] = urlencode($url_full[6]);
-		$url = implode("/", $url_full);
-		$page = getSimpleHTMLDOM($url) or returnServerError("Unable to query Yggtorrent page !");
-		$author = $page->find(".informations", 0)->find("a", 4)->plaintext;
-		$content = $page->find(".default", 1);
-		return array("author" => $author, "content" => $content);
+		$url = implode('/', $url_full);
+		$page = getSimpleHTMLDOM($url) or returnServerError('Unable to query Yggtorrent page !');
+		$author = $page->find('.informations', 0)->find('a', 4)->plaintext;
+		$content = $page->find('.default', 1);
+		return array('author' => $author, 'content' => $content);
 	}
 }

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -25,14 +25,14 @@ class YoutubeBridge extends BridgeAbstract {
 		'By channel id' => array(
 			'c' => array(
 				'name' => 'channel id',
-				'exampleValue' => "15",
+				'exampleValue' => '15',
 				'required' => true
 			)
 		),
 		'By playlist Id' => array(
 			'p' => array(
 				'name' => 'playlist id',
-				'exampleValue' => "15"
+				'exampleValue' => '15'
 			)
 		),
 		'Search result' => array(
@@ -195,7 +195,7 @@ class YoutubeBridge extends BridgeAbstract {
 			$this->request = $this->getInput('s');
 			$page = 1;
 			if($this->getInput('pa'))
-				$page = (int)preg_replace("/[^0-9]/", '', $this->getInput('pa'));
+				$page = (int)preg_replace('/[^0-9]/', '', $this->getInput('pa'));
 
 			$url_listing = self::URI
 			. 'results?search_query='

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -19,7 +19,7 @@ class FileCache implements CacheInterface {
 		$writeStream = file_put_contents($this->getCacheFile(), serialize($datas));
 
 		if($writeStream === false) {
-			throw new \Exception("Cannot write the cache... Do you have the right permissions ?");
+			throw new \Exception('Cannot write the cache... Do you have the right permissions ?');
 		}
 
 		return $this;

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -26,7 +26,7 @@ class Configuration {
 			die('"curl" extension not loaded. Please check "php.ini"');
 
 		// configuration checks
-		if(ini_get('allow_url_fopen') !== "1")
+		if(ini_get('allow_url_fopen') !== '1')
 			die('"allow_url_fopen" is not set to "1". Please check "php.ini');
 
 		// Check cache folder permissions (write permissions required)

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -24,15 +24,15 @@ abstract class FeedExpander extends BridgeAbstract {
 		switch(true) {
 		case isset($rssContent->item[0]):
 			debugMessage('Detected RSS 1.0 format');
-			$this->feedType = "RSS_1_0";
+			$this->feedType = 'RSS_1_0';
 			break;
 		case isset($rssContent->channel[0]):
 			debugMessage('Detected RSS 0.9x or 2.0 format');
-			$this->feedType = "RSS_2_0";
+			$this->feedType = 'RSS_2_0';
 			break;
 		case isset($rssContent->entry[0]):
 			debugMessage('Detected ATOM format');
-			$this->feedType = "ATOM_1_0";
+			$this->feedType = 'ATOM_1_0';
 			break;
 		default:
 			debugMessage('Unknown feed format/version');

--- a/lib/html.php
+++ b/lib/html.php
@@ -26,7 +26,7 @@ EOD;
 	$bridge = Bridge::create($bridgeName);
 
 	if($bridge == false)
-		return "";
+		return '';
 
 	$HTTPSWarning = '';
 	if(strpos($bridge->getURI(), 'https') !== 0) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -70,4 +70,8 @@
   <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
   <!-- Do not add whitespace at start or end of a file or end of a line -->
   <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+  <!-- Whenever possible use single quote strings -->
+  <rule ref="Squiz.Strings.DoubleQuoteUsage">
+    <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
+  </rule>
 </ruleset>


### PR DESCRIPTION
- Adds a new rule to enforce single quoted strings
- Fixes all files failing the check

Notice: This PR is likely to break other PRs relying on the previous ruleset!

Single quotes are the prefered way of specifying strings in RSS-Bridge, so PHPCS should enforce this rule wherever possible. The rule does not apply to strings including variables (specifically excluded rule), so using variables in double quoted strings is still allowed!

For more information see [CONTRIBUTING.md](https://github.com/RSS-Bridge/rss-bridge/blob/master/CONTRIBUTING.md)

There might be other exceptions to the rule, so let me know if anything is missing!