### PR TITLE
[contents.php] Fix logical error in getSimpleHTMLDOMCached function

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -311,7 +311,7 @@ function getSimpleHTMLDOMCached($url,
 	$time = $cache->getTime();
 	if($time !== false
 	&& (time() - $duration < $time)
-	&& Debug::isEnabled()) { // Contents within duration
+	&& !Debug::isEnabled()) { // Contents within duration
 		$content = $cache->loadData();
 	} else { // Content not within duration
 		$content = getContents($url, $header, $opts);


### PR DESCRIPTION
Previously content was only loaded from cache when debug mode was enabled (the opposite of the expected behavior)