### PR TITLE
[AppleMusicBridge] Use title from website

### DIFF
--- a/bridges/AppleMusicBridge.php
+++ b/bridges/AppleMusicBridge.php
@@ -20,6 +20,8 @@ class AppleMusicBridge extends BridgeAbstract {
 	));
 	const CACHE_TIMEOUT = 21600; // 6 hours
 
+	private $title;
+
 	public function collectData() {
 		$url = $this->getInput('url');
 		$html = getSimpleHTMLDOM($url)

--- a/bridges/AppleMusicBridge.php
+++ b/bridges/AppleMusicBridge.php
@@ -27,6 +27,8 @@ class AppleMusicBridge extends BridgeAbstract {
 
 		$imgSize = $this->getInput('imgSize');
 
+		$this->title = $html->find('title', 0)->innertext;
+
 		// Grab the json data from the page
 		$html = $html->find('script[id=shoebox-ember-data-store]', 0);
 		$html = strstr($html, '{');
@@ -58,5 +60,9 @@ class AppleMusicBridge extends BridgeAbstract {
 		usort($this->items, function($a, $b){
 			return $a['timestamp'] < $b['timestamp'];
 		});
+	}
+
+	public function getName() {
+		return $this->title ?: parent::getName();
 	}
 }


### PR DESCRIPTION
This will set the feed's title to the same as the Apple Music website that is fetched.

It will now show as the more useful "Dunderpatrullen on Apple Music" format instead of just "Apple Music".