### PR TITLE
Fix PHP Notice:  Undefined offset: 0

### DIFF
--- a/index.php
+++ b/index.php
@@ -246,7 +246,7 @@ try {
 
 				// Transform "legacy" items to FeedItems if necessary.
 				// Remove this code when support for "legacy" items ends!
-				if(is_array($items[0])) {
+				if(isset($items[0]) && is_array($items[0])) {
 					$feedItems = array();
 
 					foreach($items as $item) {


### PR DESCRIPTION
Remove Undefined offset notice. If there are no items, the below notice is triggered:

`PHP Notice:  Undefined offset: 0 in C:\php\rss-bridge\index.php on line 249`