### PR TITLE
Use file_get_contents when in CLI mode & no certs

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -52,82 +52,88 @@ function getContents($url, $header = array(), $opts = array()){
 	$params = [$url];
 	$cache->setParameters($params);
 
-	$ch = curl_init($url);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-
-	if(is_array($header) && count($header) !== 0) {
-
-		Debug::log('Setting headers: ' . json_encode($header));
-		curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
-
-	}
-
-	curl_setopt($ch, CURLOPT_USERAGENT, ini_get('user_agent'));
-	curl_setopt($ch, CURLOPT_ENCODING, '');
-	curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-
-	if(is_array($opts) && count($opts) !== 0) {
-
-		Debug::log('Setting options: ' . json_encode($opts));
-
-		foreach($opts as $key => $value) {
-			curl_setopt($ch, $key, $value);
-		}
-
-	}
-
-	if(defined('PROXY_URL') && !defined('NOPROXY')) {
-
-		Debug::log('Setting proxy url: ' . PROXY_URL);
-		curl_setopt($ch, CURLOPT_PROXY, PROXY_URL);
-
-	}
-
-	// We always want the response header as part of the data!
-	curl_setopt($ch, CURLOPT_HEADER, true);
-
-	// Build "If-Modified-Since" header
-	if(!Debug::isEnabled() && $time = $cache->getTime()) { // Skip if cache file doesn't exist
-		Debug::log('Adding If-Modified-Since');
-		curl_setopt($ch, CURLOPT_TIMEVALUE, $time);
-		curl_setopt($ch, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
-	}
-
-	// Enables logging for the outgoing header
-	curl_setopt($ch, CURLINFO_HEADER_OUT, true);
-
 	// Use file_get_contents if in CLI mode with no root certificates defined
 	if(php_sapi_name() === 'cli' && ini_get('curl.cainfo') === '') {
 		$data = file_get_contents($url);
+
 		if($data === false) {
 			$errorCode = 500;
 		} else {
 			$errorCode = 200;
 		}
+		
+		$curlError = "";
+		$curlErrno = "";
+		$headerSize = 0;
+		$finalHeader = array();
 	} else {
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+
+		if(is_array($header) && count($header) !== 0) {
+
+			Debug::log('Setting headers: ' . json_encode($header));
+			curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+
+		}
+
+		curl_setopt($ch, CURLOPT_USERAGENT, ini_get('user_agent'));
+		curl_setopt($ch, CURLOPT_ENCODING, '');
+		curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+
+		if(is_array($opts) && count($opts) !== 0) {
+
+			Debug::log('Setting options: ' . json_encode($opts));
+
+			foreach($opts as $key => $value) {
+				curl_setopt($ch, $key, $value);
+			}
+
+		}
+
+		if(defined('PROXY_URL') && !defined('NOPROXY')) {
+
+			Debug::log('Setting proxy url: ' . PROXY_URL);
+			curl_setopt($ch, CURLOPT_PROXY, PROXY_URL);
+
+		}
+
+		// We always want the response header as part of the data!
+		curl_setopt($ch, CURLOPT_HEADER, true);
+
+		// Build "If-Modified-Since" header
+		if(!Debug::isEnabled() && $time = $cache->getTime()) { // Skip if cache file doesn't exist
+			Debug::log('Adding If-Modified-Since');
+			curl_setopt($ch, CURLOPT_TIMEVALUE, $time);
+			curl_setopt($ch, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
+		}
+
+		// Enables logging for the outgoing header
+		curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+
 		$data = curl_exec($ch);
 		$errorCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		
+		$curlError = curl_error($ch);
+		$curlErrno = curl_errno($ch);
+		$curlInfo = curl_getinfo($ch);
+
+		Debug::log('Outgoing header: ' . json_encode($curlInfo));
+
+		if($data === false)
+			Debug::log('Cant\'t download ' . $url . ' cUrl error: ' . $curlError . ' (' . $curlErrno . ')');
+
+		$headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+		$header = substr($data, 0, $headerSize);
+
+		Debug::log('Response header: ' . $header);
+
+		$headers = parseResponseHeader($header);
+		$finalHeader = end($headers);
+
+		curl_close($ch);
 	}
-
-	$curlError = curl_error($ch);
-	$curlErrno = curl_errno($ch);
-	$curlInfo = curl_getinfo($ch);
-
-	Debug::log('Outgoing header: ' . json_encode($curlInfo));
-
-	if($data === false)
-		Debug::log('Cant\'t download ' . $url . ' cUrl error: ' . $curlError . ' (' . $curlErrno . ')');
-
-	$headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-	$header = substr($data, 0, $headerSize);
-
-	Debug::log('Response header: ' . $header);
-
-	$headers = parseResponseHeader($header);
-	$finalHeader = end($headers);
-
-	curl_close($ch);
 
 	switch($errorCode) {
 		case 200: // Contents received

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -107,7 +107,7 @@ function getContents($url, $header = array(), $opts = array()){
 		$data = curl_exec($ch);
 		$errorCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 	}
-		
+
 	$curlError = curl_error($ch);
 	$curlErrno = curl_errno($ch);
 	$curlInfo = curl_getinfo($ch);

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -97,7 +97,17 @@ function getContents($url, $header = array(), $opts = array()){
 	// Enables logging for the outgoing header
 	curl_setopt($ch, CURLINFO_HEADER_OUT, true);
 
-	$data = curl_exec($ch);
+	if(php_sapi_name() == 'cli' && ini_get('curl.cainfo') == '') {
+		$data = file_get_contents($url);
+		if($data)
+			$errorCode = 200;
+		else
+			$errorCode = 500;
+	} else {
+		$data = curl_exec($ch);
+		$errorCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+	}
+		
 	$curlError = curl_error($ch);
 	$curlErrno = curl_errno($ch);
 	$curlInfo = curl_getinfo($ch);
@@ -108,7 +118,6 @@ function getContents($url, $header = array(), $opts = array()){
 		Debug::log('Cant\'t download ' . $url . ' cUrl error: ' . $curlError . ' (' . $curlErrno . ')');
 
 	$headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-	$errorCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 	$header = substr($data, 0, $headerSize);
 
 	Debug::log('Response header: ' . $header);

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -98,12 +98,13 @@ function getContents($url, $header = array(), $opts = array()){
 	curl_setopt($ch, CURLINFO_HEADER_OUT, true);
 
 	// Use file_get_contents if in CLI mode with no root certificates defined
-	if(php_sapi_name() == 'cli' && ini_get('curl.cainfo') == '') {
+	if(php_sapi_name() === 'cli' && ini_get('curl.cainfo') === '') {
 		$data = file_get_contents($url);
-		if($data)
-			$errorCode = 200;
-		else
+		if($data === false) {
 			$errorCode = 500;
+		} else {
+			$errorCode = 200;
+		}
 	} else {
 		$data = curl_exec($ch);
 		$errorCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -61,9 +61,9 @@ function getContents($url, $header = array(), $opts = array()){
 		} else {
 			$errorCode = 200;
 		}
-		
-		$curlError = "";
-		$curlErrno = "";
+
+		$curlError = '';
+		$curlErrno = '';
 		$headerSize = 0;
 		$finalHeader = array();
 	} else {
@@ -114,7 +114,7 @@ function getContents($url, $header = array(), $opts = array()){
 
 		$data = curl_exec($ch);
 		$errorCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		
+
 		$curlError = curl_error($ch);
 		$curlErrno = curl_errno($ch);
 		$curlInfo = curl_getinfo($ch);

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -97,6 +97,7 @@ function getContents($url, $header = array(), $opts = array()){
 	// Enables logging for the outgoing header
 	curl_setopt($ch, CURLINFO_HEADER_OUT, true);
 
+	// Use file_get_contents if in CLI mode with no root certificates defined
 	if(php_sapi_name() == 'cli' && ini_get('curl.cainfo') == '') {
 		$data = file_get_contents($url);
 		if($data)


### PR DESCRIPTION
Use file_get_contents when in CLI mode with no root certificates for cUrl. file_get_contents can natively use system root certificates.

Relates to #954 