### PR TITLE
[FabriceBellard]: New Bridge

### DIFF
--- a/bridges/FabriceBellardBridge.php
+++ b/bridges/FabriceBellardBridge.php
@@ -17,8 +17,7 @@ class FabriceBellardBridge extends BridgeAbstract {
 			$links = $obj->find('a');
 			if (count($links) > 0) {
 				$link_uri = $links[0]->href;
-			}
-			else {
+			} else {
 				$link_uri = $this->getURI();
 			}
 

--- a/bridges/FabriceBellardBridge.php
+++ b/bridges/FabriceBellardBridge.php
@@ -12,20 +12,19 @@ class FabriceBellardBridge extends BridgeAbstract {
 		foreach ($html->find('p') as $obj) {
 			$item = array();
 
-			$links = $obj->find('a');
+			$html = defaultLinkTo($html, $this->getURI());
 
-			$link_uri = self::URI;
+			$links = $obj->find('a');
 			if (count($links) > 0) {
-				/* Fix relative links */
-				foreach ($links as $link) {
-					if (strpos($link, '://') === false) {
-						$link->href = self::URI . $link->href;
-					}
-				}
 				$link_uri = $links[0]->href;
-				if ($link_uri[-1] !== '/') {
-					$link_uri = $link_uri . '/';
-				}
+			}
+			else {
+				$link_uri = $this->getURI();
+			}
+
+			/* try to make sure the link is valid */
+			if ($link_uri[-1] !== '/' && strpos($link_uri, '/') === false) {
+				$link_uri = $link_uri . '/';
 			}
 
 			$item['title'] = strip_tags($obj->innertext);

--- a/bridges/FabriceBellardBridge.php
+++ b/bridges/FabriceBellardBridge.php
@@ -1,0 +1,38 @@
+<?php
+class FabriceBellardBridge extends BridgeAbstract {
+	const NAME = 'Fabrice Bellard';
+	const URI = 'https://bellard.org/';
+	const DESCRIPTION = "Fabrice Bellard's Home Page";
+	const MAINTAINER = 'somini';
+
+	public function collectData() {
+		$html = getSimpleHTMLDOM(self::URI)
+			or returnServerError('Could not load content');
+
+		foreach ($html->find('p') as $obj) {
+			$item = array();
+
+			$links = $obj->find('a');
+
+			$link_uri = self::URI;
+			if (count($links) > 0) {
+				/* Fix relative links */
+				foreach ($links as $link) {
+					if (strpos($link, '://') === false) {
+						$link->href = self::URI . $link->href;
+					}
+				}
+				$link_uri = $links[0]->href;
+				if ($link_uri[-1] !== '/') {
+					$link_uri = $link_uri . '/';
+				}
+			}
+
+			$item['title'] = strip_tags($obj->innertext);
+			$item['uri'] = $link_uri;
+			$item['content'] = $obj->innertext;
+
+			$this->items[] = $item;
+		}
+	}
+}


### PR DESCRIPTION
A feed for the particularly barebones (in terms of HTML, it's the opposite of the content) home page of Fabrice Bellard.

https://bellard.org/

This is the simplest HTML possible, I though this would be very easy, but it served to stress-test the HTML parser library more than I expected.

- Relative links are not "absolutized" at all.

If a link's `href` property is `apage.html`, that's the exact string returned by `->href`. At the very least, there should be a global function to do the equivalent of this, given a root domain:
https://github.com/somini/rss-bridge/blob/99a39ff2633dfa8e71f3cc2edbd17cd0575a14e0/bridges/FabriceBellardBridge.php#L19-L24

Worse, if a link is something like "http://gihub.com" (note the missing trailing slash, it is not parsed as a URI. This is hacked around here: https://github.com/somini/rss-bridge/blob/99a39ff2633dfa8e71f3cc2edbd17cd0575a14e0/bridges/FabriceBellardBridge.php#L26-L28

- There is a strange issue with the `->find` function, but only sometimes.

Consider the following HTML snippet:

```html
<body>
   <p>This is paragraph 1
   <p>This is paragraph 2
   <p>This is paragraph 3</p>
</body>
```

`$html->find('p')` returns 3 elements, as expected, the `innertext` argument works as expected (This is paragraph #). However, if you do another `find` on that returned object, the "implied" paragraph end is ignored and it will continue to find elements until the end of the page. This is an hidden bug on the implementation, since I'm only interested on the first link of each element.