### PR TITLE
[HtmlFormat] Add syndication links

### DIFF
--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -12,6 +12,7 @@ class HtmlFormat extends FormatAbstract {
 		$formatFac->setWorkingDir(PATH_LIB_FORMATS);
 
 		$buttons = '';
+		$links = '';
 
 		foreach($formatFac->getFormatNames() as $format) {
 			if(strcasecmp($format, 'HTML') === 0) {
@@ -20,6 +21,9 @@ class HtmlFormat extends FormatAbstract {
 
 			$query = str_replace('format=Html', 'format=' . $format, htmlentities($_SERVER['QUERY_STRING']));
 			$buttons .= $this->buildButton($format, $query) . PHP_EOL;
+
+			$mime = $formatFac->create($format)->getMimeType();
+			$links .= $this->buildLink($format, $query, $mime) . PHP_EOL;
 		}
 
 		$entries = '';
@@ -101,6 +105,7 @@ EOD;
 	<title>{$title}</title>
 	<link href="static/HtmlFormat.css" rel="stylesheet">
 	<link rel="icon" type="image/png" href="static/favicon.png">
+	{$links}
 	<meta name="robots" content="noindex, follow">
 </head>
 <body>
@@ -131,6 +136,13 @@ EOD;
 	private function buildButton($format, $query) {
 		return <<<EOD
 <a href="./?{$query}"><button class="rss-feed">{$format}</button></a>
+EOD;
+	}
+
+	private function buildLink($format, $query, $mime) {
+		return <<<EOD
+<link href="./?{$query}" title="{$format}" rel="alternate" type="{$mime}">
+
 EOD;
 	}
 }


### PR DESCRIPTION
Adds <link> elements for each additional output format in the <head> of HTML format output to allow RSS readers to find the actual feeds directly from the HTML page.

Closes #1298.