### PR TITLE
[ZoneTelechargement] Update Direct Download Unprotected URL

### DIFF
--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -34,7 +34,7 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 	);
 
 	// This is an URL that is not protected by robot protection for Direct Download
-	const UNPROTECTED_URI = 'https://www.zone-annuaire.com/';
+	const UNPROTECTED_URI = 'https://www.zone-telechargement.net/';
 
 	// This is an URL that is not protected by robot protection for Streaming Links
 	const UNPROTECTED_URI_STREAMING = 'https://zone-telechargement.stream/';


### PR DESCRIPTION
The old Direct Download unprotected URL does not resolve anymore. It has been replaced with a working URL.