### PR TITLE
ComboiosDePortugalBridge: HACK: Encode the URL

### DIFF
--- a/bridges/ComboiosDePortugalBridge.php
+++ b/bridges/ComboiosDePortugalBridge.php
@@ -14,7 +14,7 @@ class ComboiosDePortugalBridge extends BridgeAbstract {
 			$item = array();
 
 			$item['title'] = $element->innertext;
-			$item['uri'] = self::BASE_URI . $element->href;
+			$item['uri'] = self::BASE_URI . implode('/', array_map('urlencode', explode('/', $element->href)));
 
 			$this->items[] = $item;
 		}


### PR DESCRIPTION
This seems like a weird bug somewhere.

Either the HTML parser should return the valid page, or the CMS should
not convert the URL first, or the URL validation regex is buggy.