### PR TITLE
[HaveIBeenPwnedBridge] Add item limit parameter, set default limit to 20

### DIFF
--- a/bridges/HaveIBeenPwnedBridge.php
+++ b/bridges/HaveIBeenPwnedBridge.php
@@ -129,7 +129,7 @@ class HaveIBeenPwnedBridge extends BridgeAbstract {
 			$item['content'] = $breach['content'];
 
 			$this->items[] = $item;
-			
+
 			if (count($this->items) >= $limit) {
 				break;
 			}

--- a/bridges/HaveIBeenPwnedBridge.php
+++ b/bridges/HaveIBeenPwnedBridge.php
@@ -13,6 +13,11 @@ class HaveIBeenPwnedBridge extends BridgeAbstract {
 				'Date added to HIBP' => 'dateAdded',
 			),
 			'defaultValue' => 'dateAdded',
+		),
+		'item_limit' => array(
+			'name' => 'Limit number of returned items',
+			'type' => 'number',
+			'defaultValue' => 20,
 		)
 	));
 
@@ -109,6 +114,12 @@ class HaveIBeenPwnedBridge extends BridgeAbstract {
 	 */
 	private function createItems() {
 
+		$limit = $this->getInput('item_limit');
+
+		if ($limit < 1) {
+			$limit = 20;
+		}
+
 		foreach ($this->breaches as $breach) {
 			$item = array();
 
@@ -118,8 +129,8 @@ class HaveIBeenPwnedBridge extends BridgeAbstract {
 			$item['content'] = $breach['content'];
 
 			$this->items[] = $item;
-
-			if (count($this->items) >= 20) {
+			
+			if (count($this->items) >= $limit) {
 				break;
 			}
 		}

--- a/bridges/HaveIBeenPwnedBridge.php
+++ b/bridges/HaveIBeenPwnedBridge.php
@@ -118,6 +118,10 @@ class HaveIBeenPwnedBridge extends BridgeAbstract {
 			$item['content'] = $breach['content'];
 
 			$this->items[] = $item;
+
+			if (count($this->items) >= 20) {
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request adds the parameter `item_limit` that allows the user to control the number of items returned by bridge. Default limit is 20.