### PR TITLE
[JS improvements] Throttled search, feed format buttons optionally render URL inline instead of redirecting to it

### DIFF
--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -141,12 +141,7 @@ EOD;
 		id="searchfield" placeholder="Insert URL or bridge name"
 		value="{$query}">
 	<div class="extraoptions">
-		<input type="checkbox" id="extraoptions" class="showmore-box">
-		<label for="extraoptions" class="showmore">Show extra settings</label>
-		<div class="toggleable-content">
-			<label><input type="checkbox" id="extraoption-renderFeedUrl"> Render URLs instead of redirecting</label>
-		</div>
-		<label for="extraoptions" class="showless">Hide extra settings</label>
+		<label><input type="checkbox" id="extraoption-renderFeedUrl"> Show feed URL instead of redirecting</label>
 	</div>
 </section>
 EOD;

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -29,20 +29,13 @@ final class BridgeList {
 		return <<<EOD
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<meta name="description" content="RSS-Bridge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="RSS-Bridge">
 	<title>RSS-Bridge</title>
 	<link href="static/style.css" rel="stylesheet">
 	<link rel="icon" type="image/png" href="static/favicon.png">
 	<script src="static/search.js"></script>
 	<script src="static/select.js"></script>
-	<noscript>
-		<style>
-			.searchbar {
-				display: none;
-			}
-		</style>
-	</noscript>
 </head>
 EOD;
 	}
@@ -132,11 +125,11 @@ EOD;
 		$query = filter_input(INPUT_GET, 'q');
 
 		return <<<EOD
-<section class="searchbar">
+<section class="searchbar" style="display:none">
 	<h3>Search</h3>
 	<input type="text" name="searchfield"
 		id="searchfield" placeholder="Insert URL or bridge name"
-		onchange="search()" onkeyup="search()" value="{$query}">
+		value="{$query}">
 </section>
 EOD;
 	}
@@ -203,7 +196,7 @@ EOD;
 
 		return '<!DOCTYPE html><html lang="en">'
 		. BridgeList::getHead()
-		. '<body onload="search()">'
+		. '<body>'
 		. BridgeList::getHeader()
 		. BridgeList::getSearchbar()
 		. BridgeList::getBridges($showInactive, $totalBridges, $totalActiveBridges)

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -34,9 +34,19 @@ final class BridgeList {
 	<title>RSS-Bridge</title>
 	<link href="static/style.css" rel="stylesheet">
 	<link rel="icon" type="image/png" href="static/favicon.png">
-	<script src="static/search.js"></script>
-	<script src="static/select.js"></script>
 </head>
+EOD;
+	}
+
+	/**
+	 * Get the document scripts
+	 *
+	 * @return string The document scripts
+	 */
+	private static function getScripts() {
+		return <<<EOD
+<script src="static/search.js"></script>
+<script src="static/select.js"></script>
 EOD;
 	}
 
@@ -130,6 +140,14 @@ EOD;
 	<input type="text" name="searchfield"
 		id="searchfield" placeholder="Insert URL or bridge name"
 		value="{$query}">
+	<div class="extraoptions">
+		<input type="checkbox" id="extraoptions" class="showmore-box">
+		<label for="extraoptions" class="showmore">Show extra settings</label>
+		<div class="toggleable-content">
+			<label><input type="checkbox" id="extraoption-renderFeedUrl"> Render URLs instead of redirecting</label>
+		</div>
+		<label for="extraoptions" class="showless">Hide extra settings</label>
+	</div>
 </section>
 EOD;
 	}
@@ -201,6 +219,7 @@ EOD;
 		. BridgeList::getSearchbar()
 		. BridgeList::getBridges($showInactive, $totalBridges, $totalActiveBridges)
 		. BridgeList::getFooter($totalBridges, $totalActiveBridges, $showInactive)
+		. BridgeList::getScripts()
 		. '</body></html>';
 
 	}

--- a/static/search.js
+++ b/static/search.js
@@ -85,5 +85,5 @@
 	}
 
 	// Initialize search on DOM ready
-	w.addEventListener('DOMContentLoaded', initSearch)
+	d.addEventListener('DOMContentLoaded', initSearch)
 })(window, document)

--- a/static/search.js
+++ b/static/search.js
@@ -61,7 +61,10 @@
 				newMatchedBridges = allBridges
 			}
 
-			redrawBridgeList(newMatchedBridges)
+			// Only redraw if old and new matches differ
+			if (matchedBridges.toString() !== newMatchedBridges.toString()) {
+				redrawBridgeList(newMatchedBridges)
+			}
 		}
 
 		// Throttle function executions

--- a/static/search.js
+++ b/static/search.js
@@ -1,60 +1,89 @@
-function search() {
+(function (w, d) {
+	function initSearch () {
+		var searchableBridges = d.querySelectorAll('section[id^="bridge-"]')
 
-	var searchTerm = document.getElementById('searchfield').value;
-	var searchableElements = document.getElementsByTagName('section');
+		var bridgesByRef = []
+		var bridgesByUrl = []
+		var allBridges = []
+		var matchedBridges = []
 
-	var regexMatch = new RegExp(searchTerm, 'i');
+		// Build and cache 2 arrays of strings that will be searched through.
+		// Missing values must be included as empty strings because both arrays
+		// need the same index as the searchableBridges source.
+		searchableBridges.forEach(function (bridge, idx) {
+			bridgesByRef.push((bridge.dataset.ref || '').toLowerCase())
+			var url = bridge.querySelector('a') // Select the first <a>. It contains the bridge url
+			bridgesByUrl.push(url ? url.hostname.toLowerCase().replace(/^www\./, '') : '')
+			allBridges.push(idx)
+			matchedBridges.push(idx) // By default all bridges are visible so they all "match"
+		})
 
-	// Attempt to create anchor from search term (will default to 'localhost' on failure)
-	var searchTermUri = document.createElement('a');
-	searchTermUri.href = searchTerm;
-
-	if(searchTermUri.hostname == 'localhost') {
-		searchTermUri = null;
-	} else {
-
-		// Ignore "www."
-		if(searchTermUri.hostname.indexOf('www.') === 0) {
-			searchTermUri.hostname = searchTermUri.hostname.substr(4);
+		// Write to DOM only when change is actually requried.
+		// To do this compare the indexes of new matches with indexes of previous matches
+		// and loop only through changed indexes.
+		function redrawBridgeList (newMatchedBridges) {
+			// Hide bridges that no longer match
+			matchedBridges.forEach(function (bridgeIdx) {
+				if (!newMatchedBridges.includes(bridgeIdx)) {
+					searchableBridges[bridgeIdx].style.display = 'none'
+				}
+			})
+			// Show newly matched bridges
+			newMatchedBridges.forEach(function (bridgeIdx) {
+				searchableBridges[bridgeIdx].style.display = 'block'
+			})
+			// Update matchedBridges
+			matchedBridges = newMatchedBridges
 		}
 
-	}
+		// Search function loops through strings in bridgesByUrl and bridgesByRef
+		// builds an array of matching indexes and calls the redraw function
+		function search (e) {
+			var searchTerm = e.target.value.trim().toLowerCase()
+			var newMatchedBridges = []
 
-	for(var i = 0; i < searchableElements.length; i++) {
+			try {
+				searchTerm = new URL(searchTerm).hostname.replace(/^www\./,'')
+			} catch (err) { /* skip */ }
 
-		var textValue = searchableElements[i].getAttribute('data-ref');
-		var anchors = searchableElements[i].getElementsByTagName('a');
-
-		if(anchors != null && anchors.length > 0) {
-
-			var uriValue = anchors[0]; // First anchor is bridge URI
-
-			// Ignore "www."
-			if(uriValue.hostname.indexOf('www.') === 0) {
-				uriValue.hostname = uriValue.hostname.substr(4);
+			for (var i = 0; i < allBridges.length; i++) {
+				if (bridgesByUrl[i] === searchTerm) {
+					newMatchedBridges.push(i)
+					continue // Skip the rest if we have a match for URL
+				}
+				if (bridgesByRef[i].indexOf(searchTerm) > -1) {
+					newMatchedBridges.push(i)
+				}
 			}
 
-		}
-
-		if(textValue != null || uriValue != null) {
-
-			if(textValue.match(regexMatch) != null ||
-				uriValue.hostname.match(regexMatch) ||
-				searchTermUri != null &&
-				uriValue.hostname != 'localhost' && (
-					uriValue.href.match(regexMatch) != null ||
-					uriValue.hostname == searchTermUri.hostname)) {
-
-				searchableElements[i].style.display = 'block';
-
-			} else {
-
-				searchableElements[i].style.display = 'none';
-
+			// If no matches and searchTerm is empty, show all
+			if (!newMatchedBridges.length && !searchTerm.length) {
+				newMatchedBridges = allBridges
 			}
 
+			redrawBridgeList(newMatchedBridges)
 		}
 
+		// Throttle function executions
+		function throttle (fn, timeout) {
+			var waiting = null
+			return function (args) {
+				clearTimeout(waiting)
+				waiting = setTimeout(function () { fn(args) }, timeout)
+			}
+		}
+
+		// Attach the search function to the input element
+		var searchfield = d.getElementById('searchfield')
+		searchfield.addEventListener('keyup', throttle(search, 500), false)
+		// Show search form
+		d.querySelector('.searchbar').removeAttribute('style')
+		// Immediately run a search if an existing value is present in the field
+		if (searchfield.value) {
+			search({ target: { value: searchfield.value }})
+		}
 	}
 
-}
+	// Initialize search on DOM ready
+	w.addEventListener('DOMContentLoaded', initSearch)
+})(window, document)

--- a/static/select.js
+++ b/static/select.js
@@ -12,7 +12,7 @@
 
 	// Intercept clicks on "format" submit buttons and render the feed URL
 	// in a copy-paste-able textarea.
-	function renderFeedUrlOnSubmit (e) {
+	function renderFeedUrl (e) {
 		if (e.target.name === 'format') { // Intercept clicks on button[name="format"]
 			e.preventDefault()
 			var form = e.target.parentNode
@@ -20,7 +20,12 @@
 
 			var params = ['format=' + e.target.value]
 			for (var i = 0; i < inputs.length; i++) {
-				if (['format', 'copyfield'].includes(inputs[i].name)) continue
+				// Skip irrelevant params
+				if (
+					['format', 'copyfield'].includes(inputs[i].name) ||
+					(inputs[i].type === 'checkbox' && !inputs[i].checked)
+				) continue
+				// Use other params
 				params.push(inputs[i].name + '=' + encodeURIComponent(inputs[i].value))
 			}
 
@@ -40,5 +45,27 @@
 			copyField.value = url
 		}
 	}
-	d.addEventListener('click', renderFeedUrlOnSubmit, false)
+
+	function renderFeedUrlInitializer (toggleElement) {
+		toggleElement.addEventListener('change', function () {
+			if (toggleElement.checked) {
+				d.addEventListener('click', renderFeedUrl, false)
+			} else {
+				d.removeEventListener('click', renderFeedUrl, false)
+				d.querySelectorAll('.copyfield').forEach(function (el) {
+					el.remove()
+				})
+			}
+		}, false)
+		if (toggleElement.checked) {
+			d.addEventListener('click', renderFeedUrl, false)
+		}
+	}
+
+	function optionsInitializer () {
+		const renderFeedUrlToggler = d.getElementById('extraoption-renderFeedUrl')
+		renderFeedUrlInitializer(renderFeedUrlToggler)
+	}
+	d.addEventListener('DOMContentLoaded', optionsInitializer)
+
 })(window, document)

--- a/static/select.js
+++ b/static/select.js
@@ -1,10 +1,44 @@
-function select(){
-	var fragment = window.location.hash.substr(1);
-	var bridge = document.getElementById(fragment);
-
-	if(bridge !== null) {
-		bridge.getElementsByClassName('showmore-box')[0].checked = true;
+(function (w, d) {
+	// If there's a hash in URL, try to match it to an active bridge,
+	// expand its settings and scroll to it
+	function exposeBridgeOnHash () {
+		var bridge = d.querySelector(window.location.hash || 'none')
+		if (bridge) {
+			bridge.querySelector('.showmore-box').checked = true // Show settings
+			w.scrollTo(0, bridge.offsetTop - 10) // Scroll into view
+		}
 	}
-}
+	w.addEventListener('load', exposeBridgeOnHash)
 
-document.addEventListener('DOMContentLoaded', select);
+	// Intercept clicks on "format" submit buttons and render the feed URL
+	// in a copy-paste-able textarea.
+	function renderFeedUrlOnSubmit (e) {
+		if (e.target.name === 'format') { // Intercept clicks on button[name="format"]
+			e.preventDefault()
+			var form = e.target.parentNode
+			var inputs = form.elements
+
+			var params = ['format=' + e.target.value]
+			for (var i = 0; i < inputs.length; i++) {
+				if (['format', 'copyfield'].includes(inputs[i].name)) continue
+				params.push(inputs[i].name + '=' + encodeURIComponent(inputs[i].value))
+			}
+
+			var url = w.location.origin + w.location.pathname + '?' + params.join('&')
+
+			var copyField = form.querySelector('.copyfield')
+			if (!copyField) {
+				copyField = d.createElement('textarea')
+				copyField.className = 'copyfield'
+				copyField.name = 'copyfield'
+				copyField.readonly = 'readonly'
+				copyField.addEventListener('click', function () {
+					copyField.select()
+				})
+				form.appendChild(copyField)
+			}
+			copyField.value = url
+		}
+	}
+	d.addEventListener('click', renderFeedUrlOnSubmit, false)
+})(window, document)

--- a/static/select.js
+++ b/static/select.js
@@ -63,7 +63,7 @@
 	}
 
 	function optionsInitializer () {
-		const renderFeedUrlToggler = d.getElementById('extraoption-renderFeedUrl')
+		var renderFeedUrlToggler = d.getElementById('extraoption-renderFeedUrl')
 		renderFeedUrlInitializer(renderFeedUrlToggler)
 	}
 	d.addEventListener('DOMContentLoaded', optionsInitializer)

--- a/static/select.js
+++ b/static/select.js
@@ -16,6 +16,7 @@
 		if (e.target.name === 'format') { // Intercept clicks on button[name="format"]
 			e.preventDefault()
 			var form = e.target.parentNode
+			if (!form.reportValidity()) return
 			var inputs = form.elements
 
 			var params = ['format=' + e.target.value]

--- a/static/style.css
+++ b/static/style.css
@@ -165,8 +165,7 @@ button:hover {
 	background: #49afff;
 }
 
-.description,
-.toggleable-content {
+.description {
 	margin: 10px;
 }
 
@@ -264,9 +263,7 @@ form {
 	margin-bottom: 6px;
 }
 
-form,
-h5,
-.toggleable-content {
+form, h5 {
 	display: none;
 }
 
@@ -297,9 +294,7 @@ select {
 	display: none;
 }
 
-.showmore-box:checked ~ form,
-.showmore-box:checked ~ h5,
-.showmore-box:checked ~ .toggleable-content {
+.showmore-box:checked ~ form, .showmore-box:checked ~ h5 {
 	display: block;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -165,7 +165,8 @@ button:hover {
 	background: #49afff;
 }
 
-.description {
+.description,
+.toggleable-content {
 	margin: 10px;
 }
 
@@ -263,17 +264,15 @@ form {
 	margin-bottom: 6px;
 }
 
-form {
+form,
+h5,
+.toggleable-content {
 	display: none;
 }
 
 select {
 	padding: 5px 10px;
 	margin-left: 8px;
-}
-
-h5 {
-	display: none;
 }
 
 /* Show more / less */
@@ -298,7 +297,9 @@ h5 {
 	display: none;
 }
 
-.showmore-box:checked ~ form, .showmore-box:checked ~ h5 {
+.showmore-box:checked ~ form,
+.showmore-box:checked ~ h5,
+.showmore-box:checked ~ .toggleable-content {
 	display: block;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -64,6 +64,7 @@ header > section.critical-warning {
 }
 
 select,
+textarea,
 input[type="text"],
 input[type="number"] {
 	background-color: white;
@@ -75,6 +76,7 @@ input[type="number"] {
 }
 
 select:focus,
+textarea:focus,
 input[type="text"]:focus,
 input[type="number"]:focus {
 	outline: none;
@@ -321,6 +323,14 @@ h5 {
 
 .advice > li {
 	text-align: left;
+}
+
+.copyfield {
+	box-sizing: border-box;
+	width: 100%;
+	margin: 10px 0;
+	resize: vertical;
+	overflow: auto;
 }
 
 @media screen and (max-width: 767px) {


### PR DESCRIPTION
I've cleaned up and refactored front-end JS.

**What's changed**

`search.js` is now throttled so that it runs 500ms after last keystroke. Whether that's the best timeout is debatable. I like it.

Also, search has been sped up by searching the DOM for bridge nodes once and caching them. Also all searchable strings are compiled to arrays on init. The search function only runs on these cached arrays and creates diffs of indices. So when the DOM needs to be updated, only affected nodes will be accessed.

`select.js` has been changed to not just open the settings for the bridge's hash in the URL but will now also adjust the scroll position so that it always appears in view.

`select.js` also has a new feature which is the reason why I've done this in the first place. An extra field with settings has been added to the Search box at the top. It contains the option to render URLs instead of redirecting. When enabled, clicking any of the format buttons will be intercepted by JS which will render the feed URL into a textarea field below the form instead of redirecting the browser.

It looks like this:
![Screenshot_20200623_232521](https://user-images.githubusercontent.com/761287/85465441-171b7f80-b5a9-11ea-938e-f8eb80e8d1c0.png)


**Why?**

Simply because most browsers have dropped RSS integration so when they get sent a feed mime they don't know how to handle it and offer it as a download. I don't use a local client so I have to save the feed file and then inspect it to find the source URL.