### PR TITLE
[FacebookBridge] fix group title

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -266,7 +266,7 @@ class FacebookBridge extends BridgeAbstract {
 
 	private function extractGroupName($html) {
 
-		$ogtitle = $html->find('._de1', 0)
+		$ogtitle = $html->find('title', 0)
 			or returnServerError('Unable to find group title!');
 
 		return html_entity_decode($ogtitle->plaintext, ENT_QUOTES);


### PR DESCRIPTION
I think this fixes (partly at least) this issue: https://github.com/RSS-Bridge/rss-bridge/issues/2014

I also think that using `._de1` is not idea. I'm not sure but they look like dynamically generated tags that change over time (every FB update?) don't they?.