### PR TITLE
[MastodonBridge] Update feed URL format

### DIFF
--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -78,7 +78,7 @@ class MastodonBridge extends FeedExpander {
 
 	public function getURI(){
 		if($this->getInput('canusername'))
-			return 'https://' . $this->getInstance() . '/users/' . $this->getUsername() . '.atom';
+			return 'https://' . $this->getInstance() . '/@' . $this->getUsername() . '.rss';
 
 		return parent::getURI();
 	}


### PR DESCRIPTION
Changes feed URL from `https://instance/users/username.atom` to `https://instance/@username.rss`. Closes #1716