### PR TITLE
[InstagramBridge] Fix instagram GraphSidecar output and Video embedding

### DIFF
--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -175,7 +175,7 @@ class InstagramBridge extends BridgeAbstract {
 				$content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
 				$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $item['title'] . '" />';
 				$content .= '</a><br>';
-				array_push($enclosures, $singleMedia->display_url);						
+				array_push($enclosures, $singleMedia->display_url);
 			}
 		}
 		$content .= '<br>' . nl2br(htmlentities($textContent));

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -125,7 +125,7 @@ class InstagramBridge extends BridgeAbstract {
 
 			switch($media->__typename) {
 				case 'GraphSidecar':
-					$data = $this->getInstagramSidecarData($item['uri']);
+					$data = $this->getInstagramSidecarData($item['uri'], $item['title']);
 					$item['content'] = $data[0];
 					$item['enclosures'] = $data[1];
 					break;
@@ -158,7 +158,7 @@ class InstagramBridge extends BridgeAbstract {
 	}
 
 	// returns Sidecar(a post which has multiple media)'s contents and enclosures
-	protected function getInstagramSidecarData($uri) {
+	protected function getInstagramSidecarData($uri, $postTitle) {
 		$mediaInfo = $this->getSinglePostData($uri);
 
 		$textContent = $this->getTextContent($mediaInfo);
@@ -173,7 +173,7 @@ class InstagramBridge extends BridgeAbstract {
 			} else {
 				if(in_array($singleMedia->display_url, $enclosures)) continue; // check if not added yet
 				$content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
-				$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $item['title'] . '" />';
+				$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $postTitle . '" />';
 				$content .= '</a><br>';
 				array_push($enclosures, $singleMedia->display_url);
 			}

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -32,9 +32,9 @@ class InstagramBridge extends BridgeAbstract {
 				'required' => false,
 				'values' => array(
 					'All' => 'all',
-					'Story' => 'story',
 					'Video' => 'video',
 					'Picture' => 'picture',
+					'Multiple' => 'multiple',
 				),
 				'defaultValue' => 'all'
 			),
@@ -79,11 +79,6 @@ class InstagramBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-
-		if(is_null($this->getInput('u')) && $this->getInput('media_type') == 'story') {
-			returnClientError('Stories are not supported for hashtags nor locations!');
-		}
-
 		$directLink = !is_null($this->getInput('direct_links')) && $this->getInput('direct_links');
 
 		$data = $this->getInstagramJSON($this->getURI());
@@ -99,22 +94,18 @@ class InstagramBridge extends BridgeAbstract {
 		foreach($userMedia as $media) {
 			$media = $media->node;
 
-			if(!is_null($this->getInput('u'))) {
-				switch($this->getInput('media_type')) {
-					case 'all': break;
-					case 'video':
-						if($media->__typename != 'GraphVideo') continue 2;
-						break;
-					case 'picture':
-						if($media->__typename != 'GraphImage') continue 2;
-						break;
-					case 'story':
-						if($media->__typename != 'GraphSidecar') continue 2;
-						break;
-					default: break;
-				}
-			} else {
-				if($this->getInput('media_type') == 'video' && !$media->is_video) continue;
+			switch($this->getInput('media_type')) {
+				case 'all': break;
+				case 'video':
+					if($media->__typename != 'GraphVideo' || !$media->is_video) continue 2;
+					break;
+				case 'picture':
+					if($media->__typename != 'GraphImage') continue 2;
+					break;
+				case 'multiple':
+					if($media->__typename != 'GraphSidecar') continue 2;
+					break;
+				default: break;
 			}
 
 			$item = array();

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -164,6 +164,7 @@ class InstagramBridge extends BridgeAbstract {
 		$textContent = $this->getTextContent($mediaInfo);
 
 		$enclosures = array();
+		$content = '';
 		foreach($mediaInfo->edge_sidecar_to_children->edges as $singleMedia) {
 			$singleMedia = $singleMedia->node;
 			if($singleMedia->is_video) {
@@ -188,7 +189,7 @@ class InstagramBridge extends BridgeAbstract {
 		$mediaInfo = $this->getSinglePostData($uri);
 
 		$textContent = $this->getTextContent($mediaInfo);
-		$content .= '<video controls><source src="' . $mediaInfo->video_url . '" type="video/mp4"></video><br>';
+		$content = '<video controls><source src="' . $mediaInfo->video_url . '" type="video/mp4"></video><br>';
 		$content .= '<br>' . nl2br(htmlentities($textContent));
 
 		return array($content, array($mediaInfo->video_url));

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -39,7 +39,7 @@ class InstagramBridge extends BridgeAbstract {
 				'defaultValue' => 'all'
 			),
 			'direct_links' => array(
-				'name' => 'Use direct image links',
+				'name' => 'Use direct media links',
 				'type' => 'checkbox',
 			)
 		)


### PR DESCRIPTION
Hi, maintainers.

This PR contains following fixes.

- GraphSidecar type post (which contains 2 or more than media) wasn't outputted properly when searching with hashtag or location. It was outputted only first media.
- Video was not embedded. Instead an image was outputted.
  - it may be better to add an option to output video or image for video media...

And it seems that author misunderstood 'Story' as a post which contains multiple media. So I renamed variables and functions which related to the word 'Story'.
