### PR TITLE
 Remove curl module requirement (CLI & no certs)

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -96,8 +96,7 @@ final class Configuration {
 			die('"simplexml" extension not loaded. Please check "php.ini"');
 
 		// Allow RSS-Bridge to run without curl module in CLI mode without root certificates
-		if(!extension_loaded('curl') && !(php_sapi_name() === 'cli' && (ini_get('curl.cainfo') === ''
-		|| ini_get('curl.cainfo') === false)))
+		if(!extension_loaded('curl') && !(php_sapi_name() === 'cli' && empty(ini_get('curl.cainfo'))))
 			die('"curl" extension not loaded. Please check "php.ini"');
 
 		if(!extension_loaded('json'))

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -96,7 +96,8 @@ final class Configuration {
 			die('"simplexml" extension not loaded. Please check "php.ini"');
 
 		// Allow RSS-Bridge to run without curl module in CLI mode without root certificates
-		if(!extension_loaded('curl') && !(php_sapi_name() === 'cli' && (ini_get('curl.cainfo') === '' || ini_get('curl.cainfo') === false)))
+		if(!extension_loaded('curl') && !(php_sapi_name() === 'cli' && (ini_get('curl.cainfo') === ''
+		|| ini_get('curl.cainfo') === false)))
 			die('"curl" extension not loaded. Please check "php.ini"');
 
 		if(!extension_loaded('json'))

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -95,7 +95,8 @@ final class Configuration {
 		if(!extension_loaded('simplexml'))
 			die('"simplexml" extension not loaded. Please check "php.ini"');
 
-		if(!extension_loaded('curl'))
+		// Allow RSS-Bridge to run without curl module in CLI mode without root certificates
+		if(!extension_loaded('curl') && !(php_sapi_name() === 'cli' && (ini_get('curl.cainfo') === '' || ini_get('curl.cainfo') === false)))
 			die('"curl" extension not loaded. Please check "php.ini"');
 
 		if(!extension_loaded('json'))

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -53,7 +53,7 @@ function getContents($url, $header = array(), $opts = array()){
 	$cache->setParameters($params);
 
 	// Use file_get_contents if in CLI mode with no root certificates defined
-	if(php_sapi_name() === 'cli' && (ini_get('curl.cainfo') === '' || ini_get('curl.cainfo') === false)) {
+	if(php_sapi_name() === 'cli' && empty(ini_get('curl.cainfo'))) {
 		$data = file_get_contents($url);
 
 		if($data === false) {

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -53,7 +53,7 @@ function getContents($url, $header = array(), $opts = array()){
 	$cache->setParameters($params);
 
 	// Use file_get_contents if in CLI mode with no root certificates defined
-	if(php_sapi_name() === 'cli' && ini_get('curl.cainfo') === '') {
+	if(php_sapi_name() === 'cli' && (ini_get('curl.cainfo') === '' || ini_get('curl.cainfo') === false)) {
 		$data = file_get_contents($url);
 
 		if($data === false) {


### PR DESCRIPTION
When running in CLI mode without certificates, do not require curl module to be loaded.