### PR TITLE
[PokemonTV] Create new Bridge (only German)

### DIFF
--- a/bridges/PokemonTVBridge.php
+++ b/bridges/PokemonTVBridge.php
@@ -1,0 +1,29 @@
+<?php
+
+class PokemonTVBridge extends XPathAbstract {
+	const NAME = 'Pokémon TV (German)';
+	const URI = 'https://www.pokemon.com/de/pokemon-folgen/pokemon-tv-staffeln/';
+	const DESCRIPTION = 'Gibt die letzten Folgen einer Staffel aus';
+	const MAINTAINER = 'dhuschde';
+	const CACHE_TIMEOUT = 3600; // 1 hour
+	const XPATH_EXPRESSION_ITEM = '/html/body/div[4]/section[3]/div/ul/li[*]';
+	const XPATH_EXPRESSION_ITEM_TITLE = './/*/span[3]';
+	const XPATH_EXPRESSION_ITEM_URI = './/a/@href';
+	const XPATH_EXPRESSION_ITEM_ENCLOSURES = './/*/img/@src';
+	const SETTING_FIX_ENCODING = false;
+	const PARAMETERS = array( // Language is not easy due to Pokemons bad Link structure... Feel free to make PR
+		'' => array(
+			'staffel' => array(
+			'name' => 'Staffel',
+			'required' => true
+		)
+	));
+
+	protected function getSourceUrl(){
+		return 'https://www.pokemon.com/de/pokemon-folgen/pokemon-tv-staffeln/staffeln-' . $this->getInput('staffel');
+	}
+
+        public function getIcon() {
+                return 'https://www.google.com/s2/favicons?domain=pokemon.com/';
+        }
+}

--- a/bridges/PokemonTVBridge.php
+++ b/bridges/PokemonTVBridge.php
@@ -23,7 +23,7 @@ class PokemonTVBridge extends XPathAbstract {
 		return 'https://www.pokemon.com/de/pokemon-folgen/pokemon-tv-staffeln/staffeln-' . $this->getInput('staffel');
 	}
 
-        public function getIcon() {
-                return 'https://www.google.com/s2/favicons?domain=pokemon.com/';
-        }
+	public function getIcon() {
+		return 'https://www.google.com/s2/favicons?domain=pokemon.com/';
+	}
 }


### PR DESCRIPTION
A Bridge that gives out only German Episodes of a given Season.
Changing language isn't easy due to Pokémon bad Link structure. The Link gets translated too. That would destroy the nice looking Link from the Bridge. (At least with the way BlizzardNewsBridge deals with it.)
Feel free to give advice on how to fix that. Till that, I will only give a German Version.