### PR TITLE
Caches: Refactored API

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -86,9 +86,9 @@ class DisplayAction extends ActionAbstract {
 
 		// Initialize cache
 		$cache = Cache::create(Configuration::getConfig('cache', 'type'));
-		$cache->setPath(PATH_CACHE);
+		$cache->setScope('');
 		$cache->purgeCache(86400); // 24 hours
-		$cache->setParameters($cache_params);
+		$cache->setKey($cache_params);
 
 		$items = array();
 		$infos = array();

--- a/bridges/ElloBridge.php
+++ b/bridges/ElloBridge.php
@@ -121,7 +121,7 @@ class ElloBridge extends BridgeAbstract {
 
 	private function getAPIKey() {
 		$cache = Cache::create(Configuration::getConfig('cache', 'type'));
-		$cache->setPath(PATH_CACHE);
+		$cache->setScope(get_called_class());
 		$cache->setParameters(['key']);
 		$key = $cache->loadData();
 

--- a/bridges/ElloBridge.php
+++ b/bridges/ElloBridge.php
@@ -122,7 +122,7 @@ class ElloBridge extends BridgeAbstract {
 	private function getAPIKey() {
 		$cache = Cache::create(Configuration::getConfig('cache', 'type'));
 		$cache->setScope(get_called_class());
-		$cache->setParameters(['key']);
+		$cache->setKey(['key']);
 		$key = $cache->loadData();
 
 		if($key == null) {

--- a/bridges/WordPressPluginUpdateBridge.php
+++ b/bridges/WordPressPluginUpdateBridge.php
@@ -71,16 +71,4 @@ class WordPressPluginUpdateBridge extends BridgeAbstract {
 
 		return parent::getName();
 	}
-
-	private function getCachedDate($url){
-		Debug::log('getting pubdate from url ' . $url . '');
-		// Initialize cache
-		$cache = Cache::create(Configuration::getConfig('cache', 'type'));
-		$cache->setPath(PATH_CACHE . 'pages/');
-		$params = [$url];
-		$cache->setParameters($params);
-		// Get cachefile timestamp
-		$time = $cache->getTime();
-		return ($time !== false ? $time : time());
-	}
 }

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -3,7 +3,6 @@
 * Cache with file system
 */
 class FileCache implements CacheInterface {
-
 	protected $path;
 	protected $param;
 
@@ -58,23 +57,15 @@ class FileCache implements CacheInterface {
 	}
 
 	/**
-	* Set cache path
+	* Set cache scope
 	* @return self
 	*/
-	public function setPath($path){
-		if(is_null($path) || !is_string($path)) {
-			throw new \Exception('The given path is invalid!');
+	public function setScope($scope){
+		if(is_null($scope) || !is_string($scope)) {
+			throw new \Exception('The given scope is invalid!');
 		}
 
-		$this->path = $path;
-
-		// Make sure path ends with '/' or '\'
-		$lastchar = substr($this->path, -1, 1);
-		if($lastchar !== '/' && $lastchar !== '\\')
-			$this->path .= '/';
-
-		if(!is_dir($this->path))
-			mkdir($this->path, 0755, true);
+		$this->path = PATH_CACHE . trim($scope, " \t\n\r\0\x0B\\\/") . '/';
 
 		return $this;
 	}
@@ -95,7 +86,13 @@ class FileCache implements CacheInterface {
 	*/
 	protected function getPath(){
 		if(is_null($this->path)) {
-			throw new \Exception('Call "setPath" first!');
+			throw new \Exception('Call "setScope" first!');
+		}
+
+		if(!is_dir($this->path)) {
+			if (mkdir($this->path, 0755, true) !== true) {
+				throw new \Exception('Unable to create ' . $this->path);
+			}
 		}
 
 		return $this->path;

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -92,13 +92,13 @@ class FileCache implements CacheInterface {
 	* Return cache path (and create if not exist)
 	* @return string Cache path
 	*/
-	protected function getPath(){
+	private function getPath(){
 		if(is_null($this->path)) {
 			throw new \Exception('Call "setScope" first!');
 		}
 
 		if(!is_dir($this->path)) {
-			if (mkdir($this->path, 0644, true) !== true) {
+			if (mkdir($this->path, 0755, true) !== true) {
 				throw new \Exception('Unable to create ' . $this->path);
 			}
 		}
@@ -110,7 +110,7 @@ class FileCache implements CacheInterface {
 	* Get the file name use for cache store
 	* @return string Path to the file cache
 	*/
-	protected function getCacheFile(){
+	private function getCacheFile(){
 		return $this->getPath() . $this->getCacheName();
 	}
 
@@ -118,7 +118,7 @@ class FileCache implements CacheInterface {
 	* Determines file name for store the cache
 	* return string
 	*/
-	protected function getCacheName(){
+	private function getCacheName(){
 		if(is_null($this->key)) {
 			throw new \Exception('Call "setKey" first!');
 		}

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -4,7 +4,7 @@
 */
 class FileCache implements CacheInterface {
 	protected $path;
-	protected $param;
+	protected $key;
 
 	public function loadData(){
 		if(file_exists($this->getCacheFile())) {
@@ -57,7 +57,7 @@ class FileCache implements CacheInterface {
 	}
 
 	/**
-	* Set cache scope
+	* Set scope
 	* @return self
 	*/
 	public function setScope($scope){
@@ -71,12 +71,20 @@ class FileCache implements CacheInterface {
 	}
 
 	/**
-	* Set HTTP GET parameters
+	* Set key
 	* @return self
 	*/
-	public function setParameters(array $param){
-		$this->param = array_map('strtolower', $param);
+	public function setKey($key){
+		if (!empty($key) && is_array($key)) {
+			$key = array_map('strtolower', $key);
+		}
+		$key = json_encode($key);
 
+		if (!is_string($key)) {
+			throw new \Exception('The given key is invalid!');
+		}
+
+		$this->key = $key;
 		return $this;
 	}
 
@@ -111,12 +119,10 @@ class FileCache implements CacheInterface {
 	* return string
 	*/
 	protected function getCacheName(){
-		if(is_null($this->param)) {
-			throw new \Exception('Call "setParameters" first!');
+		if(is_null($this->key)) {
+			throw new \Exception('Call "setKey" first!');
 		}
 
-		// Change character when making incompatible changes to prevent loading
-		// errors due to incompatible file contents         \|/
-		return hash('md5', http_build_query($this->param) . 'A') . '.cache';
+		return hash('md5', $this->key) . '.cache';
 	}
 }

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -98,7 +98,7 @@ class FileCache implements CacheInterface {
 		}
 
 		if(!is_dir($this->path)) {
-			if (mkdir($this->path, 0755, true) !== true) {
+			if (mkdir($this->path, 0644, true) !== true) {
 				throw new \Exception('Unable to create ' . $this->path);
 			}
 		}

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -111,7 +111,7 @@ class SQLiteCache implements CacheInterface {
 
 	////////////////////////////////////////////////////////////////////////////
 
-	protected function getCacheKey(){
+	private function getCacheKey(){
 		if(is_null($this->key)) {
 			throw new \Exception('Call "setKey" first!');
 		}

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -3,14 +3,15 @@
  * Cache based on SQLite 3 <https://www.sqlite.org>
  */
 class SQLiteCache implements CacheInterface {
-	protected $path;
+	protected $scope;
 	protected $param;
 
 	private $db = null;
 
 	public function __construct() {
-		if (!extension_loaded('sqlite3'))
+		if (!extension_loaded('sqlite3')) {
 			die('"sqlite3" extension not loaded. Please check "php.ini"');
+		}
 
 		$file = PATH_CACHE . 'cache.sqlite';
 
@@ -73,8 +74,12 @@ class SQLiteCache implements CacheInterface {
 	* Set cache path
 	* @return self
 	*/
-	public function setPath($path){
-		$this->path = $path;
+	public function setScope($scope){
+		if(is_null($scope) || !is_string($scope)) {
+			throw new \Exception('The given scope is invalid!');
+		}
+
+		$this->scope = $scope;
 		return $this;
 	}
 
@@ -94,6 +99,6 @@ class SQLiteCache implements CacheInterface {
 			throw new \Exception('Call "setParameters" first!');
 		}
 
-		return hash('sha1', $this->path . http_build_query($this->param), true);
+		return hash('sha1', $this->scope . http_build_query($this->param), true);
 	}
 }

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -13,7 +13,15 @@ class SQLiteCache implements CacheInterface {
 			die('"sqlite3" extension not loaded. Please check "php.ini"');
 		}
 
-		$file = PATH_CACHE . 'cache.sqlite';
+		$file = Configuration::getConfig(get_called_class(), 'file');
+		if (empty($file)) {
+			die('Configuration for ' . get_called_class() . ' missing. Please check your config.ini.php');
+		}
+		if (dirname($file) == '.') {
+			$file = PATH_CACHE . $file;
+		} elseif (!is_dir(dirname($file))) {
+			die('Invalid configuration for ' . get_called_class() . '. Please check your config.ini.php');
+		}
 
 		if (!is_file($file)) {
 			$this->db = new SQLite3($file);

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -39,10 +39,10 @@ class SQLiteCache implements CacheInterface {
 		return null;
 	}
 
-	public function saveData($datas){
+	public function saveData($data){
 		$Qupdate = $this->db->prepare('INSERT OR REPLACE INTO storage (key, value, updated) VALUES (:key, :value, :updated)');
 		$Qupdate->bindValue(':key', $this->getCacheKey());
-		$Qupdate->bindValue(':value', serialize($datas));
+		$Qupdate->bindValue(':value', serialize($data));
 		$Qupdate->bindValue(':updated', time());
 		$Qupdate->execute();
 
@@ -63,9 +63,9 @@ class SQLiteCache implements CacheInterface {
 		return false;
 	}
 
-	public function purgeCache($duration){
+	public function purgeCache($seconds){
 		$Qdelete = $this->db->prepare('DELETE FROM storage WHERE updated < :expired');
-		$Qdelete->bindValue(':expired', time() - $duration);
+		$Qdelete->bindValue(':expired', time() - $seconds);
 		$Qdelete->execute();
 	}
 

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -69,7 +69,7 @@ class SQLiteCache implements CacheInterface {
 			}
 		}
 
-		return false;
+		return null;
 	}
 
 	public function purgeCache($seconds){

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -4,7 +4,7 @@
  */
 class SQLiteCache implements CacheInterface {
 	protected $scope;
-	protected $param;
+	protected $key;
 
 	private $db = null;
 
@@ -71,7 +71,7 @@ class SQLiteCache implements CacheInterface {
 	}
 
 	/**
-	* Set cache path
+	* Set scope
 	* @return self
 	*/
 	public function setScope($scope){
@@ -84,21 +84,30 @@ class SQLiteCache implements CacheInterface {
 	}
 
 	/**
-	* Set HTTP GET parameters
+	* Set key
 	* @return self
 	*/
-	public function setParameters(array $param){
-		$this->param = array_map('strtolower', $param);
+	public function setKey($key){
+		if (!empty($key) && is_array($key)) {
+			$key = array_map('strtolower', $key);
+		}
+		$key = json_encode($key);
+
+		if (!is_string($key)) {
+			throw new \Exception('The given key is invalid!');
+		}
+
+		$this->key = $key;
 		return $this;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
 
 	protected function getCacheKey(){
-		if(is_null($this->param)) {
-			throw new \Exception('Call "setParameters" first!');
+		if(is_null($this->key)) {
+			throw new \Exception('Call "setKey" first!');
 		}
 
-		return hash('sha1', $this->scope . http_build_query($this->param), true);
+		return hash('sha1', $this->scope . $this->key, true);
 	}
 }

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -52,3 +52,8 @@ username = ""
 ; The password for authentication. Insert this password when prompted for login.
 ; Use a strong password to prevent others from guessing your login!
 password = ""
+
+; --- Cache specific configuration ---------------------------------------------
+
+[SQLiteCache]
+file = "cache.sqlite"

--- a/lib/CacheInterface.php
+++ b/lib/CacheInterface.php
@@ -28,6 +28,17 @@ interface CacheInterface {
 	public function setScope($scope);
 
 	/**
+	 * Set key to assign the current data
+	 *
+	 * Since $key can be anything, the cache implementation must ensure to
+	 * assign the related data reliably; most commonly by serializing and
+	 * hashing the key in an appropriate way.
+	 *
+	 * @param array $key The key the data is related to
+	 */
+	public function setKey($key);
+
+	/**
 	 * Loads data from cache
 	 *
 	 * @return mixed The cached data or null

--- a/lib/CacheInterface.php
+++ b/lib/CacheInterface.php
@@ -13,9 +13,6 @@
 
 /**
  * The cache interface
- *
- * @todo Add missing function to the interface
- * @todo Return self more often (to allow call chaining)
  */
 interface CacheInterface {
 	/**

--- a/lib/CacheInterface.php
+++ b/lib/CacheInterface.php
@@ -22,29 +22,29 @@ interface CacheInterface {
 	/**
 	 * Loads data from cache
 	 *
-	 * @return mixed The cache data
+	 * @return mixed The cached data or null
 	 */
 	public function loadData();
 
 	/**
 	 * Stores data to the cache
 	 *
-	 * @param mixed $datas The data to store
+	 * @param mixed $data The data to store
 	 * @return self The cache object
 	 */
-	public function saveData($datas);
+	public function saveData($data);
 
 	/**
-	 * Returns the timestamp for the curent cache file
+	 * Returns the timestamp for the curent cache data
 	 *
-	 * @return int Timestamp
+	 * @return int Timestamp or null
 	 */
 	public function getTime();
 
 	/**
-	 * Removes any data that is older than the specified duration from cache
+	 * Removes any data that is older than the specified age from cache
 	 *
-	 * @param int $duration The cache duration in seconds
+	 * @param int $seconds The cache age in seconds
 	 */
-	public function purgeCache($duration);
+	public function purgeCache($seconds);
 }

--- a/lib/CacheInterface.php
+++ b/lib/CacheInterface.php
@@ -15,10 +15,18 @@
  * The cache interface
  *
  * @todo Add missing function to the interface
- * @todo Explain parameters and return values in more detail
  * @todo Return self more often (to allow call chaining)
  */
 interface CacheInterface {
+	/**
+	 * Set scope of the current cache
+	 *
+	 * If $scope is an empty string, the cache is set to a global context.
+	 *
+	 * @param string $scope The scope the data is related to
+	 */
+	public function setScope($scope);
+
 	/**
 	 * Loads data from cache
 	 *

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -50,7 +50,7 @@ function getContents($url, $header = array(), $opts = array()){
 	$cache->purgeCache(86400); // 24 hours (forced)
 
 	$params = [$url];
-	$cache->setParameters($params);
+	$cache->setKey($params);
 
 	// Use file_get_contents if in CLI mode with no root certificates defined
 	if(php_sapi_name() === 'cli' && empty(ini_get('curl.cainfo'))) {
@@ -273,7 +273,7 @@ $defaultSpanText = DEFAULT_SPAN_TEXT){
 	$cache->purgeCache(86400); // 24 hours (forced)
 
 	$params = [$url];
-	$cache->setParameters($params);
+	$cache->setKey($params);
 
 	// Determine if cached file is within duration
 	$time = $cache->getTime();

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -46,7 +46,7 @@ function getContents($url, $header = array(), $opts = array()){
 
 	// Initialize cache
 	$cache = Cache::create(Configuration::getConfig('cache', 'type'));
-	$cache->setPath(PATH_CACHE . 'server/');
+	$cache->setScope('server');
 	$cache->purgeCache(86400); // 24 hours (forced)
 
 	$params = [$url];
@@ -269,7 +269,7 @@ $defaultSpanText = DEFAULT_SPAN_TEXT){
 
 	// Initialize cache
 	$cache = Cache::create(Configuration::getConfig('cache', 'type'));
-	$cache->setPath(PATH_CACHE . 'pages/');
+	$cache->setScope('pages');
 	$cache->purgeCache(86400); // 24 hours (forced)
 
 	$params = [$url];


### PR DESCRIPTION
Addressing issue #1037, this changes the Caches interface and current implementations to make it usable for different kind of caches:

- The methods `loadData`, `saveData`, `getTime` and `purgeCache` stay the same. You only have to ensure they consistently return `null` on non-existing data.
- **Removed**: `setPath($path)` and `setParameters(array $param)` were designed with file based caching in mind
- **New**:
  - **`setScope($scope)`: Set scope of the current cache** _(replaces `setPath`)_
    If `$scope` is an empty string, the cache is set to a global context. No absolute path anymore.
  - **`setKey($key)`: Set key to assign the current data** _(replaces `setParameters`)_
    Since `$key` can be anything, the cache implementation must ensure to assign the related data reliably; most commonly by serializing and hashing the key in an appropriate way.
- Cache implementations should check all requirements on construction (extensions, configuration). See `SQLiteCache` as an example.

Feel free to add comments and suggestions :)