### PR TITLE
[TwitterBridge] Append username of retweeter to author

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -189,6 +189,8 @@ class TwitterBridge extends BridgeAbstract {
 			$item['fullname'] = htmlspecialchars_decode($tweet->getAttribute('data-name'), ENT_QUOTES);
 			// get author
 			$item['author'] = $item['fullname'] . ' (@' . $item['username'] . ')';
+			if ($tweet->getAttribute('data-screen-name') !== $this->getInput('u'))
+				$item['author'] .= ' RT: @' . $this->getInput('u');
 			// get avatar link
 			$item['avatar'] = $tweet->find('img', 0)->src;
 			// get TweetID

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -189,8 +189,9 @@ class TwitterBridge extends BridgeAbstract {
 			$item['fullname'] = htmlspecialchars_decode($tweet->getAttribute('data-name'), ENT_QUOTES);
 			// get author
 			$item['author'] = $item['fullname'] . ' (@' . $item['username'] . ')';
-			if ($tweet->getAttribute('data-screen-name') !== $this->getInput('u'))
+			if($tweet->getAttribute('data-screen-name') !== $this->getInput('u')) {
 				$item['author'] .= ' RT: @' . $this->getInput('u');
+			}
 			// get avatar link
 			$item['avatar'] = $tweet->find('img', 0)->src;
 			// get TweetID

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -190,7 +190,7 @@ class TwitterBridge extends BridgeAbstract {
 			// get author
 			$item['author'] = $item['fullname'] . ' (@' . $item['username'] . ')';
 			if ($tweet->getAttribute('data-screen-name') !== $this->getInput('u'))
-				$item['author'] .= ' RT: @' . htmlspecialchars_decode($this->getInput('u'), ENT_QUOTES);
+				$item['author'] .= ' RT: @' . $this->getInput('u');
 			// get avatar link
 			$item['avatar'] = $tweet->find('img', 0)->src;
 			// get TweetID

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -165,7 +165,7 @@ class TwitterBridge extends BridgeAbstract {
 
 			// Skip retweets?
 			if($this->getInput('noretweet')
-			&& $tweet->getAttribute('data-screen-name') !== $this->getInput('u')) {
+			&& strcasecmp($tweet->getAttribute('data-screen-name'), $this->getInput('u'))) {
 				continue;
 			}
 
@@ -189,7 +189,7 @@ class TwitterBridge extends BridgeAbstract {
 			$item['fullname'] = htmlspecialchars_decode($tweet->getAttribute('data-name'), ENT_QUOTES);
 			// get author
 			$item['author'] = $item['fullname'] . ' (@' . $item['username'] . ')';
-			if($tweet->getAttribute('data-screen-name') !== $this->getInput('u')) {
+			if(strcasecmp($tweet->getAttribute('data-screen-name'), $this->getInput('u'))) {
 				$item['author'] .= ' RT: @' . $this->getInput('u');
 			}
 			// get avatar link

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -190,7 +190,7 @@ class TwitterBridge extends BridgeAbstract {
 			// get author
 			$item['author'] = $item['fullname'] . ' (@' . $item['username'] . ')';
 			if ($tweet->getAttribute('data-screen-name') !== $this->getInput('u'))
-				$item['author'] .= ' RT: @' . $this->getInput('u');
+				$item['author'] .= ' RT: @' . htmlspecialchars_decode($this->getInput('u'), ENT_QUOTES);
 			// get avatar link
 			$item['avatar'] = $tweet->find('img', 0)->src;
 			// get TweetID


### PR DESCRIPTION
Append username of retweeter to author. Useful when viewing all unread tweets in an RSS reader which are not sorted within username folders.