### PR TITLE
Complementary fix for #1280

### DIFF
--- a/bridges/GQMagazineBridge.php
+++ b/bridges/GQMagazineBridge.php
@@ -117,7 +117,7 @@ class GQMagazineBridge extends BridgeAbstract
 	 */
 	private function loadFullArticle($uri){
 		$html = getSimpleHTMLDOMCached($uri);
-		return $html->find('section[data-test-id=ArticleBodyContent]', 0);
+		return $html->find('section[data-test-id=MainContentWrapper]', 0);
 	}
 
 	/**


### PR DESCRIPTION
As GQMagazine developers decided this weekend they should absolutely change the tag I use to identify content ...
I've not yet created an issue, cause I think you should reopen #1280, but it's not my project, so feel free to ask me to create a new issue if needed.