### PR TITLE
core: Add support for Google Analytics

### DIFF
--- a/actions/ConnectivityAction.php
+++ b/actions/ConnectivityAction.php
@@ -101,7 +101,8 @@ class ConnectivityAction extends ActionAbstract {
 	}
 
 	private function returnEntryPage() {
-	echo <<<EOD
+		$google_analytics = GoogleAnalytics::buildGlobalSiteTag();
+		echo <<<EOD
 <!DOCTYPE html>
 
 <html>
@@ -114,6 +115,7 @@ class ConnectivityAction extends ActionAbstract {
 			crossorigin="anonymous">
 		<link rel="stylesheet" href="static/connectivity.css">
 		<script src="static/connectivity.js" type="text/javascript"></script>
+		{$google_analytics}
 	</head>
 	<body>
 		<div id="main-content" class="container">

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -73,6 +73,13 @@ output = "feed"
 ; Defines how often an error must occur before it is reported to the user
 report_limit = 1
 
+[Google Analytics]
+
+; Defines the Google Analytics Tracking ID for your website
+;
+; "" = disabled
+id = ""
+
 ; --- Cache specific configuration ---------------------------------------------
 
 [SQLiteCache]

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -77,7 +77,7 @@ report_limit = 1
 
 ; Defines the Google Analytics Tracking ID for your website
 ;
-; "" = disabled
+; "" = disabled (default)
 id = ""
 
 ; --- Cache specific configuration ---------------------------------------------

--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -94,21 +94,7 @@ EOD;
 		}
 
 		$charset = $this->getCharset();
-
-		$google_analytics = '';
-		if ($id = Configuration::getConfig('Google Analytics', 'id')) {
-			$google_analytics .= <<<HTML
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={$id}"></script>
-<script>
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', '$id');
-</script>
-HTML;
-		}
+		$google_analytics = GoogleAnalytics::buildGlobalSiteTag();
 
 		/* Data are prepared, now let's begin the "MAGIE !!!" */
 		$toReturn = <<<EOD

--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -95,6 +95,21 @@ EOD;
 
 		$charset = $this->getCharset();
 
+		$google_analytics = '';
+		if ($id = Configuration::getConfig('Google Analytics', 'id')) {
+			$google_analytics .= <<<HTML
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={$id}"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', '$id');
+</script>
+HTML;
+		}
+
 		/* Data are prepared, now let's begin the "MAGIE !!!" */
 		$toReturn = <<<EOD
 <!DOCTYPE html>
@@ -107,6 +122,7 @@ EOD;
 	<link rel="icon" type="image/png" href="static/favicon.png">
 	{$links}
 	<meta name="robots" content="noindex, follow">
+	{$google_analytics}
 </head>
 <body>
 	<h1 class="pagetitle"><a href="{$uri}" target="_blank">{$title}</a></h1>

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -26,7 +26,11 @@ final class BridgeList {
 	 * @return string The document head
 	 */
 	private static function getHead() {
-		$head = <<<EOD
+
+		$google_analytics = GoogleAnalytics::buildGlobalSiteTag();
+
+		return <<<EOD
+<head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta name="description" content="RSS-Bridge" />
@@ -42,23 +46,9 @@ final class BridgeList {
 			}
 		</style>
 	</noscript>
+	{$google_analytics}
+</head>
 EOD;
-
-		if ($gaid = Configuration::getConfig('Google Analytics', 'id')) {
-			$head .= <<<HTML
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={$gaid}"></script>
-<script>
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', '$gaid');
-</script>
-HTML;
-		}
-
-		return '<head>' . $head . '</head>';
 	}
 
 	/**

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -26,8 +26,7 @@ final class BridgeList {
 	 * @return string The document head
 	 */
 	private static function getHead() {
-		return <<<EOD
-<head>
+		$head = <<<EOD
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta name="description" content="RSS-Bridge" />
@@ -43,8 +42,23 @@ final class BridgeList {
 			}
 		</style>
 	</noscript>
-</head>
 EOD;
+
+		if ($gaid = Configuration::getConfig('Google Analytics', 'id')) {
+			$head .= <<<HTML
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={$gaid}"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', '$gaid');
+</script>
+HTML;
+		}
+
+		return '<head>' . $head . '</head>';
 	}
 
 	/**

--- a/lib/GoogleAnalytics.php
+++ b/lib/GoogleAnalytics.php
@@ -17,7 +17,6 @@
  * @link	https://analytics.google.com/analytics/web/ Google Analytics
  */
 class GoogleAnalytics {
-
 	/**
 	 * Checks whether the provided ID is a valid Google Analytics ID in the format
 	 * UA-000000000-0 (number of digits can vary).
@@ -55,5 +54,4 @@ gtag('config', '$id');
 EOD;
 
 	}
-
 }

--- a/lib/GoogleAnalytics.php
+++ b/lib/GoogleAnalytics.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This file is part of RSS-Bridge, a PHP project capable of generating RSS and
+ * Atom feeds for websites that don't have one.
+ *
+ * For the full license information, please view the UNLICENSE file distributed
+ * with this source code.
+ *
+ * @package	Core
+ * @license	http://unlicense.org/ UNLICENSE
+ * @link	https://github.com/rss-bridge/rss-bridge
+ */
+
+/**
+ * Implements functions specific to Google Analytics
+ *
+ * @link	https://analytics.google.com/analytics/web/ Google Analytics
+ */
+class GoogleAnalytics {
+
+	/**
+	 * Checks whether the provided ID is a valid Google Analytics ID in the format
+	 * UA-000000000-0 (number of digits can vary).
+	 *
+	 * @return bool True if valid otherwise false.
+	 */
+	private static function isValidId($id) {
+		return (bool) preg_match('/^UA\-\d{4,10}(\-\d{1,4})?$/i', $id);
+	}
+
+	/**
+	 * Builds a global site tag.
+	 *
+	 * @link https://developers.google.com/analytics/devguides/collection/gtagjs gtag.js
+	 *
+	 * @return string The global site tag or null if the ID is not set.
+	 */
+	public static function buildGlobalSiteTag() {
+
+		$id = Configuration::getConfig('Google Analytics', 'id');
+
+		if (!self::isValidId($id)) return null;
+
+		return <<<EOD
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={$id}"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){
+	dataLayer.push(arguments);
+}
+gtag('js', new Date());
+gtag('config', '$id');
+</script>
+EOD;
+
+	}
+
+}

--- a/lib/rssbridge.php
+++ b/lib/rssbridge.php
@@ -69,6 +69,7 @@ require_once PATH_LIB . 'FeedExpander.php';
 require_once PATH_LIB . 'CacheFactory.php';
 require_once PATH_LIB . 'Authentication.php';
 require_once PATH_LIB . 'Configuration.php';
+require_once PATH_LIB . 'GoogleAnalytics.php';
 require_once PATH_LIB . 'BridgeCard.php';
 require_once PATH_LIB . 'BridgeList.php';
 require_once PATH_LIB . 'ParameterValidator.php';


### PR DESCRIPTION
This commit adds support for Google Analytics to the main page and
HTML format. Server admins need to specify their Google Analytics
Tracking ID in config.ini.php under [Google Analytics] => id.

An empty string disables Google Analytics.

DO NOT MERGE!

This is prove of concept and has multiple issues that need to be fixed before merging:

 - [x] Parse the provided Google Analytics Tracking ID to ensure it is a valid ID in the format "UA-#########-#".
 - [x] Add a separate class to handle Google Analytics in more details
 - [x] (optional) Add support for more analytics to other formats, actions, etc...

References #1273