### PR TITLE
[ParameterValidator] Ignore cache-busting param [#1701]

### DIFF
--- a/lib/ParameterValidator.php
+++ b/lib/ParameterValidator.php
@@ -135,6 +135,9 @@ class ParameterValidator {
 			return false;
 
 		foreach($data as $name => $value) {
+			// Some RSS readers add a cache-busting parameter (_=<timestamp>) to feed URLs, detect and ignore them.
+			if ($name === '_') continue;
+
 			$registered = false;
 			foreach($parameters as $context => $set) {
 				if(array_key_exists($name, $set)) {


### PR DESCRIPTION
This PR addresses #1701

**Describe the bug**
Some readers implement cache-busting logic in the form of appending a &_=<timestamp> query parameter to sequential requests. Appropriately, this is interpreted by the BridgeAbstract as a parameter to pass to the bridge. Unfortunately, this breaks some bridges.

**To Reproduce**
Steps to reproduce the behavior:

-    Append `&_=123` to any bridge request.
-    See error:
```
 Exception: Invalid parameters value(s): _ in /app/lib/error.php:24\nStack trace:\n#0 /app/lib/error.php(33): returnError(
)\n#1 /app/lib/BridgeAbstract.php(222): returnClientError()\n#2 /app/actions/DisplayAction.php(133): BridgeAbstract->setDatas()\n#3 /app/index.php(38): DisplayAction->execute()\n#4 {main}
```

**Expected behavior**
The bridge abstract should ignore unexpected parameters. Or strip cache-busting earlier in the execution process.

**Desktop (please complete the following information):**
```
    OS: MacOS
    Browser Firefox, Chrome, Safari
    Version latest
```