### PR TITLE
[YoutubeBridge] Fix bridge

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -58,7 +58,7 @@ class YoutubeBridge extends BridgeAbstract {
 	);
 
 	private $feedName = '';
-	private $feeduri = '';
+	private $feeduri = null;
 
 	private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time){
 		$html = $this->ytGetSimpleHTMLDOM(self::URI . "watch?v=$vid", true);

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -229,7 +229,7 @@ class YoutubeBridge extends BridgeAbstract {
 			returnClientError('Max duration must be greater than min duration!');
 		}
 
-		$vid_list = '';
+		// $vid_list = '';
 
 		foreach($jsonData as $item) {
 			$wrapper = null;
@@ -286,7 +286,9 @@ class YoutubeBridge extends BridgeAbstract {
 				continue;
 			}
 
-			$vid_list .= $vid . ',';
+			// $vid_list .= $vid . ',';
+			$this->ytBridgeQueryVideoInfo($vid, $author, $desc, $time);
+			$this->ytBridgeAddItem($vid, $title, $author, $desc, $time);
 		}
 	}
 

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -96,7 +96,7 @@ class YoutubeBridge extends BridgeAbstract {
 				if(isset($description->navigationEndpoint->urlEndpoint)) {
 					$url = $description->navigationEndpoint->urlEndpoint->url;
 					$url_components = parse_url($url);
-					if(isset($url_components['query'])) {
+					if(isset($url_components['query']) && strpos($url_components['query'], '&q=') !== false) {
 						parse_str($url_components['query'], $params);
 						$url = urldecode($params['q']);
 					}

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -39,6 +39,12 @@ class YoutubeBridge extends BridgeAbstract {
 			's' => array(
 				'name' => 'search keyword',
 				'exampleValue' => 'test'
+			),
+			'pa' => array(
+				'name' => 'page',
+				'type' => 'number',
+				'title' => 'This option is not work anymore, as YouTube will always return the same page',
+				'exampleValue' => 1
 			)
 		),
 		'global' => array(
@@ -216,7 +222,7 @@ class YoutubeBridge extends BridgeAbstract {
 		$count = 0;
 		foreach($jsonData as $item) {
 			$count++;
-			if($count = 20) {
+			if($count == 20) {
 				break;
 			}
 			$wrapper = null;
@@ -401,7 +407,7 @@ class YoutubeBridge extends BridgeAbstract {
 			}
 			$this->parseJSONListing($jsonData);
 			$this->feeduri = $url_listing;
-			$this->feedName = 'Search: ' . str_replace(' - YouTube', '', $html->find('title', 0)->plaintext); // feedName will be used by getName()
+			$this->feedName = 'Search: ' . $this->request; // feedName will be used by getName()
 		} else { /* no valid mode */
 			returnClientError("You must either specify either:\n - YouTube
  username (?u=...)\n - Channel id (?c=...)\n - Playlist id (?p=...)\n - Search (?s=...)");

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -330,7 +330,7 @@ class YoutubeBridge extends BridgeAbstract {
 					// Bridge immediately find its user page (/user/nasa) and then nothing happen.
 					// Digging into the data, it appear it's another account, not from NASA itself.
 					// If you use feed, it works normally cause it already raise 404 error
-					if(!isset($jsonData->content)) {	
+					if(!isset($jsonData->content)) {
 						returnServerError('');	// Throw an empty one to trigger try catch
 					}
 				}
@@ -344,7 +344,7 @@ class YoutubeBridge extends BridgeAbstract {
 			if(!$this->skipFeeds()) {
 				return $this->ytBridgeParseXmlFeed($xml);
 			}
-			
+
 			if(isset($jsonData->contents)) {
 				$jsonData = $jsonData->contents->twoColumnBrowseResultsRenderer->tabs[1];
 				$jsonData = $jsonData->tabRenderer->content->sectionListRenderer->contents[0];

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -75,14 +75,13 @@ class YoutubeBridge extends BridgeAbstract {
 	private $channel_name = '';
 	// This took from repo BetterVideoRss of VerifiedJoseph.
 	const URI_REGEX = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2    ,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"\'!?&\/\/=\-*]+|\/)?)/ims';
-	
 	/*
 	*	This allow you to use Youtube Data API.
 	*	Enter your API key here.
 	*	To get one, please check out https://developers.google.com/youtube/v3/getting-started
 	*/
 	const API_KEY = '';	// Remember to remove it when commit.
-	
+
 	private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time){
 		$html = $this->ytGetSimpleHTMLDOM(self::URI . "watch?v=$vid", true);
 
@@ -154,7 +153,7 @@ class YoutubeBridge extends BridgeAbstract {
 		if(!$thumbnail) {
 			$thumbnail = '0';	// Fallback to default thumbnail if there aren't any provided.
 		}
-		$thumbnailUri = str_replace('/www.', '/img.', self::URI) . 'vi/' . $vid . '/' . $thumbnail .'.jpg';
+		$thumbnailUri = str_replace('/www.', '/img.', self::URI) . 'vi/' . $vid . '/' . $thumbnail . '.jpg';
 		$item['content'] = '<a href="' . $item['uri'] . '"><img src="' . $thumbnailUri . '" /></a><br />' . $desc;
 		$this->items[] = $item;
 	}
@@ -297,7 +296,7 @@ class YoutubeBridge extends BridgeAbstract {
 			} elseif(isset($snippet->thumbnails->standard)) {
 				$thumbnail = 'sddefault';
 			}
-			
+
 			$this->ytBridgeAddItem($vid, $title, $author, $desc, $time, $thumbnail);
 		}
 	}
@@ -366,7 +365,7 @@ class YoutubeBridge extends BridgeAbstract {
 			} else {
 				$durationText = 0;
 			}
-			
+
 			if(preg_match('/([\d]{1,2}):([\d]{1,2})\:([\d]{2})/', $durationText)) {
 				$durationText = preg_replace('/([\d]{1,2}):([\d]{1,2})\:([\d]{2})/', '$1:$2:$3', $durationText);
 			} else {
@@ -478,7 +477,7 @@ class YoutubeBridge extends BridgeAbstract {
 			$jsonData = $jsonData->tabRenderer->content->sectionListRenderer->contents[0]->itemSectionRenderer;
 			$jsonData = $jsonData->contents[0]->playlistVideoListRenderer->contents;
 			$item_count = count($jsonData);
-			
+
 			if ($item_count <= 15 && !$this->skipFeeds() && ($xml = $this->ytGetSimpleHTMLDOM($url_feed))) {
 				$this->ytBridgeParseXmlFeed($xml);
 			} else {

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -100,7 +100,7 @@ class YoutubeBridge extends BridgeAbstract {
 						parse_str($url_components['query'], $params);
 						$url = urldecode($params['q']);
 					}
-					$desc .= "<a href=\"$url\">$description->text</a>";
+					$desc .= "<a href=\"$url\" target=\"_blank\">$description->text</a>";
 				} else {
 					$desc .= nl2br($description->text);
 				}

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -217,12 +217,7 @@ class YoutubeBridge extends BridgeAbstract {
 			returnClientError('Max duration must be greater than min duration!');
 		}
 
-		$count = 0;
 		foreach($jsonData as $item) {
-			$count++;
-			if($count == 20) {
-				break;
-			}
 			$wrapper = null;
 			if(isset($item->gridVideoRenderer)) {
 				$wrapper = $item->gridVideoRenderer;

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -77,7 +77,6 @@ class YoutubeBridge extends BridgeAbstract {
 		if(!is_null($elDatePublished))
 			$time = strtotime($elDatePublished->getAttribute('content'));
 
-		
 		$jsonData = $this->getJSONData($html);
 		$jsonData = $jsonData->contents->twoColumnWatchNextResults->results->results->contents;
 
@@ -244,7 +243,7 @@ class YoutubeBridge extends BridgeAbstract {
 				$wrapper = $item->gridVideoRenderer;
 			} elseif(isset($item->videoRenderer)) {
 				$wrapper = $item->videoRenderer;
-			} else 
+			} else
 				continue;
 
 			$vid = $wrapper->videoId;
@@ -279,7 +278,7 @@ class YoutubeBridge extends BridgeAbstract {
 
 			$this->ytBridgeQueryVideoInfo($vid, $author, $desc, $time);
 			$this->ytBridgeAddItem($vid, $title, $author, $desc, $time);
-		}		
+		}
 	}
 
 	public function collectData(){

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -319,8 +319,6 @@ class YoutubeBridge extends BridgeAbstract {
 		}
 
 		$vid_list = '';
-		$count = 0;
-		$total = count($jsonData);
 
 		foreach($jsonData as $item) {
 			$wrapper = null;

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -81,8 +81,8 @@ class YoutubeBridge extends BridgeAbstract {
 		}
 
 		$elDatePublished = $html->find('meta[itemprop=datePublished]', 0);
-			if(!is_null($elDatePublished))
-				$time = strtotime($elDatePublished->getAttribute('content'));
+		if(!is_null($elDatePublished))
+			$time = strtotime($elDatePublished->getAttribute('content'));
 
 		$jsonData = $this->getJSONData($html);
 		$jsonData = $jsonData->contents->twoColumnWatchNextResults->results->results->contents;

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -74,7 +74,7 @@ class YoutubeBridge extends BridgeAbstract {
 	private $feeduri = '';
 	private $channel_name = '';
 	// This took from repo BetterVideoRss of VerifiedJoseph.
-	const URI_REGEX = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2    ,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"\'!?&\/\/=\-*]+|\/)?)/ims';
+	const URI_REGEX = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2    ,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"\'!?&\/\/=\-*]+|\/)?)/ims'; //phpcs:ignore
 	/*
 	*	This allow you to use Youtube Data API.
 	*	Enter your API key here.

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -58,7 +58,7 @@ class YoutubeBridge extends BridgeAbstract {
 	);
 
 	private $feedName = '';
-	private $feeduri = '';
+	private $feeduri = self::URI;
 
 	private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time){
 		$html = $this->ytGetSimpleHTMLDOM(self::URI . "watch?v=$vid", true);
@@ -359,6 +359,7 @@ class YoutubeBridge extends BridgeAbstract {
 			} else {
 				$this->parseJsonPlaylist($jsonData);
 			}
+			$this->feeduri = $url_listing;
 			$this->feedName = 'Playlist: ' . str_replace(' - YouTube', '', $html->find('title', 0)->plaintext); // feedName will be used by getName()
 			usort($this->items, function ($item1, $item2) {
 				return $item2['timestamp'] - $item1['timestamp'];
@@ -397,13 +398,7 @@ class YoutubeBridge extends BridgeAbstract {
 
 	public function getURI()
 	{
-		if (!is_null($this->getInput('p'))) {
-			return static::URI . 'playlist?list=' . $this->getInput('p');
-		} elseif(!is_null($this->feeduri)) {
-			return $this->feeduri;
-		}
-
-		return parent::getURI();
+		return $this->feed_uri;
 	}
 
 	public function getName(){

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -58,7 +58,7 @@ class YoutubeBridge extends BridgeAbstract {
 	);
 
 	private $feedName = '';
-	private $feeduri = self::URI;
+	private $feeduri = '';
 
 	private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time){
 		$html = $this->ytGetSimpleHTMLDOM(self::URI . "watch?v=$vid", true);
@@ -359,7 +359,6 @@ class YoutubeBridge extends BridgeAbstract {
 			} else {
 				$this->parseJsonPlaylist($jsonData);
 			}
-			$this->feeduri = $url_listing;
 			$this->feedName = 'Playlist: ' . str_replace(' - YouTube', '', $html->find('title', 0)->plaintext); // feedName will be used by getName()
 			usort($this->items, function ($item1, $item2) {
 				return $item2['timestamp'] - $item1['timestamp'];
@@ -398,7 +397,13 @@ class YoutubeBridge extends BridgeAbstract {
 
 	public function getURI()
 	{
-		return $this->feed_uri;
+		if (!is_null($this->getInput('p'))) {
+			return static::URI . 'playlist?list=' . $this->getInput('p');
+		} elseif(!is_null($this->feeduri)) {
+			return $this->feeduri;
+		}
+
+		return parent::getURI();
 	}
 
 	public function getName(){

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -58,7 +58,7 @@ class YoutubeBridge extends BridgeAbstract {
 	);
 
 	private $feedName = '';
-	private $feeduri = null;
+	private $feeduri = '';
 
 	private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time){
 		$html = $this->ytGetSimpleHTMLDOM(self::URI . "watch?v=$vid", true);
@@ -262,14 +262,18 @@ class YoutubeBridge extends BridgeAbstract {
 			} else {
 				foreach($wrapper->thumbnailOverlays as $overlay) {
 					if(isset($overlay->thumbnailOverlayTimeStatusRenderer)) {
-						$durationText = $wrapper->thumbnailOverlays[0]->thumbnailOverlayTimeStatusRenderer->text;
+						$durationText = $overlay->thumbnailOverlayTimeStatusRenderer->text;
 						break;
 					}
 				}
 			}
 
 			$durationText = trim($durationText->simpleText);
-			$durationText = preg_replace('/([\d]{1,2})\:([\d]{2})/', '00:$1:$2', $durationText);
+			if(preg_match('/([\d]{1,2}):([\d]{1,2})\:([\d]{2})/', $durationText)) {
+				$durationText = preg_replace('/([\d]{1,2}):([\d]{1,2})\:([\d]{2})/', '$1:$2:$3', $durationText);
+			} else {
+				$durationText = preg_replace('/([\d]{1,2})\:([\d]{2})/', '00:$1:$2', $durationText);
+			}
 			sscanf($durationText, '%d:%d:%d', $hours, $minutes, $seconds);
 			$duration = $hours * 3600 + $minutes * 60 + $seconds;
 			if($duration < $duration_min || $duration > $duration_max) {
@@ -398,7 +402,7 @@ class YoutubeBridge extends BridgeAbstract {
 	{
 		if (!is_null($this->getInput('p'))) {
 			return static::URI . 'playlist?list=' . $this->getInput('p');
-		} elseif(!is_null($this->feeduri)) {
+		} elseif($this->feeduri) {
 			return $this->feeduri;
 		}
 

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -80,11 +80,9 @@ class YoutubeBridge extends BridgeAbstract {
 			$author = $elAuthor->getAttribute('content');
 		}
 
-		if(!$time) {
-			$elDatePublished = $html->find('meta[itemprop=datePublished]', 0);
+		$elDatePublished = $html->find('meta[itemprop=datePublished]', 0);
 			if(!is_null($elDatePublished))
 				$time = strtotime($elDatePublished->getAttribute('content'));
-		}
 
 		$jsonData = $this->getJSONData($html);
 		$jsonData = $jsonData->contents->twoColumnWatchNextResults->results->results->contents;
@@ -243,23 +241,10 @@ class YoutubeBridge extends BridgeAbstract {
 			} elseif(isset($wrapper->shortBylineText)) {
 				$this->channel_name = $wrapper->shortBylineText->runs[0]->text;
 			}
-			// Attempted to get correct timestamp from the string
-			$timestamp = explode($title, $accessibilityData);
-			if(isset($wrapper->viewCountText->simpleText)) {
-				$view_count = $wrapper->viewCountText->simpleText;
-				$timestamp = explode($view_count, $timestamp[1]);
-				$timestamp = explode($this->channel_name, $timestamp[0]);
-			} else {
-				$timestamp = explode($this->channel_name, $timestamp[1]);
-			}
-			if(strpos($timestamp[1], 'Streamed') !== false) {
-				$timestamp = explode('Streamed', $timestamp[1]);
-			}
-			$timestamp = strtotime(trim($timestamp[1]));
 
 			$author = '';
 			$desc = '';
-			$time = $timestamp;
+			$time = '';
 
 			// The duration comes in one of the formats:
 			// hh:mm:ss / mm:ss / m:ss


### PR DESCRIPTION
- Add support for custom channel name (as request #2206).
- Add new method to fetch JSON data.
- Search, listing now parsing data through JSON, HTML is not work anymore.
- ~Remove page number input on the Search endpoint.~
- Merge two parseJSON function into one.
- ~Add ability to get better timestamp.~
- Fix regex on duration limit.
- Add anchor on some link in the description text.
- Add URL on the getURI() for each context.
**UPDATE 20/07/2021:**
- ~Add support for Youtube Data API v3.~ => Temporary remove API support, going to create a new PR after this PR merged.
- Fix playlists that have more than 15 items not display correctly.
- Add new custom name parameter.
- Fix sorting on playlist not function correctly if use API.
- Fix duration when try to get timestamp from Premiering video. (I haven't tested this on API)
- Update regex for URL.

Notes: This bridge will handle the case like Video, Livestream. Other videos like Premiering stuff not tested.