### PR TITLE
[FacebookBridge] Replace post avatar with hires version

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -741,6 +741,7 @@ EOD;
 						$item['title'] = htmlspecialchars_decode($title, ENT_QUOTES);
 						$item['author'] = htmlspecialchars_decode($author, ENT_QUOTES);
 						$item['timestamp'] = $date;
+						$item['icon'] = htmlspecialchars_decode($profilePic, ENT_QUOTES);
 
 						if(strpos($item['content'], '<img') === false) {
 							$item['enclosures'] = array($profilePic);

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -653,6 +653,11 @@ EOD;
 							$anchor->outertext = '<p>' . $anchor->innertext . '</p>';
 						}
 
+						// Change to the hires avatar
+						foreach($content->find('._38vo') as $anchor) {
+							$anchor->outertext = '<div><img src="' . $profilePic . '" alt="" aria-label="Arte" role="img"></div>';
+						}
+
 						$content = preg_replace(
 							'/(?i)><div class=\"_3dp([^>]+)>(.+?)div\ class=\"[^u]+userContent\"/i',
 							'',


### PR DESCRIPTION
Currently the FB bridge directly uses the avatar in each post (56x56) rather than the more clear avatar in that page. This, in some RSS aggregrators which utilize the first picture as the feature image (enlarged), will lead to blurry pictures and poor experience.

This patch replaces the low-res avatar with the hi-res one.