### PR TITLE
[HeiseBridge] add TechStage support

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -62,6 +62,9 @@ class HeiseBridge extends FeedExpander {
 
 		$content = $article->find('div[class*="article-content"]', 0);
 
+		if ($content == null)
+			$content = $article->find('#article_content', 0);
+
 		foreach($content->find('p, h3, ul, table, pre, img') as $element) {
 			$item['content'] .= $element;
 		}


### PR DESCRIPTION
TechStage articles should now also be expanded and shouldn't result in an error anymore.
I already deployed this fix to my private instance for testing purpose: the change works with [this article](https://www.techstage.de/ratgeber/Sport-zu-Hause-Smart-daheim-trainieren-4158236.html?wt_mc=intern.newsticker.anrissliste.techstage).

fixes #1514 