### PR TITLE
[BridgeFactory.php] Add RSSBRIDGE_WHITELIST environment variable support

### DIFF
--- a/lib/BridgeFactory.php
+++ b/lib/BridgeFactory.php
@@ -148,7 +148,9 @@ class BridgeFactory extends FactoryAbstract {
 
 		if($firstCall) {
 
-			if(file_exists(WHITELIST)) {
+			if(getenv('RSSBRIDGE_WHITELIST')) {
+				$contents = str_replace(',', '\n', getenv('RSSBRIDGE_WHITELIST'));
+			} elseif(file_exists(WHITELIST)) {
 				$contents = trim(file_get_contents(WHITELIST));
 			} elseif(file_exists(WHITELIST_DEFAULT)) {
 				$contents = trim(file_get_contents(WHITELIST_DEFAULT));
@@ -159,7 +161,6 @@ class BridgeFactory extends FactoryAbstract {
 			if($contents === '*') { // Whitelist all bridges
 				$this->whitelist = $this->getBridgeNames();
 			} else {
-				//$this->$whitelist = array_map('$this->sanitizeBridgeName', explode("\n", $contents));
 				foreach(explode("\n", $contents) as $bridgeName) {
 					$this->whitelist[] = $this->sanitizeBridgeName($bridgeName);
 				}


### PR DESCRIPTION
Enabling/disabling bridges via the `whitelist.txt` file can be cumbersome in some setups, for example in containers. This PR introduces a `RSSBRIDGE_WHITELIST` environment variable that accepts a wildcard (`*`) or bridges names separated by a comma instead of newlines.

After merging, the [Whitelisting](https://github.com/RSS-Bridge/rss-bridge/wiki/Whitelisting) and [Docker](https://github.com/RSS-Bridge/rss-bridge/wiki/Docker) will need to be updated.

Edit : I'm of course open to modifications regarding the environment variable name or other changes.