### PR TITLE
[BingSearch] Make the bridge compatible with PHP 5.6

### DIFF
--- a/bridges/BingSearchBridge.php
+++ b/bridges/BingSearchBridge.php
@@ -75,7 +75,7 @@ class BingSearchBridge extends BridgeAbstract
 	public function getName()
 	{
 		if ($this->getInput('category')) {
-			if (isset(self::IMAGE_DISCOVER_CATEGORIES[$this->getInput('categories')])) {
+			if (null !== self::IMAGE_DISCOVER_CATEGORIES[$this->getInput('categories')]) {
 				$category = self::IMAGE_DISCOVER_CATEGORIES[$this->getInput('categories')];
 			} else {
 				$category = 'Unknown';

--- a/bridges/BingSearchBridge.php
+++ b/bridges/BingSearchBridge.php
@@ -75,7 +75,7 @@ class BingSearchBridge extends BridgeAbstract
 	public function getName()
 	{
 		if ($this->getInput('category')) {
-			if (null !== self::IMAGE_DISCOVER_CATEGORIES[$this->getInput('categories')]) {
+			if (self::IMAGE_DISCOVER_CATEGORIES[$this->getInput('categories')] !== null) {
 				$category = self::IMAGE_DISCOVER_CATEGORIES[$this->getInput('categories')];
 			} else {
 				$category = 'Unknown';


### PR DESCRIPTION
The use of isset() with an expression is not possible in PHP 5.6. I
fixed it by replacing isset() with "null !== ".