### PR TITLE
[AmazonBridge] Fix parsing of list item (fix #993 #769)

### DIFF
--- a/bridges/AmazonBridge.php
+++ b/bridges/AmazonBridge.php
@@ -72,7 +72,7 @@ class AmazonBridge extends BridgeAbstract {
 
 			// Title
 			$title = $element->find('h2', 0);
-			if ($title == null) {
+			if (is_null($title)) {
 				continue;
 			}
 

--- a/bridges/AmazonBridge.php
+++ b/bridges/AmazonBridge.php
@@ -72,6 +72,9 @@ class AmazonBridge extends BridgeAbstract {
 
 			// Title
 			$title = $element->find('h2', 0);
+			if ($title == null) {
+				continue;
+			}
 
 			$item['title'] = html_entity_decode($title->innertext, ENT_QUOTES);
 


### PR DESCRIPTION
Fix parsing of the list by skipping items (which are not products) without an `h2`title.
Should fix issues #769 and #993 .