### PR TITLE
[MrssFormat.php] make sure feed is w3c compliant

### DIFF
--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -78,7 +78,9 @@ EOD;
 		}
 
 		$charset = $this->getCharset();
-
+		
+		/* xml attributes need to have certain characters escaped to be w3c compliant */
+		$titleSafe = htmlspecialchars($title);
 		/* Data are prepared, now let's begin the "MAGIE !!!" */
 		$toReturn = <<<EOD
 <?xml version="1.0" encoding="{$charset}"?>
@@ -90,7 +92,7 @@ xmlns:atom="http://www.w3.org/2005/Atom">
 		<title>{$title}</title>
 		<link>http{$https}://{$httpHost}{$httpInfo}/</link>
 		<description>{$title}</description>
-		<image url="{$icon}" title="{$title}" link="{$uri}"/>
+		<image url="{$icon}" title="{$titleSafe}" link="{$uri}"/>
 		<atom:link rel="alternate" type="text/html" href="{$uri}" />
 		<atom:link rel="self" href="http{$https}://{$httpHost}{$serverRequestUri}" />
 		{$items}

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -78,9 +78,9 @@ EOD;
 		}
 
 		$charset = $this->getCharset();
-		
+
 		/* xml attributes need to have certain characters escaped to be w3c compliant */
-		$titleSafe = htmlspecialchars($title);
+		$imageTitle = htmlspecialchars($title, ENT_COMPAT);
 		/* Data are prepared, now let's begin the "MAGIE !!!" */
 		$toReturn = <<<EOD
 <?xml version="1.0" encoding="{$charset}"?>
@@ -92,7 +92,7 @@ xmlns:atom="http://www.w3.org/2005/Atom">
 		<title>{$title}</title>
 		<link>http{$https}://{$httpHost}{$httpInfo}/</link>
 		<description>{$title}</description>
-		<image url="{$icon}" title="{$titleSafe}" link="{$uri}"/>
+		<image url="{$icon}" title="{$imageTitle}" link="{$uri}"/>
 		<atom:link rel="alternate" type="text/html" href="{$uri}" />
 		<atom:link rel="self" href="http{$https}://{$httpHost}{$serverRequestUri}" />
 		{$items}


### PR DESCRIPTION
xml attributes need to have certain characters escaped to be valid
the title attribute in this case sometimes has double quotes in it

Initial pull request was #798 but that was a dirty fix and only for the Youtube bridge, this one is for all Mrss feeds