### PR TITLE
[SoundcloudBridge] Improves Author, Date, Description

### DIFF
--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -34,13 +34,10 @@ class SoundCloudBridge extends BridgeAbstract {
 
 		for($i = 0; $i < 10; $i++) {
 			$item = array();
-			$item['author'] = $tracks[$i]->user->username . ' - ' . $tracks[$i]->title;
+			$item['author'] = $tracks[$i]->user->username;
 			$item['title'] = $tracks[$i]->user->username . ' - ' . $tracks[$i]->title;
-			$item['content'] = '<audio src="'
-			. $tracks[$i]->uri
-			. '/stream?client_id='
-			. self::CLIENT_ID
-			. '">';
+			$item['timestamp'] = strtotime($tracks[$i]->created_at);
+			$item['content'] = $tracks[$i]->description;
 			$item['enclosures'] = array($tracks[$i]->uri
 			. '/stream?client_id='
 			. self::CLIENT_ID);


### PR DESCRIPTION
1. Author Name now doesn't include Episode Title
2. It now fetches Episode Creation Timestamp, to allow correct sorting in podcatchers
3. Description is now the actual show notes, and not an \<audio\> tag

Not implemented yet: fetch enclosure length, fetch enclosure mimetype, fetch artwork