### PR TITLE
[FeedExpander] Fix item href being used as feed uri

### DIFF
--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -265,7 +265,7 @@ abstract class FeedExpander extends BridgeAbstract {
 
 		//When "link" field is present, URL is more reliable than "id" field
 		if (count($feedItem->link) === 1) {
-			$this->uri = (string)$feedItem->link[0]['href'];
+			$item['uri'] = (string)$feedItem->link[0]['href'];
 		} else {
 			foreach($feedItem->link as $link) {
 				if(strtolower($link['rel']) === 'alternate') {


### PR DESCRIPTION
Found this while debugging an url issue on the WordPress bridge