### PR TITLE
[DealabsBridge] Workaround to unparsable Deal date

### DIFF
--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1378,8 +1378,7 @@ class PepperBridgeAbstract extends BridgeAbstract {
 		$date_str .= ' 00:00';
 		$date = DateTime::createFromFormat('j F Y H:i', $date_str);
 		// In some case, the date is not recognized : as a workaround the actual date is taken
-		if($date === FALSE)
-		{
+		if($date === false) {
 			$date = new DateTime();
 		}
 		return $date->getTimestamp();

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1376,8 +1376,12 @@ class PepperBridgeAbstract extends BridgeAbstract {
 
 		// Add the Hour and minutes
 		$date_str .= ' 00:00';
-
 		$date = DateTime::createFromFormat('j F Y H:i', $date_str);
+		// In some case, the date is not recognized : as a workaround the actual date is taken
+		if($date === FALSE)
+		{
+			$date = new DateTime();
+		}
 		return $date->getTimestamp();
 	}
 


### PR DESCRIPTION
In case of a unparsable date, the text to DateTime object failed, and
this resulted to a Fatal error while using this DateTime object . To
prevent this fatal error, if the date parsing fails, then a DateTime
object is created with the actual date.