### PR TITLE
[SoundcloudBridge.php] Fix to add RSS enclosures

### DIFF
--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -42,8 +42,8 @@ class SoundCloudBridge extends BridgeAbstract {
 			. self::CLIENT_ID
 			. '">';
 			$item['enclosures'] = array($tracks[$i]->uri
-			    . '/stream?client_id='
-			    . self::CLIENT_ID);
+			. '/stream?client_id='
+			. self::CLIENT_ID);
 
 			$item['id'] = self::URI
 				. urlencode($this->getInput('u'))

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -41,6 +41,9 @@ class SoundCloudBridge extends BridgeAbstract {
 			. '/stream?client_id='
 			. self::CLIENT_ID
 			. '">';
+			$item['enclosures'] = array($tracks[$i]->uri
+			    . '/stream?client_id='
+			    . self::CLIENT_ID);
 
 			$item['id'] = self::URI
 				. urlencode($this->getInput('u'))


### PR DESCRIPTION
Minimum viable code change to get SoundcloudBridge produce feeds that podcatchers like gPodder can understand and auto-download.