### PR TITLE
[TwitterBridge] Enable cookies with curl

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -176,7 +176,7 @@ EOD
 			$cookies = $this->getCookies($page);
 			$html = getSimpleHTMLDOM($page, array("Cookie: $cookies"));
 		} else {
-			$html = getSimpleHTMLDOM($this->getURI(), array(), array(CURLOPT_COOKIEFILE => ''));
+			$html = getSimpleHTMLDOM($page, array(), array(CURLOPT_COOKIEFILE => ''));
 		}
 
 		if(!$html) {

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -171,9 +171,14 @@ EOD
 	public function collectData(){
 		$html = '';
 		$page = $this->getURI();
-		$cookies = $this->getCookies($page);
 
-		$html = getSimpleHTMLDOM($page, array("Cookie: $cookies"));
+		if(php_sapi_name() === 'cli' && empty(ini_get('curl.cainfo'))) {
+			$cookies = $this->getCookies($page);
+			$html = getSimpleHTMLDOM($page, array("Cookie: $cookies"));
+		} else {
+			$html = getSimpleHTMLDOM($this->getURI(), array(), array(CURLOPT_COOKIEFILE => ''));
+		}
+
 		if(!$html) {
 			switch($this->queriedContext) {
 			case 'By keyword or hashtag':


### PR DESCRIPTION
Enable cookies in curl, or fall back to `file_get_contents` if in CLI mode with no curl root certificates.

Fixes issues on some installations where `allow_url_fopen` is disabled. #1231 

Credit @Roliga for curl method.