### PR TITLE
[GoogleSearch] Correct parsing uri of search result

### DIFF
--- a/bridges/GoogleSearchBridge.php
+++ b/bridges/GoogleSearchBridge.php
@@ -35,14 +35,8 @@ class GoogleSearchBridge extends BridgeAbstract {
 
 				$item = array();
 
-				// Extract direct URL from google href (eg. /url?q=...)
 				$t = $element->find('a[href]', 0)->href;
-				$item['uri'] = '' . $t;
-				parse_str(parse_url($t, PHP_URL_QUERY), $parameters);
-				if(isset($parameters['q'])) {
-					$item['uri'] = $parameters['q'];
-				}
-
+				$item['uri'] = htmlspecialchars_decode($t);
 				$item['title'] = $element->find('h3', 0)->plaintext;
 				$item['content'] = $element->find('span[class=st]', 0)->plaintext;
 


### PR DESCRIPTION
Before: https://feed.eugenemolotov.ru/before/?action=display&bridge=GoogleSearch&q=%22crm%22+site%3Afreelance.habr.com&format=Plaintext
After: https://feed.eugenemolotov.ru/dev/?action=display&bridge=GoogleSearch&q=%22crm%22+site%3Afreelance.habr.com&format=Plaintext

Pay attention to "uri"