### PR TITLE
[WIP] Return exceptions in feeds

### DIFF
--- a/index.php
+++ b/index.php
@@ -231,6 +231,17 @@ try {
 		&& (time() - $cache_timeout < $mtime)
 		&& (!defined('DEBUG') || DEBUG !== true)) { // Load cached data
 
+			// Send "Not Modified" response if client supports it
+			// Implementation based on https://stackoverflow.com/a/10847262
+			if(isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
+				$stime = strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']);
+
+				if($mtime <= $stime) { // Cached data is older or same
+					header('HTTP/1.1 304 Not Modified');
+					die();
+				}
+			}
+
 			$cached = $cache->loadData();
 
 			if(isset($cached['items']) && isset($cached['extraInfos'])) {

--- a/index.php
+++ b/index.php
@@ -221,7 +221,7 @@ try {
 
 		$items = array();
 		$infos = array();
-		$ctime = 0;
+		$mtime = 0;
 
 		// Load cache & data
 		try {
@@ -232,7 +232,7 @@ try {
 
 			$items = $bridge->getItems();
 			$infos = $bridge->getExtraInfos();
-			$ctime = $bridge->getCacheTime();
+			$mtime = $bridge->getModifiedTime();
 		} catch(Error $e) {
 			$item = array();
 
@@ -258,7 +258,7 @@ try {
 			$format = Format::create($format);
 			$format->setItems($items);
 			$format->setExtraInfos($infos);
-			$format->setLastModified($ctime);
+			$format->setLastModified($mtime);
 			$format->display();
 		} catch(Error $e) {
 			http_response_code($e->getCode());

--- a/index.php
+++ b/index.php
@@ -267,8 +267,14 @@ try {
 				// Create "new" error message every 24 hours
 				$params['_error_time'] = urlencode((int)(time() / 86400));
 
+				// Error 0 is a special case (i.e. "trying to get property of non-object")
+				if($e->getCode() === 0) {
+					$item['title'] = 'Bridge encountered an unexpected situation! (' . $params['_error_time'] . ')';
+				} else {
+					$item['title'] = 'Bridge returned error ' . $e->getCode() . '! (' . $params['_error_time'] . ')';
+				}
+
 				$item['uri'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . '?' . http_build_query($params);
-				$item['title'] = 'Bridge returned error ' . $e->getCode() . '! (' . $params['_error_time'] . ')';
 				$item['timestamp'] = time();
 				$item['content'] = buildBridgeException($e, $bridge);
 

--- a/index.php
+++ b/index.php
@@ -270,7 +270,7 @@ try {
 				$item['uri'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . '?' . http_build_query($params);
 				$item['title'] = 'Bridge returned error ' . $e->getCode() . '! (' . $params['_error_time'] . ')';
 				$item['timestamp'] = time();
-				$item['content'] = htmlspecialchars(buildBridgeException($e, $bridge));
+				$item['content'] = buildBridgeException($e, $bridge);
 
 				$items[] = $item;
 			} catch(Exception $e) {

--- a/index.php
+++ b/index.php
@@ -241,7 +241,7 @@ try {
 		} else { // Collect new data
 
 			try {
-				$bridge->setDatas($params);
+				$bridge->setDatas($bridge_params);
 				$bridge->collectData();
 
 				$items = $bridge->getItems();
@@ -253,7 +253,10 @@ try {
 			} catch(Error $e) {
 				$item = array();
 
-				$item['uri'] = http_build_query($params);
+				// Create "new" error message every 24 hours
+				$params['_error_time'] = urlencode((int)(time()/86400));
+
+				$item['uri'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . '?' . http_build_query($params);
 				$item['title'] = $e->getCode();
 				$item['timestamp'] = time();
 				$item['content'] = htmlspecialchars(buildBridgeException($e, $bridge));
@@ -262,7 +265,10 @@ try {
 			} catch(Exception $e) {
 				$item = array();
 
-				$item['uri'] = http_build_query($params);
+				// Create "new" error message every 24 hours
+				$params['_error_time'] = urlencode((int)(time()/86400));
+
+				$item['uri'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . '?' . http_build_query($params);
 				$item['title'] = $e->getCode();
 				$item['timestamp'] = time();
 				$item['content'] = buildBridgeException($e, $bridge);

--- a/index.php
+++ b/index.php
@@ -234,13 +234,23 @@ try {
 			$infos = $bridge->getExtraInfos();
 			$ctime = $bridge->getCacheTime();
 		} catch(Error $e) {
-			http_response_code($e->getCode());
-			header('Content-Type: text/html');
-			die(buildBridgeException($e, $bridge));
+			$item = array();
+
+			$item['uri'] = http_build_query($params);
+			$item['title'] = $e->getCode();
+			$item['timestamp'] = time();
+			$item['content'] = htmlspecialchars(buildBridgeException($e, $bridge));
+
+			$items[] = $item;
 		} catch(Exception $e) {
-			http_response_code($e->getCode());
-			header('Content-Type: text/html');
-			die(buildBridgeException($e, $bridge));
+			$item = array();
+
+			$item['uri'] = http_build_query($params);
+			$item['title'] = $e->getCode();
+			$item['timestamp'] = time();
+			$item['content'] = buildBridgeException($e, $bridge);
+
+			$items[] = $item;
 		}
 
 		// Data transformation

--- a/index.php
+++ b/index.php
@@ -219,12 +219,20 @@ try {
 		$cache->purgeCache(86400); // 24 hours
 		$cache->setParameters($cache_params);
 
+		$items = array();
+		$infos = array();
+		$ctime = 0;
+
 		// Load cache & data
 		try {
 			$bridge->setCache($cache);
 			$bridge->setCacheTimeout($cache_timeout);
 			$bridge->dieIfNotModified();
 			$bridge->setDatas($bridge_params);
+
+			$items = $bridge->getItems();
+			$infos = $bridge->getExtraInfos();
+			$ctime = $bridge->getCacheTime();
 		} catch(Error $e) {
 			http_response_code($e->getCode());
 			header('Content-Type: text/html');
@@ -238,9 +246,9 @@ try {
 		// Data transformation
 		try {
 			$format = Format::create($format);
-			$format->setItems($bridge->getItems());
-			$format->setExtraInfos($bridge->getExtraInfos());
-			$format->setLastModified($bridge->getCacheTime());
+			$format->setItems($items);
+			$format->setExtraInfos($infos);
+			$format->setLastModified($ctime);
 			$format->display();
 		} catch(Error $e) {
 			http_response_code($e->getCode());
@@ -249,7 +257,7 @@ try {
 		} catch(Exception $e) {
 			http_response_code($e->getCode());
 			header('Content-Type: text/html');
-			die(buildBridgeException($e, $bridge));
+			die(buildTransformException($e, $bridge));
 		}
 	} else {
 		echo BridgeList::create($whitelist_selection, $showInactive);

--- a/index.php
+++ b/index.php
@@ -254,10 +254,10 @@ try {
 				$item = array();
 
 				// Create "new" error message every 24 hours
-				$params['_error_time'] = urlencode((int)(time()/86400));
+				$params['_error_time'] = urlencode((int)(time() / 86400));
 
 				$item['uri'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . '?' . http_build_query($params);
-				$item['title'] = $e->getCode();
+				$item['title'] = 'Bridge returned error ' . $e->getCode() . '! (' . $params['_error_time'] . ')';
 				$item['timestamp'] = time();
 				$item['content'] = htmlspecialchars(buildBridgeException($e, $bridge));
 
@@ -266,10 +266,10 @@ try {
 				$item = array();
 
 				// Create "new" error message every 24 hours
-				$params['_error_time'] = urlencode((int)(time()/86400));
+				$params['_error_time'] = urlencode((int)(time() / 86400));
 
 				$item['uri'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . '?' . http_build_query($params);
-				$item['title'] = $e->getCode();
+				$item['title'] = 'Bridge returned error ' . $e->getCode() . '! (' . $params['_error_time'] . ')';
 				$item['timestamp'] = time();
 				$item['content'] = buildBridgeException($e, $bridge);
 

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -9,23 +9,9 @@ abstract class BridgeAbstract implements BridgeInterface {
 	const CACHE_TIMEOUT = 3600;
 	const PARAMETERS = array();
 
-	protected $cache;
-	protected $extraInfos;
 	protected $items = array();
 	protected $inputs = array();
 	protected $queriedContext = '';
-	protected $cacheTimeout;
-
-	/**
-	* Return cachable datas (extrainfos and items) stored in the bridge
-	* @return mixed
-	*/
-	public function getCachable(){
-		return array(
-			'items' => $this->getItems(),
-			'extraInfos' => $this->getExtraInfos()
-		);
-	}
 
 	/**
 	* Return items stored in the bridge
@@ -118,34 +104,18 @@ abstract class BridgeAbstract implements BridgeInterface {
 
 	/**
 	* Defined datas with parameters depending choose bridge
-	* Note : you can define a cache with "setCache"
 	* @param array array with expected bridge paramters
 	*/
 	public function setDatas(array $inputs){
-		if(!is_null($this->cache)) {
-			$time = $this->cache->getTime();
-			if($time !== false
-			&& (time() - $this->getCacheTimeout() < $time)
-			&& (!defined('DEBUG') || DEBUG !== true)) {
-				$cached = $this->cache->loadData();
-				if(isset($cached['items']) && isset($cached['extraInfos'])) {
-					$this->items = $cached['items'];
-					$this->extraInfos = $cached['extraInfos'];
-					return;
-				}
-			}
-		}
 
 		if(empty(static::PARAMETERS)) {
+
 			if(!empty($inputs)) {
 				returnClientError('Invalid parameters value(s)');
 			}
 
-			$this->collectData();
-			if(!is_null($this->cache)) {
-				$this->cache->saveData($this->getCachable());
-			}
 			return;
+
 		}
 
 		$validator = new ParameterValidator();
@@ -172,11 +142,6 @@ abstract class BridgeAbstract implements BridgeInterface {
 
 		$this->setInputs($inputs, $this->queriedContext);
 
-		$this->collectData();
-
-		if(!is_null($this->cache)) {
-			$this->cache->saveData($this->getCachable());
-		}
 	}
 
 	/**
@@ -201,20 +166,10 @@ abstract class BridgeAbstract implements BridgeInterface {
 	}
 
 	public function getName(){
-		// Return cached name when bridge is using cached data
-		if(isset($this->extraInfos)) {
-			return $this->extraInfos['name'];
-		}
-
 		return static::NAME;
 	}
 
 	public function getIcon(){
-		// Return cached icon when bridge is using cached data
-		if(isset($this->extraInfos)) {
-			return $this->extraInfos['icon'];
-		}
-
 		return '';
 	}
 
@@ -223,53 +178,23 @@ abstract class BridgeAbstract implements BridgeInterface {
 	}
 
 	public function getURI(){
-		// Return cached uri when bridge is using cached data
-		if(isset($this->extraInfos)) {
-			return $this->extraInfos['uri'];
-		}
-
 		return static::URI;
 	}
 
-	public function getExtraInfos(){
-		return array(
-			'name' => $this->getName(),
-			'uri' => $this->getURI(),
-			'icon' => $this->getIcon()
-		);
-	}
-
-	public function setCache(\CacheInterface $cache){
-		$this->cache = $cache;
-	}
-
-	public function setCacheTimeout($timeout){
-		if(is_numeric($timeout) && ($timeout < 1 || $timeout > 86400)) {
-			$this->cacheTimeout = static::CACHE_TIMEOUT;
-			return;
-		}
-
-		$this->cacheTimeout = $timeout;
-	}
-
 	public function getCacheTimeout(){
-		return isset($this->cacheTimeout) ? $this->cacheTimeout : static::CACHE_TIMEOUT;
+		return static::CACHE_TIMEOUT;
 	}
-
-	public function getModifiedTime(){
-		return !is_null($this->cache) ? $this->cache->getTime() : false;
-	}
-
+/*
 	public function dieIfNotModified(){
 		if ((defined('DEBUG') && DEBUG === true)) return; // disabled in debug mode
 
 		$if_modified_since = isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ? $_SERVER['HTTP_IF_MODIFIED_SINCE'] : false;
 		if (!$if_modified_since) return; // If-Modified-Since value is required
 
-		$last_modified = $this->getModifiedTime();
-		if (!$last_modified) return; // did not detect cache time
+		// $last_modified = $this->getModifiedTime();
+		// if (!$last_modified) return; // did not detect cache time
 
-		if (time() - $this->getCacheTimeout() > $last_modified) return; // cache timeout
+		// if (time() - $this->getCacheTimeout() > $last_modified) return; // cache timeout
 
 		$last_modified = (gmdate('D, d M Y H:i:s ', $last_modified) . 'GMT');
 
@@ -277,5 +202,5 @@ abstract class BridgeAbstract implements BridgeInterface {
 			header('HTTP/1.1 304 Not Modified');
 			die();
 		}
-	}
+	}*/
 }

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -256,7 +256,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 		return isset($this->cacheTimeout) ? $this->cacheTimeout : static::CACHE_TIMEOUT;
 	}
 
-	public function getCacheTime(){
+	public function getModifiedTime(){
 		return !is_null($this->cache) ? $this->cache->getTime() : false;
 	}
 
@@ -266,7 +266,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 		$if_modified_since = isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ? $_SERVER['HTTP_IF_MODIFIED_SINCE'] : false;
 		if (!$if_modified_since) return; // If-Modified-Since value is required
 
-		$last_modified = $this->getCacheTime();
+		$last_modified = $this->getModifiedTime();
 		if (!$last_modified) return; // did not detect cache time
 
 		if (time() - $this->getCacheTimeout() > $last_modified) return; // cache timeout

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -184,23 +184,5 @@ abstract class BridgeAbstract implements BridgeInterface {
 	public function getCacheTimeout(){
 		return static::CACHE_TIMEOUT;
 	}
-/*
-	public function dieIfNotModified(){
-		if ((defined('DEBUG') && DEBUG === true)) return; // disabled in debug mode
 
-		$if_modified_since = isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ? $_SERVER['HTTP_IF_MODIFIED_SINCE'] : false;
-		if (!$if_modified_since) return; // If-Modified-Since value is required
-
-		// $last_modified = $this->getModifiedTime();
-		// if (!$last_modified) return; // did not detect cache time
-
-		// if (time() - $this->getCacheTimeout() > $last_modified) return; // cache timeout
-
-		$last_modified = (gmdate('D, d M Y H:i:s ', $last_modified) . 'GMT');
-
-		if ($if_modified_since == $last_modified) {
-			header('HTTP/1.1 304 Not Modified');
-			die();
-		}
-	}*/
 }

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -7,25 +7,11 @@ interface BridgeInterface {
 	public function collectData();
 
 	/**
-	 * Returns an array of cachable elements
-	 *
-	 * @return array Associative array of cachable elements
-	 */
-	public function getCachable();
-
-	/**
 	 * Returns the description
 	 *
 	 * @return string Description
 	 */
 	public function getDescription();
-
-	/**
-	 * Return an array of extra information
-	 *
-	 * @return array Associative array of extra information
-	 */
-	public function getExtraInfos();
 
 	/**
 	 * Returns an array of collected items
@@ -68,22 +54,6 @@ interface BridgeInterface {
 	 * @return string Bridge URI
 	 */
 	public function getURI();
-
-	/**
-	 * Sets the cache instance
-	 *
-	 * @param object CacheInterface The cache instance
-	 */
-	public function setCache(\CacheInterface $cache);
-
-	/**
-	 * Sets the timeout for clearing the cache files. The timeout must be
-	 * specified between 1..86400 seconds (max. 24 hours). The default timeout
-	 * (specified by the bridge maintainer) applies for invalid values.
-	 *
-	 * @param int $timeout The cache timeout in seconds
-	 */
-	public function setCacheTimeout($timeout);
 
 	/**
 	 * Returns the cache timeout

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -76,7 +76,7 @@ function buildBridgeException($e, $bridge){
 unable to receive or process the remote website's content!";
 	$section = buildSection($e, $bridge, $message, $link);
 
-	return buildPage($title, $header, $section);
+	return $section;
 }
 
 /**

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -69,11 +69,15 @@ function buildBridgeException($e, $bridge){
 	. Configuration::getVersion()
 	. '`';
 
+	$body_html = nl2br($body);
 	$link = buildGitHubIssueQuery($title, $body, 'bug report', $bridge->getMaintainer());
 
 	$header = buildHeader($e, $bridge);
-	$message = "<strong>{$bridge->getName()}</strong> was
-unable to receive or process the remote website's content!";
+	$message = <<<EOD
+<strong>{$bridge->getName()}</strong> was unable to receive or process the
+remote website's content!<br>
+{$body_html}
+EOD;
 	$section = buildSection($e, $bridge, $message, $link);
 
 	return $section;

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -127,7 +127,7 @@ function buildSection($e, $bridge, $message, $link){
 		<ul class="advice">
 			<li>Press Return to check your input parameters</li>
 			<li>Press F5 to retry</li>
-			<li>Open a GitHub Issue if this error persists</li>
+			<li>Open a <a href="{$link}">GitHub Issue</a> if this error persists</li>
 		</ul>
 	</div>
 	<a href="{$link}" title="After clicking this button you can review


### PR DESCRIPTION
This PR is work in progress, do not merge!

Changes exception handling in order to return regular feed items for exceptions happening during bridge execution. That way feed readers will display errors as if the bridge was updated regularly.

References #814, #828

Ping @ORelio 

### TODO
 - [x] Generate unique IDs to prevent feed readers from hiding re-occurring errors
 - [x] Include unique ID in the title to prevent feed readers from "updating" existing feeds based on names
 - [x] Add caching for errors (24 h)