### PR TITLE
[InstagramBridge] Link on image, video indication in title

### DIFF
--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -88,7 +88,7 @@ class InstagramBridge extends BridgeAbstract {
 				$textContent = basename($media->display_url);
 			}
 
-			$item['title'] = trim($textContent);
+			$item['title'] = ($media->is_video ? '▶ ' : '') . trim($textContent);
 			$titleLinePos = strpos(wordwrap($item['title'], 120), "\n");
 			if ($titleLinePos != false) {
 				$item['title'] = substr($item['title'], 0, $titleLinePos) . '...';

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -99,8 +99,9 @@ class InstagramBridge extends BridgeAbstract {
 				$item['content'] = $data[0];
 				$item['enclosures'] = $data[1];
 			} else {
-				$item['content'] = '<img src="' . htmlentities($media->display_url) . '" alt="' . $item['title'] . '" />';
-				$item['content'] .= '<br><br>' . nl2br(htmlentities($textContent));
+				$item['content'] = '<a href="' . htmlentities($item['uri']) . '" target="_blank">';
+				$item['content'] .= '<img src="' . htmlentities($media->display_url) . '" alt="' . $item['title'] . '" />';
+				$item['content'] .= '</a><br><br>' . nl2br(htmlentities($textContent));
 				$item['enclosures'] = array($media->display_url);
 			}
 


### PR DESCRIPTION
A couple of improvements for the Instagram bridge:

- In item content, the image is now a clickable link to the post;
- In item title a ▶ is prepended if the post contains a video; it's impossible to tell from the content image.