### PR TITLE
[YoutubeBridge] rss readers don't like double quotes in title

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -176,7 +176,7 @@ class YoutubeBridge extends BridgeAbstract {
 
 	private function ytBridgeFixTitle($title) {
 		// convert both &#1234; and &quot; to UTF-8
-		return html_entity_decode($title, ENT_QUOTES, 'UTF-8');
+		return str_replace("\"", "_", html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 	}
 
 	private function ytGetSimpleHTMLDOM($url){

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -176,7 +176,7 @@ class YoutubeBridge extends BridgeAbstract {
 
 	private function ytBridgeFixTitle($title) {
 		// convert both &#1234; and &quot; to UTF-8
-		return str_replace("\"", "_", html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
+		return str_replace('\"', '_', html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 	}
 
 	private function ytGetSimpleHTMLDOM($url){


### PR DESCRIPTION
Both firefox and tt-rss don't like it and fail to read the feed generated. Replacing double quotes with an underscore seemed the appropriate fix as it still shows a character was there, I am open to suggestions however. This is for the Youtube bridge as that is the bridge I have the issue with.

A channel to test this with is [https://www.youtube.com/channel/UCtNIoi7VuApbYOPx-NjcVAA](https://www.youtube.com/channel/UCtNIoi7VuApbYOPx-NjcVAA)