### PR TITLE
core: Add info button for input fields with title

### DIFF
--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -122,6 +122,11 @@ This bridge is not fetching its content through a secure connection</div>';
 				} elseif($inputEntry['type'] === 'checkbox') {
 					$form .= self::getCheckboxInput($inputEntry, $idArg, $id);
 				}
+
+				if(isset($inputEntry['title']))
+					$form .= '<i class="info" title="' . filter_var($inputEntry['title'], FILTER_SANITIZE_STRING) . '">i</i>';
+				else
+					$form .= '<i></i>';
 			}
 
 			$form .= '</div>';
@@ -151,9 +156,6 @@ This bridge is not fetching its content through a secure connection</div>';
 
 		if(isset($entry['pattern']))
 			$retVal .= ' pattern="' . $entry['pattern'] . '"';
-
-		if(isset($entry['title']))
-			$retVal .= ' title="' . filter_var($entry['title'], FILTER_SANITIZE_STRING) . '"';
 
 		return $retVal;
 	}

--- a/static/style.css
+++ b/static/style.css
@@ -357,6 +357,10 @@ h5 {
 		margin: 3px auto 0;
 	}
 
+	.info {
+		display: none;
+	}
+
 	@supports (display: grid) {
 
 		.parameters {

--- a/static/style.css
+++ b/static/style.css
@@ -187,12 +187,33 @@ form {
 	content: ' :';
 }
 
+.info {
+	cursor: help;
+	opacity: 0.5;
+	width: 24px;
+	height: 24px;
+	font-size: 16px;
+	font-weight: bold;
+	font-style: italic;
+	line-height: 22px;
+	text-align: center;
+	color: #fff;
+	background: #1182DB;
+	-webkit-border-radius: 16px;
+	-moz-border-radius: 16px;
+	border-radius: 16px;
+}
+
+.info:hover {
+	opacity: 1;
+}
+
 @supports (display: grid) {
 
 	.parameters {
 		display: grid;
 		padding: 12px 0;
-		grid-template-columns: 40% max-content;
+		grid-template-columns: 40% max-content 24px;
 		grid-column-gap: 10px;
 		grid-row-gap: 5px;
 	}

--- a/static/style.css
+++ b/static/style.css
@@ -198,7 +198,7 @@ form {
 	line-height: 22px;
 	text-align: center;
 	color: #fff;
-	background: #1182DB;
+	background-image: radial-gradient(#49afff, #1182DB);
 	-webkit-border-radius: 16px;
 	-moz-border-radius: 16px;
 	border-radius: 16px;


### PR DESCRIPTION
The current solution for titles on input boxes is not obvious to the user as support varies between bridges. This commit adds an button to all input boxes with titles in order to make it clear to the user that additional information is available. This solution is purely done in CSS - no image required.

Let me know if you have a better idea for styling the icon or this solution in general. This can be merged if there are no objections.

![Screenshot from 2019-06-17 19-27-45](https://user-images.githubusercontent.com/5776685/59624405-f8351280-9136-11e9-8d70-253275dedefa.png)