### PR TITLE
[BridgeAbstract] Add loadCacheValue() and saveCacheValue()

### DIFF
--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -298,4 +298,36 @@ abstract class BridgeAbstract implements BridgeInterface {
 			return null;
 		}
 	}
+
+	/**
+	 * Loads a cached value for the specified key
+	 *
+	 * @param string $key Key name
+	 * @param int $duration Cache duration (optional, default: 24 hours)
+	 * @return mixed Cached value or null if the key doesn't exist or has expired
+	 */
+	protected function loadCacheValue($key, $duration = 86400){
+		$cacheFac = new CacheFactory();
+		$cacheFac->setWorkingDir(PATH_LIB_CACHES);
+		$cache = $cacheFac->create(Configuration::getConfig('cache', 'type'));
+		$cache->setScope(get_called_class());
+		$cache->setKey($key);
+		$cache->purgeCache($duration);
+		return $cache->loadData();
+	}
+
+	/**
+	 * Stores a value to cache with the specified key
+	 *
+	 * @param string $key Key name
+	 * @param mixed $value Value to cache
+	 */
+	protected function saveCacheValue($key, $value){
+		$cacheFac = new CacheFactory();
+		$cacheFac->setWorkingDir(PATH_LIB_CACHES);
+		$cache = $cacheFac->create(Configuration::getConfig('cache', 'type'));
+		$cache->setScope(get_called_class());
+		$cache->setKey($key);
+		$cache->saveData($value);
+	}
 }

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -312,7 +312,8 @@ abstract class BridgeAbstract implements BridgeInterface {
 		$cache = $cacheFac->create(Configuration::getConfig('cache', 'type'));
 		$cache->setScope(get_called_class());
 		$cache->setKey($key);
-		$cache->purgeCache($duration);
+		if($cache->getTime() < time() - $duration)
+			return null;
 		return $cache->loadData();
 	}
 


### PR DESCRIPTION
Bridges currently need to implement value caching manually, which
results in duplicate code and more complex bridges.

This commit adds two protected functions to BridgeAbstract that make
it possible for bridges to store and retrieve values from a temporary
cache by key.

Closes #1376