### PR TITLE
[FeedItem] avoid repeated UID hashing

### DIFF
--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -418,6 +418,9 @@ class FeedItem {
 
 		if(!is_string($uid)) {
 			Debug::log('Unique id must be a string!');
+		} else if (preg_match('/^[a-f0-9]{40}$/', $uid)) {
+			// keep id if it already is a SHA-1 hash
+			$this->uid = $uid;
 		} else {
 			$this->uid = sha1($uid);
 		}

--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -418,7 +418,7 @@ class FeedItem {
 
 		if(!is_string($uid)) {
 			Debug::log('Unique id must be a string!');
-		} else if (preg_match('/^[a-f0-9]{40}$/', $uid)) {
+		} elseif (preg_match('/^[a-f0-9]{40}$/', $uid)) {
 			// keep id if it already is a SHA-1 hash
 			$this->uid = $uid;
 		} else {


### PR DESCRIPTION
This fixes the following issue:
1. bridge sets unique ids for the items (ids get hashed)
2. items go to the cache
3. on next run items get loaded from cache
4. these items have different ids because they were hashed again
5. they show up twice in feed reader