### PR TITLE
Implemented feed item categories

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -40,6 +40,16 @@ class AtomFormat extends FormatAbstract{
 				}
 			}
 
+			$entryCategories = '';
+			if(isset($item['categories'])) {
+				foreach($item['categories'] as $category) {
+					$entryCategories .= '<category term="'
+					. $this->xml_encode($category)
+					. '"/>'
+					. PHP_EOL;
+				}
+			}
+
 			$entries .= <<<EOD
 
 	<entry>
@@ -52,6 +62,7 @@ class AtomFormat extends FormatAbstract{
 		<updated>{$entryTimestamp}</updated>
 		<content type="html">{$entryContent}</content>
 		{$entryEnclosures}
+		{$entryCategories}
 	</entry>
 
 EOD;

--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -47,6 +47,20 @@ class HtmlFormat extends FormatAbstract {
 				$entryEnclosures .= '</div>';
 			}
 
+			$entryCategories = '';
+			if(isset($item['categories'])) {
+				$entryCategories = '<div class="categories"><p>Categories:</p>';
+
+				foreach($item['categories'] as $category) {
+
+					$entryCategories .= '<li class="category">'
+					. $this->sanitizeHtml($category)
+					. '</li>';
+				}
+
+				$entryCategories .= '</div>';
+			}
+
 			$entries .= <<<EOD
 
 <section class="feeditem">
@@ -55,6 +69,7 @@ class HtmlFormat extends FormatAbstract {
 	{$entryAuthor}
 	{$entryContent}
 	{$entryEnclosures}
+	{$entryCategories}
 </section>
 
 EOD;

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -51,6 +51,16 @@ Some media files might not be shown to you. Consider using the ATOM format inste
 				}
 			}
 
+			$entryCategories = '';
+			if(isset($item['categories'])) {
+
+				foreach($item['categories'] as $category) {
+					$entryCategories .= '<category>'
+					. $category  . '</category>'
+					. PHP_EOL;
+				}
+			}
+
 			$items .= <<<EOD
 
 	<item>
@@ -61,6 +71,7 @@ Some media files might not be shown to you. Consider using the ATOM format inste
 		<description>{$itemContent}{$entryEnclosuresWarning}</description>
 		<author>{$itemAuthor}</author>
 		{$entryEnclosures}
+		{$entryCategories}
 	</item>
 
 EOD;

--- a/static/HtmlFormat.css
+++ b/static/HtmlFormat.css
@@ -69,12 +69,14 @@ a.backlink, a.backlink:link, a.backlink:visited, a.itemtitle, a.itemtitle:link, 
 
 }
 
+section > div.content, section > div.categories,
 section > div.content, section > div.attachments {
 
 	padding: 10px;
 
 }
 
+section > div.categories > li.category,
 section > div.attachments > li.enclosure {
 
 	list-style-type: circle;


### PR DESCRIPTION
Some readers have feature, that enables feed item filtering by category (or showing all saved feed items by category), given in feed items themselves.  So this PR adds these categories if present.

At this time, the only bridge that has categories is VkBridge in my https://github.com/em92/rss-bridge/tree/vk-hashtags-to-categories (wip)
Examples: 
https://feed.eugenemolotov.ru/dev/?action=display&bridge=Vk&u=tb_bolshevik&format=Html
https://feed.eugenemolotov.ru/dev/?action=display&bridge=Vk&u=tb_bolshevik&format=Atom
https://feed.eugenemolotov.ru/dev/?action=display&bridge=Vk&u=tb_bolshevik&format=Mrss

https://validator.w3.org/feed/ (by direct input) says that atom feed is valid. Mrss feed was not valid before this commit, so after this commit it is still not valid. My instance of [Tiny Tiny RSS](https://tt-rss.org/) reader detects categories in mrss feeds.
