### PR TITLE
[FacebookBridge] Facebook bridge fix, swap to touch.facebook for groups

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -199,12 +199,12 @@ class FacebookBridge extends BridgeAbstract {
 
 			$item = array();
 
-			$item['uri'] = $this->extractGroupURI($post);
-			$item['title'] = $this->extractGroupTitle($post);
-			$item['author'] = $this->extractGroupAuthor($post);
-			$item['content'] = $this->extractGroupContent($post);
-			$item['timestamp'] = $this->extractGroupTimestamp($post);
-			$item['enclosures'] = $this->extractGroupEnclosures($post);
+			$item['uri'] = $this->extractGroupPostURI($post);
+			$item['title'] = $this->extractGroupPostTitle($post);
+			$item['author'] = $this->extractGroupPostAuthor($post);
+			$item['content'] = $this->extractGroupPostContent($post);
+			$item['timestamp'] = $this->extractGroupPostTimestamp($post);
+			$item['enclosures'] = $this->extractGroupPostEnclosures($post);
 
 			$this->items[] = $item;
 
@@ -273,7 +273,7 @@ class FacebookBridge extends BridgeAbstract {
 		return html_entity_decode($ogtitle->plaintext, ENT_QUOTES);
 	}
 
-	private function extractGroupURI($post) {
+	private function extractGroupPostURI($post) {
 
 		$elements = $post->find('a')
 			or returnServerError('Unable to find URI!');
@@ -291,7 +291,7 @@ class FacebookBridge extends BridgeAbstract {
 
 	}
 
-	private function extractGroupContent($post) {
+	private function extractGroupPostContent($post) {
 
 		$content = $post->find('div.userContent', 0)
 			or returnServerError('Unable to find user content!');
@@ -300,7 +300,7 @@ class FacebookBridge extends BridgeAbstract {
 
 	}
 
-	private function extractGroupTimestamp($post) {
+	private function extractGroupPostTimestamp($post) {
 
 		$element = $post->find('abbr[data-utime]', 0)
 			or returnServerError('Unable to find timestamp!');
@@ -309,7 +309,7 @@ class FacebookBridge extends BridgeAbstract {
 
 	}
 
-	private function extractGroupAuthor($post) {
+	private function extractGroupPostAuthor($post) {
 
 		$element = $post->find('img', 0)
 			or returnServerError('Unable to find author information!');
@@ -318,7 +318,7 @@ class FacebookBridge extends BridgeAbstract {
 
 	}
 
-	private function extractGroupEnclosures($post) {
+	private function extractGroupPostEnclosures($post) {
 
 		$elements = $post->find('div.userContent', 0)->next_sibling()->find('img');
 
@@ -332,16 +332,16 @@ class FacebookBridge extends BridgeAbstract {
 
 	}
 
-	private function extractGroupTitle($post) {
+	private function extractGroupPostTitle($post) {
 
 		$element = $post->find('h5', 0)
 			or returnServerError('Unable to find title!');
 
 		if(strpos($element->plaintext, 'shared') === false) {
 
-			$content = strip_tags($this->extractGroupContent($post));
+			$content = strip_tags($this->extractGroupPostContent($post));
 
-			return $this->extractGroupAuthor($post)
+			return $this->extractGroupPostAuthor($post)
 			. ' posted: '
 			. substr(
 					$content,

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -192,7 +192,7 @@ class FacebookBridge extends BridgeAbstract {
 
 		$this->groupName = $this->extractGroupName($html);
 
-		$posts = $html->find('div.userContentWrapper')
+		$posts = $html->find('div.story_body_container')
 			or returnServerError('Failed finding posts!');
 
 		foreach($posts as $post) {

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -267,10 +267,10 @@ class FacebookBridge extends BridgeAbstract {
 
 	private function extractGroupName($html) {
 
-		$ogtitle = $html->find('meta[property="og:title"]', 0)
+		$ogtitle = $html->find('._de1', 0)
 			or returnServerError('Unable to find group title!');
 
-		return html_entity_decode($ogtitle->content, ENT_QUOTES);
+		return html_entity_decode($ogtitle->plaintext, ENT_QUOTES);
 	}
 
 	private function extractGroupURI($post) {

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -558,7 +558,7 @@ EOD;
 		}
 
 		// No captcha? We can carry on retrieving page contents :)
-		// First, we check wether the page is public or not
+		// First, we check whether the page is public or not
 		$loginForm = $html->find('._585r', 0);
 
 		if($loginForm != null) {

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -254,13 +254,15 @@ class FacebookBridge extends BridgeAbstract {
 		}
 	}
 
+	/**
+	 * @param $html simple_html_dom
+	 * @return bool
+	 */
 	private function isPublicGroup($html) {
 
-		// Facebook redirects to the groups about page for non-public groups
-		$about = $html->find('#pagelet_group_about', 0);
-
-		return !($about);
-
+		// Facebook touch just presents a login page for non-public groups
+		$title = $html->find('title', 0);
+		return $title->plaintext !== 'Log in to Facebook | Facebook';
 	}
 
 	private function extractGroupName($html) {

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -232,6 +232,9 @@ class FacebookBridge extends BridgeAbstract {
 		if (strpos($provided_host, 'm.') === 0) {
 			$provided_host = substr($provided_host, strlen('m.'));
 		}
+		if (strpos($provided_host, 'touch.') === 0) {
+			$provided_host = substr($provided_host, strlen('touch.'));
+		}
 
 		$facebook_host = parse_url(self::URI)['host'];
 

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -175,7 +175,13 @@ class FacebookBridge extends BridgeAbstract {
 			$header = array();
 		}
 
-		$html = getSimpleHTMLDOM($this->getURI(), $header)
+		$touchURI = str_replace(
+			'https://www.facebook',
+			'https://touch.facebook',
+			$this->getURI()
+		);
+
+		$html = getSimpleHTMLDOM($touchURI, $header)
 			or returnServerError('Failed loading facebook page: ' . $this->getURI());
 
 		if(!$this->isPublicGroup($html)) {


### PR DESCRIPTION
This fixes group feeds, I think. Tested on a few groups.
It's swapping over to parsing using touch.facebook.com for groups. Users are still using www.facebook.com
I've got an automated integration test in here too, not sure how you'll feel about that. I'm curious how Travis likes it, as I've only ran it manually in PHP7.

Sorry this took a little while, I've had a very busy week moving house.

(If you're happy this PR is not spam, I would appreciate a `hacktoberfest-accepted` tag, but not required)