### PR TITLE
[ParameterValidator] Handle missing parameter type

### DIFF
--- a/lib/ParameterValidator.php
+++ b/lib/ParameterValidator.php
@@ -197,9 +197,9 @@ class ParameterValidator {
 					$queriedContexts[$context] = true;
 				} elseif(isset($properties['required'])
 				&& $properties['required'] === true
-				&& isset($properties['type'])
-				&& $properties['type'] !== 'checkbox'
-				&& $properties['type'] !== 'list') {
+				&& !(isset($properties['type'])
+				&& ($properties['type'] === 'checkbox'
+				|| $properties['type'] === 'list'))) {
 					$queriedContexts[$context] = false;
 					break;
 				}

--- a/lib/ParameterValidator.php
+++ b/lib/ParameterValidator.php
@@ -195,16 +195,14 @@ class ParameterValidator {
 			foreach($set as $id => $properties) {
 				if(isset($data[$id]) && !empty($data[$id])) {
 					$queriedContexts[$context] = true;
-				} elseif(isset($properties['required'])
-				&& $properties['required'] === true
-				&& !(isset($properties['type'])
-				&& ($properties['type'] === 'checkbox'
-				|| $properties['type'] === 'list'))) {
+				} elseif (isset($properties['type'])
+					&& ($properties['type'] === 'checkbox' || $properties['type'] === 'list')) {
+					continue;
+				} elseif(isset($properties['required']) && $properties['required'] === true) {
 					$queriedContexts[$context] = false;
 					break;
 				}
 			}
-
 		}
 
 		// Abort if one of the globally required parameters is not satisfied


### PR DESCRIPTION
If the 'type' property for a required parameter is not specified it was treated as if it was not required by getQueriedContext since 434c126.

Maybe there's some more readable way to write this but this seems to make it work as intended at least!