### PR TITLE
[GoComics] Update to new website structure

### DIFF
--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -28,7 +28,7 @@ class GoComicsBridge extends BridgeAbstract {
 
 			$page = getSimpleHTMLDOM($link)
 				or returnServerError('Could not request GoComics: ' . $link);
-			$imagelink = $page->find('.img-fluid', 1)->src;
+			$imagelink = $page->find('.comic.container', 0)->getAttribute('data-image');
 			$date = explode('/', $link);
 
 			$item['id'] = $imagelink;


### PR DESCRIPTION
GoComics.com has updated their website.  The image location is now a
data attribute in a div.

Here is an example from https://www.gocomics.com/lio/2020/02/21:

```html
<div class="comic container js-comic-2952528 js-item-init js-item-share js-comic-swipe bg-white border rounded" data-shareable-model="FeatureItem"
--
  | data-shareable-id="2952528"
  | data-transcript=""
  | data-id="2952528"
  | data-feature-id="162"
  | data-feature-name="Lio"
  | data-feature-code="lio"
  | data-feature-type="comic"
  | data-feature-format="print"
  | data-date="2020-02-21"
  | data-formatted-date="February 21, 2020"
  | data-url="https://www.gocomics.com/lio/2020/02/21"
  | data-creator="Mark Tatulli"
  | data-title="Lio for February 21, 2020 \| GoComics.com"
  | data-tags=""
  | data-description="For February 21, 2020"
  | data-image="https://assets.amuniversal.com/298bf7002b690138e5f1005056a9545d"
  | itemtype="http://schema.org/CreativeWork"
  | accountableperson="Andrews McMeel Universal"
  | creator="Mark Tatulli">
```