### PR TITLE
[FB2Bridge] Do not strip <h3> and <h4>

### DIFF
--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -109,7 +109,7 @@ EOD;
 			}
 
 			//Remove html nodes, keep only img, links, basic formatting
-			$content = strip_tags($content, '<a><img><i><u><br><p>');
+			$content = strip_tags($content, '<a><img><i><u><br><p><h3><h4>');
 
 			//Adapt link hrefs: convert relative links into absolute links and bypass external link redirection
 			$content = preg_replace_callback('/ href=\"([^"]+)\"/i', $unescape_fb_link, $content);


### PR DESCRIPTION
Do not strip &lt;h3&gt; and &lt;h4&gt;, output looks better when they are retained. See below.

Without &lt;h3&gt;&lt;h4&gt;:

![without-h3h4](https://user-images.githubusercontent.com/42704418/45587544-e8b24000-b8fe-11e8-8fc8-062e5680754e.png)

With &lt;h3&gt;&lt;h4&gt;:

![with-h3h4](https://user-images.githubusercontent.com/42704418/45587543-e8b24000-b8fe-11e8-9156-766bc0a19194.png)