### PR TITLE
Automatically select a bridge based on a URL

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -66,6 +66,41 @@ class TwitterBridge extends BridgeAbstract {
 		)
 	);
 
+	public function detectParameters(string $url){
+		$params = array();
+
+		// By keyword or hashtag (search)
+		$regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/search.*(\?|&)q=([^\/&?\n]+)/';
+		if(preg_match($regex, $url, $matches) > 0) {
+			$params['q'] = urldecode($matches[4]);
+			return $params;
+		}
+
+		// By hashtag
+		$regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/hashtag\/([^\/?\n]+)/';
+		if(preg_match($regex, $url, $matches) > 0) {
+			$params['q'] = urldecode($matches[3]);
+			return $params;
+		}
+
+		// By list
+		$regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/([^\/?\n]+)\/lists\/([^\/?\n]+)/';
+		if(preg_match($regex, $url, $matches) > 0) {
+			$params['user'] = urldecode($matches[3]);
+			$params['list'] = urldecode($matches[4]);
+			return $params;
+		}
+
+		// By username
+		$regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/([^\/?\n]+)/';
+		if(preg_match($regex, $url, $matches) > 0) {
+			$params['u'] = urldecode($matches[3]);
+			return $params;
+		}
+
+		return null;
+	}
+
 	public function getName(){
 		switch($this->queriedContext) {
 		case 'By keyword or hashtag':

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -66,7 +66,7 @@ class TwitterBridge extends BridgeAbstract {
 		)
 	);
 
-	public function detectParameters(string $url){
+	public function detectParameters($url){
 		$params = array();
 
 		// By keyword or hashtag (search)

--- a/index.php
+++ b/index.php
@@ -55,7 +55,7 @@ try {
 	$showInactive = filter_input(INPUT_GET, 'show_inactive', FILTER_VALIDATE_BOOLEAN);
 	$action = array_key_exists('action', $params) ? $params['action'] : null;
 	$bridge = array_key_exists('bridge', $params) ? $params['bridge'] : null;
-	$url = array_key_exists('url', $params) ? $params['url'] : null;
+	$targetURL = array_key_exists('url', $params) ? $params['url'] : null;
 
 	// Return list of bridges as JSON formatted text
 	if($action === 'list') {
@@ -112,14 +112,14 @@ try {
 
 			$bridgeParams = $bridge->detectParameters($url);
 
-			if($bridgeParams === null) {
+			if(is_null($bridgeParams)) {
 				continue;
 			}
 
 			$bridgeParams['bridge'] = $bridgeName;
 			$bridgeParams['format'] = $format;
 
-			header('Location: ?action=display&' . http_build_query($bridgeParams));
+			header('Location: ?action=display&' . http_build_query($bridgeParams), true, 301);
 			die();
 
 		}

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -185,7 +185,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 		return static::CACHE_TIMEOUT;
 	}
 
-	public function detectParameters(string $url){
+	public function detectParameters($url){
 		$regex = '/^(https?:\/\/)?(www\.)?(.+?)(\/)?$/';
 		if(empty(static::PARAMETERS)
 		&& preg_match($regex, $url, $urlMatches) > 0

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -186,7 +186,15 @@ abstract class BridgeAbstract implements BridgeInterface {
 	}
 
 	public function detectParameters(string $url){
-		return null;
+		$regex = '/^(https?:\/\/)?(www\.)?(.+?)(\/)?$/';
+		if(empty(static::PARAMETERS)
+		&& preg_match($regex, $url, $urlMatches) > 0
+		&& preg_match($regex, static::URI, $bridgeUriMatches) > 0
+		&& $urlMatches[3] === $bridgeUriMatches[3]) {
+			return array();
+		} else {
+			return null;
+		}
 	}
 
 }

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -185,6 +185,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 		return static::CACHE_TIMEOUT;
 	}
 
+	/** {@inheritdoc} */
 	public function detectParameters($url){
 		$regex = '/^(https?:\/\/)?(www\.)?(.+?)(\/)?$/';
 		if(empty(static::PARAMETERS)

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -185,4 +185,8 @@ abstract class BridgeAbstract implements BridgeInterface {
 		return static::CACHE_TIMEOUT;
 	}
 
+	public function detectParameters(string $url){
+		return null;
+	}
+
 }

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -65,8 +65,8 @@ interface BridgeInterface {
 	/**
 	 * Returns parameters from given URL or null if URL is not applicable
 	 *
-	 * @param $url string URL to extract parameters from
-	 * @return array Bridge parameters
+	 * @param string $url URL to extract parameters from
+	 * @return array|null List of bridge parameters or null if detection failed.
 	 */
 	public function detectParameters($url);
 }

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -61,4 +61,12 @@ interface BridgeInterface {
 	 * @return int Cache timeout
 	 */
 	public function getCacheTimeout();
+
+	/**
+	 * Returns parameters from given URL or null if URL is not applicable
+	 *
+	 * @param $url URL to extract parameters from
+	 * @return array Bridge parameters
+	 */
+	public function detectParameters(string $url);
 }

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -65,8 +65,8 @@ interface BridgeInterface {
 	/**
 	 * Returns parameters from given URL or null if URL is not applicable
 	 *
-	 * @param $url URL to extract parameters from
+	 * @param $url string URL to extract parameters from
 	 * @return array Bridge parameters
 	 */
-	public function detectParameters(string $url);
+	public function detectParameters($url);
 }


### PR DESCRIPTION
Hey some time ago I opened #743 and I thought I'd give implementing this feature a shot.

To summarize idea here is to add a new `detect` action which when given a URL automatically redirects the user directly to a feed, similar to the "I'm feeling lucky" feature some search engines have.

For example to get a feed from: [#rss-bridge on twitter](https://twitter.com/search?q=%23rss-bridge) we could send a request to:
`/?action=detect&format=Atom&url=twitter.com/search%3Fq%3D%2523rss-bridge`
which would redirect to: `/?action=display&q=%23rss-bridge&bridge=Twitter&format=Atom`.

My personal use case for this is integration with my web browser: A browser shortcut that sends the current page URL to rss-bridge which then gives me a feed right away.

In #743 it was brought up to use this to display and auto-fill a bridge in the rss-bridge web UI. That'd need some more work, but it should be compatible with the server-side code in this PR I'd imagine!

Either way feedback appreciated! (: