### PR TITLE
[TelegramBridge] Fix timestamp for videos

### DIFF
--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -250,11 +250,8 @@ EOD;
 
 	private function processDate($messageDiv) {
 
-		if ($messageDiv->find('time', 0)->datetime) {
-			return $messageDiv->find('time', 0)->datetime;
-		} else {
-			return $messageDiv->find('time', 1)->datetime;
-		}
+		$messageMeta = $messageDiv->find('span.tgme_widget_message_meta', 0);
+		return $messageMeta->find('time', 0)->datetime;
 
 	}
 

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -249,11 +249,13 @@ EOD;
 	}
 
 	private function processDate($messageDiv) {
+
 		if ($messageDiv->find('time', 0)->datetime) {
 			return $messageDiv->find('time', 0)->datetime;
 		} else {
 			return $messageDiv->find('time', 1)->datetime;
 		}
+
 	}
 
 	private function ellipsisTitle($text) {

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -249,7 +249,11 @@ EOD;
 	}
 
 	private function processDate($messageDiv) {
-		return $messageDiv->find('time', 0)->datetime;
+		if ($messageDiv->find('time', 0)->datetime) {
+			return $messageDiv->find('time', 0)->datetime;
+		} else {
+			return $messageDiv->find('time', 1)->datetime;
+		}
 	}
 
 	private function ellipsisTitle($text) {


### PR DESCRIPTION
For Telegram videos, the video timestamp is the second `<time>` occurrence, not the first.