### PR TITLE
[FeedExpander] Handle Atom enclosures

### DIFF
--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -270,7 +270,9 @@ abstract class FeedExpander extends BridgeAbstract {
 			foreach($feedItem->link as $link) {
 				if(strtolower($link['rel']) === 'alternate') {
 					$item['uri'] = (string)$link['href'];
-					break;
+				}
+				if(strtolower($link['rel']) === 'enclosure') {
+					$item['enclosures'][] = (string)$link['href'];
 				}
 			}
 		}


### PR DESCRIPTION
Tried to chain the WordPress bridge with the Filter bridge and noticed that enclosures were gone.
The FeedExpander component was the culprit: it does not pass on Atom enclosures. This PR aims to fix that.