### PR TITLE
[HtmlFormat] Use str_ireplace() when creating feed URLs

### DIFF
--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -19,7 +19,7 @@ class HtmlFormat extends FormatAbstract {
 				continue;
 			}
 
-			$query = str_replace('format=Html', 'format=' . $format, htmlentities($_SERVER['QUERY_STRING']));
+			$query = str_ireplace('format=Html', 'format=' . $format, htmlentities($_SERVER['QUERY_STRING']));
 			$buttons .= $this->buildButton($format, $query) . PHP_EOL;
 
 			$mime = $formatFac->create($format)->getMimeType();


### PR DESCRIPTION
Fixes feed URLs not being created with correct format value if base URL uses a lowercase format value. Fixes issue introduced in #1967. 