### PR TITLE
[Bridges] Use defaultLinkTo()

### DIFF
--- a/bridges/BastaBridge.php
+++ b/bridges/BastaBridge.php
@@ -19,13 +19,11 @@ class BastaBridge extends BridgeAbstract {
 				$item['title'] = $element->find('title', 0)->innertext;
 				$item['uri'] = $element->find('guid', 0)->plaintext;
 				$item['timestamp'] = strtotime($element->find('dc:date', 0)->plaintext);
-				// Replaces all relative image URLs by absolute URLs.
-				// Relative URLs always start with 'local/'!
-				$item['content'] = preg_replace(
-					'/src=["\']{1}([^"\']+)/ims',
-					'src=\'' . self::URI . '$1\'',
-					getSimpleHTMLDOM($item['uri'])->find('div.texte', 0)->innertext
-				);
+
+				$html = getSimpleHTMLDOM($item['uri']);
+				$html = defaultLinkTo($html, self::URI);
+
+				$item['content'] = $html->find('div.texte', 0)->innertext;
 				$this->items[] = $item;
 				$limit++;
 			}

--- a/bridges/KernelBugTrackerBridge.php
+++ b/bridges/KernelBugTrackerBridge.php
@@ -61,6 +61,8 @@ class KernelBugTrackerBridge extends BridgeAbstract {
 		if($html === false)
 			returnServerError('Failed to load page!');
 
+		$html = defaultLinkTo($html, self::URI);
+
 		// Store header information into private members
 		$this->bugid = $html->find('#bugzilla-body', 0)->find('a', 0)->innertext;
 		$this->bugdesc = $html->find('table.bugfields', 0)->find('tr', 0)->find('td', 0)->innertext;
@@ -93,7 +95,7 @@ class KernelBugTrackerBridge extends BridgeAbstract {
 			$item['content'] = str_replace("\n", '<br>', $item['content']);
 
 			// Fix relative URIs
-			$item['content'] = $this->replaceRelativeURI($item['content']);
+			$item['content'] = $item['content'];
 
 			$this->items[] = $item;
 		}
@@ -123,17 +125,6 @@ class KernelBugTrackerBridge extends BridgeAbstract {
 				break;
 			default: return parent::getName();
 		}
-	}
-
-	/**
-	 * Replaces all relative URIs with absolute ones
-	 *
-	 * @param string $content The source string
-	 * @return string Returns the source string with all relative URIs replaced
-	 * by absolute ones.
-	 */
-	private function replaceRelativeURI($content){
-		return preg_replace('/href="(?!http)/', 'href="' . self::URI . '/', $content);
 	}
 
 	/**

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -8,6 +8,7 @@ class ReporterreBridge extends BridgeAbstract {
 
 		private function extractContent($url){
 			$html2 = getSimpleHTMLDOM($url);
+			$html2 = defaultLinkTo($html2, self::URI);
 
 			foreach($html2->find('div[style=text-align:justify]') as $e) {
 				$text = $e->outertext;
@@ -15,13 +16,6 @@ class ReporterreBridge extends BridgeAbstract {
 
 			$html2->clear();
 			unset($html2);
-
-			// Replace all relative urls with absolute ones
-			$text = preg_replace(
-				'/(href|src)(\=[\"\'])(?!http)([^"\']+)/ims',
-				'$1$2' . self::URI . '$3',
-				$text
-			);
 
 			$text = strip_tags($text, '<p><br><a><img>');
 			return $text;


### PR DESCRIPTION
Updates bridges `ReporterreBridge`, `KernelBugTrackerBridge` and `BastaBridge` to use `defaultLinkTo()` instead of their custom URL fixing functions.