### PR TITLE
[FacebookBridge] Removed non-unique parameter __xts__ from item uri

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -540,12 +540,9 @@ EOD;
 
 						$uri = $post->find('abbr')[0]->parent()->getAttribute('href');
 
-						$old_qs = parse_url($uri, PHP_URL_QUERY);
-						parse_str($old_qs, $qs_items);
-
-						if (isset($qs_items['__xts__'])) unset($qs_items['__xts__']);
-
-						$uri = str_replace($old_qs, http_build_query($qs_items), $uri);
+						if (false !== strpos($uri, '?')) {
+							$uri = substr($uri, 0, strpos($uri, '?'));
+						}
 
 						//Build and add final item
 						$item['uri'] = htmlspecialchars_decode($uri);

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -430,6 +430,8 @@ EOD;
 
 		if(isset($element)) {
 
+			defaultLinkTo($element, self::URI);
+
 			$author = str_replace(' | Facebook', '', $html->find('title#pageTitle', 0)->innertext);
 			$profilePic = 'https://graph.facebook.com/'
 			. $this->getInput('u')
@@ -536,7 +538,14 @@ EOD;
 						if(strlen($title) > 64)
 							$title = substr($title, 0, strpos(wordwrap($title, 64), "\n")) . '...';
 
-						$uri = self::URI . $post->find('abbr')[0]->parent()->getAttribute('href');
+						$uri = $post->find('abbr')[0]->parent()->getAttribute('href');
+
+						$old_qs = parse_url($uri, PHP_URL_QUERY);
+						parse_str($old_qs, $qs_items);
+
+						if (isset($qs_items['__xts__'])) unset($qs_items['__xts__']);
+
+						$uri = str_replace($old_qs, http_build_query($qs_items), $uri);
 
 						//Build and add final item
 						$item['uri'] = htmlspecialchars_decode($uri);


### PR DESCRIPTION
Fixes https://github.com/RSS-Bridge/rss-bridge/issues/805

Before: https://feed.eugenemolotov.ru/dev4/?action=display&bridge=Facebook&u=georgehtakei&media_type=all&format=Html

(check 2nd post and reload page. Pay attention that __xts__ param changes after reloading)

After: https://feed.eugenemolotov.ru/dev/?action=display&bridge=Facebook&u=georgehtakei&media_type=all&format=Html

