### PR TITLE
[CI] Update ubuntu version (16.04 => 20.04)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   phpcs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
@@ -21,7 +21,7 @@ jobs:
       - run: phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
 
   phpcompatibility:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-versions: ['5.6', '7.4']

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   phpcs:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
@@ -21,7 +21,7 @@ jobs:
       - run: phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
 
   phpcompatibility:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         php-versions: ['5.6', '7.4']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   phpunit6:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         php-versions: ['7.0', '7.1', '7.2']
@@ -21,7 +21,7 @@ jobs:
       - run: phpunit --configuration=phpunit.xml --include-path=lib/
 
   phpunit7:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         php-versions: ['7.1', '7.2', '7.3']
@@ -34,7 +34,7 @@ jobs:
       - run: phpunit --configuration=phpunit.xml --include-path=lib/
 
   phpunit8:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         php-versions: ['7.3', '7.4']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   phpunit6:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-versions: ['7.0', '7.1', '7.2']
@@ -21,7 +21,7 @@ jobs:
       - run: phpunit --configuration=phpunit.xml --include-path=lib/
 
   phpunit7:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-versions: ['7.1', '7.2', '7.3']
@@ -34,7 +34,7 @@ jobs:
       - run: phpunit --configuration=phpunit.xml --include-path=lib/
 
   phpunit8:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-versions: ['7.3', '7.4']


### PR DESCRIPTION
setup-php is dropping support for Ubuntu 16.04 on August 1, 2021.

>Support for Ubuntu 16.04 (Xenial Xerus) runners is deprecated and will be removed on August 1, 2021
https://github.com/shivammathur/setup-php/issues/452