### PR TITLE
CSS adjustments to improve readability for bridge parameters

### DIFF
--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -39,6 +39,8 @@ This bridge is not fetching its content through a secure connection</div>';
 	$parameters = array()) {
 		$form = BridgeCard::getFormHeader($bridgeName, $isHttps);
 
+		$form .= '<div class="parameters">';
+
 		foreach($parameters as $id => $inputEntry) {
 			if(!isset($inputEntry['exampleValue']))
 				$inputEntry['exampleValue'] = '';
@@ -70,6 +72,8 @@ This bridge is not fetching its content through a secure connection</div>';
 				$form .= BridgeCard::getCheckboxInput($inputEntry, $idArg, $id);
 			}
 		}
+
+		$form .= '</div>';
 
 		if($isActive) {
 			$form .= BridgeCard::buildFormatButtons($formats);
@@ -106,7 +110,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		. filter_var($entry['exampleValue'], FILTER_SANITIZE_STRING)
 		. '" name="'
 		. $name
-		. '" /><br>'
+		. '" />'
 		. PHP_EOL;
 	}
 
@@ -121,7 +125,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		. filter_var($entry['exampleValue'], FILTER_SANITIZE_NUMBER_INT)
 		. '" name="'
 		. $name
-		. '" /><br>'
+		. '" />'
 		. PHP_EOL;
 	}
 
@@ -172,7 +176,7 @@ This bridge is not fetching its content through a secure connection</div>';
 			}
 		}
 
-		$list .= '</select><br>';
+		$list .= '</select>';
 
 		return $list;
 	}
@@ -186,7 +190,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		. $name
 		. '" '
 		. ($entry['defaultValue'] === 'checked' ?: '')
-		. ' /><br>'
+		. ' />'
 		. PHP_EOL;
 	}
 

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -61,7 +61,7 @@ This bridge is not fetching its content through a secure connection</div>';
 					. $idArg
 					. '">'
 					. filter_var($inputEntry['name'], FILTER_SANITIZE_STRING)
-					. ' : </label>'
+					. '</label>'
 					. PHP_EOL;
 
 				if(!isset($inputEntry['type']) || $inputEntry['type'] === 'text') {

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -39,41 +39,45 @@ This bridge is not fetching its content through a secure connection</div>';
 	$parameters = array()) {
 		$form = BridgeCard::getFormHeader($bridgeName, $isHttps);
 
-		$form .= '<div class="parameters">';
+		if(count($parameters) > 0) {
 
-		foreach($parameters as $id => $inputEntry) {
-			if(!isset($inputEntry['exampleValue']))
-				$inputEntry['exampleValue'] = '';
+			$form .= '<div class="parameters">';
 
-			if(!isset($inputEntry['defaultValue']))
-				$inputEntry['defaultValue'] = '';
+			foreach($parameters as $id => $inputEntry) {
+				if(!isset($inputEntry['exampleValue']))
+					$inputEntry['exampleValue'] = '';
 
-			$idArg = 'arg-'
-				. urlencode($bridgeName)
-				. '-'
-				. urlencode($parameterName)
-				. '-'
-				. urlencode($id);
+				if(!isset($inputEntry['defaultValue']))
+					$inputEntry['defaultValue'] = '';
 
-			$form .= '<label for="'
-				. $idArg
-				. '">'
-				. filter_var($inputEntry['name'], FILTER_SANITIZE_STRING)
-				. ' : </label>'
-				. PHP_EOL;
+				$idArg = 'arg-'
+					. urlencode($bridgeName)
+					. '-'
+					. urlencode($parameterName)
+					. '-'
+					. urlencode($id);
 
-			if(!isset($inputEntry['type']) || $inputEntry['type'] === 'text') {
-				$form .= BridgeCard::getTextInput($inputEntry, $idArg, $id);
-			} elseif($inputEntry['type'] === 'number') {
-				$form .= BridgeCard::getNumberInput($inputEntry, $idArg, $id);
-			} else if($inputEntry['type'] === 'list') {
-				$form .= BridgeCard::getListInput($inputEntry, $idArg, $id);
-			} elseif($inputEntry['type'] === 'checkbox') {
-				$form .= BridgeCard::getCheckboxInput($inputEntry, $idArg, $id);
+				$form .= '<label for="'
+					. $idArg
+					. '">'
+					. filter_var($inputEntry['name'], FILTER_SANITIZE_STRING)
+					. ' : </label>'
+					. PHP_EOL;
+
+				if(!isset($inputEntry['type']) || $inputEntry['type'] === 'text') {
+					$form .= BridgeCard::getTextInput($inputEntry, $idArg, $id);
+				} elseif($inputEntry['type'] === 'number') {
+					$form .= BridgeCard::getNumberInput($inputEntry, $idArg, $id);
+				} else if($inputEntry['type'] === 'list') {
+					$form .= BridgeCard::getListInput($inputEntry, $idArg, $id);
+				} elseif($inputEntry['type'] === 'checkbox') {
+					$form .= BridgeCard::getCheckboxInput($inputEntry, $idArg, $id);
+				}
 			}
-		}
 
-		$form .= '</div>';
+			$form .= '</div>';
+
+		}
 
 		if($isActive) {
 			$form .= BridgeCard::buildFormatButtons($formats);

--- a/static/style.css
+++ b/static/style.css
@@ -59,6 +59,7 @@ header > section.critical-warning {
 	color: white;
 }
 
+select,
 input[type="text"],
 input[type="number"] {
 	background-color: white;
@@ -69,7 +70,9 @@ input[type="number"] {
 	padding: 5px 10px;
 }
 
-input[type="text"]:focus {
+select:focus,
+input[type="text"]:focus,
+input[type="number"]:focus {
 	outline: none;
 	border-color: #888;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -13,6 +13,13 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
 	display: block;
 }
 
+/* Adjust parameters for browsers that don't support the grid layout */
+
+.parameters label:before {
+	content: " ";
+	display: block;
+}
+
 /* Let's go for the actual style */
 body {
 	background-color: #f0f0f0;

--- a/static/style.css
+++ b/static/style.css
@@ -163,6 +163,12 @@ section.footer .version {
 	margin-bottom: 6px;
 }
 
+.parameters label::first-letter {
+
+	text-transform: capitalize;
+
+}
+
 .parameters label::after {
 
 	content: ' :';

--- a/static/style.css
+++ b/static/style.css
@@ -6,10 +6,13 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
 	font-size: 100%;
 	font: inherit;
 	vertical-align: baseline;
+
 }
 /* HTML5 display-role reset for older browsers */
- article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+
 	display: block;
+
 }
 /* Let's go for the actual style */
  body {
@@ -112,6 +115,13 @@ input[type="text"]:focus {
 }
  section.footer:hover {
 	opacity: 1;
+
+}
+
+section.footer .version {
+
+	font-size: 80%;
+
 }
  section > h2 {
 	font-size: 200%;
@@ -197,7 +207,9 @@ select {
  .showmore-box:not(:checked) ~ .showless {
 	display: none;
 }
- .showmore-box:checked ~ form, .showmore-box:checked ~ h5 {
+
+.showmore-box:checked ~ form, .showmore-box:checked ~ h5 {
+
 	display: block;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -163,6 +163,12 @@ section.footer .version {
 	margin-bottom: 6px;
 }
 
+.parameters label::after {
+
+	content: ' :';
+
+}
+
 @supports (display: grid) {
 
 	.parameters {

--- a/static/style.css
+++ b/static/style.css
@@ -78,11 +78,17 @@ input[type="text"]:focus {
 }
  .searchbar input[type="text"]::placeholder {
 	text-align: center;
+
 }
- .searchbar input[type="text"]:focus::-webkit-input-placeholder { opacity: 0; }
- .searchbar input[type="text"]:focus::-moz-placeholder { opacity: 0; }
- .searchbar input[type="text"]:focus:-moz-placeholder { opacity: 0; }
- .searchbar input[type="text"]:focus:-ms-input-placeholder { opacity: 0; }
+
+.searchbar input[type="text"]:focus::-webkit-input-placeholder,
+.searchbar input[type="text"]:focus::-moz-placeholder,
+.searchbar input[type="text"]:focus:-moz-placeholder,
+.searchbar input[type="text"]:focus:-ms-input-placeholder {
+
+	opacity: 0;
+
+}
 
  .searchbar > h3 {
 	font-size: 200%;

--- a/static/style.css
+++ b/static/style.css
@@ -55,8 +55,9 @@ a:hover {
 	 color: white;
  }
 
-/* Input boxes */
- input[type="text"] {
+input[type="text"],
+input[type="number"] {
+
 	background-color: white;
 	color: #404552;
 	border: 1px solid #dedede;

--- a/static/style.css
+++ b/static/style.css
@@ -162,7 +162,45 @@ section.footer .version {
  form {
 	margin-bottom: 6px;
 }
- .maintainer {
+
+@supports (display: grid) {
+
+	.parameters {
+
+		display: grid;
+		grid-template-columns: 40% max-content;
+		grid-column-gap: 10px;
+		grid-row-gap: 5px;
+
+	}
+
+	.parameters label {
+
+		text-align: right;
+
+	}
+
+	.parameters input[type="text"],
+	.parameters input[type="number"],
+	.parameters input[type="checkbox"],
+	.parameters select {
+
+		margin-left: 0;
+
+	}
+
+	.parameters input[type="text"],
+	.parameters input[type="number"] {
+
+		width: auto;
+		color: #404552;
+
+	}
+
+} /* @supports (display: grid) */
+
+.maintainer {
+
 	color: #888888;
 	font-size: 70%;
 	text-align: right;

--- a/static/style.css
+++ b/static/style.css
@@ -168,6 +168,7 @@ section.footer .version {
 	.parameters {
 
 		display: grid;
+		padding: 12px 0;
 		grid-template-columns: 40% max-content;
 		grid-column-gap: 10px;
 		grid-row-gap: 5px;

--- a/static/style.css
+++ b/static/style.css
@@ -6,16 +6,15 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
 	font-size: 100%;
 	font: inherit;
 	vertical-align: baseline;
-
 }
+
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
-
 	display: block;
-
 }
+
 /* Let's go for the actual style */
- body {
+body {
 	background-color: #f0f0f0;
 	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
 }
@@ -26,38 +25,42 @@ a, a:link, a:visited {
 }
 
 a:hover {
- text-decoration: underline;
+	text-decoration: underline;
 }
 
 /* Header */
- header {
+
+header {
 	margin-top: 40px;
 	text-align: center;
 	color: #1182DB;
 }
- header > h1 {
+
+header > h1 {
 	font-size: 500%;
 	font-weight: bold;
 }
- header > h2 {
+
+header > h2 {
 	margin-left: 1em;
 	font-size: 200%;
 }
- header > section.warning {
+
+header > section.warning {
 	width: 40%;
 	background-color: #ffc600;
 	color: #5f5f5f;
 }
- header > section.critical-warning {
-	 width: 40%;
-	 background-color: #cf3e3e;
-	 font-weight: bold;
-	 color: white;
- }
+
+header > section.critical-warning {
+	width: 40%;
+	background-color: #cf3e3e;
+	font-weight: bold;
+	color: white;
+}
 
 input[type="text"],
 input[type="number"] {
-
 	background-color: white;
 	color: #404552;
 	border: 1px solid #dedede;
@@ -65,36 +68,37 @@ input[type="number"] {
 	margin-bottom: 10px;
 	padding: 5px 10px;
 }
+
 input[type="text"]:focus {
 	outline: none;
 	border-color: #888;
 }
- .searchbar {
+
+.searchbar {
 	width: 40%;
 	margin: 40px auto 100px;
 }
- .searchbar input[type="text"] {
+
+.searchbar input[type="text"] {
 	width: 90%;
 	margin: auto;
 	font-size: 1.1em;
 	text-align: center;
 	margin-bottom: 10px;
 }
- .searchbar input[type="text"]::placeholder {
-	text-align: center;
 
+.searchbar input[type="text"]::placeholder {
+	text-align: center;
 }
 
 .searchbar input[type="text"]:focus::-webkit-input-placeholder,
 .searchbar input[type="text"]:focus::-moz-placeholder,
 .searchbar input[type="text"]:focus:-moz-placeholder,
 .searchbar input[type="text"]:focus:-ms-input-placeholder {
-
 	opacity: 0;
-
 }
 
- .searchbar > h3 {
+.searchbar > h3 {
 	font-size: 200%;
 	font-weight: bold;
 	color: #1182DB;
@@ -102,7 +106,7 @@ input[type="text"]:focus {
 }
 
 /* Section */
- section {
+section {
 	background-color: #FFFFFF;
 	width: 60%;
 	margin: 30px auto;
@@ -111,27 +115,26 @@ input[type="text"]:focus {
 	box-shadow: 0 6px 15px rgba(0, 0, 0, 0.09);
 	border-radius: 4px;
 }
- section.footer {
+
+section.footer {
 	opacity: 0.5;
 }
- section.footer:hover {
-	opacity: 1;
 
+section.footer:hover {
+	opacity: 1;
 }
 
 section.footer .version {
-
 	font-size: 80%;
-
 }
- section > h2 {
+
+section > h2 {
 	font-size: 200%;
 	font-weight: bold;
 }
 
-
 /* Buttons */
- button {
+button {
 	line-height: 1.9em;
 	color: #FFF;
 	font-weight: bold;
@@ -144,88 +147,78 @@ section.footer .version {
 	cursor: pointer;
 	width: calc(20% - 4px);
 }
- button.small {
+
+button.small {
 	width: auto;
 	line-height: 1.2em;
 }
- button:hover {
-   background: #49afff;
- }
 
- .description {
+button:hover {
+	background: #49afff;
+}
+
+.description {
 	margin: 10px;
 }
- h5 {
+
+h5 {
 	margin: 20px;
 	font-weight: bold;
 }
- form {
+
+form {
 	margin-bottom: 6px;
 }
 
 .parameters label::first-letter {
-
 	text-transform: capitalize;
-
 }
 
 .parameters label::after {
-
 	content: ' :';
-
 }
 
 @supports (display: grid) {
 
 	.parameters {
-
 		display: grid;
 		padding: 12px 0;
 		grid-template-columns: 40% max-content;
 		grid-column-gap: 10px;
 		grid-row-gap: 5px;
-
 	}
 
 	.parameters label {
-
 		text-align: right;
-
 	}
 
 	.parameters input[type="text"],
 	.parameters input[type="number"],
 	.parameters input[type="checkbox"],
 	.parameters select {
-
 		margin-left: 0;
-
 	}
 
 	.parameters input[type="text"],
 	.parameters input[type="number"] {
-
 		width: auto;
 		color: #404552;
-
 	}
 
 	.parameters input[type="checkbox"] {
-
 		width: 20px;
 		height: 20px;
-
 	}
 
 } /* @supports (display: grid) */
 
 .maintainer {
-
 	color: #888888;
 	font-size: 70%;
 	text-align: right;
 }
- .secure-warning {
+
+.secure-warning {
 	background-color: #ffc600;
 	color: #5f5f5f;
 	box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3);
@@ -235,7 +228,8 @@ section.footer .version {
 	margin: auto;
 	margin-bottom: 6px;
 }
- form {
+
+form {
 	display: none;
 }
 
@@ -244,15 +238,16 @@ select {
 	margin-left: 8px;
 }
 
- h5 {
+h5 {
 	display: none;
 }
 
 /* Show more / less */
- .showmore-box {
+.showmore-box {
 	display: none;
 }
- .showmore, .showless {
+
+.showmore, .showless {
 	color: #888888;
 	cursor: pointer;
 }
@@ -260,20 +255,21 @@ select {
 	color: #000;
 	cursor: pointer;
 }
- .showmore-box:checked ~ .showmore {
+
+.showmore-box:checked ~ .showmore {
 	display: none;
 }
- .showmore-box:not(:checked) ~ .showless {
+
+.showmore-box:not(:checked) ~ .showless {
 	display: none;
 }
 
 .showmore-box:checked ~ form, .showmore-box:checked ~ h5 {
-
 	display: block;
 }
 
 /* Additional styles for error pages */
- .exception-message {
+.exception-message {
 	background-color: #c00000;
 	color: #FFFFFF;
 	font-weight: bold;
@@ -284,11 +280,13 @@ select {
 	margin: auto;
 	margin-bottom: 6px;
 }
- .advice {
+
+.advice {
 	margin-left: auto;
 	margin-right: auto;
 	display: table;
 }
- .advice > li {
+
+.advice > li {
 	text-align: left;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -210,6 +210,13 @@ section.footer .version {
 
 	}
 
+	.parameters input[type="checkbox"] {
+
+		width: 20px;
+		height: 20px;
+
+	}
+
 } /* @supports (display: grid) */
 
 .maintainer {


### PR DESCRIPTION
This PR does some adjustments to the CSS in order to (hopefully) improve readability of parameters:

- Use Grid layout (for simplicity) to align parameters
- Use the same style for numeric and text inputs
- Capitalize the first letter of labels
- Use CSS to add the colon ':' after labels (were created via PHP before)

Please notice that my testing setup is very limited, which is why I request others to test this PR using different browsers. Read on how to checkout PRs here: https://help.github.com/articles/checking-out-pull-requests-locally/ or just execute this command in your RSS-Bridge workspace: `git fetch origin pull/763/head:pr_763`, which fetches this PR to 'pr_763' in your workspace. 

Following browsers should be tested for better coverage (I filled in my own setup):

- [X] Google Chrome 69.0.3497.81 (64-bit) on Windows 10 1803
- [X] Microsoft Edge 42.17134.1.0 (64-bit) on Windows 10 1803
- [X] Firefox ESR 52.9.0 (64-bit) on Debian 9.5 (Stretch)
- [X] Firefox ESR 60.2.0 (64-bit) on Debian 9.5 (Stretch)

Here are two screen shots for comparison:

**before**

![screen shot 2018-08-04 at 23 01 05](https://user-images.githubusercontent.com/5776685/43680417-7bdb3e1c-983a-11e8-8c1c-2035b194fafe.png)

**after**

![screen shot 2018-08-04 at 23 08 39](https://user-images.githubusercontent.com/5776685/43680450-593a0572-983b-11e8-9a3a-e47022b5ff2b.png)

I'm not an expert in CSS, so any feedback is appreciated :grin: 