### PR TITLE
[core] Returning 304 http code when returning cached data

### DIFF
--- a/index.php
+++ b/index.php
@@ -195,6 +195,7 @@ try {
 		try {
 			$bridge->setCache($cache);
 			$bridge->setCacheTimeout($cache_timeout);
+			$bridge->dieIfNotModified();
 			$bridge->setDatas($params);
 		} catch(Error $e) {
 			http_response_code($e->getCode());
@@ -211,6 +212,7 @@ try {
 			$format = Format::create($format);
 			$format->setItems($bridge->getItems());
 			$format->setExtraInfos($bridge->getExtraInfos());
+			$format->setLastModified($bridge->getCacheTime());
 			$format->display();
 		} catch(Error $e) {
 			http_response_code($e->getCode());

--- a/lib/FormatAbstract.php
+++ b/lib/FormatAbstract.php
@@ -7,6 +7,7 @@ abstract class FormatAbstract implements FormatInterface {
 		$contentType,
 		$charset,
 		$items,
+		$lastModified,
 		$extraInfos;
 
 	public function setCharset($charset){
@@ -27,11 +28,18 @@ abstract class FormatAbstract implements FormatInterface {
 		return $this;
 	}
 
+	public function setLastModified($lastModified){
+		$this->lastModified = $lastModified;
+	}
+
 	protected function callContentType(){
 		header('Content-Type: ' . $this->contentType);
 	}
 
 	public function display(){
+		if ($this->lastModified) {
+			header('Last-Modified: ' . gmdate('D, d M Y H:i:s ', $this->lastModified) . 'GMT');
+		}
 		echo $this->stringify();
 
 		return $this;


### PR DESCRIPTION
There is no body on 304 response, so it gives some more performance. In my bridge instance ratio of 304 responses is given below (Asia/Yekaterinburg timezone):
![](https://feed.eugenemolotov.ru/plots/2018-08-23.png)

After 13:00 percentage of 304 responses raises after fixing filecache https://github.com/RSS-Bridge/rss-bridge/pull/792