### PR TITLE
[ParameterValidator] Ensure context has all user provided parameters

### DIFF
--- a/lib/ParameterValidator.php
+++ b/lib/ParameterValidator.php
@@ -191,6 +191,10 @@ class ParameterValidator {
 		foreach($parameters as $context => $set) {
 			$queriedContexts[$context] = null;
 
+			// Ensure all user data exist in the context
+			if(sizeof(array_diff_key($data, $set)) > 0)
+				continue;
+
 			// Check if all parameters of the context are satisfied
 			foreach($set as $id => $properties) {
 				if(isset($data[$id]) && !empty($data[$id])) {

--- a/lib/ParameterValidator.php
+++ b/lib/ParameterValidator.php
@@ -191,8 +191,11 @@ class ParameterValidator {
 		foreach($parameters as $context => $set) {
 			$queriedContexts[$context] = null;
 
-			// Ensure all user data exist in the context
-			if(sizeof(array_diff_key($data, $set)) > 0)
+			// Ensure all user data exist in the current context
+			$notInContext = array_diff_key($data, $set);
+			if(array_key_exists('global', $parameters))
+				$notInContext = array_diff_key($notInContext, $parameters['global']);
+			if(sizeof($notInContext) > 0)
 				continue;
 
 			// Check if all parameters of the context are satisfied


### PR DESCRIPTION
Previously if a bridge had a set of parameters like:

    const PARAMETERS = array(
        'ContextA' => array(
            'Param1' => array(
                'name' => 'Param1',
                'required' => true
            )
        ),
        'ContextB' => array(
            'Param1' => array(
                'name' => 'Param1',
                'required' => true
            ),
            'Param2' => array(
                'name' => 'Param2',
                'required' => true
            )
        )
    )

and a query specifying both `Param1` and `Param2` was provided a `Mixed context parameters` error would be returned. This change ensures `ContextA` in the above example would not be considered a relevant context.

Not sure if this is necessarily needed since 1591e18 but it might be nice for completeness.