### PR TITLE
[TelegramBridge] Display the name of the attachments

### DIFF
--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -133,7 +133,7 @@ class TelegramBridge extends BridgeAbstract {
 			);
 		}
 		if ($messageDiv->find('div.tgme_widget_message_document', 0)) {
-			$message .= "Attachments:";
+			$message .= 'Attachments:';
 			foreach ($messageDiv->find('div.tgme_widget_message_document') as $attachments) {
 				$message .= $attachments->find('div.tgme_widget_message_document_title.accent_color', 0);
 			}

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -134,7 +134,6 @@ class TelegramBridge extends BridgeAbstract {
 		}
 		if ($messageDiv->find('div.tgme_widget_message_document', 0)) {
 			$message .= "Attachments:";
-			
 			foreach ($messageDiv->find('div.tgme_widget_message_document') as $attachments) {
 				$message .= $attachments->find('div.tgme_widget_message_document_title.accent_color', 0);
 			}

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -132,7 +132,6 @@ class TelegramBridge extends BridgeAbstract {
 				$messageDiv->find('div.tgme_widget_message_text.js-message_text', 0)->plaintext
 			);
 		}
-		
 		if ($messageDiv->find('div.tgme_widget_message_document', 0)) {
 			$message .= "Attachments:";
 			

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -132,6 +132,14 @@ class TelegramBridge extends BridgeAbstract {
 				$messageDiv->find('div.tgme_widget_message_text.js-message_text', 0)->plaintext
 			);
 		}
+		
+		if ($messageDiv->find('div.tgme_widget_message_document', 0)) {
+			$message .= "Attachments:";
+			
+			foreach ($messageDiv->find('div.tgme_widget_message_document') as $attachments) {
+				$message .= $attachments->find('div.tgme_widget_message_document_title.accent_color', 0);
+			}
+		}
 
 		if ($messageDiv->find('a.tgme_widget_message_link_preview', 0)) {
 			$message .= $this->processLinkPreview($messageDiv);


### PR DESCRIPTION
Sometimes attachments are posted in Telegram channels without any text. 

The script recognizes a new message but does not report any text, with this commit the file names will also be included in the RSS Feed.