### PR TITLE
[BridgeImplementationTest] Allow multiple contexts to have empty parameter arrays

### DIFF
--- a/tests/BridgeImplementationTest.php
+++ b/tests/BridgeImplementationTest.php
@@ -69,6 +69,10 @@ class BridgeImplementationTest extends TestCase {
 				$this->assertNotEmpty($context, 'empty context name');
 			}
 
+			if (empty($params)) {
+				continue;
+			}
+
 			foreach ($paramsSeen as $seen) {
 				$this->assertNotEquals($seen, $params, 'same set of parameters not allowed');
 			}


### PR DESCRIPTION
Currently if multiple contexts have an empty parameters array the test fails and reports duplicate parameters found, which is not the case. This pull request updates `testParameters()` in `BridgeImplementationTest.php` to allow multiple contexts to have an empty parameters array.