### PR TITLE
[PcGamerBridge] - Add all articles, full content and images

### DIFF
--- a/bridges/PcGamerBridge.php
+++ b/bridges/PcGamerBridge.php
@@ -4,7 +4,7 @@ class PcGamerBridge extends BridgeAbstract
 	const NAME = 'PC Gamer';
 	const URI = 'https://www.pcgamer.com/archive/';
 	const DESCRIPTION = 'PC Gamer Most Read Stories';
-	const CACHE_TIMEOUT = 10;
+	const CACHE_TIMEOUT = 3600;
 	const MAINTAINER = 'IceWreck, mdemoss';
 
 	public function collectData()
@@ -14,7 +14,7 @@ class PcGamerBridge extends BridgeAbstract
 		$i=0;
 		// Find induvidual stories in the archive page
 		foreach ($stories as $element) {
-			if($i==10) break;
+			if($i==15) break;
 			$item['uri'] = $element->find('a', 0)->href;
 			// error_log(print_r($item['uri'], TRUE));
 			$articleHtml = getSimpleHTMLDOMCached($item['uri']);

--- a/bridges/PcGamerBridge.php
+++ b/bridges/PcGamerBridge.php
@@ -11,10 +11,10 @@ class PcGamerBridge extends BridgeAbstract
 	{
 		$html = getSimpleHTMLDOMCached($this->getURI(), 300);
 		$stories = $html->find('ul.basic-list li.day-article');
-		$i=0;
+		$i = 0;
 		// Find induvidual stories in the archive page
 		foreach ($stories as $element) {
-			if($i==15) break;
+			if($i == 15) break;
 			$item['uri'] = $element->find('a', 0)->href;
 			// error_log(print_r($item['uri'], TRUE));
 			$articleHtml = getSimpleHTMLDOMCached($item['uri']);

--- a/bridges/PcGamerBridge.php
+++ b/bridges/PcGamerBridge.php
@@ -2,22 +2,43 @@
 class PcGamerBridge extends BridgeAbstract
 {
 	const NAME = 'PC Gamer';
-	const URI = 'https://www.pcgamer.com/';
+	const URI = 'https://www.pcgamer.com/archive/';
 	const DESCRIPTION = 'PC Gamer Most Read Stories';
-	const MAINTAINER = 'mdemoss';
+	const CACHE_TIMEOUT = 10;
+	const MAINTAINER = 'IceWreck, mdemoss';
 
 	public function collectData()
 	{
 		$html = getSimpleHTMLDOMCached($this->getURI(), 300);
-		$stories = $html->find('div#popularcontent li.most-popular-item');
+		$stories = $html->find('ul.basic-list li.day-article');
+		$i=0;
+		// Find induvidual stories in the archive page
 		foreach ($stories as $element) {
+			if($i==10) break;
 			$item['uri'] = $element->find('a', 0)->href;
+			// error_log(print_r($item['uri'], TRUE));
 			$articleHtml = getSimpleHTMLDOMCached($item['uri']);
-			$item['title'] = $element->find('h4 a', 0)->plaintext;
+			$item['title'] = $element->find('a', 0)->plaintext;
 			$item['timestamp'] = strtotime($articleHtml->find('meta[name=pub_date]', 0)->content);
-			$item['content'] = $articleHtml->find('meta[name=description]', 0)->content;
-			$item['author'] = $articleHtml->find('a[itemprop=author]', 0)->plaintext;
+			$item['author'] = $articleHtml->find('span.by-author a', 0)->plaintext;
+
+			// Get the article content
+			$articleContents = $articleHtml->find('#article-body', 0);
+
+			/*
+				By default the img src has a link to an error image and then the actual image
+				is added in by JS. So we replace the error image with the actual full size image
+				whoose link is in one of the attributes of the img tag
+			*/
+			foreach($articleContents->find('img') as $img) {
+				$imgsrc = $img->getAttribute('data-original-mos');
+				// error_log($imgsrc);
+				$img->src = $imgsrc;
+			}
+
+			$item['content'] = $articleContents;
 			$this->items[] = $item;
+			$i++;
 		}
 	}
 }


### PR DESCRIPTION
Previously, this bridge was only capturing the "buying guides" style articles that were in a list on the front page. (maybe to due backend changes at pcgamer?)

I've modified it to now feature all articles, news, reviews, buying guides, etc. It also gives you the complete article content including text and images instead of just the tagline.