### PR TITLE
[Config] Don't check PATH_CACHE for memcached

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+.phpunit.result.cache
 .tox
 
 #Translations

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -6,6 +6,15 @@ class FileCache implements CacheInterface {
 	protected $path;
 	protected $key;
 
+	public function __construct() {
+		if (!is_writable(PATH_CACHE)) {
+			returnServerError(
+				'RSS-Bridge does not have write permissions for '
+				. PATH_CACHE . '!'
+			);
+		}
+	}
+
 	public function loadData(){
 		if(file_exists($this->getCacheFile())) {
 			return unserialize(file_get_contents($this->getCacheFile()));

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -13,6 +13,13 @@ class SQLiteCache implements CacheInterface {
 			die('"sqlite3" extension not loaded. Please check "php.ini"');
 		}
 
+		if (!is_writable(PATH_CACHE)) {
+			returnServerError(
+				'RSS-Bridge does not have write permissions for '
+				. PATH_CACHE . '!'
+			);
+		}
+
 		$file = Configuration::getConfig(get_called_class(), 'file');
 		if (empty($file)) {
 			die('Configuration for ' . get_called_class() . ' missing. Please check your ' . FILE_CONFIG);

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -102,10 +102,6 @@ final class Configuration {
 		if(!extension_loaded('json'))
 			self::reportError('"json" extension not loaded. Please check "php.ini"');
 
-		// Check cache folder permissions (write permissions required)
-		if(!is_writable(PATH_CACHE))
-			self::reportError('RSS-Bridge does not have write permissions for ' . PATH_CACHE . '!');
-
 	}
 
 	/**


### PR DESCRIPTION
#### Motivation

Be able to run RSS-Bridge from a read-only directory with `memcached` cache.

#### Changes

Move the check for `PATH_CACHE` from `Configuration` to the respective cache implementations.

Also gitignore `.phpunit.result.cache` which is created when running `phpunit` as described in the [Coding style policy](https://github.com/RSS-Bridge/rss-bridge/wiki/Coding-style-policy).

#### Testing

1. Check that `file` cache fails when `PATH_CACHE` is not writable:

    ``` shell
    $ chmod -w cache
    $ echo "[cache]
    type=\"file\"" > config.ini.php
    $ php index.php action=display bridge=Twitter context=By+username u=jack norep=on format=Atom
    Exception: RSS-Bridge does not have write permissions for /home/jakub/devel/rss-bridge/lib/../cache/! in /home/jakub/devel/rss-bridge/lib/error.php:24
    #0 /home/jakub/devel/rss-bridge/lib/error.php(42): returnError()
    #1 /home/jakub/devel/rss-bridge/caches/FileCache.php(13): returnServerError()
    ```

2. Check that `sqlite` cache fails when `PATH_CACHE` is not writable:

    ``` shell
    $ chmod -w cache
    $ echo "[cache]
    type=\"sqlite\"" > config.ini.php
    $ php index.php action=display bridge=Twitter context=By+username u=jack norep=on format=Atom
    Exception: RSS-Bridge does not have write permissions for /home/jakub/devel/rss-bridge/lib/../cache/! in /home/jakub/devel/rss-bridge/lib/error.php:24
    Stack trace:
    #0 /home/jakub/devel/rss-bridge/lib/error.php(42): returnError()
    #1 /home/jakub/devel/rss-bridge/caches/SQLiteCache.php(19): returnServerError()
    ...
    ```

3. Check that `memcached` doesn't fail when `PATH_CACHE` is not writable:

    ``` shell
    $ chmod -w cache
    $ echo "[cache]
    type=\"memcached\"" > config.ini.php
    $ php index.php action=display bridge=Twitter context=By+username u=jack norep=on format=Atom
    <?xml version="1.0" encoding="UTF-8"?>
    <feed xmlns="http://www.w3.org/2005/Atom">
    ...
    ```