### PR TITLE
[HackerNewsUserThreads] New bridge

### DIFF
--- a/bridges/HackerNewsUserThreadsBridge.php
+++ b/bridges/HackerNewsUserThreadsBridge.php
@@ -23,13 +23,22 @@ class HackerNewsUserThreadsBridge extends BridgeAbstract {
 
 		$item = array();
 		$articles = $html->find('tr[class*="comtr"]');
+		$story = '';
 
 		foreach ($articles as $element) {
 			$id = $element->getAttribute('id');
 			$item['uri'] = 'https://news.ycombinator.com/item?id=' . $id;
-			$title = $element->find('span[class*="comhead"]', 0)->innertext;
+
+			$author = $element->find('span[class*="comhead"]', 0)->find('a[class="hnuser"]', 0)->innertext;
+			$newstory = $element->find('span[class*="comhead"]', 0)->find('span[class="storyon"]', 0);
+			if (count($newstory->find('a')) > 0) {
+				$story = $newstory->find('a', 0)->innertext;
+			}
+
+			$title = $author . ' | on ' . $story;
+			$item['author'] = $author;
 			$item['title'] = $title;
-			$item['timestamp'] = strtotime($element->find('span[class*="age"]', 0)->find('a', 0)->innertext);
+			$item['timestamp'] = $element->find('span[class*="age"]', 0)->find('a', 0)->innertext;
 			$item['content'] = $element->find('span[class*="commtext"]', 0)->innertext;
 
 			$this->items[] = $item;

--- a/bridges/HackerNewsUserThreadsBridge.php
+++ b/bridges/HackerNewsUserThreadsBridge.php
@@ -4,7 +4,7 @@ class HackerNewsUserThreadsBridge extends BridgeAbstract {
 	const MAINTAINER = 'rakoo';
 	const NAME = 'Hacker News User Threads';
 	const URI = 'https://news.ycombinator.com';
-	const CACHE_TIMEOUT = 7200; // 2h
+	const CACHE_TIMEOUT = 7200; // 2 hours
 	const DESCRIPTION = 'Hacker News threads for a user (at https://news.ycombinator.com/threads?id=xxx)';
 	const PARAMETERS = array( array(
 		'user' => array(

--- a/bridges/HackerNewsUserThreadsBridge.php
+++ b/bridges/HackerNewsUserThreadsBridge.php
@@ -1,0 +1,38 @@
+<?php
+class HackerNewsUserThreadsBridge extends BridgeAbstract {
+
+	const MAINTAINER = 'rakoo';
+	const NAME = 'Hacker News User Threads';
+	const URI = 'https://news.ycombinator.com';
+	const CACHE_TIMEOUT = 7200; // 2h
+	const DESCRIPTION = 'Hacker News threads for a user (at https://news.ycombinator.com/threads?id=xxx)';
+	const PARAMETERS = array( array(
+		'user' => array(
+			'name' => 'User',
+			'type' => 'text',
+			'required' => true,
+			'title' => 'User whose threads you want to see'
+		)
+	));
+
+	public function collectData(){
+		$url = 'https://news.ycombinator.com/threads?id=' . $this->getInput('user');
+		$html = getSimpleHTMLDOM($url) or returnServerError('Could not request HN.');
+		Debug::log('queried ' . $url);
+		Debug::log('found ' . $html);
+
+		$item = array();
+		$articles = $html->find('tr[class*="comtr"]');
+
+		foreach ($articles as $element) {
+			$id = $element->getAttribute('id');
+			$item['uri'] = 'https://news.ycombinator.com/item?id=' . $id;
+			$title = $element->find('span[class*="comhead"]', 0)->innertext;
+			$item['title'] = $title;
+			$item['timestamp'] = strtotime($element->find('span[class*="age"]', 0)->find('a', 0)->innertext);
+			$item['content'] = $element->find('span[class*="commtext"]', 0)->innertext;
+
+			$this->items[] = $item;
+		}
+	}
+}


### PR DESCRIPTION
New bridge for HN's threads page of a specific user, for example for [my user](https://news.ycombinator.com/threads?id=rakoo) you get entries like this:

```
<entry>
  <title type="html">rakoo | on Our Year in Review: How We’ve Made Firefox Faster ...</title>
  <published>2020-12-18T14:40:56+00:00</published>
  <updated>2020-12-18T14:40:56+00:00</updated>
  <id>https://news.ycombinator.com/item?id=25462604</id>
  <link rel="alternate" type="text/html" href="https://news.ycombinator.com/item?id=25462604"/>
  <author>
    <name>rakoo</name>
  </author>
  <content type="html">
The concern with Pocket is primarily, IMO, that the service wasn&#x27;t and still isn&#x27;t Open Source, which is a hard sell for a browser that champions user control.
  </content>
</entry>
```

My goal is to know when there's been a reply to one of the comments I did, or anywhere in the chain (ie a reply of a reply, ...). HN doesn't provide any indications like this, so the next best thing is to use RSS :)