### PR TITLE
[TwitScoopBridge] Remove less than (<) character from item title

### DIFF
--- a/bridges/TwitScoopBridge.php
+++ b/bridges/TwitScoopBridge.php
@@ -110,11 +110,11 @@ class TwitScoopBridge extends BridgeAbstract {
 
 			$item['title'] = '#' . $number . ' - ' . $name . ' (' . $tweets . ' tweets)';
 			$item['uri'] = 'https://twitter.com/search?q=' . rawurlencode($name);
-			
+
 			if ($tweets === '10K') {
 				$tweets = 'less than 10K';
 			}
-			
+
 			$item['content'] = <<<EOD
 <strong>Rank</strong><br>
 <p>{$number}</p>

--- a/bridges/TwitScoopBridge.php
+++ b/bridges/TwitScoopBridge.php
@@ -106,10 +106,15 @@ class TwitScoopBridge extends BridgeAbstract {
 
 			$name = rtrim($li->find('span.trend.name', 0)->plaintext, '&nbsp');
 			$tweets = str_replace(' tweets', '', $li->find('span.tweets', 0)->plaintext);
-			$tweets = str_replace('<', '&lt;', $tweets);
+			$tweets = str_replace('<', '', $tweets);
 
 			$item['title'] = '#' . $number . ' - ' . $name . ' (' . $tweets . ' tweets)';
 			$item['uri'] = 'https://twitter.com/search?q=' . rawurlencode($name);
+			
+			if ($tweets === '10K') {
+				$tweets = 'less than 10K';
+			}
+			
 			$item['content'] = <<<EOD
 <strong>Rank</strong><br>
 <p>{$number}</p>


### PR DESCRIPTION
Removes less than (<) character from item title, fixing issues @travstrat has been having with thefeedreaderbot.com. 