### PR TITLE
[TwitterBridge] Remember cookies during redirects

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -171,7 +171,9 @@ EOD
 	public function collectData(){
 		$html = '';
 
-		$html = getSimpleHTMLDOM($this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI(),
+			array(),
+			array(CURLOPT_COOKIEFILE => ''));
 		if(!$html) {
 			switch($this->queriedContext) {
 			case 'By keyword or hashtag':


### PR DESCRIPTION
The first request to twitter now sets a session cookie then redirects to
the same page, so without this cookie a redirect loop happens.

This change tells curl to remember cookies when redirects happen.

References #1225.