### PR TITLE
[Docker] Add support for arm32/64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM php:7-apache
+ARG FROM_ARCH=amd64
+
+# Multi-stage build, see https://docs.docker.com/develop/develop-images/multistage-build/
+FROM alpine AS builder
+
+# Download QEMU
+ADD https://github.com/balena-io/qemu/releases/download/v5.2.0%2Bbalena4/qemu-5.2.0.balena4-arm.tar.gz .
+RUN tar zxvf qemu-5.2.0.balena4-arm.tar.gz --strip-components 1
+ADD https://github.com/balena-io/qemu/releases/download/v5.2.0%2Bbalena4/qemu-5.2.0.balena4-aarch64.tar.gz .
+RUN tar zxvf qemu-5.2.0.balena4-aarch64.tar.gz --strip-components 1
+
+FROM $FROM_ARCH/php:7-apache
+
+LABEL description="RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for websites that don't have one."
+LABEL repository="https://github.com/RSS-Bridge/rss-bridge"
+LABEL website="https://github.com/RSS-Bridge/rss-bridge"
+
+# Add QEMU
+COPY --from=builder qemu-arm-static /usr/bin
+COPY --from=builder qemu-aarch64-static /usr/bin
 
 ENV APACHE_DOCUMENT_ROOT=/app
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Custom build script to build images for all supported architectures.
+# Example for IMAGE_NAME: rss-builder/rss-builder:stable
+
+for arch in amd64 arm32v7 arm64v8
+do
+  echo "Building $IMAGE_NAME-$arch"
+  docker build --build-arg FROM_ARCH=$arch --file $DOCKERFILE_PATH --tag $IMAGE_NAME-$arch .
+done

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Use manifest-tool to create the manifest, given the experimental
+# "docker manifest" command isn't available yet on Docker Hub.
+MANIFEST_TOOL_VERSION=$(curl -s https://api.github.com/repos/estesp/manifest-tool/releases/latest | grep 'tag_name' | cut -d\" -f4)
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/$MANIFEST_TOOL_VERSION/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Generate the manifest file.
+# Parameter 1 is the multi-arch image name, e.g. rss-bridge/rss-bridge:stable
+function generate_manifest {
+  cat > manifest-generated.yaml << EOF
+image: $1
+manifests:
+  - image: $1-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: $1-arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7
+  - image: $1-arm64v8
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+EOF
+}
+
+echo "Pushing multi-arch manifest $IMAGE_NAME"
+generate_manifest $IMAGE_NAME
+./manifest-tool push from-spec manifest-generated.yaml

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Register qemu-*-static for all supported processors except the
+# current one, but also remove all registered binfmt_misc before
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Custom build script to push images for all supported architectures.
+
+for arch in amd64 arm32v7 arm64v8
+do
+  echo "Pushing $IMAGE_NAME-$arch"
+  docker push $IMAGE_NAME-$arch
+done


### PR DESCRIPTION
This adds arm32v7 and arm64v8 containers to the dockerhub "latest" tag.

To see how this looks like on dockerhub, check my test image:

Latest tag containing all three architectures: [click](https://hub.docker.com/r/bocki/rss-bridge-test/tags?page=1&ordering=last_updated)

Build Rules:
![image](https://user-images.githubusercontent.com/16492843/117076696-1b6f0800-ad37-11eb-93a0-c4712731bbe6.png)
You would need to change the branch name to "master" but keep everything else exactly how it is (docker tag and dockerfile location with the names).

The way the post script works is that you will have to run all image generations at least once (it will fail once for every image). Starting from the second run, all images will be flagged as "successful". That is because the post script wants to link all 3 images under one tag. If you are building them one by one, this step will fail every time because at least one of the images is not available at that point. This will solve itself on the second run though.