### PR TITLE
[core] Fixed broken caching

### DIFF
--- a/index.php
+++ b/index.php
@@ -306,7 +306,7 @@ try {
 			$format = Format::create($format);
 			$format->setItems($items);
 			$format->setExtraInfos($infos);
-			$format->setLastModified($mtime);
+			$format->setLastModified($cache->getTime());
 			$format->display();
 		} catch(Error $e) {
 			http_response_code($e->getCode());


### PR DESCRIPTION
Fixes https://github.com/RSS-Bridge/rss-bridge/issues/875
Edit and run bash script to check. Must return OK in the end:

```bash
#!/usr/bin/env bash

# cache timeout
CACHE_TIMEOUT=10

# must be less than CACHE_TIMEOUT
SLEEP_TIME=1

# example feed with disabled debug and enabled custom cache timeout
URL="https://feed.eugenemolotov.ru/dev-cachefix/?action=display&bridge=Pikabu&tag=it&filter=hot&format=Html&_cache_timeout=$CACHE_TIMEOUT"

# headers output file
HEADERS_FILE=/tmp/headers.php

curl -sSL -D - "$URL" -o /dev/null >$HEADERS_FILE
cat $HEADERS_FILE
LAST_MOD=`cat $HEADERS_FILE | grep "Last-Modified" | cut -c 16-`

if [[ -z $LAST_MOD ]]
then
	echo "missing LAST-MODIFIED"
	echo "check url: $URL"
	exit 1
fi

sleep $SLEEP_TIME

curl -sSL -D - -H "IF-Modified-Since: $LAST_MOD" "$URL" -o /dev/null >$HEADERS_FILE
cat $HEADERS_FILE
HTTP_RESULT=`cat $HEADERS_FILE | grep "HTTP/1.1" | cut -d' ' -f 2`

if [[ "$HTTP_RESULT" -eq "304" ]]
then
	echo "(sleeping while cache timeout)"
	echo
	sleep $CACHE_TIMEOUT
else
	echo "NOT FIXED"
	exit 1
fi

curl -sSL -D - -H "IF-Modified-Since: $LAST_MOD" "$URL" -o /dev/null >$HEADERS_FILE
cat $HEADERS_FILE
HTTP_RESULT=`cat $HEADERS_FILE | grep "HTTP/1.1" | cut -d' ' -f 2`
if [[ "$HTTP_RESULT" -eq "200" ]]
then
	echo "OK"
else
	echo "UNEXPECTED CODE"
	exit 1
fi

```