### PR TITLE
[GoogleSearchBridge] Fix no results

### DIFF
--- a/bridges/GoogleSearchBridge.php
+++ b/bridges/GoogleSearchBridge.php
@@ -31,7 +31,7 @@ class GoogleSearchBridge extends BridgeAbstract {
 		. '&num=100&complete=0&tbs=qdr:y,sbd:1')
 			or returnServerError('No results for this query.');
 
-		$emIsRes = $html->find('div[id=ires]', 0);
+		$emIsRes = $html->find('div[id=res]', 0);
 
 		if(!is_null($emIsRes)) {
 			foreach($emIsRes->find('div[class=g]') as $element) {


### PR DESCRIPTION
Fixes no results being returned by replacing `div[id=ires]` with `div[id=res]` on line 34.