### PR TITLE
bridges: change 'tags' to 'categories'

### DIFF
--- a/bridges/DanbooruBridge.php
+++ b/bridges/DanbooruBridge.php
@@ -44,14 +44,14 @@ class DanbooruBridge extends BridgeAbstract {
 		$item['postid'] = (int)preg_replace('/[^0-9]/', '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();
 		$thumbnailUri = $element->find('img', 0)->src;
-		$item['tags'] = $this->getTags($element);
+		$item['categories'] = array_filter(explode(' ', $this->getTags($element)));
 		$item['title'] = $this->getName() . ' | ' . $item['postid'];
 		$item['content'] = '<a href="'
 		. $item['uri']
 		. '"><img src="'
 		. $thumbnailUri
 		. '" /></a><br>Tags: '
-		. $item['tags'];
+		. $this->getTags($element);
 
 		return $item;
 	}

--- a/bridges/Rule34pahealBridge.php
+++ b/bridges/Rule34pahealBridge.php
@@ -16,14 +16,14 @@ class Rule34pahealBridge extends Shimmie2Bridge {
 		$item['id'] = (int)preg_replace('/[^0-9]/', '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();
 		$thumbnailUri = $element->find('a', 1)->href;
-		$item['tags'] = $element->getAttribute('data-tags');
+		$item['categories'] = explode(' ', $element->getAttribute('data-tags'));
 		$item['title'] = $this->getName() . ' | ' . $item['id'];
 		$item['content'] = '<a href="'
 		. $item['uri']
 		. '"><img src="'
 		. $thumbnailUri
 		. '" /></a><br>Tags: '
-		. $item['tags'];
+		. $element->getAttribute('data-tags');
 		return $item;
 	}
 }

--- a/bridges/Shimmie2Bridge.php
+++ b/bridges/Shimmie2Bridge.php
@@ -24,14 +24,14 @@ class Shimmie2Bridge extends DanbooruBridge {
 		$item['id'] = (int)preg_replace('/[^0-9]/', '', $element->getAttribute(static::IDATTRIBUTE));
 		$item['timestamp'] = time();
 		$thumbnailUri = $this->getURI() . $element->find('img', 0)->src;
-		$item['tags'] = $element->getAttribute('data-tags');
+		$item['categories'] = explode(' ', $element->getAttribute('data-tags'));
 		$item['title'] = $this->getName() . ' | ' . $item['id'];
 		$item['content'] = '<a href="'
 		. $item['uri']
 		. '"><img src="'
 		. $thumbnailUri
 		. '" /></a><br>Tags: '
-		. $item['tags'];
+		. $element->getAttribute('data-tags');
 
 		return $item;
 	}


### PR DESCRIPTION
Danbooru and bridges based on it used 'tags' instead of 'categories'.