### PR TITLE
[AsahiShimbunAJW] New Bridge

### DIFF
--- a/bridges/AsahiShimbunAJWBridge.php
+++ b/bridges/AsahiShimbunAJWBridge.php
@@ -1,7 +1,7 @@
 <?php
 class AsahiShimbunAJWBridge extends BridgeAbstract {
 	const NAME = 'Asahi Shimbun AJW';
-	const BASE_URI =  'http://www.asahi.com';
+	const BASE_URI = 'http://www.asahi.com';
 	const URI = self::BASE_URI . '/ajw/';
 	const DESCRIPTION = 'Asahi Shimbun - Asia & Japan Watch';
 	const MAINTAINER = 'somini';
@@ -39,20 +39,19 @@ class AsahiShimbunAJWBridge extends BridgeAbstract {
 		$html = getSimpleHTMLDOM($this->getSectionURI($this->getInput('section')))
 			or returnServerError('Could not load content');
 
-		foreach($html->find("#MainInner li a") as $element) {
-			if ($element->parent()->class == "HeadlineTopImage-S") {
-				Debug::log("Skip Headline, it is repeated below");
+		foreach($html->find('#MainInner li a') as $element) {
+			if ($element->parent()->class == 'HeadlineTopImage-S') {
+				Debug::log('Skip Headline, it is repeated below');
 				continue;
 			}
 			$item = array();
-			
+
 			$item['uri'] = self::BASE_URI . $element->href;
-			$e_lead = $element->find("span.Lead", 0);
+			$e_lead = $element->find('span.Lead', 0);
 			if ($e_lead) {
 				$item['content'] = $e_lead->innertext;
 				$e_lead->outertext = '';
-			}
-			else {
+			} else {
 				$item['content'] = $element->innertext;
 			}
 			$e_date = $element->find('span.EnDate', 0);
@@ -61,7 +60,6 @@ class AsahiShimbunAJWBridge extends BridgeAbstract {
 				$e_date->outertext = '';
 			}
 			$item['title'] = $element->innertext;
-
 
 			$this->items[] = $item;
 		}

--- a/bridges/AsahiShimbunAJWBridge.php
+++ b/bridges/AsahiShimbunAJWBridge.php
@@ -59,6 +59,11 @@ class AsahiShimbunAJWBridge extends BridgeAbstract {
 				$item['timestamp'] = strtotime($e_date->innertext);
 				$e_date->outertext = '';
 			}
+			$e_video = $element->find('span.EnVideo', 0);
+			if ($e_video) {
+				$e_video->outertext = '';
+				$element->innertext = "VIDEO: $element->innertext";
+			}
 			$item['title'] = $element->innertext;
 
 			$this->items[] = $item;

--- a/bridges/AsahiShimbunAJWBridge.php
+++ b/bridges/AsahiShimbunAJWBridge.php
@@ -1,0 +1,69 @@
+<?php
+class AsahiShimbunAJWBridge extends BridgeAbstract {
+	const NAME = 'Asahi Shimbun AJW';
+	const BASE_URI =  'http://www.asahi.com';
+	const URI = self::BASE_URI . '/ajw/';
+	const DESCRIPTION = 'Asahi Shimbun - Asia & Japan Watch';
+	const MAINTAINER = 'somini';
+	const PARAMETERS = array(
+		array(
+			'section' => array(
+				'type' => 'list',
+				'name' => 'Section',
+				'values' => array(
+					'Japan » Social Affairs' => 'japan/social',
+					'Japan » People' => 'japan/people',
+					'Japan » 3/11 Disaster' => 'japan/0311disaster',
+					'Japan » Sci & Tech' => 'japan/sci_tech',
+					'Politics' => 'politics',
+					'Business' => 'business',
+					'Culture » Style' => 'culture/style',
+					'Culture » Movies' => 'culture/movies',
+					'Culture » Manga & Anime' => 'culture/manga_anime',
+					'Asia » China' => 'asia/china',
+					'Asia » Korean Peninsula' => 'asia/korean_peninsula',
+					'Asia » Around Asia' => 'asia/around_asia',
+					'Opinion » Editorial' => 'opinion/editorial',
+					'Opinion » Vox Populi' => 'opinion/vox',
+				),
+				'defaultValue' => 'Politics',
+			)
+		)
+	);
+
+	private function getSectionURI($section) {
+		return self::getURI() . $section . '/';
+	}
+
+	public function collectData() {
+		$html = getSimpleHTMLDOM($this->getSectionURI($this->getInput('section')))
+			or returnServerError('Could not load content');
+
+		foreach($html->find("#MainInner li a") as $element) {
+			if ($element->parent()->class == "HeadlineTopImage-S") {
+				Debug::log("Skip Headline, it is repeated below");
+				continue;
+			}
+			$item = array();
+			
+			$item['uri'] = self::BASE_URI . $element->href;
+			$e_lead = $element->find("span.Lead", 0);
+			if ($e_lead) {
+				$item['content'] = $e_lead->innertext;
+				$e_lead->outertext = '';
+			}
+			else {
+				$item['content'] = $element->innertext;
+			}
+			$e_date = $element->find('span.EnDate', 0);
+			if ($e_date) {
+				$item['timestamp'] = strtotime($e_date->innertext);
+				$e_date->outertext = '';
+			}
+			$item['title'] = $element->innertext;
+
+
+			$this->items[] = $item;
+		}
+	}
+}


### PR DESCRIPTION
http://www.asahi.com/ajw/

Their site is not available using HTTPS.
Only the main site uses HTTPS, this AJW section with English language news is redirected to HTTP even though they have a valid certificate for `www.asahi.com`. *mindblown*

There is a feed per category because the HTML is much easier to parse and has the same content. If you want all the news from "Japan News" for example, subscribe to all the feeds directly, or add new commits to this PR.