### PR TITLE
[Explosm] Added bridge

### DIFF
--- a/bridges/ExplosmBridge.php
+++ b/bridges/ExplosmBridge.php
@@ -15,8 +15,8 @@ class ExplosmBridge extends FeedExpander {
 		$item = parent::parseItem($feedItem);
 		$comicpage = getSimpleHTMLDOM($item['uri']);
 		$image = $comicpage->find('div[id=comic-wrap]', 0)->find('img', 0)->getAttribute('src');
-		$item['content'] = '<img src="http:' . $image . '" />';
+		$item['content'] = '<img src="https:' . $image . '" />';
 
 		return $item;
-    }
+	}
 }

--- a/bridges/ExplosmBridge.php
+++ b/bridges/ExplosmBridge.php
@@ -1,0 +1,22 @@
+<?php
+class ExplosmBridge extends FeedExpander {
+
+	const MAINTAINER = 'bockiii';
+	const NAME = 'Explosm Bridge';
+	const URI = 'https://www.explosm.com/';
+	const CACHE_TIMEOUT = 4800; //2hours
+	const DESCRIPTION = 'Returns the last 5 comics';
+
+	public function collectData(){
+		$this->collectExpandableDatas('https://feeds.feedburner.com/Explosm');
+	}
+
+    protected function parseItem($feedItem){
+        $item = parent::parseItem($feedItem);
+		$comicpage = getSimpleHTMLDOM($item['uri']);
+		$image = $comicpage->find('div[id=comic-wrap]', 0)->find('img', 0)->getAttribute('src');
+        $item['content'] = '<img src="http:' . $image . '" />';
+    
+        return $item;
+    }
+}

--- a/bridges/ExplosmBridge.php
+++ b/bridges/ExplosmBridge.php
@@ -11,12 +11,12 @@ class ExplosmBridge extends FeedExpander {
 		$this->collectExpandableDatas('https://feeds.feedburner.com/Explosm');
 	}
 
-    protected function parseItem($feedItem){
-        $item = parent::parseItem($feedItem);
+	protected function parseItem($feedItem){
+		$item = parent::parseItem($feedItem);
 		$comicpage = getSimpleHTMLDOM($item['uri']);
 		$image = $comicpage->find('div[id=comic-wrap]', 0)->find('img', 0)->getAttribute('src');
-        $item['content'] = '<img src="http:' . $image . '" />';
-    
-        return $item;
+		$item['content'] = '<img src="http:' . $image . '" />';
+
+		return $item;
     }
 }


### PR DESCRIPTION
Greetings,

The official Explosm feed (and with that, the webcomic Cyanide and Happiness) does not provide the images in the RSS items.

This fixes that.