### PR TITLE
[GithubTrendingBridge] Fix PHP notice.

### DIFF
--- a/bridges/GithubTrendingBridge.php
+++ b/bridges/GithubTrendingBridge.php
@@ -614,7 +614,9 @@ class GithubTrendingBridge extends BridgeAbstract {
 			$item['title'] = str_replace('  ', '', trim(strip_tags($element->find('h1 a', 0)->plaintext)));
 
 			// Description
-			$item['content'] = trim(strip_tags($element->find('p.text-gray', 0)->innertext));
+			$description = $element->find('p.text-gray', 0);
+			if ($description != null)
+				$item['content'] = trim(strip_tags($description->innertext));
 
 			// Time
 			$item['timestamp'] = time();


### PR DESCRIPTION
A repo owner can leave the repo description empty, which means the HTML element isn't there. In this case the code produced a PHP notice. This is fixed by checking for null.