### PR TITLE
remove support for slideshows in nordbayern news

### DIFF
--- a/bridges/NordbayernBridge.php
+++ b/bridges/NordbayernBridge.php
@@ -64,6 +64,13 @@ class NordbayernBridge extends BridgeAbstract {
 		$item = array();
 		$article = getSimpleHTMLDOM($link);
 		$content = $article->find('div[class*=article-content]', 0);
+		if(is_null($content)) {
+			// If content is null its most likely a slideshow.
+			// we do not support slideshows right now as I (theScrabi)
+			// think there is to little informational value in these
+			// to actually add support to them.
+			return;
+		}
 		$item['uri'] = $link;
 		$item['title'] = $article->find('h1', 0)->innertext;
 		$item['content'] = '';


### PR DESCRIPTION
Remove Slideshow support for nordbayern news, as there is llitle informational value in them, and they constantly brake the parsing. They weren't even supported in the first place, but triggered a null exception so far.