### PR TITLE
[BridgeCard] Allow config options noproxy & cache_timeout when a bridge has no parameters

### DIFF
--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -347,10 +347,12 @@ This bridge is not fetching its content through a secure connection</div>';
 CARD;
 
 		// If we don't have any parameter for the bridge, we print a generic form to load it.
-		if(count($parameters) === 0
-		|| count($parameters) === 1 && array_key_exists('global', $parameters)) {
-
+		if (count($parameters) === 0) {
 			$card .= self::getForm($bridgeName, $formats, $isActive, $isHttps);
+
+		// Display form with cache timeout and/or noproxy options (if enabled) when bridge has no parameters
+		} else if (count($parameters) === 1 && array_key_exists('global', $parameters)) {
+			$card .= self::getForm($bridgeName, $formats, $isActive, $isHttps, '', $parameters['global']);
 
 		} else {
 


### PR DESCRIPTION
Updates `displayBridgeCard()` in `BridgeCard` to allow configuration options noproxy and cache_timeout to be displayed, if enabled, when a bridge has no parameters in its `PARAMETERS` array. Closes #1648