### PR TITLE
[MastodonBridge] Add a bridge to Mastodon

### DIFF
--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -29,7 +29,7 @@ class MastodonBridge extends FeedExpander {
 	public function getName(){
 		switch($this->queriedContext) {
 		case 'By username':
-			$param = 'canusername';
+			return $this->getInput('canusername');
 			break;
 		default: return parent::getName();
 		}

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -51,7 +51,7 @@ class MastodonBridge extends FeedExpander {
 				return null;
 			}
 
-			preg_match("/shared a status by (\S{0,})/", $title, $matches);
+			preg_match('/shared a status by (\S{0,})/', $title, $matches);
 			$item['title'] = 'Boost ' . $matches[1] . ' ' . $item['title'];
 			$item['author'] = $matches[1];
 		} else {
@@ -59,7 +59,7 @@ class MastodonBridge extends FeedExpander {
 		}
 
 		// Check if it's a initial toot or a response
-		if($this->getInput('norep') && preg_match("/^@.+/", trim($content->plaintext))) {
+		if($this->getInput('norep') && preg_match('/^@.+/', trim($content->plaintext))) {
 			return null;
 		}
 
@@ -67,12 +67,12 @@ class MastodonBridge extends FeedExpander {
 	}
 
 	public function getInstance(){
-		preg_match("/^@[a-zA-Z0-9_]+@(.+)/", $this->getInput('canusername'), $matches);
+		preg_match('/^@[a-zA-Z0-9_]+@(.+)/', $this->getInput('canusername'), $matches);
 		return $matches[1];
 	}
 
 	public function getUsername(){
-		preg_match("/^@([a-zA-Z_0-9_]+)@.+/", $this->getInput('canusername'), $matches);
+		preg_match('/^@([a-zA-Z_0-9_]+)@.+/', $this->getInput('canusername'), $matches);
 		return $matches[1];
 	}
 

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -79,7 +79,7 @@ class MastodonBridge extends FeedExpander {
 	public function getURI(){
 		if($this->getInput('canusername'))
 			return 'https://' . $this->getInstance() . '/users/' . $this->getUsername() . '.atom';
-		
+
 		return parent::getURI();
 	}
 

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -4,7 +4,7 @@ class MastodonBridge extends FeedExpander {
 
 	const MAINTAINER = 'husim0';
 	const NAME = 'Mastodon Bridge';
-	const CACHE_TIMEOUT = 0; // 1h
+	const CACHE_TIMEOUT = 900; // 15mn
 	const DESCRIPTION = 'Returns toots';
 	const URI = 'https://mastodon.social';
 

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -77,7 +77,10 @@ class MastodonBridge extends FeedExpander {
 	}
 
 	public function getURI(){
-		return 'https://' . $this->getInstance() . '/users/' . $this->getUsername() . '.atom';
+		if($this->getInput('canusername'))
+			return 'https://' . $this->getInstance() . '/users/' . $this->getUsername() . '.atom';
+		
+		return parent::getURI();
 	}
 
 	public function collectData(){

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -66,7 +66,7 @@ class MastodonBridge extends FeedExpander {
 		return $item;
 	}
 
-	public function getInstance(){
+	private function getInstance(){
 		preg_match('/^@[a-zA-Z0-9_]+@(.+)/', $this->getInput('canusername'), $matches);
 		return $matches[1];
 	}

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -71,7 +71,7 @@ class MastodonBridge extends FeedExpander {
 		return $matches[1];
 	}
 
-	public function getUsername(){
+	private function getUsername(){
 		preg_match('/^@([a-zA-Z_0-9_]+)@.+/', $this->getInput('canusername'), $matches);
 		return $matches[1];
 	}

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -8,33 +8,30 @@ class MastodonBridge extends FeedExpander {
 	const DESCRIPTION = 'Returns toots';
 	const URI = 'https://mastodon.social';
 
-	const PARAMETERS = [[
-		'canusername' => [
+	const PARAMETERS = array(array(
+		'canusername' => array(
 			'name' => 'Canonical username (ex : @sebsauvage@framapiaf.org)',
 			'required' => true,
-		],
-		'norep' => [
+		),
+		'norep' => array(
 			'name' => 'Without replies',
 			'type' => 'checkbox',
 			'title' => 'Only return initial toots'
-		],
-		'noboost' => [
+		),
+		'noboost' => array(
 			'name' => 'Without boosts',
 			'required' => false,
 			'type' => 'checkbox',
 			'title' => 'Hide boosts'
-		]
-	]];
+			)
+		));
 
 	public function getName(){
 		switch($this->queriedContext) {
 		case 'By username':
 			return $this->getInput('canusername');
-			break;
 		default: return parent::getName();
 		}
-		
-		return $this->getInput($param);
 	}
 
 	protected function parseItem($newItem){
@@ -44,6 +41,7 @@ class MastodonBridge extends FeedExpander {
 		$title = str_get_html($item['title']);
 
 		$item['title'] = $content->plaintext;
+
 		if(strlen($item['title']) > 75) {
 			$item['title'] = substr($item['title'], 0, strpos(wordwrap($item['title'], 75), "\n")) . '...';
 		}
@@ -83,10 +81,6 @@ class MastodonBridge extends FeedExpander {
 	}
 
 	public function collectData(){
-		try{
-			$this->collectExpandableDatas($this->getURI());
-		} catch (Exception $e) {
-			$this->collectExpandableDatas($this->getURI());
-		}
+		return $this->collectExpandableDatas($this->getURI());
 	}
 }

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -1,0 +1,89 @@
+<?php
+
+class MastodonBridge extends FeedExpander {
+
+	const MAINTAINER = 'husim0';
+	const NAME = 'Mastodon Bridge';
+	const CACHE_TIMEOUT = 0; // 1h
+	const DESCRIPTION = 'Returns toots';
+	const URI = 'https://mastodon.social';
+
+	const PARAMETERS = [[
+		'canusername' => [
+			'name' => 'Canonical username (ex : @sebsauvage@framapiaf.org)',
+			'required' => true,
+		],
+		'norep' => [
+			'name' => 'Without replies',
+			'type' => 'checkbox',
+			'title' => 'Only return initial toots'
+		],
+		'noboost' => [
+			'name' => 'Without boosts',
+			'required' => false,
+			'type' => 'checkbox',
+			'title' => 'Hide boosts'
+		]
+	]];
+
+	public function getName(){
+		switch($this->queriedContext) {
+		case 'By username':
+			$param = 'canusername';
+			break;
+		default: return parent::getName();
+		}
+		
+		return $this->getInput($param);
+	}
+
+	protected function parseItem($newItem){
+		$item = parent::parseItem($newItem);
+
+		$content = str_get_html($item['content']);
+		$title = str_get_html($item['title']);
+
+		$item['title'] = substr($content->plaintext,0,75) . (strlen($content->plaintext) >= 75 ? '...' : '');
+
+		if(strpos($title, 'shared a status by') !== false) {
+			if($this->getInput('noboost')) {
+				return null;
+			}
+
+			preg_match("/shared a status by (\S{0,})/", $title, $matches);
+			$item['title'] = 'Boost ' . $matches[1] . ' ' . $item['title'];
+			$item['author'] = $matches[1];
+		} else {
+			$item['author'] = $this->getInput('canusername');
+		}
+
+		// Check if it's a initial toot or a response
+		if($this->getInput('norep') && preg_match("/^@.+/", trim($content->plaintext))) {
+			return null;
+		}
+
+		return $item;
+	}
+
+	public function getInstance(){
+		preg_match("/^@[a-zA-Z0-9_]+@(.+)/", $this->getInput('canusername'), $matches);
+		return $matches[1];
+	}
+
+	public function getUsername(){
+		preg_match("/^@([a-zA-Z_0-9_]+)@.+/", $this->getInput('canusername'), $matches);
+		return $matches[1];
+	}
+
+	public function getURI(){
+		return 'https://' . $this->getInstance() . '/users/' . $this->getUsername() . '.atom';
+	}
+
+	public function collectData(){
+		try{
+			$this->collectExpandableDatas($this->getURI());
+		} catch (Exception $e) {
+			$this->collectExpandableDatas($this->getURI());
+		}
+	}
+}

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -43,7 +43,10 @@ class MastodonBridge extends FeedExpander {
 		$content = str_get_html($item['content']);
 		$title = str_get_html($item['title']);
 
-		$item['title'] = substr($content->plaintext,0,75) . (strlen($content->plaintext) >= 75 ? '...' : '');
+		$item['title'] = $content->plaintext;
+		if(strlen($item['title']) > 75) {
+			$item['title'] = substr($item['title'], 0, strpos(wordwrap($item['title'], 75), "\n")) . '...';
+		}
 
 		if(strpos($title, 'shared a status by') !== false) {
 			if($this->getInput('noboost')) {


### PR DESCRIPTION
Hello,

I made a little bridge for Mastodon. Indeed Mastodon provides atom feeds but they are not usable in a RSS aggregator (title is for example "New status by user"). [Feed example](https://mastodon.gougere.fr/users/bortzmeyer.atom).

It's an improvement about solution proposed [here](https://github.com/RSS-Bridge/rss-bridge/issues/587#issuecomment-408628828). You can filter if you don't want boots nor answers to other toots.

It's my first contribution, please be kind to me :) I'll be glad to improve it if necessary.
 