### PR TITLE
[RainbowSixSiegeBridge] Fix missing news

### DIFF
--- a/bridges/RainbowSixSiegeBridge.php
+++ b/bridges/RainbowSixSiegeBridge.php
@@ -13,8 +13,8 @@ class RainbowSixSiegeBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$dlUrl = 'https://prod-tridionservice.ubisoft.com/live/v1/News/Latest?templateId=tcm%3A152-7677';
-		$dlUrl .= '8-32&pageIndex=0&pageSize=10&language=en-US&detailPageId=tcm%3A152-194572-64';
-		$dlUrl .= '&keywordList=175426&siteId=undefined&useSeoFriendlyUrl=true';
+		$dlUrl .= '8-32&pageIndex=0&pageSize=10&language=en-US&detailPageId=tcm%3A150-194572-64';
+		$dlUrl .= '&keywordList=233416%2C316144%2C233418%2C233417&siteId=undefined&useSeoFriendlyUrl=true';
 		$jsonString = getContents($dlUrl) or returnServerError('Error while downloading the website content');
 
 		$json = json_decode($jsonString, true);


### PR DESCRIPTION
The URL for the news source has changed, so an update was needed to fetch all the news.