### PR TITLE
[Dockerfile] Clean up apt cache, make image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
 	&& apt-get --yes --no-install-recommends install \
 		zlib1g-dev \
 		libmemcached-dev \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& pecl install memcached \
 	&& docker-php-ext-enable memcached \
 	&& sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \


### PR DESCRIPTION
This will make the image smaller! (From 438MB to 421MB)