### PR TITLE
[LoadingArtist] Add bridge

### DIFF
--- a/bridges/LoadingArtistBridge.php
+++ b/bridges/LoadingArtistBridge.php
@@ -1,0 +1,21 @@
+<?php
+class LoadingArtistBridge extends FeedExpander {
+
+	const MAINTAINER = 'bockiii';
+	const NAME = 'Loading Artist Bridge';
+	const URI = 'https://www.loadingartist.com/';
+	const CACHE_TIMEOUT = 4800; //2hours
+	const DESCRIPTION = 'Returns the last 10 comics';
+
+	public function collectData(){
+		$this->collectExpandableDatas(static::URI . 'feed');
+	}
+
+    protected function parseItem($feedItem){
+        $item = parent::parseItem($feedItem);
+        $item['content'] = str_replace('width="150" height="150" ','',$item['content']);
+        $item['content'] = str_replace('-150x150','',$item['content']);
+    
+        return $item;
+    }
+}


### PR DESCRIPTION
Greetings,

This adds the comic feed from LoadingArtist.com. 

The site itself has a feed but the feed only transports a 150x150 preview image. This bridge removes that limitation and provides the full image.

First contribution, I assume I did it correctly but let me know if I need to adapt something ;)

Code comment:
- The first string replace removes the img width/height headers
- The second string replace removes the 150x150 from the img src, providing the actual jpg name

I maybe could have done it in one replace action but this way its readable and maintainable.

Greetings