### PR TITLE
[BridgeCard] Use full bridge name in data-ref tag

### DIFF
--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -339,7 +339,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		}
 
 		$card = <<<CARD
-			<section id="bridge-{$bridgeName}" data-ref="{$bridgeName}">
+			<section id="bridge-{$bridgeName}" data-ref="{$name}">
 				<h2><a href="{$uri}">{$name}</a></h2>
 				<p class="description">{$description}</p>
 				<input type="checkbox" class="showmore-box" id="showmore-{$bridgeName}" />


### PR DESCRIPTION
Updates the `data-ref` tag of each bridge card to use the bridge's full name (eg. Apple Music) instead of its filename (eg. AppleMusic). This fixes issues with the search not returned some bridges.

Fixes #1518. Closes #1540