### PR TITLE
[TwitterBridge] apikey fetched every time

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -369,7 +369,7 @@ EOD;
 		$data = $cache->loadData();
 
 		$apiKey = null;
-		if($data === null || !is_array($data) || count($data) != 1) {
+		if($data === null || (time() - $refresh) > self::GUEST_TOKEN_EXPIRY) {
 			$twitterPage = getContents('https://twitter.com');
 
 			$jsMainRegex = '/(https:\/\/abs\.twimg\.com\/responsive-web\/web_legacy\/main\.[^\.]+\.js)/m';


### PR DESCRIPTION
The apikey is fetched every time because `$data` is not an array. Update the condition to expire the api key at the same time as the guest token.

Fixes #1666 