### PR TITLE
[core] Add configuration for bridges, allowing private bridges

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -122,7 +122,7 @@ class DisplayAction extends ActionAbstract {
 
 			try {
 				$bridge->setDatas($bridge_params);
-				$bridge->loadBridgeConfiguration();
+				$bridge->loadConfiguration();
 				$bridge->collectData();
 
 				$items = $bridge->getItems();

--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -122,6 +122,7 @@ class DisplayAction extends ActionAbstract {
 
 			try {
 				$bridge->setDatas($bridge_params);
+				$bridge->loadBridgeConfiguration();
 				$bridge->collectData();
 
 				$items = $bridge->getItems();

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -276,22 +276,6 @@ abstract class BridgeAbstract implements BridgeInterface {
 	}
 
 	/**
-	 * Check if configuration allows for this bridge loading
-	 *
-	 * @return boolean
-	 */
-	public function isConfigurationValid() {
-		foreach(static::CONFIGURATION as $optionName => $optionValue) {
-			if(isset($optionValue['required'])
-				&& $optionValue['required'] === true
-				&& Configuration::getConfig(get_class($this), $optionName) === null) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
 	 * Returns the value for the provided input
 	 *
 	 * @param string $input The input name

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -253,7 +253,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 *
 	 * @return void
 	 */
-	public function loadBridgeConfiguration() {
+	public function loadConfiguration() {
 		foreach(static::CONFIGURATION as $optionName => $optionValue) {
 
 			$configurationOption = Configuration::getConfig(get_class($this), $optionName);
@@ -263,18 +263,17 @@ abstract class BridgeAbstract implements BridgeInterface {
 				continue;
 			}
 
-			if($optionValue['required']) {
-				returnClientError(
+			if(isset($optionValue['required']) && $optionValue['required'] === true) {
+				returnServerError(
 					'Missing configuration option :'
 					. $optionName
 				);
-			} else {
+			} elseif(isset($optionValue['defaultValue'])) {
 				$this->configuration[$optionName] = $optionValue['defaultValue'];
 			}
 
 		}
 	}
-
 
 	/**
 	 * Check if configuration allows for this bridge loading
@@ -283,13 +282,14 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 */
 	public function isConfigurationValid() {
 		foreach(static::CONFIGURATION as $optionName => $optionValue) {
-			if($optionValue["required"] && Configuration::getConfig(get_class($this), $optionName) === null) {
+			if(isset($optionValue['required'])
+				&& $optionValue['required'] === true
+				&& Configuration::getConfig(get_class($this), $optionName) === null) {
 				return false;
 			}
 		}
 		return true;
 	}
-
 
 	/**
 	 * Returns the value for the provided input
@@ -310,13 +310,12 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 * @param string $input The option name
 	 * @return mixed|null The option value or null if the input is not defined
 	 */
-	protected function getOption($input){
-		if(!isset($this->configuration[$input])) {
+	protected function getOption($name){
+		if(!isset($this->configuration[$name])) {
 			return null;
 		}
-		return $this->configuration[$input];
+		return $this->configuration[$name];
 	}
-
 
 	/** {@inheritdoc} */
 	public function getDescription(){

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -265,7 +265,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 
 			if(isset($optionValue['required']) && $optionValue['required'] === true) {
 				returnServerError(
-					'Missing configuration option :'
+					'Missing configuration option: '
 					. $optionName
 				);
 			} elseif(isset($optionValue['defaultValue'])) {

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -310,7 +310,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 * @param string $input The option name
 	 * @return mixed|null The option value or null if the input is not defined
 	 */
-	protected function getOption($name){
+	public function getOption($name){
 		if(!isset($this->configuration[$name])) {
 			return null;
 		}

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -69,7 +69,7 @@ interface BridgeInterface {
 	 * @param string $input The option name
 	 * @return mixed|null The option value or null if the input is not defined
 	 */
-	protected function getOption($name);
+	public function getOption($name);
 
 	/**
 	 * Returns the description

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -59,6 +59,19 @@ interface BridgeInterface {
 	public function collectData();
 
 	/**
+	* Get the user's supplied configuration for the bridge
+	*/
+	public function getConfiguration();
+
+	/**
+	 * Returns the value for the selected configuration
+	 *
+	 * @param string $input The option name
+	 * @return mixed|null The option value or null if the input is not defined
+	 */
+	protected function getOption($name);
+
+	/**
 	 * Returns the description
 	 *
 	 * @return string Description

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -74,7 +74,7 @@ EOD;
 
 		foreach($bridgeList as $bridgeName) {
 
-			if($bridgeFac->isWhitelisted($bridgeName)) {
+			if($bridgeFac->isWhitelisted($bridgeName) && $bridgeFac->create($bridgeName)->isConfigurationValid()) {
 
 				$body .= BridgeCard::displayBridgeCard($bridgeName, $formats);
 				$totalActiveBridges++;

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -74,7 +74,7 @@ EOD;
 
 		foreach($bridgeList as $bridgeName) {
 
-			if($bridgeFac->isWhitelisted($bridgeName) && $bridgeFac->create($bridgeName)->isConfigurationValid()) {
+			if($bridgeFac->isWhitelisted($bridgeName)) {
 
 				$body .= BridgeCard::displayBridgeCard($bridgeName, $formats);
 				$totalActiveBridges++;

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -145,10 +145,7 @@ final class Configuration {
 			// Replace default configuration with custom settings
 			foreach(parse_ini_file(FILE_CONFIG, true, INI_SCANNER_TYPED) as $header => $section) {
 				foreach($section as $key => $value) {
-					// Skip unknown sections and keys
-					if(array_key_exists($header, Configuration::$config) && array_key_exists($key, Configuration::$config[$header])) {
-						Configuration::$config[$header][$key] = $value;
-					}
+					Configuration::$config[$header][$key] = $value;
 				}
 			}
 		}
@@ -211,13 +208,11 @@ final class Configuration {
 	 * @return mixed|null The parameter value.
 	 */
 	public static function getConfig($section, $key) {
-
 		if(array_key_exists($section, self::$config) && array_key_exists($key, self::$config[$section])) {
 			return self::$config[$section][$key];
 		}
 
 		return null;
-
 	}
 
 	/**


### PR DESCRIPTION
Starting to work on option for bridges, in the same way as the `PARAMETERS` array, expanding on what @fulmeek did.
In order for this to work, it works this way:
You create an optional array, named `CONFIGURATION`:
```PHP
	const CONFIGURATION = array(
			'api_key' => array(
				'required' => true,
			),
                       'api_key_can_fetch_images' => array(
                                'required' => false,
                                'defaultValue' => 'no',
                       )
	);
```
The configuration can then be put in the configuration, like this:
```ini
; --- Bridge Specific Options ---------------------------------------------------
[MyBridge]
api_key = "eeeeeeeeee"
```

If a bridge is in the whitelist, but the configuration options that are marked as `required`, then the bride will not be loaded. This allows for integration of private bridges without having to worry on hosts where all bridges are enabled.