### PR TITLE
Add "filter" to Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ RSS-Bridge requires PHP 5.6 or higher with following extensions enabled:
   - [`simplexml`](https://secure.php.net/manual/en/book.simplexml.php)
   - [`curl`](https://secure.php.net/manual/en/book.curl.php)
   - [`json`](https://secure.php.net/manual/en/book.json.php)
+  - [`filter`](https://secure.php.net/manual/en/book.filter.php)
   - [`sqlite3`](http://php.net/manual/en/book.sqlite3.php) (only when using SQLiteCache)
 
 Find more information on our [Wiki](https://github.com/rss-bridge/rss-bridge/wiki)


### PR DESCRIPTION
This extension is required by filter_var()

https://github.com/RSS-Bridge/rss-bridge/blob/6af87b2f326b5e52943e1413952ca40ea8570a49/lib/ParameterValidator.php#L67

https://github.com/RSS-Bridge/rss-bridge/blob/6af87b2f326b5e52943e1413952ca40ea8570a49/lib/FeedItem.php#L154

(Wiki has already been updated)