### PR TITLE
Fix 9GAG bridge outputting http:// URL for main link -> change to https://

### DIFF
--- a/bridges/NineGagBridge.php
+++ b/bridges/NineGagBridge.php
@@ -148,7 +148,7 @@ class NineGagBridge extends BridgeAbstract {
 			}
 
 			if (!$AvoidElement) {
-				$item['uri'] = $post['url'];
+				$item['uri'] = preg_replace("/^http:/i", "https:", $post['url']);
 				$item['title'] = $post['title'];
 				$item['content'] = self::getContent($post);
 				$item['categories'] = self::getCategories($post);


### PR DESCRIPTION
I was wondering why articles not show up in feed reader ... due filter on http:// links.  
With change from this PR, rewrite the link URL from insecure http to https.

Before

![Screenshot_20201014-001949](https://user-images.githubusercontent.com/6735650/95922334-5ae20100-0db3-11eb-84a3-0e65ca34dd5f.png)

After

![Screenshot_20201014-001909](https://user-images.githubusercontent.com/6735650/95922344-5fa6b500-0db3-11eb-99e2-1f51186bcf8a.png)