### PR TITLE
[InstagramBridge] Improve sidecar and video data retrieval

### DIFF
--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -131,7 +131,7 @@ class InstagramBridge extends BridgeAbstract {
 
 			switch($media->__typename) {
 				case 'GraphSidecar':
-					$data = $this->getInstagramSidecarData($item['uri'], $item['title']);
+					$data = $this->getInstagramSidecarData($item['uri'], $item['title'], $media, $textContent);
 					$item['content'] = $data[0];
 					$item['enclosures'] = $data[1];
 					break;
@@ -142,7 +142,7 @@ class InstagramBridge extends BridgeAbstract {
 					$item['enclosures'] = array($mediaURI);
 					break;
 				case 'GraphVideo':
-					$data = $this->getInstagramVideoData($item['uri'], $mediaURI);
+					$data = $this->getInstagramVideoData($item['uri'], $mediaURI, $media, $textContent);
 					$item['content'] = $data[0];
 					if($directLink) {
 						$item['enclosures'] = $data[1];
@@ -160,11 +160,7 @@ class InstagramBridge extends BridgeAbstract {
 	}
 
 	// returns Sidecar(a post which has multiple media)'s contents and enclosures
-	protected function getInstagramSidecarData($uri, $postTitle) {
-		$mediaInfo = $this->getSinglePostData($uri);
-
-		$textContent = $this->getTextContent($mediaInfo);
-
+	protected function getInstagramSidecarData($uri, $postTitle, $mediaInfo, $textContent) {
 		$enclosures = array();
 		$content = '';
 		foreach($mediaInfo->edge_sidecar_to_children->edges as $singleMedia) {
@@ -187,10 +183,7 @@ class InstagramBridge extends BridgeAbstract {
 	}
 
 	// returns Video post's contents and enclosures
-	protected function getInstagramVideoData($uri, $mediaURI) {
-		$mediaInfo = $this->getSinglePostData($uri);
-
-		$textContent = $this->getTextContent($mediaInfo);
+	protected function getInstagramVideoData($uri, $mediaURI, $mediaInfo, $textContent) {
 		$content = '<video controls>';
 		$content .= '<source src="' . $mediaInfo->video_url . '" poster="' . $mediaURI . '" type="video/mp4">';
 		$content .= '<img src="' . $mediaURI . '" alt="">';


### PR DESCRIPTION
getInstagramSidecarData and getInstagramVideoData were unnecessarily calling getSinglePostData to retrieve JSON information already present from collectData's call of getInstagramJSON.  getSinglePostData sometimes doesn't retrieve this data properly resulting in incomplete processing like #1890 .  Since the information needed is already present, pass it from collectData instead and eliminate the redundant data collection which will improve reliability.