### PR TITLE
[Bridges] Use HTTPS when fetching feedburner feeds

### DIFF
--- a/bridges/KoreusBridge.php
+++ b/bridges/KoreusBridge.php
@@ -3,7 +3,7 @@ class KoreusBridge extends FeedExpander {
 
 	const MAINTAINER = 'pit-fgfjiudghdf';
 	const NAME = 'Koreus';
-	const URI = 'http://www.koreus.com/';
+	const URI = 'https://www.koreus.com/';
 	const DESCRIPTION = 'Returns the newest posts from Koreus (full text)';
 
 	protected function parseItem($item){
@@ -17,6 +17,6 @@ class KoreusBridge extends FeedExpander {
 	}
 
 	public function collectData(){
-		$this->collectExpandableDatas('http://feeds.feedburner.com/Koreus-articles');
+		$this->collectExpandableDatas('https://feeds.feedburner.com/Koreus-articles');
 	}
 }

--- a/bridges/VarietyBridge.php
+++ b/bridges/VarietyBridge.php
@@ -8,7 +8,7 @@ class VarietyBridge extends FeedExpander {
 	const DESCRIPTION = 'RSS feed for Variety';
 
 	public function collectData(){
-		$this->collectExpandableDatas('http://feeds.feedburner.com/variety/headlines', 15);
+		$this->collectExpandableDatas('https://feeds.feedburner.com/variety/headlines', 15);
 	}
 
 	protected function parseItem($newsItem){


### PR DESCRIPTION
Updates bridges `Koreus` and `Variety` to use HTTPS when fetching FeedBurner feeds.