### PR TITLE
Add support for proxy authentication

### DIFF
--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -35,6 +35,14 @@ email = ""
 ; ""    = Proxy disabled (default)
 url = ""
 
+; Sets username for the proxy
+; ""    = No username (default)
+username = ""
+
+; Sets password for the proxy
+; ""    = No password (default)
+password = ""
+
 ; Sets the proxy name that is shown on the bridge instead of the proxy url.
 ; ""    = Show proxy url
 name = "Hidden proxy name"

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -164,6 +164,22 @@ final class Configuration {
 			define('PROXY_URL', self::getConfig('proxy', 'url'));
 		}
 
+		if(!is_string(self::getConfig('proxy', 'username')))
+			self::reportConfigurationError('proxy', 'username', 'Is not a valid string');
+		
+		if(!empty(self::getConfig('proxy', 'username'))) {
+			/** Username for the proxy server */
+			define('PROXY_USERNAME', self::getConfig('proxy', 'username'));
+		}
+
+		if(!is_string(self::getConfig('proxy', 'password')))
+			self::reportConfigurationError('proxy', 'password', 'Is not a valid string');
+
+		if(!empty(self::getConfig('proxy', 'password'))) {
+			/** PAssword for the proxy server */
+			define('PROXY_PASSWORD', self::getConfig('proxy', 'password'));
+		}
+
 		if(!is_bool(self::getConfig('proxy', 'by_bridge')))
 			self::reportConfigurationError('proxy', 'by_bridge', 'Is not a valid Boolean');
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -166,7 +166,7 @@ final class Configuration {
 
 		if(!is_string(self::getConfig('proxy', 'username')))
 			self::reportConfigurationError('proxy', 'username', 'Is not a valid string');
-		
+
 		if(!empty(self::getConfig('proxy', 'username'))) {
 			/** Username for the proxy server */
 			define('PROXY_USERNAME', self::getConfig('proxy', 'username'));

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -176,7 +176,7 @@ final class Configuration {
 			self::reportConfigurationError('proxy', 'password', 'Is not a valid string');
 
 		if(!empty(self::getConfig('proxy', 'password'))) {
-			/** PAssword for the proxy server */
+			/** Password for the proxy server */
 			define('PROXY_PASSWORD', self::getConfig('proxy', 'password'));
 		}
 

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -120,6 +120,9 @@ function getContents($url, $header = array(), $opts = array(), $returnHeader = f
 			Debug::log('Setting proxy url: ' . PROXY_URL);
 			curl_setopt($ch, CURLOPT_PROXY, PROXY_URL);
 
+			if(defined('PROXY_USERNAME') && defined('PROXY_PASSWORD')) {
+				curl_setopt($ch, CURLOPT_USERPWD, PROXY_USERNAME . ':' . PROXY_PASSWORD);
+			}
 		}
 
 		// We always want the response header as part of the data!


### PR DESCRIPTION
Adds support for proxies that require username and password authentication. Closes #2021

Adds parameters `username` and `password` in the proxy section of `config.default.ini.php` and updates `lib/Configuration.php` and `lib\contents.php`.