### PR TITLE
RSS Feed to SEC Filings, using only Ticker as input

### DIFF
--- a/bridges/StockFilingsBridge.php
+++ b/bridges/StockFilingsBridge.php
@@ -12,15 +12,17 @@ class StockFilingsBridge extends FeedExpander {
 	const PARAMETERS = array(
 		array(
 		'ticker' => array(
-			'name' 			=> 'cik',
-			'required' 		=> true,
-			'exampleValue' 	=> 'AMD',
+			'name'          => 'cik',
+			'required'      => true,
+			'exampleValue'  => 'AMD',
 			// https://stackoverflow.com/a/12827734
-			'pattern'		=> '[A-Za-z0-9]+',
+			'pattern'       => '[A-Za-z0-9]+',
 		),
 	));
 
-	protected $title;
+	public function getIcon() {
+		return 'https://www.sec.gov/favicon.ico';
+	}
 
 	/**
 	 * Generates search URL
@@ -74,9 +76,5 @@ class StockFilingsBridge extends FeedExpander {
 		} else {
 			returnClientError('Could not find RSS Feed URL. Are you sure you used a valid CIK?');
 		}
-	}
-
-	protected function parseItem($newsItem) {
-		return parent::parseATOMItem($newsItem);
 	}
 }

--- a/bridges/StockFilingsBridge.php
+++ b/bridges/StockFilingsBridge.php
@@ -1,0 +1,93 @@
+<?php
+
+class StockFilingsBridge extends BridgeAbstract {
+	const MAINTAINER = 'captn3m0';
+	const NAME = 'SEC Stock filings';
+	const URI = 'https://www.sec.gov/edgar/searchedgar/companysearch.html';
+	const CACHE_TIMEOUT = 3600; // 1h
+	const DESCRIPTION = 'Tracks SEC Filings for a single company';
+	const SEARCH_URL = 'https://www.sec.gov/cgi-bin/browse-edgar?owner=exclude&action=getcompany&CIK=';
+
+	const PARAMETERS = array(
+		array(
+		'ticker' => array(
+			'name' 			=> 'cik',
+			'required' 		=> true,
+			'exampleValue' 	=> 'AMD',
+			// https://stackoverflow.com/a/12827734
+			'pattern'		=> '[A-Za-z0-9]+',
+		),
+	));
+
+	protected $title;
+
+	/**
+	 * Generates search URL
+	 */
+	private function getSearchUrl() {
+		return self::SEARCH_URL . $this->getInput('ticker');
+	}
+
+	/**
+	 * Returns the Company Name
+	 */
+	private function getTitle($html) {
+		$titleTag = $html->find('span.companyName', 0);
+
+		if (!$titleTag) {
+			return "No Such Company";
+		} else {
+			// Remove <acronym> and <a> tags
+			foreach($titleTag->children as $child) {
+				$child->outertext = "";
+			}
+			return substr($titleTag->innertext, 0, -4);
+		}
+	}
+
+	/**
+	 * Returns name for the feed
+	 * Uses title (already scraped) if it has one
+	 */
+	public function getName() {
+		if (isset($this->title)) {
+			return $this->title;
+		} else {
+			return parent::getName();
+		}
+	}
+
+	/**
+	 * Return \simple_html_dom object
+	 * for the entire html of the product page
+	 */
+	private function getHtml() {
+		$uri = $this->getSearchUrl();
+
+		return getSimpleHTMLDOM($uri) ?: returnServerError('Could not request SEC.');
+	}
+
+	/**
+	 * Scrape method for Amazon product page
+	 * @return [type] [description]
+	 */
+	public function collectData() {
+		$html = $this->getHtml();
+		$this->title = $this->getTitle($html);
+		$this->
+
+		// $data = $this->scrapePriceFromMetrics($html) ?: $this->scrapePriceGeneric($html);
+
+		// $item = array(
+		// 	'title' 	=> $this->title,
+		// 	'uri' 		=> $this->getURI(),
+		// 	'content' 	=> "$imageTag<br/>Price: {$data['price']} {$data['currency']}",
+		// );
+
+		// if ($data['shipping'] !== '0') {
+		// 	$item['content'] .= "<br>Shipping: {$data['shipping']} {$data['currency']}</br>";
+		// }
+
+		// $this->items[] = $item;
+	}
+}

--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -76,7 +76,7 @@ class FeedItem {
 	 * $item['uri'] = 'https://www.github.com/rss-bridge/rss-bridge/';
 	 * $item['title'] = 'Title';
 	 * $item['timestamp'] = strtotime('now');
-	 * $item['autor'] = 'Unknown author';
+	 * $item['author'] = 'Unknown author';
 	 * $item['content'] = 'Hello World!';
 	 * $item['enclosures'] = array('https://github.com/favicon.ico');
 	 * $item['categories'] = array('php', 'rss-bridge', 'awesome');


### PR DESCRIPTION
This is based upon a request I received over twitter from [@JStomos](https://twitter.com/JStomos).

This does the equivalent of searching for a Ticker symbol on the "Fast Search" option at https://www.sec.gov/edgar/searchedgar/companysearch.html, and then using the RSS Feed URL in the results page. It does a naive expansion using FeedExpander, but can be improved down the line to scrape information from deeper pages.

This is helpful, as it uses SEC as the direct source, and you don't need to find the CIK of a company to get their filings.