### PR TITLE
[BridgeCard] Make HTML default, remove other buttons

### DIFF
--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -21,27 +21,6 @@
  */
 final class BridgeCard {
 	/**
-	 * Build a HTML document string of buttons for each of the provided formats
-	 *
-	 * @param array $formats A list of format names
-	 * @return string The document string
-	 */
-	private static function buildFormatButtons($formats) {
-		$buttons = '';
-
-		foreach($formats as $name) {
-			$buttons .= '<button type="submit" name="format" value="'
-			. $name
-			. '">'
-			. $name
-			. '</button>'
-			. PHP_EOL;
-		}
-
-		return $buttons;
-	}
-
-	/**
 	 * Get the form header for a bridge card
 	 *
 	 * @param string $bridgeName The bridge name
@@ -134,7 +113,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		}
 
 		if($isActive) {
-			$form .= self::buildFormatButtons($formats);
+			$form .= '<button type="submit" name="format" value="Html">Show Feed</button>';
 		} else {
 			$form .= '<span style="font-weight: bold;">Inactive</span>';
 		}

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -113,7 +113,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		}
 
 		if($isActive) {
-			$form .= '<button type="submit" name="format" value="Html">Show Feed</button>';
+			$form .= '<button type="submit" name="format" value="Html">Generate Feed</button>';
 		} else {
 			$form .= '<span style="font-weight: bold;">Inactive</span>';
 		}

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -113,7 +113,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		}
 
 		if($isActive) {
-			$form .= '<button type="submit" name="format" value="Html">Generate Feed</button>';
+			$form .= '<button type="submit" name="format" value="Html">Generate feed</button>';
 		} else {
 			$form .= '<span style="font-weight: bold;">Inactive</span>';
 		}


### PR DESCRIPTION
Contribution to #2099 

This will get rid of the list of buttons on the bridge overview and replace it with a single "show feed" button that goes to the html feed.

Unclutters the front, removes UX issues with the atom/mrss feed urls (you cannot use right-click-copy-link on the bridge overview but you can do it in the html view), adds the "hit enter and go to html feed" behavior.