### PR TITLE
[MediapartBridge] Add a bridge for Mediapart

### DIFF
--- a/bridges/MediapartBridge.php
+++ b/bridges/MediapartBridge.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 
 class MediapartBridge extends FeedExpander {
 	const MAINTAINER = 'killruana';

--- a/bridges/MediapartBridge.php
+++ b/bridges/MediapartBridge.php
@@ -1,0 +1,43 @@
+<?PHP
+
+class MediapartBridge extends FeedExpander {
+	const MAINTAINER = 'killruana';
+	const NAME = 'Mediapart Bridge';
+	const URI = 'https://www.mediapart.fr/';
+	const PARAMETERS = array(
+		array(
+			'MPSESSID' => array(
+				'name' => 'MPSESSID',
+				'type' => 'text',
+				'title' => 'Cookie session'
+			)
+		)
+	);
+	const CACHE_TIMEOUT = 7200; // 2h
+	const DESCRIPTION = 'Returns the newest articles.';
+
+	public function collectData() {
+		$url = self::URI . 'articles/feed';
+		$this->collectExpandableDatas($url);
+	}
+
+	protected function parseItem($newsItem) {
+		$item = parent::parseItem($newsItem);
+		$item['uri'] .= '?onglet=full';
+
+		$opt = array();
+		$mpsessid = $this->getInput('MPSESSID');
+		if (!empty($mpsessid)) {
+			$opt[CURLOPT_COOKIE] = 'MPSESSID=' . $mpsessid;
+		}
+
+		$articlePage = getSimpleHTMLDOM($item['uri'], array(), $opt);
+		$introduction = $articlePage->find('div.introduction', 0)->innertext;
+		$article = $articlePage->find('div.content-article', 0)->innertext;
+		$content = sanitize($introduction . $article);
+		$content = defaultLinkTo($content, static::URI);
+		$item['content'] = $content;
+
+		return $item;
+	}
+}

--- a/bridges/MediapartBridge.php
+++ b/bridges/MediapartBridge.php
@@ -6,10 +6,10 @@ class MediapartBridge extends FeedExpander {
 	const URI = 'https://www.mediapart.fr/';
 	const PARAMETERS = array(
 		array(
-			'MPSESSID' => array(
+			'mpsessid' => array(
 				'name' => 'MPSESSID',
 				'type' => 'text',
-				'title' => 'Cookie session'
+				'title' => 'Value of the session cookie MPSESSID'
 			)
 		)
 	);
@@ -25,12 +25,13 @@ class MediapartBridge extends FeedExpander {
 		$item = parent::parseItem($newsItem);
 		$item['uri'] .= '?onglet=full';
 
-		$mpsessid = $this->getInput('MPSESSID');
+		$mpsessid = $this->getInput('mpsessid');
 		if (!empty($mpsessid)) {
 			$opt = array();
 			$opt[CURLOPT_COOKIE] = 'MPSESSID=' . $mpsessid;
 			$articlePage = getSimpleHTMLDOM($item['uri'], array(), $opt);
-			$content = sanitize($articlePage->find('div.content-article', 0)->innertext);
+			$content = $articlePage->find('div.content-article', 0)->innertext;
+			$content = sanitize($content);
 			$content = defaultLinkTo($content, static::URI);
 			$item['content'] .= $content;
 		}

--- a/bridges/MediapartBridge.php
+++ b/bridges/MediapartBridge.php
@@ -25,18 +25,15 @@ class MediapartBridge extends FeedExpander {
 		$item = parent::parseItem($newsItem);
 		$item['uri'] .= '?onglet=full';
 
-		$opt = array();
 		$mpsessid = $this->getInput('MPSESSID');
 		if (!empty($mpsessid)) {
+			$opt = array();
 			$opt[CURLOPT_COOKIE] = 'MPSESSID=' . $mpsessid;
+			$articlePage = getSimpleHTMLDOM($item['uri'], array(), $opt);
+			$content = sanitize($articlePage->find('div.content-article', 0)->innertext);
+			$content = defaultLinkTo($content, static::URI);
+			$item['content'] .= $content;
 		}
-
-		$articlePage = getSimpleHTMLDOM($item['uri'], array(), $opt);
-		$introduction = $articlePage->find('div.introduction', 0)->innertext;
-		$article = $articlePage->find('div.content-article', 0)->innertext;
-		$content = sanitize($introduction . $article);
-		$content = defaultLinkTo($content, static::URI);
-		$item['content'] = $content;
 
 		return $item;
 	}

--- a/bridges/MediapartBridge.php
+++ b/bridges/MediapartBridge.php
@@ -29,7 +29,7 @@ class MediapartBridge extends FeedExpander {
 
 	protected function parseItem($newsItem) {
 		$item = parent::parseItem($newsItem);
-		
+
 		// Enable single page mode?
 		if ($this->getInput('single_page_mode') === true) {
 			$item['uri'] .= '?onglet=full';
@@ -44,8 +44,8 @@ class MediapartBridge extends FeedExpander {
 
 			// Get the page
 			$articlePage = getSimpleHTMLDOM(
-				$newsItem->link . '?onglet=full', 
-				array(), 
+				$newsItem->link . '?onglet=full',
+				array(),
 				$opt);
 
 			// Extract the article content


### PR DESCRIPTION
Hi,

I have just created a bridge for the french newspaper Mediapart (https://www.mediapart.fr/).

The bridge has two parameters.
The first one is for viewing articles in a single page. When the parameter is set, the RSS link field redirect to the single page version of the article. By default, Mediapart split long articles on multiple pages and I found this behavior annoying.

The second parameter is for setting the user session cookie and getting the full article in the stream.
Without session cookie:
![Without session cookie](https://i.zcraft.fr/5530221557757619.png)

With invalid session:
![With invalid session cookie](https://i.zcraft.fr/7444791557757687.png)

With valid session:
![With valid session cookie](https://i.zcraft.fr/5745291557757739.png)