### PR TITLE
[GithubTrendingBridge] Fix selector for description text

### DIFF
--- a/bridges/GithubTrendingBridge.php
+++ b/bridges/GithubTrendingBridge.php
@@ -614,7 +614,7 @@ class GithubTrendingBridge extends BridgeAbstract {
 			$item['title'] = str_replace('  ', '', trim(strip_tags($element->find('h1 a', 0)->plaintext)));
 
 			// Description
-			$item['content'] = trim(strip_tags($element->find('p.text-gray', 0)->innertext));
+			$item['content'] = trim(strip_tags($element->find('p', 0)->innertext));
 
 			// Time
 			$item['timestamp'] = time();


### PR DESCRIPTION
The `<p>` tag that holds the repo description on the [github trending page](https://github.com/trending) no longer has a `text-gray` class associated with it.

Fixes #2327