### PR TITLE
[Docker] Switch Docker Image to official php base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,14 @@
 .git
+.gitattributes
+.github/*
+.travis.yml
 cache/*
+CONTRIBUTING.md
 DEBUG
 Dockerfile
-whitelist.txt
+phpcompatibility.xml
 phpcs.xml
-CONTRIBUTING.md
+phpcs.xml
+scalingo.json
+tests/*
+whitelist.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-FROM ulsmith/alpine-apache-php7
+FROM php:7-apache
 
-COPY ./ /app/public/
+ENV APACHE_DOCUMENT_ROOT=/app
 
-RUN chown -R apache:root /app/public
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
+	&& apt-get --yes update && apt-get --yes install libxml2-dev \
+	&& docker-php-ext-install -j$(nproc) simplexml \
+	&& sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
+	&& sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+COPY --chown=www-data:www-data ./ /app/


### PR DESCRIPTION
Switches away from the unofficial Alpine+php image
to the official php-apache image. This has 2 advantages:

1. Official image is guaranteed to have regular updates etc
2. The persistent Docker Alpine DNS Issue goes away; https://github.com/gliderlabs/docker-alpine/issues/255