### PR TITLE
[Rule34pahealBridge] Use full size image

### DIFF
--- a/bridges/Rule34pahealBridge.php
+++ b/bridges/Rule34pahealBridge.php
@@ -8,12 +8,14 @@ class Rule34pahealBridge extends Shimmie2Bridge {
 	const URI = 'https://rule34.paheal.net/';
 	const DESCRIPTION = 'Returns images from given page';
 
+	const PATHTODATA = '.shm-thumb';
+
 	protected function getItemFromElement($element){
 		$item = array();
-		$item['uri'] = $this->getURI() . $element->href;
+		$item['uri'] = rtrim($this->getURI(), '/') . $element->find('.shm-thumb-link', 0)->href;
 		$item['id'] = (int)preg_replace('/[^0-9]/', '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();
-		$thumbnailUri = $element->find('img', 0)->src;
+		$thumbnailUri = $element->find('a', 1)->href;
 		$item['tags'] = $element->getAttribute('data-tags');
 		$item['title'] = $this->getName() . ' | ' . $item['id'];
 		$item['content'] = '<a href="'


### PR DESCRIPTION
Paheal has "Image Only" links, so IMO there's no reason, not to use them.

As a bonus, this commit fixes tags.