### PR TITLE
[style] add dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ https://gist.github.com/LogMANOriginal/da00cd1e5f0ca31cef8e193509b17fd8
 * [sunchaserinfo](https://github.com/sunchaserinfo)
 * [SuperSandro2000](https://github.com/SuperSandro2000)
 * [sysadminstory](https://github.com/sysadminstory)
+* [t0stiman](https://github.com/t0stiman)
 * [tameroski](https://github.com/tameroski)
 * [teromene](https://github.com/teromene)
 * [tgkenney](https://github.com/tgkenney)

--- a/static/HtmlFormat.css
+++ b/static/HtmlFormat.css
@@ -113,3 +113,26 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
 	}
 
 }
+
+/* Dark theme, will automatically be set for those that have dark mode on their OS. */
+@media (prefers-color-scheme: dark){
+
+	* {
+		scrollbar-color: #202324 #454a4d;
+	}
+
+	body {
+		background-color: #202325;
+		color: #e8e6e3;
+	}
+
+	a, a:link, a:visited {
+		color: #0A6AB6;
+	}
+
+	/* Section */
+	section {
+		background-color: #181A1B;
+	}
+
+}

--- a/static/style.css
+++ b/static/style.css
@@ -383,3 +383,55 @@ h5 {
 	}
 
 }
+
+/* Dark theme */
+@media (prefers-color-scheme: dark){
+	* {
+		scrollbar-color: #202324 #454a4d;
+	}
+
+	body {
+		background-color: #202325;
+		color: #e8e6e3;
+	}
+
+	a, a:link, a:visited {
+		color: #0A6AB6;
+	}
+
+	/* Header */
+	select,
+	input[type="text"],
+	input[type="number"] {
+		background-color: #181A1B;
+		/* does not apply to placeholder text without !important */
+		color: white !important;
+
+		border: 1px solid #393E40;
+	}
+
+	/* Section */
+	section {
+		background-color: #181A1B;
+	}
+
+	/* Buttons */
+	button {
+		background: #0A6AB6 none repeat scroll 0% 0%;
+	}
+
+	button:hover {
+		background: #004daa;
+	}
+
+	@supports (display: grid){
+		.parameters input[type="number"] {
+			color: #BAB4AB;
+		}
+	}
+
+	/* Show more / less */
+	.showmore:hover, .showless:hover {
+		color: #d8d3cb;
+	}
+}


### PR DESCRIPTION
Resolves #2011 

This PR adds a dark mode to RSS-Bridge. The dark mode will automatically be used when the users OS is set to a dark theme, using `@media (prefers-color-scheme: dark)`. This way, the dark mode only gets applied to users who actually prefer dark themes.

https://user-images.githubusercontent.com/18124323/112636515-7874c580-8e3d-11eb-8acc-1eec5d2db05f.mp4


