### PR TITLE
[Configuration.php] Fix notice of undefined offset when in detached HEAD state.

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -244,9 +244,13 @@ final class Configuration {
 		if(@is_readable($headFile)) {
 
 			$revisionHashFile = '.git/' . substr(file_get_contents($headFile), 5, -1);
-			$branchName = explode('/', $revisionHashFile)[3];
-			if(file_exists($revisionHashFile)) {
-				return 'git.' . $branchName . '.' . substr(file_get_contents($revisionHashFile), 0, 7);
+			$parts = explode('/', $revisionHashFile);
+
+			if(isset($parts[3])) {
+				$branchName = $parts[3];
+				if(file_exists($revisionHashFile)) {
+					return 'git.' . $branchName . '.' . substr(file_get_contents($revisionHashFile), 0, 7);
+				}
 			}
 		}
 


### PR DESCRIPTION
When a clone is in a detached HEAD state (e.g. when a tag is checked out), the format of the .git/HEAD file is different and contains an hash only. This means there is nothing to ```explode()``` and the array access fails, producing ```Notice: Undefined offset: 3 in <path>\Configuration.php on line 247```. This PR fixes this by checking if the array element exists and is not NULL.

Steps to reproduce:

- Clone the repo in a folder served by a webserver and having PHP set to report E_NOTICE:
```git clone https://github.com/RSS-Bridge/rss-bridge.git .```
- Check out the latest tag:
```git checkout tags/2020-02-26```
(.git/HEAD contains "0705a2e7bb391d2eac707bb1d195e51f5911b334" now)
- Open the clone in a browser
- The notice mentioned above is displayed above the rss-bridge logo