### PR TITLE
[NYTBridge] : New bridge for the new york times

### DIFF
--- a/bridges/NYTBridge.php
+++ b/bridges/NYTBridge.php
@@ -1,0 +1,26 @@
+<?php
+class NYTBridge extends FeedExpander {
+
+	const MAINTAINER = 'IceWreck';
+	const NAME = 'New York Times Bridge';
+	const URI = 'https://www.nytimes.com/';
+	const CACHE_TIMEOUT = 3600;
+	const DESCRIPTION = 'RSS feed for the New York Times';
+
+	public function collectData(){
+		$this->collectExpandableDatas('https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml', 15);
+	}
+
+	protected function parseItem($newsItem){
+		$item = parent::parseItem($newsItem);
+		// $articlePage gets the entire page's contents
+		$articlePage = getSimpleHTMLDOM($newsItem->link);
+		// figure contain's the main article image
+		$article = $articlePage->find('figure', 0);
+		// p > css-exrw3m has the actual article
+		foreach($articlePage->find('p.css-exrw3m') as $element)
+			$article = $article . $element;
+		$item['content'] = $article;
+		return $item;
+	}
+}


### PR DESCRIPTION
The New York Times website is behind a metered paywall (doesn't let you view more than 10 articles per month unless you use specific mitigations like uBlock Origin's annoyances list or similar  / blocking their tracking)
The feed gives you the latest articles from their homepage, complete with full article content.