### PR TITLE
[Releases3DS] Add support for Switch releases

### DIFF
--- a/bridges/Releases3DSBridge.php
+++ b/bridges/Releases3DSBridge.php
@@ -4,28 +4,15 @@ class Releases3DSBridge extends BridgeAbstract {
 	const MAINTAINER = 'ORelio';
 	const NAME = '3DS Scene Releases';
 	const URI = 'http://www.3dsdb.com/';
-	const URI_SWITCH = 'http://www.nswdb.com/';
 	const CACHE_TIMEOUT = 10800; // 3h
-	const DESCRIPTION = 'Returns the newest scene releases for Nintendo 3DS or Switch.';
-	const PARAMETERS = array(
-		array(
-			'console' => array(
-				'name' => 'Console',
-				'type' => 'list',
-				'values' => array(
-					'3DS' => '3ds',
-					'Switch' => 'switch'
-				)
-			)
-		)
-	);
+	const DESCRIPTION = 'Returns the newest scene releases for Nintendo 3DS.';
 
 	public function collectData(){
+		$this->collectDataUrl(self::URI . 'xml.php');
+	}
 
-		$baseUrl = self::URI;
-		if ($this->getInput('console') == 'switch')
-			$baseUrl = self::URI_SWITCH;
-		$dataUrl = $baseUrl . 'xml.php';
+	protected function collectDataUrl($dataUrl){
+
 		$xml = getContents($dataUrl)
 			or returnServerError('Could not request URL: ' . $dataUrl);
 		$limit = 0;
@@ -135,7 +122,7 @@ class Releases3DSBridge extends BridgeAbstract {
 
 	private function typeToString($type){
 		switch($type) {
-			case 1: return '3DS Game';
+			case 1: return 'Card Game';
 			case 4: return 'eShop';
 			default: return '??? (' . $type . ')';
 		}

--- a/bridges/Releases3DSBridge.php
+++ b/bridges/Releases3DSBridge.php
@@ -68,17 +68,25 @@ class Releases3DSBridge extends BridgeAbstract {
 
 			$ignSearchUrl = 'https://www.ign.com/search?q=' . urlencode($name);
 			if($ignResult = getSimpleHTMLDOMCached($ignSearchUrl)) {
-				$ignCoverArt = $ignResult->find('div.search-item-media', 0)->find('img', 0)->src;
-				$ignDesc = $ignResult->find('div.search-item-description', 0)->plaintext;
-				$ignLink = $ignResult->find('div.search-item-sub-title', 0)->find('a', 1)->href;
-				$ignDate = strtotime(trim($ignResult->find('span.publish-date', 0)->plaintext));
-				$ignDescription = '<div><img src="'
-				. $ignCoverArt
-				. '" /></div><div>'
-				. $ignDesc
-				. ' <a href="'
-				. $ignLink
-				. '">More at IGN</a></div>';
+				$ignCoverArt = $ignResult->find('div.search-item-media', 0);
+				$ignDesc = $ignResult->find('div.search-item-description', 0);
+				$ignLink = $ignResult->find('div.search-item-sub-title', 0);
+				$ignDate = $ignResult->find('span.publish-date', 0);
+				if (is_object($ignCoverArt))
+					$ignCoverArt = $ignCoverArt->find('img', 0);
+				if (is_object($ignLink))
+					$ignLink = $ignLink->find('a', 1);
+				if (is_object($ignDate))
+					$ignDate = strtotime(trim($ignDate->plaintext));
+				if (is_object($ignCoverArt) && is_object($ignDesc) && is_object($ignLink)) {
+					$ignDescription = '<div><img src="'
+					. $ignCoverArt->src
+					. '" /></div><div>'
+					. $ignDesc->plaintext
+					. ' <a href="'
+					. $ignLink->href
+					. '">More at IGN</a></div>';
+				}
 			}
 
 			//Main section : Release description from 3DS database

--- a/bridges/Releases3DSBridge.php
+++ b/bridges/Releases3DSBridge.php
@@ -4,14 +4,30 @@ class Releases3DSBridge extends BridgeAbstract {
 	const MAINTAINER = 'ORelio';
 	const NAME = '3DS Scene Releases';
 	const URI = 'http://www.3dsdb.com/';
+	const URI_SWITCH = 'http://www.nswdb.com/';
 	const CACHE_TIMEOUT = 10800; // 3h
-	const DESCRIPTION = 'Returns the newest scene releases.';
+	const DESCRIPTION = 'Returns the newest scene releases for Nintendo 3DS or Switch.';
+	const PARAMETERS = array(
+		array(
+			'console' => array(
+				'name' => 'Console',
+				'type' => 'list',
+				'values' => array(
+					'3DS' => '3ds',
+					'Switch' => 'switch'
+				)
+			)
+		)
+	);
 
 	public function collectData(){
 
-		$dataUrl = self::URI . 'xml.php';
+		$baseUrl = self::URI;
+		if ($this->getInput('console') == 'switch')
+			$baseUrl = self::URI_SWITCH;
+		$dataUrl = $baseUrl . 'xml.php';
 		$xml = getContents($dataUrl)
-			or returnServerError('Could not request 3dsdb: ' . $dataUrl);
+			or returnServerError('Could not request URL: ' . $dataUrl);
 		$limit = 0;
 
 		foreach(array_reverse(explode('<release>', $xml)) as $element) {

--- a/bridges/ReleasesSwitchBridge.php
+++ b/bridges/ReleasesSwitchBridge.php
@@ -1,0 +1,17 @@
+<?php
+
+// This bridge depends on Releases3DSBridge
+if (!class_exists('Releases3DSBridge')){
+	include('Releases3DSBridge.php');
+}
+
+class ReleasesSwitchBridge extends Releases3DSBridge {
+
+	const NAME = 'Switch Scene Releases';
+	const URI = 'http://www.nswdb.com/';
+	const DESCRIPTION = 'Returns the newest scene releases for Nintendo Switch.';
+
+	public function collectData(){
+		$this->collectDataUrl(self::URI . 'xml.php');
+	}
+}


### PR DESCRIPTION
_This pull request contains changes separated from #1507._

Request nswdb.com instead of 3dsdb.com for Switch releases.
The two websites are identical, only the URL changes.