### PR TITLE
[Dockerfile] Build memcached extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,20 @@ FROM php:7-apache
 ENV APACHE_DOCUMENT_ROOT=/app
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
-	&& apt-get --yes update && apt-get --yes install libxml2-dev \
+	&& apt-get --yes update && apt-get --yes install libxml2-dev zlib1g-dev libmemcached-dev \
 	&& docker-php-ext-install -j$(nproc) simplexml \
 	&& sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
 	&& sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
 	&& sed -ri -e 's/(MinProtocol\s*=\s*)TLSv1\.2/\1None/' /etc/ssl/openssl.cnf \
 	&& sed -ri -e 's/(CipherString\s*=\s*DEFAULT)@SECLEVEL=2/\1/' /etc/ssl/openssl.cnf
+
+RUN curl https://codeload.github.com/php-memcached-dev/php-memcached/tar.gz/v3.1.5 --output /tmp/php-memcached.tar.gz \
+	&& mkdir -p /usr/src/php/ext \
+	&& tar xzvf /tmp/php-memcached.tar.gz -C /usr/src/php/ext \
+	&& mv /usr/src/php/ext/php-memcached-3.1.5 /usr/src/php/ext/memcached \
+	&& cd /usr/src/php/ext/memcached \
+	&& docker-php-ext-configure /usr/src/php/ext/memcached --disable-memcached-sasl \
+	&& docker-php-ext-install /usr/src/php/ext/memcached \
+	&& rm -rf /usr/src/php/ext/memcached
 
 COPY --chown=www-data:www-data ./ /app/


### PR DESCRIPTION
Implements https://github.com/RSS-Bridge/rss-bridge/issues/1410
Used this `docker-compose.yml` for testing:
```
version: '3.7'
services:
  web:
    build: .
    ports:
      - "3000:80"
    volumes:
      - type: bind
        source: ./
        target: /app
    depends_on:
      - memcached
  memcached:
     image: sameersbn/memcached:1.5.6-2
     restart: always
```
And this config.ini.php
```
; <?php exit; ?> DO NOT REMOVE THIS LINE

[cache]
type = "memcached"

[MemcachedCache]
host = "memcached"
port = 11211
```

ping @itsTurnip for approving