### PR TITLE
[ImgurBridge] Web-scraping imgur bridge

### DIFF
--- a/bridges/ImgurBridge.php
+++ b/bridges/ImgurBridge.php
@@ -1,0 +1,23 @@
+<?php
+class ImgurBridge extends BridgeAbstract {
+
+	const MAINTAINER = 'joshcoales';
+	const NAME = 'Imgur Bridge';
+	const URI = 'https://imgur.com/';
+	const CACHE_TIMEOUT = 300; // 5min
+	const DESCRIPTION = 'Input a search term or tag.';
+
+	const PARAMETERS = array(
+		'Search' => array(
+			'q' => array(
+				'name' => 'Search query',
+				'required' => true
+			) // Could be expanded with file type, or image size
+		)
+	);
+
+	public function collectData()
+	{
+		// TODO: Implement collectData() method.
+	}
+}

--- a/bridges/ImgurBridge.php
+++ b/bridges/ImgurBridge.php
@@ -1,5 +1,7 @@
 <?php
-class ImgurBridge extends BridgeAbstract {
+
+class ImgurBridge extends BridgeAbstract
+{
 
 	const MAINTAINER = 'joshcoales';
 	const NAME = 'Imgur Bridge';
@@ -16,8 +18,33 @@ class ImgurBridge extends BridgeAbstract {
 		)
 	);
 
+	public function getURI()
+	{
+		return self::URI
+			. '/search/time/?q='
+			. filter_var($this->getInput('g'), FILTER_SANITIZE_URL)
+			. '&qs=list';
+	}
+
 	public function collectData()
 	{
-		// TODO: Implement collectData() method.
+		$html = getSimpleHTMLDOM($this->getURI());
+
+		$posts = $html->find('div.post-list')
+		or returnServerError('Failed finding posts!');
+
+		foreach ($posts as $post) {
+
+			$item = array();
+
+			$item['uri'] = $this::URI . $post->find('a', 0)->href;
+			$item['title'] = $post->find('p.search-item-title', 0)->plaintext;
+			$item['author'] = $post->find('div.post-byline a.account', 0)->plaintext;
+			$item['content'] = '';  // TODO
+			$item['timestamp'] = ''; // TODO
+			$item['enclosures'] = ''; // TODO
+
+			$this->items[] = $item;
+		}
 	}
 }

--- a/bridges/ImgurBridge.php
+++ b/bridges/ImgurBridge.php
@@ -22,7 +22,7 @@ class ImgurBridge extends BridgeAbstract
 	{
 		return self::URI
 			. '/search/time/?q='
-			. filter_var($this->getInput('g'), FILTER_SANITIZE_URL)
+			. filter_var($this->getInput('q'), FILTER_SANITIZE_URL)
 			. '&qs=list';
 	}
 
@@ -37,14 +37,25 @@ class ImgurBridge extends BridgeAbstract
 
 			$item = array();
 
-			$item['uri'] = $this::URI . $post->find('a', 0)->href;
-			$item['title'] = $post->find('p.search-item-title', 0)->plaintext;
+			$item['uri'] = $this->getPostUrl($post);
+			$item['title'] = $this->getPostTitle($post);
 			$item['author'] = $post->find('div.post-byline a.account', 0)->plaintext;
-			$item['content'] = '';  // TODO
 			$item['timestamp'] = ''; // TODO
-			$item['enclosures'] = ''; // TODO
 
 			$this->items[] = $item;
 		}
+	}
+
+	private function getPostUrl($post)
+	{
+		return $this::URI . ltrim($post->find('a', 0)->href, '/');
+	}
+
+	private function getPostTitle($post)
+	{
+		return html_entity_decode(
+			$post->find('p.search-item-title', 0)->plaintext,
+			ENT_QUOTES
+		);
 	}
 }


### PR DESCRIPTION
A bit of a request for comment really. A start of what #1068 wants. Scrapes the website rather than using the API like #1662.
For filling in timestamp, content, and enclosures, it would need to request the page for each post in the feed, is this what we want? That seems rather heavy, are there other bridges that do this so I can understand our best practice around caching in that instance?

Alternatively on timestamps, imgur does say "4 hours ago" on the search page, and maybe I could parse that, but it would be messy, changing frequently.