### PR TITLE
[FreeCodeCampBridge] - rss feed for FreeCodeCamp

### DIFF
--- a/bridges/FreeCodeCampBridge.php
+++ b/bridges/FreeCodeCampBridge.php
@@ -1,0 +1,27 @@
+<?php
+class FreeCodeCampBridge extends FeedExpander {
+
+	const MAINTAINER = 'IceWreck';
+	const NAME = 'FreeCodecamp Bridge';
+	const URI = 'https://www.freecodecamp.org';
+	const CACHE_TIMEOUT = 3600;
+	const DESCRIPTION = 'RSS feed for FreeCodeCamp';
+	// Freecodecamp removed their old full content rss feed and replaced it with one liner content.
+
+	public function collectData(){
+		$this->collectExpandableDatas('https://www.freecodecamp.org/news/rss/', 15);
+	}
+
+	protected function parseItem($newsItem){
+		$item = parent::parseItem($newsItem);
+		// $articlePage gets the entire page's contents
+		$articlePage = getSimpleHTMLDOM($newsItem->link);
+		// figure contain's the main article image
+		$article = $articlePage->find('figure', 0);
+		// the actual article
+		foreach($articlePage->find('.post-full-content') as $element)
+			$article = $article . $element;
+		$item['content'] = $article;
+		return $item;
+	}
+}


### PR DESCRIPTION
So FreeCodeCamp replaced their [blog/tutorial site](https://www.freecodecamp.org/news/) on medium with a selfhosted one - okay, good for them. However in doing so, they crippled their rss feed, which used to be complete and is now completely useless.

This bridge aims to fix that.