### PR TITLE
[BridgeImplementationTest] Rewritten unit test to check bridges

### DIFF
--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -15,6 +15,8 @@ class BridgeImplementationTest extends TestCase {
 	public function testClassName($path) {
 		$this->setBridge($path);
 		$this->assertTrue($this->class === ucfirst($this->class), 'class name must start with uppercase character');
+		$this->assertEquals(0, substr_count($this->class, ' '), 'class name must not contain spaces');
+		$this->assertStringEndsWith('Bridge', $this->class, 'class name must end with "Bridge"');
 	}
 
 	/**
@@ -22,7 +24,7 @@ class BridgeImplementationTest extends TestCase {
 	 */
 	public function testClassType($path) {
 		$this->setBridge($path);
-		$this->assertInstanceOf('BridgeAbstract', $this->obj);
+		$this->assertInstanceOf(BridgeInterface::class, $this->obj);
 	}
 
 	/**
@@ -129,9 +131,9 @@ class BridgeImplementationTest extends TestCase {
 	 * @dataProvider dataBridgesProvider
 	 */
 	public function testVisibleMethods($path) {
-		$allowedBridgeAbstract = get_class_methods('BridgeAbstract');
+ 		$allowedBridgeAbstract = get_class_methods(BridgeAbstract::class);
 		sort($allowedBridgeAbstract);
-		$allowedFeedExpander = get_class_methods('FeedExpander');
+ 		$allowedFeedExpander = get_class_methods(FeedExpander::class);
 		sort($allowedFeedExpander);
 
 		$this->setBridge($path);
@@ -185,7 +187,7 @@ class BridgeImplementationTest extends TestCase {
 
 	public function dataBridgesProvider() {
 		$bridges = array();
-		foreach (glob(self::PATH_BRIDGES . '*Bridge.php') as $path) {
+		foreach (glob(self::PATH_BRIDGES . '*.php') as $path) {
 			$bridges[basename($path, '.php')] = array($path);
 		}
 		return $bridges;
@@ -193,12 +195,12 @@ class BridgeImplementationTest extends TestCase {
 
 	private function setBridge($path) {
 		require_once $path;
-		$this->class = basename($path, '.php');
+ 		$this->class = basename($path, '.php');
+ 		$this->assertTrue(class_exists($this->class), 'class ' . $this->class . ' doesn\'t exist');
 		$this->obj = new $this->class();
 	}
 
 	private function checkUrl($url) {
 		$this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL), 'no valid URL: ' . $url);
-		//$this->assertContains('https://', $url);
 	}
 }

--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -107,15 +107,17 @@ class BridgeImplementationTest extends TestCase {
 
 				if (isset($options['pattern'])) {
 					$this->assertInternalType('string', $options['pattern'], $field . ': invalid pattern');
-					$this->assertNotEmpty($options['pattern'], $field . ': empty pattern');
+					$this->assertNotEquals('', $options['pattern'], $field . ': empty pattern');
 				}
 
 				if (isset($options['exampleValue'])) {
-					$this->assertNotEmpty($options['exampleValue'], $field . ': empty exampleValue');
+					if (is_string($options['exampleValue']))
+						$this->assertNotEquals('', $options['exampleValue'], $field . ': empty exampleValue');
 				}
 
 				if (isset($options['defaultValue'])) {
-					$this->assertNotEmpty($options['defaultValue'], $field . ': empty defaultValue');
+					if (is_string($options['defaultValue']))
+						$this->assertNotEquals('', $options['defaultValue'], $field . ': empty defaultValue');
 				}
 			}
 		}

--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -129,9 +129,9 @@ class BridgeImplementationTest extends TestCase {
 	 * @dataProvider dataBridgesProvider
 	 */
 	public function testVisibleMethods($path) {
- 		$allowedBridgeAbstract = get_class_methods(BridgeAbstract::class);
+		$allowedBridgeAbstract = get_class_methods(BridgeAbstract::class);
 		sort($allowedBridgeAbstract);
- 		$allowedFeedExpander = get_class_methods(FeedExpander::class);
+		$allowedFeedExpander = get_class_methods(FeedExpander::class);
 		sort($allowedFeedExpander);
 
 		$this->setBridge($path);
@@ -193,8 +193,8 @@ class BridgeImplementationTest extends TestCase {
 
 	private function setBridge($path) {
 		require_once $path;
- 		$this->class = basename($path, '.php');
- 		$this->assertTrue(class_exists($this->class), 'class ' . $this->class . ' doesn\'t exist');
+		$this->class = basename($path, '.php');
+		$this->assertTrue(class_exists($this->class), 'class ' . $this->class . ' doesn\'t exist');
 		$this->obj = new $this->class();
 	}
 

--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -4,8 +4,6 @@ require_once __DIR__ . '/../lib/rssbridge.php';
 use PHPUnit\Framework\TestCase;
 
 class BridgeImplementationTest extends TestCase {
-	const PATH_BRIDGES = __DIR__ . '/../bridges/';
-
 	private $class;
 	private $obj;
 
@@ -187,7 +185,7 @@ class BridgeImplementationTest extends TestCase {
 
 	public function dataBridgesProvider() {
 		$bridges = array();
-		foreach (glob(self::PATH_BRIDGES . '*.php') as $path) {
+		foreach (glob(PATH_LIB_BRIDGES . '*.php') as $path) {
 			$bridges[basename($path, '.php')] = array($path);
 		}
 		return $bridges;

--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -51,7 +51,9 @@ class BridgeImplementationTest extends TestCase {
 	public function testParameters($path) {
 		$this->setBridge($path);
 
-		$multiContexts = (count($this->obj::PARAMETERS) > 1);
+		$multiMinimum = 2;
+		if (isset($this->obj::PARAMETERS['global'])) ++$multiMinimum;
+		$multiContexts = (count($this->obj::PARAMETERS) >= $multiMinimum);
 		$paramsSeen = array();
 
 		$allowedTypes = array(

--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -3,13 +3,11 @@ require_once __DIR__ . '/../lib/rssbridge.php';
 
 use PHPUnit\Framework\TestCase;
 
-
 class BridgeImplementationTest extends TestCase {
 	const PATH_BRIDGES = __DIR__ . '/../bridges/';
 
 	private $class;
 	private $obj;
-
 
 	/**
 	 * @dataProvider dataBridgesProvider
@@ -19,7 +17,6 @@ class BridgeImplementationTest extends TestCase {
 		$this->assertTrue($this->class === ucfirst($this->class), 'class name must start with uppercase character');
 	}
 
-
 	/**
 	 * @dataProvider dataBridgesProvider
 	 */
@@ -27,7 +24,6 @@ class BridgeImplementationTest extends TestCase {
 		$this->setBridge($path);
 		$this->assertInstanceOf('BridgeAbstract', $this->obj);
 	}
-
 
 	/**
 	 * @dataProvider dataBridgesProvider
@@ -48,7 +44,6 @@ class BridgeImplementationTest extends TestCase {
 		$this->assertInternalType('int', $this->obj::CACHE_TIMEOUT, 'class::CACHE_TIMEOUT');
 		$this->assertGreaterThanOrEqual(0, $this->obj::CACHE_TIMEOUT, 'class::CACHE_TIMEOUT');
 	}
-
 
 	/**
 	 * @dataProvider dataBridgesProvider
@@ -78,54 +73,53 @@ class BridgeImplementationTest extends TestCase {
 			$paramsSeen[] = $params;
 
 			foreach ($params as $field => $options) {
-				$this->assertInternalType('string', $field, $field.': invalid id');
-				$this->assertNotEmpty($field, $field.':empty id');
+				$this->assertInternalType('string', $field, $field . ': invalid id');
+				$this->assertNotEmpty($field, $field . ':empty id');
 
-				$this->assertInternalType('string', $options['name'], $field.': invalid name');
-				$this->assertNotEmpty($options['name'], $field.': empty name');
+				$this->assertInternalType('string', $options['name'], $field . ': invalid name');
+				$this->assertNotEmpty($options['name'], $field . ': empty name');
 
 				if (isset($options['type'])) {
-					$this->assertInternalType('string', $options['type'], $field.': invalid type');
-					$this->assertContains($options['type'], $allowedTypes, $field.': unknown type');
+					$this->assertInternalType('string', $options['type'], $field . ': invalid type');
+					$this->assertContains($options['type'], $allowedTypes, $field . ': unknown type');
 
 					if ($options['type'] == 'list') {
-						$this->assertArrayHasKey('values', $options, $field.': missing list values');
-						$this->assertInternalType('array', $options['values'], $field.': invalid list values');
-						$this->assertNotEmpty($options['values'], $field.': empty list values');
+						$this->assertArrayHasKey('values', $options, $field . ': missing list values');
+						$this->assertInternalType('array', $options['values'], $field . ': invalid list values');
+						$this->assertNotEmpty($options['values'], $field . ': empty list values');
 
 						foreach ($options['values'] as $valueName => $value) {
-							$this->assertInternalType('string', $valueName, $field.': invalid value name');
+							$this->assertInternalType('string', $valueName, $field . ': invalid value name');
 						}
 					}
 				}
 
 				if (isset($options['required'])) {
-					$this->assertInternalType('bool', $options['required'], $field.': invalid required');
+					$this->assertInternalType('bool', $options['required'], $field . ': invalid required');
 				}
 
 				if (isset($options['title'])) {
-					$this->assertInternalType('string', $options['title'], $field.': invalid title');
-					$this->assertNotEmpty($options['title'], $field.': empty title');
+					$this->assertInternalType('string', $options['title'], $field . ': invalid title');
+					$this->assertNotEmpty($options['title'], $field . ': empty title');
 				}
 
 				if (isset($options['pattern'])) {
-					$this->assertInternalType('string', $options['pattern'], $field.': invalid pattern');
-					$this->assertNotEmpty($options['pattern'], $field.': empty pattern');
+					$this->assertInternalType('string', $options['pattern'], $field . ': invalid pattern');
+					$this->assertNotEmpty($options['pattern'], $field . ': empty pattern');
 				}
 
 				if (isset($options['exampleValue'])) {
-					$this->assertNotEmpty($options['exampleValue'], $field.': empty exampleValue');
+					$this->assertNotEmpty($options['exampleValue'], $field . ': empty exampleValue');
 				}
 
 				if (isset($options['defaultValue'])) {
-					$this->assertNotEmpty($options['defaultValue'], $field.': empty defaultValue');
+					$this->assertNotEmpty($options['defaultValue'], $field . ': empty defaultValue');
 				}
 			}
 		}
 
 		$this->assertTrue(true);
 	}
-
 
 	/**
 	 * @dataProvider dataBridgesProvider
@@ -146,7 +140,6 @@ class BridgeImplementationTest extends TestCase {
 			$this->assertEquals($allowedBridgeAbstract, $methods);
 		}
 	}
-
 
 	/**
 	 * @dataProvider dataBridgesProvider
@@ -174,7 +167,6 @@ class BridgeImplementationTest extends TestCase {
 		$this->assertInternalType('string', $value, '$class->getIcon()');
 	}
 
-
 	/**
 	 * @dataProvider dataBridgesProvider
 	 */
@@ -185,9 +177,7 @@ class BridgeImplementationTest extends TestCase {
 		$this->checkUrl($this->obj->getURI());
 	}
 
-
 	////////////////////////////////////////////////////////////////////////////
-
 
 	public function dataBridgesProvider() {
 		$bridges = array();
@@ -197,13 +187,11 @@ class BridgeImplementationTest extends TestCase {
 		return $bridges;
 	}
 
-
 	private function setBridge($path) {
 		require_once $path;
 		$this->class = basename($path, '.php');
 		$this->obj = new $this->class();
 	}
-
 
 	private function checkUrl($url) {
 		$this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL), 'no valid URL');

--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -198,7 +198,7 @@ class BridgeImplementationTest extends TestCase {
 	}
 
 	private function checkUrl($url) {
-		$this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL), 'no valid URL');
-		$this->assertContains('https://', $url);
+		$this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL), 'no valid URL: ' . $url);
+		//$this->assertContains('https://', $url);
 	}
 }

--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -1,188 +1,212 @@
 <?php
-
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestResult;
-use PHPUnit\Framework\AssertionFailedError;
-
 require_once __DIR__ . '/../lib/rssbridge.php';
 
-/**
- * This class checks bridges for implementation details:
- *
- * - A bridge must not implement public functions other than the ones specified
- *   by the bridge interfaces. Custom functions must be defined in private or
- *   protected scope.
- * - getName() must return a valid string (non-empty)
- * - getURI() must return a valid URI
- * - A bridge must define constants for NAME, URI, DESCRIPTION and MAINTAINER,
- *   CACHE_TIMEOUT and PARAMETERS are optional
- */
-final class BridgeImplementationTest extends TestCase {
-	private function CheckBridgePublicFunctions($bridgeName){
+use PHPUnit\Framework\TestCase;
 
-		$parent_methods = array();
 
-		if(in_array('BridgeInterface', class_parents($bridgeName))) {
-			$parent_methods = array_merge($parent_methods, get_class_methods('BridgeInterface'));
-		}
+class BridgeImplementationTest extends TestCase {
+	const PATH_BRIDGES = __DIR__ . '/../bridges/';
 
-		if(in_array('BridgeAbstract', class_parents($bridgeName))) {
-			$parent_methods = array_merge($parent_methods, get_class_methods('BridgeAbstract'));
-		}
+	private $class;
+	private $obj;
 
-		if(in_array('FeedExpander', class_parents($bridgeName))) {
-			$parent_methods = array_merge($parent_methods, get_class_methods('FeedExpander'));
-		}
 
-		// Receive all non abstract methods
-		$methods = array_diff(get_class_methods($bridgeName), $parent_methods);
-		$method_names = implode(', ', $methods);
-
-		$errmsg = $bridgeName
-		. ' implements additional public method(s): '
-		. $method_names
-		. '! Custom functions must be defined in private or protected scope!';
-
-		$this->assertEmpty($method_names, $errmsg);
-
+	/**
+	 * @dataProvider dataBridgesProvider
+	 */
+	public function testClassName($path) {
+		$this->setBridge($path);
+		$this->assertTrue($this->class === ucfirst($this->class), 'class name must start with uppercase character');
 	}
 
-	private function CheckBridgeGetNameDefaultValue($bridgeName){
 
-		if(in_array('BridgeAbstract', class_parents($bridgeName))) { // Is bridge
-
-			if(!$this->isFunctionMemberOf($bridgeName, 'getName'))
-				return;
-
-			$bridge = new $bridgeName();
-			$abstract = new BridgeAbstractTest();
-
-			$message = $bridgeName . ': \'getName\' must return a valid name!';
-
-			$this->assertNotEmpty(trim($bridge->getName()), $message);
-
-		}
-
+	/**
+	 * @dataProvider dataBridgesProvider
+	 */
+	public function testClassType($path) {
+		$this->setBridge($path);
+		$this->assertInstanceOf('BridgeAbstract', $this->obj);
 	}
 
-	// Checks whether the getURI function returns empty or default values
-	private function CheckBridgeGetURIDefaultValue($bridgeName){
 
-		if(in_array('BridgeAbstract', class_parents($bridgeName))) { // Is bridge
+	/**
+	 * @dataProvider dataBridgesProvider
+	 */
+	public function testConstants($path) {
+		$this->setBridge($path);
 
-			if(!$this->isFunctionMemberOf($bridgeName, 'getURI'))
-				return;
+		$this->assertInternalType('string', $this->obj::NAME, 'class::NAME');
+		$this->assertNotEmpty($this->obj::NAME, 'class::NAME');
+		$this->assertInternalType('string', $this->obj::URI, 'class::URI');
+		$this->assertNotEmpty($this->obj::URI, 'class::URI');
+		$this->assertInternalType('string', $this->obj::DESCRIPTION, 'class::DESCRIPTION');
+		$this->assertNotEmpty($this->obj::DESCRIPTION, 'class::DESCRIPTION');
+		$this->assertInternalType('string', $this->obj::MAINTAINER, 'class::MAINTAINER');
+		$this->assertNotEmpty($this->obj::MAINTAINER, 'class::MAINTAINER');
 
-			$bridge = new $bridgeName();
-			$abstract = new BridgeAbstractTest();
-
-			$message = $bridgeName . ': \'getURI\' must return a valid URI!';
-
-			$this->assertNotEmpty(trim($bridge->getURI()), $message);
-
-		}
-
+		$this->assertInternalType('array', $this->obj::PARAMETERS, 'class::PARAMETERS');
+		$this->assertInternalType('int', $this->obj::CACHE_TIMEOUT, 'class::CACHE_TIMEOUT');
+		$this->assertGreaterThanOrEqual(0, $this->obj::CACHE_TIMEOUT, 'class::CACHE_TIMEOUT');
 	}
 
-	private function CheckBridgePublicConstants($bridgeName){
 
-		// Assertion only works for BridgeAbstract!
-		if(in_array('BridgeAbstract', class_parents($bridgeName))) {
+	/**
+	 * @dataProvider dataBridgesProvider
+	 */
+	public function testParameters($path) {
+		$this->setBridge($path);
 
-			$ref = new ReflectionClass($bridgeName);
-			$constants = $ref->getConstants();
+		$multiContexts = (count($this->obj::PARAMETERS) > 1);
+		$paramsSeen = array();
 
-			$ref = new ReflectionClass('BridgeAbstract');
-			$parent_constants = $ref->getConstants();
+		$allowedTypes = array(
+			'text',
+			'number',
+			'list',
+			'checkbox'
+		);
 
-			foreach($parent_constants as $key => $value) {
+		foreach($this->obj::PARAMETERS as $context => $params) {
+			if ($multiContexts) {
+				$this->assertInternalType('string', $context, 'invalid context name');
+				$this->assertNotEmpty($context, 'empty context name');
+			}
 
-				$this->assertArrayHasKey($key, $constants, 'Constant ' . $key . ' missing in ' . $bridgeName);
+			foreach ($paramsSeen as $seen) {
+				$this->assertNotEquals($seen, $params, 'same set of parameters not allowed');
+			}
+			$paramsSeen[] = $params;
 
-				// Skip optional constants
-				if($key !== 'PARAMETERS' && $key !== 'CACHE_TIMEOUT') {
-					$this->assertNotEquals($value, $constants[$key], 'Constant ' . $key . ' missing in ' . $bridgeName);
+			foreach ($params as $field => $options) {
+				$this->assertInternalType('string', $field, $field.': invalid id');
+				$this->assertNotEmpty($field, $field.':empty id');
+
+				$this->assertInternalType('string', $options['name'], $field.': invalid name');
+				$this->assertNotEmpty($options['name'], $field.': empty name');
+
+				if (isset($options['type'])) {
+					$this->assertInternalType('string', $options['type'], $field.': invalid type');
+					$this->assertContains($options['type'], $allowedTypes, $field.': unknown type');
+
+					if ($options['type'] == 'list') {
+						$this->assertArrayHasKey('values', $options, $field.': missing list values');
+						$this->assertInternalType('array', $options['values'], $field.': invalid list values');
+						$this->assertNotEmpty($options['values'], $field.': empty list values');
+
+						foreach ($options['values'] as $valueName => $value) {
+							$this->assertInternalType('string', $valueName, $field.': invalid value name');
+						}
+					}
 				}
 
-			}
+				if (isset($options['required'])) {
+					$this->assertInternalType('bool', $options['required'], $field.': invalid required');
+				}
 
+				if (isset($options['title'])) {
+					$this->assertInternalType('string', $options['title'], $field.': invalid title');
+					$this->assertNotEmpty($options['title'], $field.': empty title');
+				}
+
+				if (isset($options['pattern'])) {
+					$this->assertInternalType('string', $options['pattern'], $field.': invalid pattern');
+					$this->assertNotEmpty($options['pattern'], $field.': empty pattern');
+				}
+
+				if (isset($options['exampleValue'])) {
+					$this->assertNotEmpty($options['exampleValue'], $field.': empty exampleValue');
+				}
+
+				if (isset($options['defaultValue'])) {
+					$this->assertNotEmpty($options['defaultValue'], $field.': empty defaultValue');
+				}
+			}
 		}
 
+		$this->assertTrue(true);
 	}
 
-	private function isFunctionMemberOf($bridgeName, $functionName){
 
-		$bridgeReflector = new ReflectionClass($bridgeName);
-		$bridgeMethods = $bridgeReflector->GetMethods();
-		$bridgeHasMethod = false;
+	/**
+	 * @dataProvider dataBridgesProvider
+	 */
+	public function testVisibleMethods($path) {
+		$allowedBridgeAbstract = get_class_methods('BridgeAbstract');
+		sort($allowedBridgeAbstract);
+		$allowedFeedExpander = get_class_methods('FeedExpander');
+		sort($allowedFeedExpander);
 
-		foreach($bridgeMethods as $method) {
+		$this->setBridge($path);
 
-			if($method->name === $functionName && $method->class === $bridgeReflector->name) {
-				return true;
-			}
-
+		$methods = get_class_methods($this->obj);
+		sort($methods);
+		if ($this->obj instanceof FeedExpander) {
+			$this->assertEquals($allowedFeedExpander, $methods);
+		} else {
+			$this->assertEquals($allowedBridgeAbstract, $methods);
 		}
-
-		return false;
-
 	}
 
-	public function testBridgeImplementation($bridgeName){
 
-		require_once('bridges/' . $bridgeName . '.php');
+	/**
+	 * @dataProvider dataBridgesProvider
+	 */
+	public function testMethodValues($path) {
+		$this->setBridge($path);
 
-		$this->CheckBridgePublicFunctions($bridgeName);
-		$this->CheckBridgePublicConstants($bridgeName);
-		$this->CheckBridgeGetNameDefaultValue($bridgeName);
-		$this->CheckBridgeGetURIDefaultValue($bridgeName);
+		$value = $this->obj->getDescription();
+		$this->assertInternalType('string', $value, '$class->getDescription()');
+		$this->assertNotEmpty($value, '$class->getDescription()');
 
+		$value = $this->obj->getMaintainer();
+		$this->assertInternalType('string', $value, '$class->getMaintainer()');
+		$this->assertNotEmpty($value, '$class->getMaintainer()');
+
+		$value = $this->obj->getName();
+		$this->assertInternalType('string', $value, '$class->getName()');
+		$this->assertNotEmpty($value, '$class->getName()');
+
+		$value = $this->obj->getURI();
+		$this->assertInternalType('string', $value, '$class->getURI()');
+		$this->assertNotEmpty($value, '$class->getURI()');
+
+		$value = $this->obj->getIcon();
+		$this->assertInternalType('string', $value, '$class->getIcon()');
 	}
 
-	public function count() {
-		return count(Bridge::getBridgeNames());
+
+	/**
+	 * @dataProvider dataBridgesProvider
+	 */
+	public function testUri($path) {
+		$this->setBridge($path);
+
+		$this->checkUrl($this->obj::URI);
+		$this->checkUrl($this->obj->getURI());
 	}
 
-	public function run(TestResult $result = null) {
 
-		if ($result === null) {
-			$result = new TestResult;
+	////////////////////////////////////////////////////////////////////////////
+
+
+	public function dataBridgesProvider() {
+		$bridges = array();
+		foreach (glob(self::PATH_BRIDGES . '*Bridge.php') as $path) {
+			$bridges[basename($path, '.php')] = array($path);
 		}
-
-		foreach (Bridge::getBridgeNames() as $bridge) {
-
-			$bridge .= 'Bridge';
-
-			$result->startTest($this);
-			PHP_Timer::start();
-			$stopTime = null;
-
-			try {
-				$this->testBridgeImplementation($bridge);
-			} catch (AssertionFailedError $e) {
-
-				$stopTime = PHP_Timer::stop();
-				$result->addFailure($this, $e, $stopTime);
-
-			} catch (Exception $e) {
-
-				$stopTime = PHP_Timer::stop();
-				$result->addError($this, $e, $stopTime);
-
-			}
-
-			if ($stopTime === null) {
-				$stopTime = PHP_Timer::stop();
-			}
-
-			$result->endTest($this, $stopTime);
-
-		}
-
-		return $result;
+		return $bridges;
 	}
-}
 
-class BridgeAbstractTest extends BridgeAbstract {
-	public function collectData(){}
+
+	private function setBridge($path) {
+		require_once $path;
+		$this->class = basename($path, '.php');
+		$this->obj = new $this->class();
+	}
+
+
+	private function checkUrl($url) {
+		$this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL), 'no valid URL');
+		$this->assertContains('https://', $url);
+	}
 }


### PR DESCRIPTION
This is a completely rewritten unit test to check whether the bridges are implemented as mentioned in the wiki.

It performs the following tests on each bridge:
- class name starts with an uppercase character
- class is an instance of BridgeAbstract
- all documented constants have the expected types, the required ones are not empty
- formal inspection of the parameter list
- class has only public methods that are visible in BridgeAbstract or FeedExpander
- all documented methods return the expected types
- the URI is a valid URL and uses HTTPS

However, it **does not** perform any item checks. Since the generated items heavily depend on the source and the actual parameters, they should be checked directly by the format classes or an intermediate item class to generate a valid feed.

Unfortunately, there are many bridges that do not pass this unit test. They mostly have less clean parameter lists, or they don't use HTTPS even though they usually could. It may take some effort to fix them all. I'm not sure if we should force HTTPS though.

I'm usually not comfortable with completely replacing something that has evolved over the time. What do you think?