### PR TITLE
[FacebookBridge] Remove relative date from content

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -580,6 +580,8 @@ EOD;
 							'._5mly', // Remove embedded videos (the preview image remains)
 							'._2ezg', // Remove "Views ..."
 							'.hidden_elem', // Remove hidden elements (they are hidden anyway)
+							'.timestampContent', // Remove relative timestamp
+							'._6spk', // Remove redundant separator
 						);
 
 						foreach($content_filters as $filter) {


### PR DESCRIPTION
Remove relative date from content, as well as the separator after it.

As mentioned in #1188.