### PR TITLE
fix heroku deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Deploy
 Thanks to the community, hosting your own instance of RSS-Bridge is as easy as clicking a button!
 
 [![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/sebsauvage/rss-bridge)
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/RSS-Bridge/rss-bridge/)
 
 Getting involved
 ===


### PR DESCRIPTION
Following the instructions here: https://devcenter.heroku.com/articles/heroku-button

Probably fixes: https://github.com/RSS-Bridge/rss-bridge/issues/1501

Basically just adding a link to the repo so the deploy can happen automatically.