### PR TITLE
Apple AppStore Apps Bridge

### DIFF
--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -1,0 +1,94 @@
+<?php
+
+class AppleAppStoreBridge extends BridgeAbstract {
+
+	const MAINTAINER = 'captn3m0';
+	const NAME = 'Apple App Store';
+	const URI = 'https://apps.apple.com/';
+	const CACHE_TIMEOUT = 3600; // 1h
+	const DESCRIPTION = 'Returns version updates for a specific application';
+
+	const PARAMETERS = array(array(
+		'id' => array(
+			'name' => 'Application ID',
+			'required' => true,
+			'defaultValue' => '310633997'
+		),
+		'p' => array(
+			'name' => 'Platform',
+			'type' => 'list',
+			'values' => array(
+				'Web' => 'web',
+				'Apple TV' => 'appletv',
+				'iPad' => 'ipad',
+				'iPhone' => 'iphone',
+				'Mac' => 'mac',
+			),
+			'defaultValue' => 'web',
+		),
+		'country' => array(
+			'name' => 'Store Country',
+			'type' => 'list',
+			'values' => array(
+				'US'	=> 'US',
+				'India'	=> 'IN',
+				'Canada'=> 'CA'
+			),
+			'defaultValue' => 'US',
+		),
+	));
+
+	private function makeHtmlUrl($id){
+	return "https://apps.apple.com/in/app/whatsapp-messenger/id$id";
+	}
+
+	private function makeJsonUrl($id, $platform = 'iphone', $country = 'US'){
+		return "https://amp-api.apps.apple.com/v1/catalog/$country/apps/$id?platform=$platform&extend=versionHistory";
+	}
+
+	public function collectData() {
+
+		$id = $this->getInput('id');
+		$country = $this->getInput('country');
+		$platform = $this->getInput('p');
+
+		$uri = $this->makeHtmlUrl($id);
+
+		$html = getSimpleHTMLDOM($uri);
+
+		$meta = $html->find('meta[name="web-experience-app/config/environment"]', 0);
+
+		$json = urldecode($meta->content);
+
+		$json = json_decode(urldecode($meta->content));
+
+		$token = $json->MEDIA_API->token;
+
+		$uri = $this->makeJsonUrl($id, $platform, $country);
+
+		$headers = [
+			'Authorization' => "Bearer $token",
+			'Accept'		=> 'application/json',
+			'User-Agent'	=> 'rss-bridge',
+		];
+
+		// var_dump($uri, $headers);die;
+
+		$json = json_decode(getSimpleHTMLDOM($uri, $headers), true);
+
+		$json = $json['JSON']['data'];
+
+		$data = $json['attributes']['platformAttributes'][$platform]['versionHistory'];
+		$name = $json['attributes']['name'];
+		$author = $json['attributes']['artistName'];
+
+		foreach ($data as $row){
+			$item = [
+				'content' => $row['releaseNotes'],
+				'title'   => $name " - " $row['versionDisplay'],
+				'timestamp' => $row['releaseDate'],
+				'author'	=> 
+			];
+		}
+	}
+}

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -59,7 +59,7 @@ class AppleAppStoreBridge extends BridgeAbstract {
 	 */
 	private function getDataFromShoebox($id, $platform, $country){
 		$uri = $this->makeHtmlUrl($id, $country);
-		$html = getSimpleHTMLDOM($uri, 3600);
+		$html = getSimpleHTMLDOMCached($uri, 3600);
 		$script = $html->find('script[id="shoebox-ember-data-store"]', 0);
 
 		$json = json_decode($script->innertext, true);


### PR DESCRIPTION
This provides a RSS feed of version changes of any iDevice application. Currently tested with the following apps:

iPhone: https://apps.apple.com/us/app/id310633997
Mac https://apps.apple.com/us/app/id982486948
iPad: https://apps.apple.com/us/app/procreate/id425073498

`appletv` and `web` are present in responses, but I couldn't find any applications for those, so those are not officially supported right now.

TODO:

- [x] Test with other platforms
- [x] check style guide
- [x] make sure it looks good. see if additional content stuffing is needed
~(screenshots?)~. `Just `nl2br` was sufficient.

<summary>

The title of each "item" in the feed intentionally contains the Application Name. 

<details>
I made the mistake of omitting application names while working on a different RSS project previously (https://github.com/captn3m0/opml-gen) which tracked GitHub Release feeds (quite similar content). The issue becomes when you get multiple feed items with title like the following:

- 2.3.0
- 1.2.5
- 1.2.1rc1

This becomes very problematic in most feed readers, especially if all these feeds are within the same category/tag, which is fairly common.

Instead, adding the application names makes it like:

- WhatsApp Messenger - 2.3.0
- Red Dead Redemption - 1.2.2
- Procreate Final - 6.3.1

which is much more readable.

</details>

I hope this will be useful to people:

- tracking iOS/Mac applications for parity against Android
- wanting to set up automated alerts for version updates on iDevice apps