### PR TITLE
[StoriesIGBridge] Use getName() to create custom feed titles

### DIFF
--- a/bridges/StoriesIGBridge.php
+++ b/bridges/StoriesIGBridge.php
@@ -44,4 +44,13 @@ class StoriesIGBridge extends BridgeAbstract {
 
 		return parent::getURI();
 	}
+	
+	public function getName() {
+
+		if (!is_null($this->getInput('username'))) {
+			return $this->getInput('username') . ' - ' . self::NAME;
+		}
+
+		return parent::getName();
+	}
 }

--- a/bridges/StoriesIGBridge.php
+++ b/bridges/StoriesIGBridge.php
@@ -44,7 +44,7 @@ class StoriesIGBridge extends BridgeAbstract {
 
 		return parent::getURI();
 	}
-	
+
 	public function getName() {
 
 		if (!is_null($this->getInput('username'))) {


### PR DESCRIPTION
Use getName() to create custom feed titles, instead of always using the bridge name.