### PR TITLE
Goodreads Bridge

### DIFF
--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -86,3 +86,4 @@ class GoodreadsBridge extends BridgeAbstract {
     }
   }
 }
+

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -62,7 +62,7 @@ class GoodreadsBridge extends BridgeAbstract {
 
       $item['title'] = $row->find('.bookTitle', 0)->plaintext;
       $item['uri'] = $item['uid'] = $row->find('.bookTitle', 0)->getAttribute('href');
-      $item['author'] = $row->find('authorName', 0)->plaintext;
+      $item['author'] = $row->find('.authorName', 0)->plaintext;
       $item['content'] = $row->find('.bookCover', 0)->outertext;
       $item['timestamp'] = $date;
       $item['enclosures'] = array(

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -1,89 +1,90 @@
 <?php
+
 class GoodreadsBridge extends BridgeAbstract {
 
-  const MAINTAINER = 'captn3m0';
-  const NAME = 'Goodreads Bridge';
-  const URI = 'https://www.goodreads.com/';
-  const CACHE_TIMEOUT = 0; // 30min
-  const DESCRIPTION = 'Various RSS feeds from Goodreads';
+	const MAINTAINER = 'captn3m0';
+	const NAME = 'Goodreads Bridge';
+	const URI = 'https://www.goodreads.com/';
+	const CACHE_TIMEOUT = 0; // 30min
+	const DESCRIPTION = 'Various RSS feeds from Goodreads';
 
-  const CONTEXT_AUTHOR_BOOKS = 'Books by Author';
+	const CONTEXT_AUTHOR_BOOKS = 'Books by Author';
 
-  // Using a specific context because I plan to expand this soon
-  const PARAMETERS = array(
-    'Books by Author' => array(
-      'author_url' => array(
-        'name' => 'Link to author\'s page on Goodreads',
-        'type' => 'text',
-        'required' => 'yes',
-        'title' => 'Should look somewhat like goodreads.com/author/show/',
-        'pattern' => '^(https:\/\/)?(www.)?goodreads\.com\/author\/show\/\d+\..*$',
-        'exampleValue' => 'https://www.goodreads.com/author/show/38550.Brandon_Sanderson'
-      ),
-      'published_only' => array(
-        'name' => 'Show published books only',
-        'type' => 'checkbox',
-        'required' => false,
-        'title' => 'If left unchecked, this will return unpublished books as well',
-        'defaultValue' => 'checked',
-      ),
-    ),
-  );
+	// Using a specific context because I plan to expand this soon
+	const PARAMETERS = array(
+		'Books by Author' => array(
+			'author_url' => array(
+				'name' => 'Link to author\'s page on Goodreads',
+				'type' => 'text',
+				'required' => 'yes',
+				'title' => 'Should look somewhat like goodreads.com/author/show/',
+				'pattern' => '^(https:\/\/)?(www.)?goodreads\.com\/author\/show\/\d+\..*$',
+				'exampleValue' => 'https://www.goodreads.com/author/show/38550.Brandon_Sanderson'
+			),
+			'published_only' => array(
+				'name' => 'Show published books only',
+				'type' => 'checkbox',
+				'required' => false,
+				'title' => 'If left unchecked, this will return unpublished books as well',
+				'defaultValue' => 'checked',
+			),
+		),
+	);
 
-  private function collectAuthorBooks($url) {
+	private function collectAuthorBooks($url) {
 
-    $regex = '/goodreads\.com\/author\/show\/(\d+)/';
+		$regex = '/goodreads\.com\/author\/show\/(\d+)/';
 
-    preg_match($regex, $url, $matches);
+		preg_match($regex, $url, $matches);
 
-    $authorId = $matches[1];
+		$authorId = $matches[1];
 
-    $authorListUrl = "https://www.goodreads.com/author/list/$authorId?sort=original_publication_year";
+		$authorListUrl = "https://www.goodreads.com/author/list/$authorId?sort=original_publication_year";
 
-    $html = getSimpleHTMLDOMCached($authorListUrl, self::CACHE_TIMEOUT);
+		$html = getSimpleHTMLDOMCached($authorListUrl, self::CACHE_TIMEOUT);
 
-    foreach($html->find('tr[itemtype="http://schema.org/Book"]') as $row) {
-      $dateSpan = $row->find('.uitext', 0)->plaintext;
-      $date = null;
+		foreach($html->find('tr[itemtype="http://schema.org/Book"]') as $row) {
+		$dateSpan = $row->find('.uitext', 0)->plaintext;
+		$date = null;
 
-      // If book is not yet published, ignore for now
-      if(preg_match('/published\s+(\d{4})/', $dateSpan, $matches) === 1) {
-        // Goodreads doesn't give us exact publication date here, only a year
-        // We are skipping future dates anyway, so this is def published
-        // but we can't pick a dynamic date either to keep clients from getting
-        // confused. So we pick a guaranteed date of 1st-Jan instead.
-        $date = $matches[1] . "-01-01";
-      } else if ($this->getInput('published_only') !== 'checked') {
-        // We can return unpublished books as well
-        $date = date("Y-01-01");
-      } else {
-        continue;
-      }
+		// If book is not yet published, ignore for now
+		if(preg_match('/published\s+(\d{4})/', $dateSpan, $matches) === 1) {
+			// Goodreads doesn't give us exact publication date here, only a year
+			// We are skipping future dates anyway, so this is def published
+			// but we can't pick a dynamic date either to keep clients from getting
+			// confused. So we pick a guaranteed date of 1st-Jan instead.
+			$date = $matches[1] . "-01-01";
+		} else if ($this->getInput('published_only') !== 'checked') {
+			// We can return unpublished books as well
+			$date = date("Y-01-01");
+		} else {
+			continue;
+		}
 
-      $item['title'] = $row->find('.bookTitle', 0)->plaintext;
-      $item['uri'] = $item['uid'] = $row->find('.bookTitle', 0)->getAttribute('href');
-      $item['author'] = $row->find('.authorName', 0)->plaintext;
-      $item['content'] = $row->find('.bookCover', 0)->outertext;
-      $item['timestamp'] = $date;
-      $item['enclosures'] = array(
-        $row->find('.bookCover', 0)->getAttribute('src')
-      );
+		$item['title'] = $row->find('.bookTitle', 0)->plaintext;
+		$item['uri'] = $item['uid'] = $row->find('.bookTitle', 0)->getAttribute('href');
+		$item['author'] = $row->find('.authorName', 0)->plaintext;
+		$item['content'] = $row->find('.bookCover', 0)->outertext;
+		$item['timestamp'] = $date;
+		$item['enclosures'] = array(
+			$row->find('.bookCover', 0)->getAttribute('src')
+		);
 
-      $this->items[] = $item; // Add item to the list
-    }
-  }
+		$this->items[] = $item; // Add item to the list
+		}
+	}
 
-  public function collectData() {
+	public function collectData() {
 
-    switch ($this->queriedContext) {
-      case self::CONTEXT_AUTHOR_BOOKS:
-        $this->collectAuthorBooks($this->getInput('author_url'));
-        break;
+		switch ($this->queriedContext) {
+		case self::CONTEXT_AUTHOR_BOOKS:
+			$this->collectAuthorBooks($this->getInput('author_url'));
+			break;
 
-      default:
-        throw new Exception("Invalid context", 1);
-        break;
-    }
-  }
+		default:
+			throw new Exception("Invalid context", 1);
+			break;
+		}
+	}
 }
 

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -16,7 +16,7 @@ class GoodreadsBridge extends BridgeAbstract {
 			'author_url' => array(
 				'name' => 'Link to author\'s page on Goodreads',
 				'type' => 'text',
-				'required' => 'yes',
+				'required' => true,
 				'title' => 'Should look somewhat like goodreads.com/author/show/',
 				'pattern' => '^(https:\/\/)?(www.)?goodreads\.com\/author\/show\/\d+\..*$',
 				'exampleValue' => 'https://www.goodreads.com/author/show/38550.Brandon_Sanderson'
@@ -61,10 +61,16 @@ class GoodreadsBridge extends BridgeAbstract {
 			continue;
 		}
 
+		$row = defaultLinkTo($row, $this->getURI());
+
 		$item['title'] = $row->find('.bookTitle', 0)->plaintext;
-		$item['uri'] = $item['uid'] = $row->find('.bookTitle', 0)->getAttribute('href');
+		$item['uri'] = $row->find('.bookTitle', 0)->getAttribute('href');
 		$item['author'] = $row->find('.authorName', 0)->plaintext;
-		$item['content'] = $row->find('.bookCover', 0)->outertext;
+		$item['content'] = '<a href="'
+		. $row->find('.bookTitle', 0)->getAttribute('href')
+		. '"><img src="'
+		. $row->find('.bookCover', 0)->getAttribute('src')
+		. '"></a>';
 		$item['timestamp'] = $date;
 		$item['enclosures'] = array(
 			$row->find('.bookCover', 0)->getAttribute('src')
@@ -87,4 +93,3 @@ class GoodreadsBridge extends BridgeAbstract {
 		}
 	}
 }
-

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -53,10 +53,10 @@ class GoodreadsBridge extends BridgeAbstract {
 			// We are skipping future dates anyway, so this is def published
 			// but we can't pick a dynamic date either to keep clients from getting
 			// confused. So we pick a guaranteed date of 1st-Jan instead.
-			$date = $matches[1] . "-01-01";
+			$date = $matches[1] . '-01-01';
 		} else if ($this->getInput('published_only') !== 'checked') {
 			// We can return unpublished books as well
-			$date = date("Y-01-01");
+			$date = date('Y-01-01');
 		} else {
 			continue;
 		}
@@ -88,7 +88,7 @@ class GoodreadsBridge extends BridgeAbstract {
 			break;
 
 		default:
-			throw new Exception("Invalid context", 1);
+			throw new Exception('Invalid context', 1);
 			break;
 		}
 	}

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -1,0 +1,78 @@
+<?php
+class GoodreadsBridge extends BridgeAbstract {
+
+  const MAINTAINER = 'captn3m0';
+  const NAME = 'Goodreads Bridge';
+  const URI = 'https://www.goodreads.com/';
+  const CACHE_TIMEOUT = 0; // 30min
+  const DESCRIPTION = 'Various RSS feeds from Goodreads';
+
+  const CONTEXT_AUTHOR_BOOKS = 'Books by Author';
+
+  // Using a specific context because I plan to expand this soon
+  const PARAMETERS = array(
+    'Books by Author' => array(
+      'author_url' => array(
+        'name' => 'Link to author\'s page on Goodreads',
+        'type' => 'text',
+        'required' => 'yes',
+        'title' => 'Should look somewhat like goodreads.com/author/show/',
+        'pattern' => '^(https:\/\/)?(www.)?goodreads\.com\/author\/show\/\d+\..*$',
+        'exampleValue' => 'https://www.goodreads.com/author/show/38550.Brandon_Sanderson'
+      )
+    ),
+  );
+
+  private function collectAuthorBooks($url) {
+
+    $regex = '/goodreads\.com\/author\/show\/(\d+)/';
+
+    preg_match($regex, $url, $matches);
+
+    $authorId = $matches[1];
+
+    $authorListUrl = "https://www.goodreads.com/author/list/$authorId?sort=original_publication_year";
+
+    $html = getSimpleHTMLDOMCached($authorListUrl, self::CACHE_TIMEOUT);
+
+    foreach($html->find('tr[itemtype="http://schema.org/Book"]') as $row) {
+      $dateSpan = $row->find('.uitext', 0)->plaintext;
+      $date = null;
+
+      // If book is not yet published, ignore for now
+      if(preg_match('/published\s+(\d{4})/', $dateSpan, $matches) === 1) {
+        // Goodreads doesn't give us exact publication date here, only a year
+        // We are skipping future dates anyway, so this is def published
+        // but we can't pick a dynamic date either to keep clients from getting
+        // confused. So we pick a guaranteed date of 1st-Jan instead.
+        $date = $matches[1] . "-01-01";
+      } else {
+        continue;
+      }
+
+      $item['title'] = $row->find('.bookTitle', 0)->plaintext;
+      $item['uri'] = $item['uid'] = $row->find('.bookTitle', 0)->getAttribute('href');
+      $item['author'] = $row->find('authorName', 0)->plaintext;
+      $item['content'] = $row->find('.bookCover', 0)->outertext;
+      $item['timestamp'] = $date;
+      $item['enclosures'] = array(
+        $row->find('.bookCover', 0)->getAttribute('src')
+      );
+
+      $this->items[] = $item; // Add item to the list
+    }
+  }
+
+  public function collectData() {
+
+    switch ($this->queriedContext) {
+      case self::CONTEXT_AUTHOR_BOOKS:
+        $this->collectAuthorBooks($this->getInput('author_url'));
+        break;
+
+      default:
+        throw new Exception("Invalid context", 1);
+        break;
+    }
+  }
+}

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -19,7 +19,14 @@ class GoodreadsBridge extends BridgeAbstract {
         'title' => 'Should look somewhat like goodreads.com/author/show/',
         'pattern' => '^(https:\/\/)?(www.)?goodreads\.com\/author\/show\/\d+\..*$',
         'exampleValue' => 'https://www.goodreads.com/author/show/38550.Brandon_Sanderson'
-      )
+      ),
+      'published_only' => array(
+        'name' => 'Show published books only',
+        'type' => 'checkbox',
+        'required' => false,
+        'title' => 'If left unchecked, this will return unpublished books as well',
+        'defaultValue' => 'checked',
+      ),
     ),
   );
 
@@ -46,6 +53,9 @@ class GoodreadsBridge extends BridgeAbstract {
         // but we can't pick a dynamic date either to keep clients from getting
         // confused. So we pick a guaranteed date of 1st-Jan instead.
         $date = $matches[1] . "-01-01";
+      } else if ($this->getInput('published_only') !== 'checked') {
+        // We can return unpublished books as well
+        $date = date("Y-01-01");
       } else {
         continue;
       }


### PR DESCRIPTION
Lots of requests on the Goodreads developer forums for better RSS feeds:

- https://www.goodreads.com/topic/show/2164751-shelf-rss-feed-behavior-for-shelfsize-100
- https://help.goodreads.com/s/question/0D51H00004RMENw/why-has-the-rss-feed-stopped-working
- https://www.goodreads.com/blog/show/20-more-rss-feeds

A lot of the old RSS feeds are broken/unmaintained as well. As of now, this implements a single RSS feed to _fetch all books by an author_.

The usecase is to get notified when a new book by an author is published. If you turn off the "published_only" filter, then you get notified when a new book by an author is announced.

I'm using a specific context, because I want to add more RSS feeds to this, and don't want to break existing links when we do.