### PR TITLE
[core] Add getMimeType() function to formats

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -7,6 +7,8 @@
  * https://validator.w3.org/feed/
  */
 class AtomFormat extends FormatAbstract{
+	const MIME_TYPE = 'application/atom+xml';
+
 	const LIMIT_TITLE = 140;
 
 	public function stringify(){
@@ -147,7 +149,7 @@ EOD;
 
 	public function display(){
 		$this
-			->setContentType('application/atom+xml; charset=' . $this->getCharset())
+			->setContentType(self::MIME_TYPE . '; charset=' . $this->getCharset())
 			->callContentType();
 
 		return parent::display();

--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -1,5 +1,7 @@
 <?php
 class HtmlFormat extends FormatAbstract {
+	const MIME_TYPE = 'text/html';
+
 	public function stringify(){
 		$extraInfos = $this->getExtraInfos();
 		$title = htmlspecialchars($extraInfos['name']);
@@ -120,7 +122,7 @@ EOD;
 
 	public function display() {
 		$this
-			->setContentType('text/html; charset=' . $this->getCharset())
+			->setContentType(self::MIME_TYPE . '; charset=' . $this->getCharset())
 			->callContentType();
 
 		return parent::display();

--- a/formats/JsonFormat.php
+++ b/formats/JsonFormat.php
@@ -8,6 +8,8 @@
  * https://github.com/vigetlabs/json-feed-validator
  */
 class JsonFormat extends FormatAbstract {
+	const MIME_TYPE = 'application/json';
+
 	const VENDOR_EXCLUDES = array(
 		'author',
 		'title',
@@ -119,7 +121,7 @@ class JsonFormat extends FormatAbstract {
 
 	public function display(){
 		$this
-			->setContentType('application/json; charset=' . $this->getCharset())
+			->setContentType(self::MIME_TYPE . '; charset=' . $this->getCharset())
 			->callContentType();
 
 		return parent::display();

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -25,6 +25,8 @@
  *   RSS 2.0 feed that works with feed readers that don't support the extension.
  */
 class MrssFormat extends FormatAbstract {
+	const MIME_TYPE = 'application/rss+xml';
+
 	const ALLOWED_IMAGE_EXT = array(
 		'.gif', '.jpg', '.png'
 	);
@@ -150,7 +152,7 @@ EOD;
 
 	public function display(){
 		$this
-			->setContentType('application/rss+xml; charset=' . $this->getCharset())
+			->setContentType(self::MIME_TYPE . '; charset=' . $this->getCharset())
 			->callContentType();
 
 		return parent::display();

--- a/formats/PlaintextFormat.php
+++ b/formats/PlaintextFormat.php
@@ -4,6 +4,8 @@
 * Returns $this->items as raw php data.
 */
 class PlaintextFormat extends FormatAbstract {
+	const MIME_TYPE = 'text/plain';
+
 	public function stringify(){
 		$items = $this->getItems();
 		$data = array();
@@ -22,7 +24,7 @@ class PlaintextFormat extends FormatAbstract {
 
 	public function display(){
 		$this
-			->setContentType('text/plain; charset=' . $this->getCharset())
+			->setContentType(self::MIME_TYPE . '; charset=' . $this->getCharset())
 			->callContentType();
 
 		return parent::display();

--- a/lib/FormatAbstract.php
+++ b/lib/FormatAbstract.php
@@ -21,6 +21,9 @@ abstract class FormatAbstract implements FormatInterface {
 	/** The default charset (UTF-8) */
 	const DEFAULT_CHARSET = 'UTF-8';
 
+	/** MIME type of format output */
+	const MIME_TYPE = 'text/plain';
+
 	/** @var string|null $contentType The content type */
 	protected $contentType = null;
 
@@ -38,6 +41,11 @@ abstract class FormatAbstract implements FormatInterface {
 
 	/** @var array $extraInfos The extra infos */
 	protected $extraInfos;
+
+	/** {@inheritdoc} */
+	public function getMimeType(){
+		return static::MIME_TYPE;
+	}
 
 	/**
 	 * {@inheritdoc}

--- a/lib/FormatInterface.php
+++ b/lib/FormatInterface.php
@@ -67,6 +67,13 @@ interface FormatInterface {
 	public function getExtraInfos();
 
 	/**
+	 * Return MIME type
+	 *
+	 * @return string The MIME type
+	 */
+	public function getMimeType();
+
+	/**
 	 * Set charset
 	 *
 	 * @param string $charset The charset


### PR DESCRIPTION
Allows getting the expected MIME type of the format's output. A corresponding MIME_TYPE constant is also defined in FormatAbstract for the format implementations to overwrite.

This is a prerequisite for #1298. I'll open a PR for my [syndication-links branch](Roliga/rss-bridge/tree/syndication-links) to implement that if this gets merged.

Of course the wiki will also be updated to reflect this!