### PR TITLE
[TwitScoopBridge] Fix encoding of less than (<) character

### DIFF
--- a/bridges/TwitScoopBridge.php
+++ b/bridges/TwitScoopBridge.php
@@ -106,11 +106,12 @@ class TwitScoopBridge extends BridgeAbstract {
 
 			$name = rtrim($li->find('span.trend.name', 0)->plaintext, '&nbsp');
 			$tweets = str_replace(' tweets', '', $li->find('span.tweets', 0)->plaintext);
+			$tweets = str_replace('<', '&lt;', $tweets);
 
-			$item['title'] = '#' . $number . ' - ' . $name . ' - ' . htmlentities($tweets) . ' tweets';
+			$item['title'] = '#' . $number . ' - ' . $name . ' (' . $tweets . ' tweets)';
 			$item['uri'] = 'https://twitter.com/search?q=' . rawurlencode($name);
 			$item['content'] = <<<EOD
-<Strong>Rank</strong><br>
+<strong>Rank</strong><br>
 <p>{$number}</p>
 <Strong>Topic</strong><br>
 <p>{$name}</p>


### PR DESCRIPTION
Fixes encoding of less than character (<) in item titles. Fix for https://github.com/RSS-Bridge/rss-bridge/pull/2018#issuecomment-802351310