### PR TITLE
[FileCache] reseting cached file stat result to have correct getTime() result

### DIFF
--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -27,6 +27,7 @@ class FileCache implements CacheInterface {
 
 	public function getTime(){
 		$cacheFile = $this->getCacheFile();
+		clearstatcache(FALSE, $cacheFile);
 		if(file_exists($cacheFile)) {
 			return filemtime($cacheFile);
 		}

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -27,7 +27,7 @@ class FileCache implements CacheInterface {
 
 	public function getTime(){
 		$cacheFile = $this->getCacheFile();
-		clearstatcache(FALSE, $cacheFile);
+		clearstatcache(false, $cacheFile);
 		if(file_exists($cacheFile)) {
 			return filemtime($cacheFile);
 		}


### PR DESCRIPTION
Fixes https://github.com/RSS-Bridge/rss-bridge/issues/791

Reference: http://php.net/manual/en/function.filemtime.php

> Note: The results of this function are cached. See clearstatcache() for more details.