### PR TITLE
[InstagramBridge] No Media in Content Option

### DIFF
--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -42,6 +42,10 @@ class InstagramBridge extends BridgeAbstract {
 				'name' => 'Use direct media links',
 				'type' => 'checkbox',
 			)
+			'no_media_in_text' => array(
+				'name' => 'Exclude media from text',
+				'type' => 'checkbox',
+			)
 		)
 
 	);
@@ -49,6 +53,8 @@ class InstagramBridge extends BridgeAbstract {
 	const USER_QUERY_HASH = '58b6785bea111c67129decbe6a448951';
 	const TAG_QUERY_HASH = '174a5243287c5f3a7de741089750ab3b';
 	const SHORTCODE_QUERY_HASH = '865589822932d1b43dfe312121dd353a';
+	
+	protected $noMediaInText;
 
 	protected function getInstagramUserId($username) {
 
@@ -80,6 +86,7 @@ class InstagramBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$directLink = !is_null($this->getInput('direct_links')) && $this->getInput('direct_links');
+		$this->$noMediaInText = !is_null($this->getInput('no_media_in_text')) && $this->getInput('no_media_in_text');
 
 		$data = $this->getInstagramJSON($this->getURI());
 
@@ -117,7 +124,7 @@ class InstagramBridge extends BridgeAbstract {
 
 			$textContent = $this->getTextContent($media);
 
-			$item['title'] = ($media->is_video ? '▶ ' : '') . $textContent;
+			$item['title'] = ($media->is_video ? 'в–¶ ' : '') . $textContent;
 			$titleLinePos = strpos(wordwrap($item['title'], 120), "\n");
 			if ($titleLinePos != false) {
 				$item['title'] = substr($item['title'], 0, $titleLinePos) . '...';
@@ -135,9 +142,13 @@ class InstagramBridge extends BridgeAbstract {
 					} else {
 						$mediaURI = self::URI . 'p/' . $media->shortcode . '/media?size=l';
 					}
-					$item['content'] = '<a href="' . htmlentities($item['uri']) . '" target="_blank">';
-					$item['content'] .= '<img src="' . htmlentities($mediaURI) . '" alt="' . $item['title'] . '" />';
-					$item['content'] .= '</a><br><br>' . nl2br(htmlentities($textContent));
+					if ($this->$noMediaInText) {
+						$item['content'] = nl2br(htmlentities($textContent));
+					} else {						
+						$item['content'] = '<a href="' . htmlentities($item['uri']) . '" target="_blank">';
+						$item['content'] .= '<img src="' . htmlentities($mediaURI) . '" alt="' . $item['title'] . '" />';
+						$item['content'] .= '</a><br><br>' . nl2br(htmlentities($textContent));
+					}						
 					$item['enclosures'] = array($mediaURI);
 					break;
 				case 'GraphVideo':
@@ -165,21 +176,24 @@ class InstagramBridge extends BridgeAbstract {
 
 		$enclosures = array();
 		$content = '';
-		foreach($mediaInfo->edge_sidecar_to_children->edges as $singleMedia) {
-			$singleMedia = $singleMedia->node;
-			if($singleMedia->is_video) {
-				if(in_array($singleMedia->video_url, $enclosures)) continue; // check if not added yet
-				$content .= '<video controls><source src="' . $singleMedia->video_url . '" type="video/mp4"></video><br>';
-				array_push($enclosures, $singleMedia->video_url);
-			} else {
-				if(in_array($singleMedia->display_url, $enclosures)) continue; // check if not added yet
-				$content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
-				$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $postTitle . '" />';
-				$content .= '</a><br>';
-				array_push($enclosures, $singleMedia->display_url);
+		if (!$this->$noMediaInText) {
+			foreach($mediaInfo->edge_sidecar_to_children->edges as $singleMedia) {
+				$singleMedia = $singleMedia->node;
+				if($singleMedia->is_video) {
+					if(in_array($singleMedia->video_url, $enclosures)) continue; // check if not added yet
+					$content .= '<video controls><source src="' . $singleMedia->video_url . '" type="video/mp4"></video><br>';
+					array_push($enclosures, $singleMedia->video_url);
+				} else {
+					if(in_array($singleMedia->display_url, $enclosures)) continue; // check if not added yet
+					$content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
+					$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $postTitle . '" />';
+					$content .= '</a><br>';
+					array_push($enclosures, $singleMedia->display_url);
+				}
 			}
-		}
-		$content .= '<br>' . nl2br(htmlentities($textContent));
+			$content .= '<br>';
+		}			
+		$content .= nl2br(htmlentities($textContent));
 
 		return array($content, $enclosures);
 	}
@@ -189,8 +203,12 @@ class InstagramBridge extends BridgeAbstract {
 		$mediaInfo = $this->getSinglePostData($uri);
 
 		$textContent = $this->getTextContent($mediaInfo);
-		$content = '<video controls><source src="' . $mediaInfo->video_url . '" type="video/mp4"></video><br>';
-		$content .= '<br>' . nl2br(htmlentities($textContent));
+		
+		$content = '';
+		if (!$this->$noMediaInText) {
+			$content .= '<video controls><source src="' . $mediaInfo->video_url . '" type="video/mp4"></video><br><br>';
+		}			
+		$content .= nl2br(htmlentities($textContent));
 
 		return array($content, array($mediaInfo->video_url));
 	}

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -86,7 +86,7 @@ class InstagramBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$directLink = !is_null($this->getInput('direct_links')) && $this->getInput('direct_links');
-		$this->$noMediaInText = !is_null($this->getInput('no_media_in_text')) && $this->getInput('no_media_in_text');
+		$this->noMediaInText = !is_null($this->getInput('no_media_in_text')) && $this->getInput('no_media_in_text');
 
 		$data = $this->getInstagramJSON($this->getURI());
 
@@ -142,7 +142,7 @@ class InstagramBridge extends BridgeAbstract {
 					} else {
 						$mediaURI = self::URI . 'p/' . $media->shortcode . '/media?size=l';
 					}
-					if ($this->$noMediaInText) {
+					if ($this->noMediaInText) {
 						$item['content'] = nl2br(htmlentities($textContent));
 					} else {
 						$item['content'] = '<a href="' . htmlentities($item['uri']) . '" target="_blank">';
@@ -180,13 +180,13 @@ class InstagramBridge extends BridgeAbstract {
 			$singleMedia = $singleMedia->node;
 			if($singleMedia->is_video) {
 				if(in_array($singleMedia->video_url, $enclosures)) continue; // check if not added yet
-				if (!$this->$noMediaInText) {
+				if (!$this->noMediaInText) {
 					$content .= '<video controls><source src="' . $singleMedia->video_url . '" type="video/mp4"></video><br>';
 				}
 				array_push($enclosures, $singleMedia->video_url);
 			} else {
 				if(in_array($singleMedia->display_url, $enclosures)) continue; // check if not added yet
-				if (!$this->$noMediaInText) {
+				if (!$this->noMediaInText) {
 					$content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
 					$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $postTitle . '" />';
 					$content .= '</a><br>';
@@ -206,7 +206,7 @@ class InstagramBridge extends BridgeAbstract {
 		$textContent = $this->getTextContent($mediaInfo);
 
 		$content = '';
-		if (!$this->$noMediaInText) {
+		if (!$this->noMediaInText) {
 			$content .= '<video controls><source src="' . $mediaInfo->video_url . '" type="video/mp4"></video><br><br>';
 		}
 		$content .= nl2br(htmlentities($textContent));

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -124,7 +124,7 @@ class InstagramBridge extends BridgeAbstract {
 
 			$textContent = $this->getTextContent($media);
 
-			$item['title'] = ($media->is_video ? 'в–¶ ' : '') . $textContent;
+			$item['title'] = ($media->is_video ? '▶' : '') . $textContent;
 			$titleLinePos = strpos(wordwrap($item['title'], 120), "\n");
 			if ($titleLinePos != false) {
 				$item['title'] = substr($item['title'], 0, $titleLinePos) . '...';

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -53,7 +53,7 @@ class InstagramBridge extends BridgeAbstract {
 	const USER_QUERY_HASH = '58b6785bea111c67129decbe6a448951';
 	const TAG_QUERY_HASH = '174a5243287c5f3a7de741089750ab3b';
 	const SHORTCODE_QUERY_HASH = '865589822932d1b43dfe312121dd353a';
-	
+
 	protected $noMediaInText;
 
 	protected function getInstagramUserId($username) {
@@ -144,11 +144,11 @@ class InstagramBridge extends BridgeAbstract {
 					}
 					if ($this->$noMediaInText) {
 						$item['content'] = nl2br(htmlentities($textContent));
-					} else {						
+					} else {
 						$item['content'] = '<a href="' . htmlentities($item['uri']) . '" target="_blank">';
 						$item['content'] .= '<img src="' . htmlentities($mediaURI) . '" alt="' . $item['title'] . '" />';
 						$item['content'] .= '</a><br><br>' . nl2br(htmlentities($textContent));
-					}						
+					}
 					$item['enclosures'] = array($mediaURI);
 					break;
 				case 'GraphVideo':
@@ -182,7 +182,7 @@ class InstagramBridge extends BridgeAbstract {
 				if(in_array($singleMedia->video_url, $enclosures)) continue; // check if not added yet
 				if (!$this->$noMediaInText) {
 					$content .= '<video controls><source src="' . $singleMedia->video_url . '" type="video/mp4"></video><br>';
-				}					
+				}
 				array_push($enclosures, $singleMedia->video_url);
 			} else {
 				if(in_array($singleMedia->display_url, $enclosures)) continue; // check if not added yet
@@ -204,11 +204,11 @@ class InstagramBridge extends BridgeAbstract {
 		$mediaInfo = $this->getSinglePostData($uri);
 
 		$textContent = $this->getTextContent($mediaInfo);
-		
+
 		$content = '';
 		if (!$this->$noMediaInText) {
 			$content .= '<video controls><source src="' . $mediaInfo->video_url . '" type="video/mp4"></video><br><br>';
-		}			
+		}
 		$content .= nl2br(htmlentities($textContent));
 
 		return array($content, array($mediaInfo->video_url));

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -41,7 +41,7 @@ class InstagramBridge extends BridgeAbstract {
 			'direct_links' => array(
 				'name' => 'Use direct media links',
 				'type' => 'checkbox',
-			)
+			),
 			'no_media_in_text' => array(
 				'name' => 'Exclude media from text',
 				'type' => 'checkbox',
@@ -176,24 +176,25 @@ class InstagramBridge extends BridgeAbstract {
 
 		$enclosures = array();
 		$content = '';
-		if (!$this->$noMediaInText) {
-			foreach($mediaInfo->edge_sidecar_to_children->edges as $singleMedia) {
-				$singleMedia = $singleMedia->node;
-				if($singleMedia->is_video) {
-					if(in_array($singleMedia->video_url, $enclosures)) continue; // check if not added yet
+		foreach($mediaInfo->edge_sidecar_to_children->edges as $singleMedia) {
+			$singleMedia = $singleMedia->node;
+			if($singleMedia->is_video) {
+				if(in_array($singleMedia->video_url, $enclosures)) continue; // check if not added yet
+				if (!$this->$noMediaInText) {
 					$content .= '<video controls><source src="' . $singleMedia->video_url . '" type="video/mp4"></video><br>';
-					array_push($enclosures, $singleMedia->video_url);
-				} else {
-					if(in_array($singleMedia->display_url, $enclosures)) continue; // check if not added yet
+				}					
+				array_push($enclosures, $singleMedia->video_url);
+			} else {
+				if(in_array($singleMedia->display_url, $enclosures)) continue; // check if not added yet
+				if (!$this->$noMediaInText) {
 					$content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
 					$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $postTitle . '" />';
 					$content .= '</a><br>';
-					array_push($enclosures, $singleMedia->display_url);
-				}
+				}					
+				array_push($enclosures, $singleMedia->display_url);
 			}
-			$content .= '<br>';
-		}			
-		$content .= nl2br(htmlentities($textContent));
+		}
+		$content .= '<br>' . nl2br(htmlentities($textContent));
 
 		return array($content, $enclosures);
 	}

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -190,7 +190,7 @@ class InstagramBridge extends BridgeAbstract {
 					$content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
 					$content .= '<img src="' . $singleMedia->display_url . '" alt="' . $postTitle . '" />';
 					$content .= '</a><br>';
-				}					
+				}
 				array_push($enclosures, $singleMedia->display_url);
 			}
 		}

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -124,7 +124,7 @@ class InstagramBridge extends BridgeAbstract {
 
 			$textContent = $this->getTextContent($media);
 
-			$item['title'] = ($media->is_video ? '▶' : '') . $textContent;
+			$item['title'] = ($media->is_video ? '▶ ' : '') . $textContent;
 			$titleLinePos = strpos(wordwrap($item['title'], 120), "\n");
 			if ($titleLinePos != false) {
 				$item['title'] = substr($item['title'], 0, $titleLinePos) . '...';


### PR DESCRIPTION
Hi,

Here is the suggestion to add an option that removes Media from Content. 
Sometimes (e.g. in JSON) you don't need Media in Content, because it already listed in Attachment\Enclosure. This pull reqest adds an option for that.