### PR TITLE
Initial InstagramBridge private feed - Include CSRF

### DIFF
--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -63,7 +63,7 @@ class InstagramBridge extends BridgeAbstract {
 		$key = $cache->loadData();
 
 		if($key == null) {
-			$headers = array("Authorization: Bearer $token");
+			$headers = array();
 			if (CSRF_TOKEN != "") $headers[] = "X-CSRFToken: " . CSRF_TOKEN;
 			$data = getContents(self::URI . 'web/search/topsearch/?query=' . $username, $headers);
 
@@ -214,7 +214,7 @@ class InstagramBridge extends BridgeAbstract {
 
 	protected function getSinglePostData($uri) {
 		$shortcode = explode('/', $uri)[4];
-		$headers = array("Authorization: Bearer $token");
+		$headers = array();
 		if (CSRF_TOKEN != "") $headers[] = "X-CSRFToken: " . CSRF_TOKEN;
 		$data = getContents(self::URI .
 					'graphql/query/?query_hash=' .
@@ -227,7 +227,7 @@ class InstagramBridge extends BridgeAbstract {
 	}
 
 	protected function getInstagramJSON($uri) {
-		$headers = array("Authorization: Bearer $token");
+		$headers = array();
 		if (CSRF_TOKEN != "") $headers[] = "X-CSRFToken: " . CSRF_TOKEN;
 
 		if(!is_null($this->getInput('u'))) {


### PR DESCRIPTION
**[HOLD PR]**
A bit more research needs to be done to store the full cookie data. Since the `urlgen` cookie variable is tied to IP, this is not as straight forward as first appeared. The 429 block may have expired during my testing causing false positives with the CSRF token

**Purpose**
While integration with the new configuration PR (https://github.com/RSS-Bridge/rss-bridge/pull/1343) is required, this takes the first steps to enabling private feeds in the Instagram Bridge.

**Caveats**
I cannot fully validate this without wider user testing for 429 errors, however in my brief testing it has worked well.

**Usage**
Until the above integration occurs, users will need to edit the `CSRF_TOKEN` variable ([see here](https://github.com/Fmstrat/rss-bridge/blob/insta_csrf/bridges/InstagramBridge.php#L48)) to match a token they get from Instagram. To get a token, users can view any page on Instagram while logged in and look at the network inspector for any call to a `/graphql` URL:

![CSRF](https://user-images.githubusercontent.com/971474/101991907-be868e80-3c7d-11eb-9662-d39aa2fac389.png)
