### PR TITLE
[TwitterBridge] Get cookies before sending request

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -170,8 +170,10 @@ EOD
 
 	public function collectData(){
 		$html = '';
+		$page = $this->getURI();
+		$cookies = $this->getCookies($page);
 
-		$html = getSimpleHTMLDOM($this->getURI());
+		$html = getSimpleHTMLDOM($page, array("Cookie: $cookies"));
 		if(!$html) {
 			switch($this->queriedContext) {
 			case 'By keyword or hashtag':
@@ -428,4 +430,28 @@ EOD;
 
 		return null;
 	}
+	
+	private function getCookies($pageURL){
+
+		$ctx = stream_context_create(array(
+			'http' => array(
+				'follow_location' => false
+				)
+			)
+		);
+		$a = file_get_contents($pageURL, 0, $ctx);
+
+		//First request to get the cookie
+		$cookies = '';
+		foreach($http_response_header as $hdr) {
+			if(stripos($hdr, 'Set-Cookie') !== false) {
+				$cLine = explode(':', $hdr)[1];
+				$cLine = explode(';', $cLine)[0];
+				$cookies .= ';' . $cLine;
+			}
+		}
+
+		return substr($cookies, 2);
+	}
+
 }

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -430,7 +430,7 @@ EOD;
 
 		return null;
 	}
-	
+
 	private function getCookies($pageURL){
 
 		$ctx = stream_context_create(array(
@@ -453,5 +453,4 @@ EOD;
 
 		return substr($cookies, 2);
 	}
-
 }


### PR DESCRIPTION
Twitter now requires cookies to be set before requesting a page. This will fetch the cookies and send them to `getSimpleHTMLDOM()`.

Fixes #1225 #1231
Supersedes PR #1226 
Function to get cookies borrowed from @teromene / FB2Bridge