### PR TITLE
[HaerringersSpottschauBridge] Add bridge for the Spottschau comic

### DIFF
--- a/bridges/HaerringersSpottschauBridge.php
+++ b/bridges/HaerringersSpottschauBridge.php
@@ -22,6 +22,7 @@ class HaerringersSpottschauBridge extends BridgeAbstract {
 			'content' => '<img src="' . $imgurl . '">',
 			'enclosures' => array($imgurl),
 			'author' => 'Christoph Härringer',
+			'uid' => $imgurl,
 			);
 	}
 }

--- a/bridges/HaerringersSpottschauBridge.php
+++ b/bridges/HaerringersSpottschauBridge.php
@@ -1,0 +1,27 @@
+<?php
+class HaerringersSpottschauBridge extends BridgeAbstract {
+	const MAINTAINER = 'mibe';
+	const NAME = 'Härringers Spottschau Bridge';
+	const URI = 'https://spottschau.com/';
+	const CACHE_TIMEOUT = 86400; // 24h
+	const DESCRIPTION = 'Returns the latest strip from the "Härringers Spottschau" comic.';
+
+	public function collectData()
+	{
+		$html = getSimpleHTMLDOMCached(self::URI, self::CACHE_TIMEOUT)
+			or returnServerError('Could not request ' . self::URI);
+
+		$strip = $html->find('div.strip > a > img', 0)
+			or returnServerError('Could not find the proper HTML element of the strip.');
+
+		$imgurl = self::URI . $strip->src;
+
+		$this->items[] = array(
+			'uri' => self::URI,
+			'title' => 'Strip der Woche',
+			'content' => '<img src="' . $imgurl . '">',
+			'enclosures' => array($imgurl),
+			'author' => 'Christoph Härringer',
+			);
+	}
+}


### PR DESCRIPTION
This PR adds a new bridge to retrieve the current comic strip of the "[Härringers Spottschau](https://spottschau.com/)" comic.

I transliterated the German umlaut "ä" to "ae" for the file name, although this violates the [how-to](https://github.com/RSS-Bridge/rss-bridge/wiki/How-to-create-a-new-Bridge) ("_It starts with the full name of the site_"). Is there a policy how to handle non-ASCII characters?

FYI: The cache time is deliberately set to 24h since this is a weekly comic.