### PR TITLE
[FB2Bridge] clean up Facebook links

### DIFF
--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -22,7 +22,7 @@ class FB2Bridge extends BridgeAbstract {
 			if(is_array($matches) && count($matches) > 1) {
 				$link = $matches[1];
 				if(strpos($link, '/') === 0)
-					$link = self::URI . $link . '"';
+					$link = self::URI . substr($link, 1);
 				if(strpos($link, 'facebook.com/l.php?u=') !== false)
 					$link = urldecode(extractFromDelimiters($link, 'facebook.com/l.php?u=', '&'));
 				return ' href="' . $link . '"';


### PR DESCRIPTION
Prevent Facebook link href's ending in two quotes.

Additionally prevent Facebook links having two forward slashes after the hostname.