### PR TITLE
[CommonDreamBridge] Promote to secure bridge (fix #777)

### DIFF
--- a/bridges/CommonDreamsBridge.php
+++ b/bridges/CommonDreamsBridge.php
@@ -3,7 +3,7 @@ class CommonDreamsBridge extends FeedExpander {
 
 	const MAINTAINER = 'nyutag';
 	const NAME = 'CommonDreams Bridge';
-	const URI = 'http://www.commondreams.org/';
+	const URI = 'https://www.commondreams.org/';
 	const DESCRIPTION = 'Returns the newest articles.';
 
 	public function collectData(){


### PR DESCRIPTION
As per issue 777, promote to secure bridge as the website supports HTTPS.