### PR TITLE
Fix double XML encoding on Atom feed title

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -37,7 +37,7 @@ class AtomFormat extends FormatAbstract{
 		$entries = '';
 		foreach($this->getItems() as $item) {
 			$entryTimestamp = $item->getTimestamp();
-			$entryTitle = $this->xml_encode($item->getTitle());
+			$entryTitle = $item->getTitle();
 			$entryContent = $item->getContent();
 			$entryUri = $item->getURI();
 			$entryID = '';


### PR DESCRIPTION
This can be seen on the current Dilbert bridge, there's a title named:

```
Can't Succeed Within The Rules - Dilbert by Scott Adams
```
This title will disappear tomorrow, a new comic will take its place. :D