### PR TITLE
[TwitterBridge] Fix username matching to be case insensitive with noretweet option

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -388,7 +388,7 @@ EOD;
 					}
 					break;
 				case 'By username':
-					if ($this->getInput('noretweet') && $item['username'] != $this->getInput('u')) {
+					if ($this->getInput('noretweet') && strtolower($item['username']) != strtolower($this->getInput('u'))) {
 						continue 2; // switch + for-loop!
 					}
 					break;

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -266,7 +266,7 @@ EOD
 			$item['username'] = $user_info->screen_name;
 			$item['fullname'] = $user_info->name;
 			$item['author'] = $item['fullname'] . ' (@' . $item['username'] . ')';
-			if (null !== $this->getInput('u') && $item['username'] != $this->getInput('u')) {
+			if (null !== $this->getInput('u') && strtolower($item['username']) != strtolower($this->getInput('u'))) {
 				$item['author'] .= ' RT: @' . $this->getInput('u');
 			}
 			$item['avatar'] = $user_info->profile_image_url_https;


### PR DESCRIPTION
Makes username comparisons case insensitive with `strtolower`.  This fixes the problem where all tweets are considered as a retweet if the input username is not cased the same as the actual username.

For example: `aoc` instead of the actual username `AOC` with no retweets turned on will [return empty results](https://rss-bridge.bb8.fun/?action=display&bridge=Twitter&context=By+username&u=aoc&noretweet=on&format=Json).