### PR TITLE
[FacebookBridge] Fix permalink issue

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -701,8 +701,15 @@ EOD;
 
 						$uri = $post->find('abbr')[0]->parent()->getAttribute('href');
 
-						if (false !== strpos($uri, '?')) {
-							$uri = substr($uri, 0, strpos($uri, '?'));
+						// Extract fbid and patch link
+						if (strpos($uri, '?') !== false) {
+							$query = substr($uri, strpos($uri, '?') + 1);
+							parse_str($query, $query_params);
+							if (isset($query_params['story_fbid'])) {
+								$uri = self::URI . $query_params['story_fbid'];
+							} else {
+								$uri = substr($uri, 0, strpos($uri, '?'));
+							}
 						}
 
 						//Build and add final item


### PR DESCRIPTION
Facebook has changed their strategy regarding permalinks, which
now include lots of unnecessary target data. Fortunately it also
contains the unique story id which we can utilize as URI.

Closes #969

It seems to work on my end (link points to the story), but I'd like some feedback from actual users before merging.