### PR TITLE
[NYTBridge] Fix article parsing (fix #1930)

### DIFF
--- a/bridges/NYTBridge.php
+++ b/bridges/NYTBridge.php
@@ -4,22 +4,33 @@ class NYTBridge extends FeedExpander {
 	const MAINTAINER = 'IceWreck';
 	const NAME = 'New York Times Bridge';
 	const URI = 'https://www.nytimes.com/';
-	const CACHE_TIMEOUT = 3600;
+	const CACHE_TIMEOUT = 900; // 15 minutes
 	const DESCRIPTION = 'RSS feed for the New York Times';
 
 	public function collectData(){
-		$this->collectExpandableDatas('https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml', 15);
+		$this->collectExpandableDatas('https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml', 40);
 	}
 
 	protected function parseItem($newsItem){
 		$item = parent::parseItem($newsItem);
+		$article = '';
+
 		// $articlePage gets the entire page's contents
 		$articlePage = getSimpleHTMLDOM($newsItem->link);
+
+		// handle subtitle
+		$subtitle = $articlePage->find('p.css-w6ymp8', 0);
+		if ($subtitle != null) {
+			$article .= '<strong>' . $subtitle->plaintext . '</strong>';
+		}
+
 		// figure contain's the main article image
-		$article = $articlePage->find('figure', 0);
-		// p > css-exrw3m has the actual article
-		foreach($articlePage->find('p.css-exrw3m') as $element)
-			$article = $article . $element;
+		$article .= $articlePage->find('figure', 0) . '<br />';
+
+		// section.meteredContent has the actual article
+		foreach($articlePage->find('section.meteredContent p') as $element)
+			$article .= '' . $element . '';
+
 		$item['content'] = $article;
 		return $item;
 	}


### PR DESCRIPTION
Commit a reworked version of the fix proposed by @podiki in #1930 :
- Fix the missing full article content
- Fix the missing article subtitle
- Reduce CACHE_TIMEOUT + change `collectExpandableDatas` from 15 to 40 latest articles to avoid to avoid missing articles.

It is still a bit buggy for the content on some articles (interactive content for example) though, but should work for most articles.