### PR TITLE
[VkBridge] Change access token

### DIFF
--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -28,7 +28,7 @@ class VkBridge extends BridgeAbstract
 
 	protected function getAccessToken()
 	{
-		return 'c8071613517c155c6cfbd2a059b2718e9c37b89094c4766834969dda75f657a2c1cbb49bab4c5e649f1db';
+		return 'e69b2db9f6cd4a97c0716893232587165c18be85bc1af1834560125c1d3c8ec281eb407a78cca0ae16776';
 	}
 
 	public function getURI()


### PR DESCRIPTION
Previous access token was revoked

To make sure, access token is valid - example request https://api.vk.com/method/video.get?v=5.80&videos=-143617457_456240511&access_token=e69b2db9f6cd4a97c0716893232587165c18be85bc1af1834560125c1d3c8ec281eb407a78cca0ae16776

It must return about video info