### PR TITLE
[Rule34pahealBridge] Fix thumbnail uri

### DIFF
--- a/bridges/Rule34pahealBridge.php
+++ b/bridges/Rule34pahealBridge.php
@@ -7,4 +7,21 @@ class Rule34pahealBridge extends Shimmie2Bridge {
 	const NAME = 'Rule34paheal';
 	const URI = 'http://rule34.paheal.net/';
 	const DESCRIPTION = 'Returns images from given page';
+
+	protected function getItemFromElement($element){
+		$item = array();
+		$item['uri'] = $this->getURI() . $element->href;
+		$item['id'] = (int)preg_replace('/[^0-9]/', '', $element->getAttribute(static::IDATTRIBUTE));
+		$item['timestamp'] = time();
+		$thumbnailUri = $element->find('img', 0)->src;
+		$item['tags'] = $element->getAttribute('data-tags');
+		$item['title'] = $this->getName() . ' | ' . $item['id'];
+		$item['content'] = '<a href="'
+		. $item['uri']
+		. '"><img src="'
+		. $thumbnailUri
+		. '" /></a><br>Tags: '
+		. $item['tags'];
+		return $item;
+	}
 }


### PR DESCRIPTION
rule34.paheal.net no longer uses relative URIs for thumbnails.
This commit fixes this problem.