### PR TITLE
[InstagramBridge] Truncate long titles and use full text as content

### DIFF
--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -88,7 +88,13 @@ class InstagramBridge extends BridgeAbstract {
 				$textContent = basename($media->display_url);
 			}
 
-			$item['title'] = self::truncate($textContent, 120);
+			$item['title'] = trim($textContent);
+			if (strlen($item['title']) > 120) {
+				$titleLinePos = strpos(wordwrap($item['title'], 120), "\n");
+				if ($titleLinePos != false) {
+					$item['title'] = substr($item['title'], 0, $titleLinePos) . '...';
+				}
+			}
 
 			if(!is_null($this->getInput('u')) && $media->__typename == 'GraphSidecar') {
 				$data = $this->getInstagramStory($item['uri']);
@@ -96,9 +102,7 @@ class InstagramBridge extends BridgeAbstract {
 				$item['enclosures'] = $data[1];
 			} else {
 				$item['content'] = '<img src="' . htmlentities($media->display_url) . '" alt="' . $item['title'] . '" />';
-				if (mb_strlen($item['title']) != mb_strlen($textContent)) {
-					$item['content'] .= '<br><br>' . htmlentities($textContent);
-				}
+				$item['content'] .= '<br><br>' . nl2br(htmlentities($textContent));
 				$item['enclosures'] = array($media->display_url);
 			}
 
@@ -164,16 +168,6 @@ class InstagramBridge extends BridgeAbstract {
 			return self::URI . 'explore/locations/' . urlencode($this->getInput('l'));
 		}
 		return parent::getURI();
-	}
-
-	/** Truncate a string after n chars
-	 * @param string $string The string to truncate
-	 * @param int $n Maximum number of chars
-	 * @param string $append To string to append if trucation is done (default: '...') */
-	private static function truncate($string, $n, $append = '...') {
-		$n = intval($n);
-		if (mb_strlen($string) <= $n) return $string;
-		return (mb_substr($string, 0, $n) . $append);
 	}
 
 }

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -87,7 +87,7 @@ class InstagramBridge extends BridgeAbstract {
 			} else {
 				$textContent = basename($media->display_url);
 			}
-			
+
 			$item['title'] = self::truncate($textContent, 120);
 
 			if(!is_null($this->getInput('u')) && $media->__typename == 'GraphSidecar') {
@@ -165,7 +165,7 @@ class InstagramBridge extends BridgeAbstract {
 		}
 		return parent::getURI();
 	}
-	
+
 	/** Truncate a string after n chars
 	 * @param string $string The string to truncate
 	 * @param int $n Maximum number of chars
@@ -175,5 +175,5 @@ class InstagramBridge extends BridgeAbstract {
 		if (mb_strlen($string) <= $n) return $string;
 		return (mb_substr($string, 0, $n) . $append);
 	}
-	
+
 }

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -89,11 +89,9 @@ class InstagramBridge extends BridgeAbstract {
 			}
 
 			$item['title'] = trim($textContent);
-			if (strlen($item['title']) > 120) {
-				$titleLinePos = strpos(wordwrap($item['title'], 120), "\n");
-				if ($titleLinePos != false) {
-					$item['title'] = substr($item['title'], 0, $titleLinePos) . '...';
-				}
+			$titleLinePos = strpos(wordwrap($item['title'], 120), "\n");
+			if ($titleLinePos != false) {
+				$item['title'] = substr($item['title'], 0, $titleLinePos) . '...';
 			}
 
 			if(!is_null($this->getInput('u')) && $media->__typename == 'GraphSidecar') {

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -83,10 +83,12 @@ class InstagramBridge extends BridgeAbstract {
 			$item['uri'] = self::URI . 'p/' . $media->shortcode . '/';
 
 			if (isset($media->edge_media_to_caption->edges[0]->node->text)) {
-				$item['title'] = $media->edge_media_to_caption->edges[0]->node->text;
+				$textContent = $media->edge_media_to_caption->edges[0]->node->text;
 			} else {
-				$item['title'] = basename($media->display_url);
+				$textContent = basename($media->display_url);
 			}
+			
+			$item['title'] = self::truncate($textContent, 120);
 
 			if(!is_null($this->getInput('u')) && $media->__typename == 'GraphSidecar') {
 				$data = $this->getInstagramStory($item['uri']);
@@ -94,6 +96,9 @@ class InstagramBridge extends BridgeAbstract {
 				$item['enclosures'] = $data[1];
 			} else {
 				$item['content'] = '<img src="' . htmlentities($media->display_url) . '" alt="' . $item['title'] . '" />';
+				if (mb_strlen($item['title']) != mb_strlen($textContent)) {
+					$item['content'] .= '<br><br>' . htmlentities($textContent);
+				}
 				$item['enclosures'] = array($media->display_url);
 			}
 
@@ -160,4 +165,15 @@ class InstagramBridge extends BridgeAbstract {
 		}
 		return parent::getURI();
 	}
+	
+	/** Truncate a string after n chars
+	 * @param string $string The string to truncate
+	 * @param int $n Maximum number of chars
+	 * @param string $append To string to append if trucation is done (default: '...') */
+	private static function truncate($string, $n, $append = '...') {
+		$n = intval($n);
+		if (mb_strlen($string) <= $n) return $string;
+		return (mb_substr($string, 0, $n) . $append);
+	}
+	
 }


### PR DESCRIPTION
Instagram posts' text can be very long used as feed items' title. This PR truncates titles over 120 characters, and uses the full text as items' content if truncated.

Possible changes I can make on this PR if you prefer:

* Always put the full text in items' content, also if it was short enough to not be truncated in items' title.
* Use a better truncation function that preserves words' integrity.