### PR TITLE
[MediapartBlogsBridge] Fix travis-ci issue

### DIFF
--- a/bridges/MediapartBlogsBridge.php
+++ b/bridges/MediapartBlogsBridge.php
@@ -45,5 +45,4 @@ class MediapartBlogsBridge extends BridgeAbstract {
 		}
 		return parent::getName();
 	}
-
 }


### PR DESCRIPTION
Fixes travis-ci issue in bridge by removing blank line after ` getName()` function.

https://travis-ci.org/github/RSS-Bridge/rss-bridge/jobs/670465159?utm_medium=notification&utm_source=github_status