### PR TITLE
[SensCritique] Fix search display

### DIFF
--- a/bridges/SensCritiqueBridge.php
+++ b/bridges/SensCritiqueBridge.php
@@ -3,15 +3,11 @@ class SensCritiqueBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'kranack';
 	const NAME = 'Sens Critique';
-	const URI = 'http://www.senscritique.com/';
+	const URI = 'https://www.senscritique.com/';
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'Sens Critique news';
 
 	const PARAMETERS = array( array(
-		'm' => array(
-			'name' => 'Movies',
-			'type' => 'checkbox'
-		),
 		's' => array(
 			'name' => 'Series',
 			'type' => 'checkbox'
@@ -40,8 +36,6 @@ class SensCritiqueBridge extends BridgeAbstract {
 			if($this->getInput($category)) {
 				$uri = self::URI;
 				switch($category) {
-				case 'm': $uri .= 'films/cette-semaine';
-				break;
 				case 's': $uri .= 'series/actualite';
 				break;
 				case 'g': $uri .= 'jeuxvideo/actualite';
@@ -77,20 +71,25 @@ class SensCritiqueBridge extends BridgeAbstract {
 			. ' '
 			. $movie->find('.elco-date', 0)->plaintext;
 
-			$item['content'] = '<em>'
-			. $movie->find('.elco-original-title', 0)->plaintext
-			. '</em><br><br>'
-			. $movie->find('.elco-baseline', 0)->plaintext
+			$item['content'] = '';
+			$originalTitle = $movie->find('.elco-original-title', 0);
+			$description = $movie->find('.elco-description', 0);
+
+			if ($originalTitle) {
+				$item['content'] = '<em>' . $originalTitle->plaintext . '</em><br><br>';
+			}
+
+			$item['content'] .= $movie->find('.elco-baseline', 0)->plaintext
 			. '<br>'
 			. $movie->find('.elco-baseline', 1)->plaintext
 			. '<br><br>'
-			. $movie->find('.elco-description', 0)->plaintext
+			. ($description ? $description->plaintext : '')
 			. '<br><br>'
 			. trim($movie->find('.erra-ratings .erra-global', 0)->plaintext)
 			. ' / 10';
 
-			$item['id'] = $this->getURI() . $movie->find('.elco-title a', 0)->href;
-			$item['uri'] = $this->getURI() . $movie->find('.elco-title a', 0)->href;
+			$item['id'] = $this->getURI() . ltrim($movie->find('.elco-title a', 0)->href, '/');
+			$item['uri'] = $this->getURI() . ltrim($movie->find('.elco-title a', 0)->href, '/');
 			$this->items[] = $item;
 		}
 	}


### PR DESCRIPTION
- Remove movies search. It appears the website changed their movies
  displays and data cannot be easily extracted for now.
- Fix some errors on items without proper description and/or original
  title.