### PR TITLE
[FacebookBridge] Prevent sending empty header

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -142,7 +142,7 @@ class FacebookBridge extends BridgeAbstract {
 
 	private function collectGroupData() {
 
-		if (getEnv('HTTP_ACCEPT_LANGUAGE')) {
+		if(getEnv('HTTP_ACCEPT_LANGUAGE')) {
 			$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE') . "\r\n");
 		} else {
 			$header = array();
@@ -509,7 +509,7 @@ EOD;
 		// Retrieve page contents
 		if(is_null($html)) {
 
-			if (getEnv('HTTP_ACCEPT_LANGUAGE')) {
+			if(getEnv('HTTP_ACCEPT_LANGUAGE')) {
 				$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE'));
 			} else {
 				$header = array();

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -142,7 +142,11 @@ class FacebookBridge extends BridgeAbstract {
 
 	private function collectGroupData() {
 
-		$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE') . "\r\n");
+		if (getEnv('HTTP_ACCEPT_LANGUAGE')) {
+			$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE') . "\r\n");
+		} else {
+			$header = array();
+		}
 
 		$html = getSimpleHTMLDOM($this->getURI(), $header)
 			or returnServerError('Failed loading facebook page: ' . $this->getURI());
@@ -505,7 +509,11 @@ EOD;
 		// Retrieve page contents
 		if(is_null($html)) {
 
-			$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE'));
+			if (getEnv('HTTP_ACCEPT_LANGUAGE')) {
+				$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE'));
+			} else {
+				$header = array();
+			}
 
 			$html = getSimpleHTMLDOM($this->getURI(), $header)
 				or returnServerError('No results for this query.');

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -143,7 +143,7 @@ class FacebookBridge extends BridgeAbstract {
 	private function collectGroupData() {
 
 		if(getEnv('HTTP_ACCEPT_LANGUAGE')) {
-			$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE') . "\r\n");
+			$header = array('Accept-Language: ' . getEnv('HTTP_ACCEPT_LANGUAGE'));
 		} else {
 			$header = array();
 		}


### PR DESCRIPTION
When running in CLI mode, `getEnv('HTTP_ACCEPT_LANGUAGE')` returns `false`. In that case, don't send the `Accept-Language` header.