### PR TITLE
Clarify Facebook bridges status

### DIFF
--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -12,7 +12,12 @@ class FB2Bridge extends BridgeAbstract {
 		'u' => array(
 			'name' => 'Username',
 			'required' => true
-		)
+		),
+		'abbrev_name' => array(
+			'name' => 'Abbreviate author name in title',
+			'type' => 'checkbox',
+			'defaultValue' => true,
+		),
 	));
 
 	public function getIcon() {
@@ -182,8 +187,10 @@ EOD
 			$item['content'] = html_entity_decode($content, ENT_QUOTES);
 
 			$title = $author;
-			if (strlen($title) > 24)
-				$title = substr($title, 0, strpos(wordwrap($title, 24), "\n")) . '...';
+			if ($this->getInput('abbrev_name') === true) {
+				if (strlen($title) > 24)
+					$title = substr($title, 0, strpos(wordwrap($title, 24), "\n")) . '...';
+			}
 			$title = $title . ' | ' . strip_tags($content);
 			if (strlen($title) > 64)
 				$title = substr($title, 0, strpos(wordwrap($title, 64), "\n")) . '...';

--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -292,7 +292,7 @@ EOD
 		if (isset($username)) {
 			return $this->getInput('u') . ' | Facebook';
 		} else {
-			return 'Facebook Bridge | v2';
+			return self::NAME;
 		}
 	}
 

--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -2,7 +2,7 @@
 class FB2Bridge extends BridgeAbstract {
 
 	const MAINTAINER = 'teromene';
-	const NAME = 'Facebook Alternate';
+	const NAME = 'Facebook Bridge | Touch Site';
 	const URI = 'https://www.facebook.com/';
 	const CACHE_TIMEOUT = 1000;
 	const DESCRIPTION = 'Input a page title or a profile log. For a profile log,
@@ -102,7 +102,7 @@ EOD
 			else
 				$timestamp = 0;
 
-			$item['uri'] = html_entity_decode('http://touch.facebook.com'
+			$item['uri'] = html_entity_decode('https://touch.facebook.com'
 			. $content->find("div[class='_52jc _5qc4 _78cz _24u0 _36xo']", 0)->find('a', 0)->getAttribute('href'), ENT_QUOTES);
 
 			//Decode images
@@ -281,10 +281,20 @@ EOD
 	}
 
 	public function getName(){
-		return (isset($this->name) ? $this->name . ' - ' : '') . 'Facebook Bridge';
+		$username = $this->getInput('u');
+		if (isset($username)) {
+			return $this->getInput('u') . ' | Facebook';
+		} else {
+			return 'Facebook Bridge | v2';
+		}
 	}
 
 	public function getURI(){
-		return 'http://facebook.com';
+		$username = $this->getInput('u');
+		if (isset($username)) {
+			return 'https://facebook.com/' . $this->getInput('u') . '/posts';
+		} else {
+			return self::URI;
+		}
 	}
 }

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -2,7 +2,7 @@
 class FacebookBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'teromene, logmanoriginal';
-	const NAME = 'Facebook Bridge';
+	const NAME = 'Facebook Bridge | Main Site';
 	const URI = 'https://www.facebook.com/';
 	const CACHE_TIMEOUT = 300; // 5min
 	const DESCRIPTION = 'Input a page title or a profile log. For a profile log,

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -66,14 +66,13 @@ class FacebookBridge extends BridgeAbstract {
 
 			case 'User':
 				if(!empty($this->authorName)) {
-					return isset($this->extraInfos['name']) ? $this->extraInfos['name'] : $this->authorName
-					. ' - ' . static::NAME;
+					return isset($this->extraInfos['name']) ? $this->extraInfos['name'] : $this->authorName;
 				}
 				break;
 
 			case 'Group':
 				if(!empty($this->groupName)) {
-					return $this->groupName . ' - ' . static::NAME;
+					return $this->groupName;
 				}
 				break;
 


### PR DESCRIPTION
The fact that there were two bridges and one is deprecated should be
made more clear.
This preserves all existing URL.

This also updates all URL to secure HTTPS versions.

---

I was using the legacy Facebook bridge myself, since the new one was using insecure URI.