### PR TITLE
[WIP][BandcampBridge] Add band feed

### DIFF
--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -231,4 +231,25 @@ class BandcampBridge extends BridgeAbstract {
 
 		return parent::getName();
 	}
+
+	public function detectParameters($url) {
+		$params = array();
+
+		// By band
+		$regex = '/^(https?:\/\/)?([^\/.&?\n]+?)\.bandcamp\.com/';
+		if(preg_match($regex, $url, $matches) > 0) {
+			$params['band'] = urldecode($matches[2]);
+			$params['tracks'] = 'on';
+			return $params;
+		}
+
+		// By tag
+		$regex = '/^(https?:\/\/)?bandcamp\.com\/tag\/([^\/.&?\n]+)/';
+		if(preg_match($regex, $url, $matches) > 0) {
+			$params['tag'] = urldecode($matches[2]);
+			return $params;
+		}
+
+		return null;
+	}
 }

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -110,9 +110,12 @@ class BandcampBridge extends BridgeAbstract {
 			for($i = 0; $i < $num_albums; $i++) {
 				$album_basic_data = $band_data->discography[$i];
 
+				// 'a' or 't' for albums and individual tracks respectively
+				$tralbum_type = substr($album_basic_data->item_type, 0, 1);
+
 				$query_data = array(
 					'band_id' => $band_id,
-					'tralbum_type' => 'a',
+					'tralbum_type' => $tralbum_type,
 					'tralbum_id' => $album_basic_data->item_id
 				);
 				$album_data = $this->apiGet('mobile/22/tralbum_details', $query_data);

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -2,69 +2,174 @@
 class BandcampBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'sebsauvage';
-	const NAME = 'Bandcamp Tag';
+	const NAME = 'Bandcamp Bridge';
 	const URI = 'https://bandcamp.com/';
 	const CACHE_TIMEOUT = 600; // 10min
-	const DESCRIPTION = 'New bandcamp release by tag';
-	const PARAMETERS = array( array(
-		'tag' => array(
-			'name' => 'tag',
-			'type' => 'text',
-			'required' => true
+	const DESCRIPTION = 'New bandcamp releases by tag or band';
+	const PARAMETERS = array(
+		'By tag' => array(
+			'tag' => array(
+				'name' => 'tag',
+				'type' => 'text',
+				'required' => true
+			)
+		),
+		'By band' => array(
+			'band' => array(
+				'name' => 'band',
+				'type' => 'text',
+				'required' => true
+			),
+			'tracks' => array(
+				'name' => 'new tracks',
+				'type' => 'checkbox',
+				'title' => 'Releases show up anew when new tracks are added',
+				'defaultValue' => 'checked'
+			),
+			'limit' => array(
+				'name' => 'limit',
+				'type' => 'number',
+				'title' => 'Number of releases to return',
+				'defaultValue' => 5
+			)
 		)
-	));
+	);
 	const IMGURI = 'https://f4.bcbits.com/';
 	const IMGSIZE_300PX = 23;
 	const IMGSIZE_700PX = 16;
+
+	private $feedName;
 
 	public function getIcon() {
 		return 'https://s4.bcbits.com/img/bc_favicon.ico';
 	}
 
 	public function collectData(){
-		$url = self::URI . 'api/hub/1/dig_deeper';
-		$data = $this->buildRequestJson();
-		$header = array(
-			'Content-Type: application/json',
-			'Content-Length: ' . strlen($data)
-		);
-		$opts = array(
-			CURLOPT_CUSTOMREQUEST => 'POST',
-			CURLOPT_POSTFIELDS => $data
-		);
-		$content = getContents($url, $header, $opts)
-			or returnServerError('Could not complete request to: ' . $url);
-
-		$json = json_decode($content);
-
-		if ($json->ok !== true) {
-			returnServerError('Invalid response');
-		}
-
-		foreach ($json->items as $entry) {
-			$url = $entry->tralbum_url;
-			$artist = $entry->artist;
-			$title = $entry->title;
-			// e.g. record label is the releaser, but not the artist
-			$releaser = $entry->band_name !== $entry->artist ? $entry->band_name : null;
-
-			$full_title = $artist . ' - ' . $title;
-			$full_artist = $artist;
-			if (isset($releaser)) {
-				$full_title .= ' (' . $releaser . ')';
-				$full_artist .= ' (' . $releaser . ')';
-			}
-			$small_img = $this->getImageUrl($entry->art_id, self::IMGSIZE_300PX);
-			$img = $this->getImageUrl($entry->art_id, self::IMGSIZE_700PX);
-
-			$item = array(
-				'uri' => $url,
-				'author' => $full_artist,
-				'title' => $full_title
+		switch($this->queriedContext) {
+		case 'By tag':
+			$url = self::URI . 'api/hub/1/dig_deeper';
+			$data = $this->buildRequestJson();
+			$header = array(
+				'Content-Type: application/json',
+				'Content-Length: ' . strlen($data)
 			);
-			$item['content'] = "<img src='$small_img' /><br/>$full_title";
-			$item['enclosures'] = array($img);
-			$this->items[] = $item;
+			$opts = array(
+				CURLOPT_CUSTOMREQUEST => 'POST',
+				CURLOPT_POSTFIELDS => $data
+			);
+			$content = getContents($url, $header, $opts)
+				or returnServerError('Could not complete request to: ' . $url);
+
+			$json = json_decode($content);
+
+			if ($json->ok !== true) {
+				returnServerError('Invalid response');
+			}
+
+			foreach ($json->items as $entry) {
+				$url = $entry->tralbum_url;
+				$artist = $entry->artist;
+				$title = $entry->title;
+				// e.g. record label is the releaser, but not the artist
+				$releaser = $entry->band_name !== $entry->artist ? $entry->band_name : null;
+
+				$full_title = $artist . ' - ' . $title;
+				$full_artist = $artist;
+				if (isset($releaser)) {
+					$full_title .= ' (' . $releaser . ')';
+					$full_artist .= ' (' . $releaser . ')';
+				}
+				$small_img = $this->getImageUrl($entry->art_id, self::IMGSIZE_300PX);
+				$img = $this->getImageUrl($entry->art_id, self::IMGSIZE_700PX);
+
+				$item = array(
+					'uri' => $url,
+					'author' => $full_artist,
+					'title' => $full_title
+				);
+				$item['content'] = "<img src='$small_img' /><br/>$full_title";
+				$item['enclosures'] = array($img);
+				$this->items[] = $item;
+			}
+			break;
+		case 'By band':
+			$html = getSimpleHTMLDOMCached($this->getURI(), 86400);
+			$this->feedName = $html->find('head meta[name=title]', 0)->content;
+
+			$regex = '/band_id=(\d+)/';
+			if(preg_match($regex, $html, $matches) == false)
+				returnServerError('Unable to find band ID');
+			$band_id = $matches[1];
+
+			$query_data = array(
+				'band_id' => $band_id
+			);
+			$band_data = $this->apiGet('mobile/22/band_details', $query_data);
+
+			$num_albums = min(count($band_data->discography), $this->getInput('limit'));
+			for($i = 0; $i < $num_albums; $i++) {
+				$album_basic_data = $band_data->discography[$i];
+
+				$query_data = array(
+					'band_id' => $band_id,
+					'tralbum_type' => 'a',
+					'tralbum_id' => $album_basic_data->item_id
+				);
+				$album_data = $this->apiGet('mobile/22/tralbum_details', $query_data);
+
+				$url = $album_data->bandcamp_url;
+				$artist = $album_data->tralbum_artist;
+				$title = $album_data->title;
+				// e.g. record label is the releaser, but not the artist
+				$releaser = $band_data->name !== $artist ? $band_data->name : null;
+
+				$full_title = $artist . ' - ' . $title;
+				$full_artist = $artist;
+				if (isset($releaser)) {
+					$full_title .= ' (' . $releaser . ')';
+					$full_artist .= ' (' . $releaser . ')';
+				}
+				$small_img = $this->getImageUrl($album_data->art_id, self::IMGSIZE_300PX);
+				$img = $this->getImageUrl($album_data->art_id, self::IMGSIZE_700PX);
+
+				$item = array(
+					'uri' => $url,
+					'author' => $full_artist,
+					'title' => $full_title
+				);
+				$item['enclosures'] = array($img);
+				$item['timestamp'] = $album_data->release_date;
+
+				$item['categories'] = array();
+				foreach ($album_data->tags as $tag) {
+					$item['categories'][] = $tag->norm_name;
+				}
+
+				// Give articles a unique UID depending on its track list
+				// Releases should then show up as new articles when tracks are added
+				if ($this->getInput('tracks') === true) {
+					$item['uid'] = "bandcamp/$band_id/$album_basic_data->item_id/";
+					foreach ($album_data->tracks as $track) {
+						$item['uid'] .= $track->track_id;
+					}
+				}
+
+				$item['content'] = "<img src='$small_img' /><br/>$full_title<br/><ol>";
+				foreach ($album_data->tracks as $track) {
+					$item['content'] .= "<li>$track->title</li>";
+				}
+				$item['content'] .= '</ol>';
+
+				if (!empty($album_data->about)) {
+					$item['content'] .= '<p>'
+						. nl2br($album_data->about)
+						. '</p>';
+				}
+
+				$this->items[] = $item;
+			}
+
+			break;
 		}
 	}
 
@@ -81,9 +186,47 @@ class BandcampBridge extends BridgeAbstract {
 		return self::IMGURI . 'img/a' . $id . '_' . $size . '.jpg';
 	}
 
+	private function apiGet($endpoint, $query_data) {
+		$url = self::URI . 'api/' . $endpoint . '?' . http_build_query($query_data);
+		$data = json_decode(getContents($url))
+			or returnServerError('API request to "' . $url . '" failed.');
+		return $data;
+	}
+
+	public function getURI(){
+		switch($this->queriedContext) {
+		case 'By tag':
+			if(!is_null($this->getInput('tag'))) {
+				return self::URI
+				. 'tag/'
+				. urlencode($this->getInput('tag'))
+				. '?sort_field=date';
+			}
+			break;
+		case 'By band':
+			if(!is_null($this->getInput('band'))) {
+				return 'https://' . $this->getInput('band') . '.bandcamp.com';
+			}
+			break;
+		}
+
+		return parent::getURI();
+	}
+
 	public function getName(){
-		if(!is_null($this->getInput('tag'))) {
-			return $this->getInput('tag') . ' - Bandcamp Tag';
+		switch($this->queriedContext) {
+		case 'By tag':
+			if(!is_null($this->getInput('tag'))) {
+				return $this->getInput('tag') . ' - Bandcamp Tag';
+			}
+			break;
+		case 'By band':
+			if(isset($this->feedName)) {
+				return $this->feedName . ' - Bandcamp Band';
+			} elseif(!is_null($this->getInput('band'))) {
+				return $this->getInput('band') . ' - Bandcamp Band';
+			}
+			break;
 		}
 
 		return parent::getName();


### PR DESCRIPTION
This uses a undocumented API from the bandcamp mobile app. It is however much faster than loading the normal band/album pages, seems less prone to randomly throwing errors and should hopefully not change as much.

It returns a limited number of the most recent releases by a band. It can also give each of those recent releases a unique UID depending on its track list, which should make them show up as new articles when tracks are added or removed.

Per-album feeds were requested in #581 as well, hence WIP for now.