### PR TITLE
[TwitterBridge] Skip advertisment tweets

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -219,7 +219,7 @@ EOD
 			}
 
 			// Skip tweets with source "Twitter for Advertisers"
-			if (strpos($tweet->source, "ads-api.twitter.com") !== false) {
+			if (strpos($tweet->source, 'ads-api.twitter.com') !== false) {
 				continue;
 			}
 

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -218,6 +218,11 @@ EOD
 				continue;
 			}
 
+			// Skip tweets with source "Twitter for Advertisers"
+			if (strpos($tweet->source, "ads-api.twitter.com") !== false) {
+				continue;
+			}
+
 			$item = array();
 			// extract username and sanitize
 			$user_info = $this->getUserInformation($tweet->user_id_str, $data->globalObjects);

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -210,6 +210,17 @@ EOD
 
 		$hidePictures = $this->getInput('nopic');
 
+		$promotedTweetIds = array_reduce($data->timeline->instructions[0]->addEntries->entries, function($carry, $entry) {
+			if (!isset($entry->content->item)) {
+				return $carry;
+			}
+			$tweet = $entry->content->item->content->tweet;
+			if (isset($tweet->promotedMetadata)) {
+				$carry[] = $tweet->id;
+			}
+			return $carry;
+		}, array());
+
 		foreach($data->globalObjects->tweets as $tweet) {
 
 			/* Debug::log('>>> ' . json_encode($tweet)); */
@@ -218,8 +229,8 @@ EOD
 				continue;
 			}
 
-			// Skip tweets with source "Twitter for Advertisers"
-			if (strpos($tweet->source, 'ads-api.twitter.com') !== false) {
+			// Skip promoted tweets
+			if (in_array($tweet->id_str, $promotedTweetIds)) {
 				continue;
 			}
 


### PR DESCRIPTION
For example: https://feed.eugenemolotov.ru/?action=display&bridge=Twitter&context=By+keyword+or+hashtag&q=%23quakelive&format=Html

It is search by hashtag `#quakelive`. There are posts, that do not contain this hashtag, 'cos they are ads. As of writing, those titles are:
- English is the most spoken language in the world. Can you guess what No. 2 is? (in the end of feed)
- Advertisement for some audio devices (at the start of feed)

Thanks to twitter devs for adding source field.