### PR TITLE
[TelegramBridge] Set 'username' parameter as required

### DIFF
--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -8,6 +8,7 @@ class TelegramBridge extends BridgeAbstract {
 			'username' => array(
 				'name' => 'Username',
 				'type' => 'text',
+				'required' => true,
 				'exampleValue' => '@telegram',
 			)
 		)


### PR DESCRIPTION
This pull request updates the parameters array to make the `username` parameter required.