### PR TITLE
[WIP] core: Add option to disable errors in feeds

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -146,19 +146,58 @@ class DisplayAction extends ActionAbstract {
 			} catch(Error $e) {
 				error_log($e);
 
-				$item = new \FeedItem();
+				if(Configuration::getConfig('error', 'output') === 'feed') {
+					$item = new \FeedItem();
 
-				// Create "new" error message every 24 hours
-				$this->userData['_error_time'] = urlencode((int)(time() / 86400));
+					// Create "new" error message every 24 hours
+					$this->userData['_error_time'] = urlencode((int)(time() / 86400));
 
-				// Error 0 is a special case (i.e. "trying to get property of non-object")
-				if($e->getCode() === 0) {
-					$item->setTitle(
-						'Bridge encountered an unexpected situation! ('
-						. $this->userData['_error_time']
-						. ')'
+					// Error 0 is a special case (i.e. "trying to get property of non-object")
+					if($e->getCode() === 0) {
+						$item->setTitle(
+							'Bridge encountered an unexpected situation! ('
+							. $this->userData['_error_time']
+							. ')'
+						);
+					} else {
+						$item->setTitle(
+							'Bridge returned error '
+							. $e->getCode()
+							. '! ('
+							. $this->userData['_error_time']
+							. ')'
+						);
+					}
+
+					$item->setURI(
+						(isset($_SERVER['REQUEST_URI']) ? parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) : '')
+						. '?'
+						. http_build_query($this->userData)
 					);
-				} else {
+
+					$item->setTimestamp(time());
+					$item->setContent(buildBridgeException($e, $bridge));
+
+					$items[] = $item;
+				} elseif(Configuration::getConfig('error', 'output') === 'http') {
+					header('Content-Type: text/html', true, $e->getCode());
+					die(buildTransformException($e, $bridge));
+				}
+			} catch(Exception $e) {
+				error_log($e);
+
+				if(Configuration::getConfig('error', 'output') === 'feed') {
+					$item = new \FeedItem();
+
+					// Create "new" error message every 24 hours
+					$this->userData['_error_time'] = urlencode((int)(time() / 86400));
+
+					$item->setURI(
+						(isset($_SERVER['REQUEST_URI']) ? parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) : '')
+						. '?'
+						. http_build_query($this->userData)
+					);
+
 					$item->setTitle(
 						'Bridge returned error '
 						. $e->getCode()
@@ -166,43 +205,14 @@ class DisplayAction extends ActionAbstract {
 						. $this->userData['_error_time']
 						. ')'
 					);
+					$item->setTimestamp(time());
+					$item->setContent(buildBridgeException($e, $bridge));
+
+					$items[] = $item;
+				} elseif(Configuration::getConfig('error', 'output') === 'http') {
+					header('Content-Type: text/html', true, $e->getCode());
+					die(buildTransformException($e, $bridge));
 				}
-
-				$item->setURI(
-					(isset($_SERVER['REQUEST_URI']) ? parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) : '')
-					. '?'
-					. http_build_query($this->userData)
-				);
-
-				$item->setTimestamp(time());
-				$item->setContent(buildBridgeException($e, $bridge));
-
-				$items[] = $item;
-			} catch(Exception $e) {
-				error_log($e);
-
-				$item = new \FeedItem();
-
-				// Create "new" error message every 24 hours
-				$this->userData['_error_time'] = urlencode((int)(time() / 86400));
-
-				$item->setURI(
-					(isset($_SERVER['REQUEST_URI']) ? parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) : '')
-					. '?'
-					. http_build_query($this->userData)
-				);
-
-				$item->setTitle(
-					'Bridge returned error '
-					. $e->getCode()
-					. '! ('
-					. $this->userData['_error_time']
-					. ')'
-				);
-				$item->setTimestamp(time());
-				$item->setContent(buildBridgeException($e, $bridge));
-
-				$items[] = $item;
 			}
 
 			// Store data in cache

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -61,6 +61,15 @@ username = ""
 ; Use a strong password to prevent others from guessing your login!
 password = ""
 
+[error]
+
+; Defines how error messages are returned by RSS-Bridge
+;
+; "feed" = As part of the feed (default)
+; "http" = As HTTP error message
+; "none" = No errors are reported
+output = "feed"
+
 ; --- Cache specific configuration ---------------------------------------------
 
 [SQLiteCache]

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -201,6 +201,9 @@ final class Configuration {
 		&& !filter_var(self::getConfig('admin', 'email'), FILTER_VALIDATE_EMAIL))
 			self::reportConfigurationError('admin', 'email', 'Is not a valid email address');
 
+		if(!is_string(self::getConfig('error', 'output')))
+			self::reportConfigurationError('error', 'output', 'Is not a valid String');
+
 	}
 
 	/**


### PR DESCRIPTION
Bridge errors are currently included as part of the feed to
notify users about erroneous bridges (before that, bridges
silently failed).

This solution, however, can produce a high load of error
messages if servers are down (see #994 for more details).

Admins may also not want to include error messages in feeds
in order to keep those kind of problems away from users or
simply to silently fail by choice.

This commit adds a new configuration section "error" with
one option "in_feed" which can be set to "true" to enable
the current behaviour (this is the default option) or to
"false" to disable it.

References #1066