### PR TITLE
[contents] Respect passed headers for file_get_contents()

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -70,7 +70,7 @@ function getContents($url, $header = array(), $opts = array()){
 			)
 		);
 
-		$data = file_get_contents($url, 0, $ctx);
+		$data = @file_get_contents($url, 0, $ctx);
 
 		if($data === false) {
 			$errorCode = 500;

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -60,8 +60,8 @@ function getContents($url, $header = array(), $opts = array()){
 		$httpHeaders = array();
 
 		foreach ($header as $headerL) {
-			$key = explode(":", $headerL)[0];
-			$value = explode(":", $headerL)[1];
+			$key = explode(':', $headerL)[0];
+			$value = explode(':', $headerL)[1];
 			$httpHeaders[$key] = trim($value);
 		}
 

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -56,7 +56,21 @@ function getContents($url, $header = array(), $opts = array()){
 
 	// Use file_get_contents if in CLI mode with no root certificates defined
 	if(php_sapi_name() === 'cli' && empty(ini_get('curl.cainfo'))) {
-		$data = @file_get_contents($url);
+
+		$httpHeaders = array();
+
+		foreach ($header as $headerL) {
+			$key = explode(":", $headerL)[0];
+			$value = explode(":", $headerL)[1];
+			$httpHeaders[$key] = trim($value);
+		}
+
+		$ctx = stream_context_create(array(
+			'http' => $httpHeaders
+			)
+		);
+
+		$data = file_get_contents($url, 0, $ctx);
 
 		if($data === false) {
 			$errorCode = 500;

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -57,18 +57,17 @@ function getContents($url, $header = array(), $opts = array()){
 	// Use file_get_contents if in CLI mode with no root certificates defined
 	if(php_sapi_name() === 'cli' && empty(ini_get('curl.cainfo'))) {
 
-		$httpHeaders = array();
+		$httpHeaders = '';
 
 		foreach ($header as $headerL) {
-			$key = explode(':', $headerL)[0];
-			$value = explode(':', $headerL)[1];
-			$httpHeaders[$key] = trim($value);
+			$httpHeaders .= $headerL . "\r\n";
 		}
 
 		$ctx = stream_context_create(array(
-			'http' => $httpHeaders
+			'http' => array(
+				'header' => $httpHeaders
 			)
-		);
+		));
 
 		$data = @file_get_contents($url, 0, $ctx);
 


### PR DESCRIPTION
Adds in code to apply http headers passed into `getContents()` to `file_get_contents()`.