### PR TITLE
[MemcachedCache] loadData now returns null instead of false

### DIFF
--- a/caches/MemcachedCache.php
+++ b/caches/MemcachedCache.php
@@ -40,7 +40,7 @@ class MemcachedCache implements CacheInterface {
 		if ($this->data) return $this->data;
 		$result = $this->conn->get($this->getCacheKey());
 		if ($result === false) {
-			return false;
+			return null;
 		}
 
 		$this->time = $result['time'];


### PR DESCRIPTION
FileCache and SQLiteCache returns null on cache miss. This is important if using strict comparing (for example when using "===")

In https://github.com/RSS-Bridge/rss-bridge/issues/1562#issuecomment-639979807 @markwaters reported, that recent twitter rewrite didn't work when using Memcached.

Probably it happened due to strict comparing here and incorrect return value of loadData (false, instead of null):
https://github.com/RSS-Bridge/rss-bridge/blob/06891ae35f0947d8f2a8daa0094b25e2db862226/bridges/TwitterBridge.php#L321-L323

Also, @markwaters, please report if this fix works for you.