### PR TITLE
[FacebookBridge] Handle mobile links and standardise host validation

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -228,22 +228,22 @@ class FacebookBridge extends BridgeAbstract {
 	}
 
 	private function validateHost($provided_host) {
-        // Handle mobile links
-        if (strpos($provided_host, "m.") === 0) {
-            $provided_host = substr($provided_host, strlen("m."));
-        }
+		// Handle mobile links
+		if (strpos($provided_host, 'm.') === 0) {
+			$provided_host = substr($provided_host, strlen('m.'));
+		}
 
-        $facebook_host = parse_url(self::URI)['host'];
+		$facebook_host = parse_url(self::URI)['host'];
 
-        if ($provided_host !== $facebook_host
-            && 'www.' . $provided_host !== $facebook_host) {
-            returnClientError('The host you provided is invalid! Received "'
-                . $provided_host
-                . '", expected "'
-                . $facebook_host
-                . '"!');
-        }
-    }
+		if ($provided_host !== $facebook_host
+			&& 'www.' . $provided_host !== $facebook_host) {
+			returnClientError('The host you provided is invalid! Received "'
+				. $provided_host
+				. '", expected "'
+				. $facebook_host
+				. '"!');
+		}
+	}
 
 	private function isPublicGroup($html) {
 

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -215,15 +215,7 @@ class FacebookBridge extends BridgeAbstract {
 
 			$urlparts = parse_url($group);
 
-			if(!$this->validateHost($urlparts['host'])) {
-
-				returnClientError('The host you provided is invalid! Received "'
-				. $urlparts['host']
-				. '", expected "'
-				. parse_url(self::URI)['host']
-				. '"!');
-
-			}
+			$this->validateHost($urlparts['host']);
 
 			return explode('/', $urlparts['path'])[2];
 
@@ -243,8 +235,14 @@ class FacebookBridge extends BridgeAbstract {
 
         $facebook_host = parse_url(self::URI)['host'];
 
-        return ($provided_host !== $facebook_host
-            && 'www.' . $provided_host !== $facebook_host);
+        if ($provided_host !== $facebook_host
+            && 'www.' . $provided_host !== $facebook_host) {
+            returnClientError('The host you provided is invalid! Received "'
+                . $provided_host
+                . '", expected "'
+                . $facebook_host
+                . '"!');
+        }
     }
 
 	private function isPublicGroup($html) {
@@ -359,13 +357,7 @@ class FacebookBridge extends BridgeAbstract {
 
 			$urlparts = parse_url($user);
 
-			if(!$this->validateHost($urlparts['host'])) {
-				returnClientError('The host you provided is invalid! Received "'
-				. $urlparts['host']
-				. '", expected "'
-				. parse_url(self::URI)['host']
-				. '"!');
-			}
+			$this->validateHost($urlparts['host']);
 
 			if(!array_key_exists('path', $urlparts)
 			|| $urlparts['path'] === '/') {

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -215,8 +215,7 @@ class FacebookBridge extends BridgeAbstract {
 
 			$urlparts = parse_url($group);
 
-			if($urlparts['host'] !== parse_url(self::URI)['host']
-			&& 'www.' . $urlparts['host'] !== parse_url(self::URI)['host']) {
+			if(!$this->validateHost($urlparts['host'])) {
 
 				returnClientError('The host you provided is invalid! Received "'
 				. $urlparts['host']
@@ -235,6 +234,18 @@ class FacebookBridge extends BridgeAbstract {
 		}
 
 	}
+
+	private function validateHost($provided_host) {
+        // Handle mobile links
+        if (strpos($provided_host, "m.") === 0) {
+            $provided_host = substr($provided_host, strlen("m."));
+        }
+
+        $facebook_host = parse_url(self::URI)['host'];
+
+        return ($provided_host !== $facebook_host
+            && 'www.' . $provided_host !== $facebook_host);
+    }
 
 	private function isPublicGroup($html) {
 
@@ -348,7 +359,7 @@ class FacebookBridge extends BridgeAbstract {
 
 			$urlparts = parse_url($user);
 
-			if($urlparts['host'] !== parse_url(self::URI)['host']) {
+			if(!$this->validateHost($urlparts['host'])) {
 				returnClientError('The host you provided is invalid! Received "'
 				. $urlparts['host']
 				. '", expected "'


### PR DESCRIPTION
A simple little change to standardise host validation between user and group links, and allow mobile links, which should close #1782 and avoid issues like that again in the future.

I'm not sure whether this is enough to justify a `hacktoberfest-accepted` [label](https://hacktoberfest.digitalocean.com/hacktoberfest-update), but I would be quite happy if it did. I've had my eye on some things here for hacktoberfest this year, but more than I expected are blocked by #1170 