### PR TITLE
[WordPress] Limit feed to 20 items

### DIFF
--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -22,12 +22,6 @@ class WordPressBridge extends FeedExpander {
 	protected function parseItem($newItem){
 		$item = parent::parseItem($newItem);
 
-		// Limit feed to the first 20 items
-		static $expand_count = 1;
-		if ($expand_count > 20)
-			return null;
-		$expand_count++;
-
 		$article_html = getSimpleHTMLDOMCached($item['uri']);
 
 		$article = null;
@@ -98,9 +92,9 @@ class WordPressBridge extends FeedExpander {
 			returnClientError('The url parameter must either refer to http or https protocol.');
 		}
 		try{
-			$this->collectExpandableDatas($this->getURI() . '/feed/atom/');
+			$this->collectExpandableDatas($this->getURI() . '/feed/atom/', 20);
 		} catch (Exception $e) {
-			$this->collectExpandableDatas($this->getURI() . '/?feed=atom');
+			$this->collectExpandableDatas($this->getURI() . '/?feed=atom', 20);
 		}
 
 	}

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -22,6 +22,12 @@ class WordPressBridge extends FeedExpander {
 	protected function parseItem($newItem){
 		$item = parent::parseItem($newItem);
 
+		// Limit expanding to the first 20 items
+		static $expand_count = 1;
+		if ($expand_count > 20)
+			return $item;
+		$expand_count++;
+
 		$article_html = getSimpleHTMLDOMCached($item['uri']);
 
 		$article = null;

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -22,10 +22,10 @@ class WordPressBridge extends FeedExpander {
 	protected function parseItem($newItem){
 		$item = parent::parseItem($newItem);
 
-		// Limit expanding to the first 20 items
+		// Limit feed to the first 20 items
 		static $expand_count = 1;
 		if ($expand_count > 20)
-			return $item;
+			return null;
 		$expand_count++;
 
 		$article_html = getSimpleHTMLDOMCached($item['uri']);


### PR DESCRIPTION
I encountered a WordPress site having _all its articles from the beginning_ in its feed, which meant hundreds of entries.
Fetching all the articles is time consuming, so the feed failed to load in RSS-Bridge because of a script timeout.
This PR adds a limit of 20 items in WordPress bridge to keep load times reasonable and avoid hammering the target site.
Extra items are kept unexpanded so they will still be present in the feed.