### PR TITLE
[HaveIBeenPwnedBridge] Limit number of feed items

### DIFF
--- a/bridges/HaveIBeenPwnedBridge.php
+++ b/bridges/HaveIBeenPwnedBridge.php
@@ -98,6 +98,10 @@ class HaveIBeenPwnedBridge extends BridgeAbstract {
 			$item['content'] = $breach['content'];
 
 			$this->items[] = $item;
+			
+			if (count($this->items) >= 20) {
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request limits the number of feed items returned to 20. The bridge currently returns all 300+ breached websites.