### PR TITLE
[AO3Bridge] Add new bridge

### DIFF
--- a/bridges/AO3Bridge.php
+++ b/bridges/AO3Bridge.php
@@ -1,0 +1,100 @@
+<?php
+
+class AO3Bridge extends BridgeAbstract {
+	const NAME = 'AO3';
+	const URI = 'https://archiveofourown.org/';
+	const CACHE_TIMEOUT = 1800;
+	const DESCRIPTION = 'Works list (browse, search, filter) OR Work chapters';
+	const MAINTAINER = 'Obsidienne';
+	const PARAMETERS = array(
+		'List' => array(
+			'url' => array(
+				'name' => 'url',
+				'required' => true,
+				// Example: F/F tag, complete works only
+				'exampleValue' => 'https://archiveofourown.org/works?work_search[complete]=T&tag_id=F*s*F',
+			),
+		),
+		'Work' => array(
+			'id' => array(
+				'name' => 'id',
+				'required' => true,
+				// Example: latest chapters from A Better Past by LysSerris
+				'exampleValue' => '18181853',
+			),
+		)
+	);
+
+	// Feed for lists of works (e.g. recent works, search results, filtered tags,
+	// bookmarks, series, collections).
+	private function collectList($url) {
+		$html = getSimpleHTMLDOM($url)
+			or returnServerError('could not request AO3');
+		$html = defaultLinkTo($html, self::URI);
+
+		foreach($html->find('.index.group > li') as $element) {
+			$item = array();
+
+			$title = $element->find('div h4 a', 0);
+			if (!isset($title)) continue; // discard deleted works
+			$item['title'] = $title->plaintext;
+			$item['content'] = $element;
+			$item['uri'] = $title->href;
+
+			$strdate = $element->find('div p.datetime', 0)->plaintext;
+			$item['timestamp'] = strtotime($strdate);
+
+			$chapters = $element->find('dl dd.chapters', 0)->plaintext;
+			$item['uid'] = $item['uri'] . "/$strdate/$chapters";
+
+			$this->items[] = $item;
+		}
+	}
+
+	// Feed for recent chapters of a specific work.
+	private function collectWork() {
+		$id = $this->getInput('id');
+		$url = self::URI . "/works/$id/navigate";
+		$html = getSimpleHTMLDOM($url)
+			or returnServerError('could not request AO3');
+		$html = defaultLinkTo($html, self::URI);
+
+		$this->title = $html->find('h2 a', 0)->plaintext;
+
+		foreach($html->find('ol.index.group > li') as $element) {
+			$item = array();
+
+			$item['title'] = $element->find('a', 0)->plaintext;
+			$item['content'] = $element;
+			$item['uri'] = $element->find('a', 0)->href;
+
+			$strdate = $element->find('span.datetime', 0)->plaintext;
+			$strdate = str_replace('(', '', $strdate);
+			$strdate = str_replace(')', '', $strdate);
+			$item['timestamp'] = strtotime($strdate);
+
+			$item['uid'] = $item['uri'] . "/$strdate";
+
+			$this->items[] = $item;
+		}
+
+		$this->items = array_reverse($this->items);
+	}
+
+	public function collectData() {
+		switch($this->queriedContext) {
+			case 'List': return $this->collectList();
+			case 'Work': return $this->collectWork();
+		}
+	}
+
+	public function getName() {
+		$name = parent::getName() . " $this->queriedContext";
+		if (isset($this->title)) $name .= " - $this->title";
+		return $name;
+	}
+
+	public function getIcon() {
+		return self::URI . '/favicon.ico';
+	}
+}


### PR DESCRIPTION
New bridge for https://archiveofourown.org/.

The `List` context returns a feed for pages listing works. A few URLs you can test: [recent works](https://archiveofourown.org/works), [search results](https://archiveofourown.org/works/search?utf8=%E2%9C%93&work_search%5Bquery%5D=test&work_search%5Btitle%5D=&work_search%5Bcreators%5D=&work_search%5Brevised_at%5D=&work_search%5Bcomplete%5D=T&work_search%5Bcrossover%5D=F&work_search%5Bsingle_chapter%5D=0&work_search%5Bword_count%5D=&work_search%5Blanguage_id%5D=&work_search%5Bfandom_names%5D=&work_search%5Brating_ids%5D=&work_search%5Bcharacter_names%5D=&work_search%5Brelationship_names%5D=&work_search%5Bfreeform_names%5D=&work_search%5Bhits%5D=&work_search%5Bkudos_count%5D=&work_search%5Bcomments_count%5D=&work_search%5Bbookmarks_count%5D=&work_search%5Bsort_column%5D=revised_at&work_search%5Bsort_direction%5D=desc&commit=Search), [filtered tag](https://archiveofourown.org/works?utf8=%E2%9C%93&commit=Sort+and+Filter&work_search%5Bsort_column%5D=revised_at&include_work_search%5Bcategory_ids%5D%5B%5D=116&work_search%5Bother_tag_names%5D=&exclude_work_search%5Brating_ids%5D%5B%5D=13&exclude_work_search%5Bwarning_ids%5D%5B%5D=20&exclude_work_search%5Bwarning_ids%5D%5B%5D=19&exclude_work_search%5Bcategory_ids%5D%5B%5D=22&exclude_work_search%5Bcategory_ids%5D%5B%5D=23&work_search%5Bexcluded_tag_names%5D=&work_search%5Bcrossover%5D=F&work_search%5Bcomplete%5D=T&work_search%5Bwords_from%5D=10000&work_search%5Bwords_to%5D=&work_search%5Bdate_from%5D=&work_search%5Bdate_to%5D=&work_search%5Bquery%5D=&work_search%5Blanguage_id%5D=1&tag_id=Little+Witch+Academia), [bookmarks](https://archiveofourown.org/users/Nyaaru/bookmarks?bookmark_search[sort_column]=bookmarkable_date), [collections](https://archiveofourown.org/collections/Femslash_Friday/works).

The `Bookmarks` context returns a feed for users' bookmarks. It's just a shortcut to the `List` context. Examples: *LysSerris*, *sniperct*.

The `Work` context returns a feed containing the latest chapters of a specific work. Examples: *18181853*, *15791256*.

**Note**: AO3 already has feeds for individual canonical tags ([example](https://archiveofourown.org/tags/116/feed.atom)), but freeform tags and filtering are not supported. [[1]](https://archiveofourown.org/faq/subscriptions-and-feeds?language_id=en#additionalfeed) [[2]](https://archiveofourown.org/faq/subscriptions-and-feeds?language_id=en#filteringfeeds)