### PR TITLE
[FeedArticleExpanderBridge] Create new Bridge

### DIFF
--- a/bridges/FeedArticleExpanderBridge.php
+++ b/bridges/FeedArticleExpanderBridge.php
@@ -20,9 +20,8 @@ class FeedArticleExpanderBridge extends FeedExpander {
 		),
 			'img-ident' => array(
 				'name' => 'Identifier of Image',
-				'title' => 'Sometimes, the Thumbnail is seperated from the Content.<br> If that is the Case, use this.<br> Please use an CSS Class again. If no Image is available, use *',
-				'defaultValue' => '*',
-				'required' => true,
+				'title' => 'Sometimes, the Thumbnail is seperated from the Content.<br> If that is the Case, use this.<br> Please use an CSS Class again.',
+				'exampleValue' => '.wp-post-image',
 		),
 			'img-src' => array(
 				'name' => 'Image source Attribute',
@@ -39,7 +38,9 @@ class FeedArticleExpanderBridge extends FeedExpander {
 		$item = parent::parseItem($feedItem);
 		$articlepage = getSimpleHTMLDOM($item['uri']);
 		$article = $articlepage->find($this->getInput('ident'), 0);
+		if('' !== ($this->getInput('img-ident'))) {
 		$image = $articlepage->find($this->getInput('img-ident'), 0)->getAttribute($this->getInput('img-src'));
+		}
 		$item['content'] = '<img src="' . $image . '" />' . $article;
 		return $item;
 	}

--- a/bridges/FeedArticleExpanderBridge.php
+++ b/bridges/FeedArticleExpanderBridge.php
@@ -1,0 +1,42 @@
+<?php //Bridge based on ExplosmBridge from bockiii
+class FeedArticleExpanderBridge extends FeedExpander {
+
+	const MAINTAINER = 'dhuschde';
+	const NAME = 'Article Expander';
+	const URI = 'https://github.com/RSS-Bridge/rss-bridge/';
+	const CACHE_TIMEOUT = 4800; //2hours
+	const DESCRIPTION = 'You have a RSS Feed, which only gives out a small summary? <br> Then try this Bridge';
+	const PARAMETERS = array(
+		'' => array(
+			'feed' => array(
+				'name' => 'Feed URL',
+				'required' => true
+		),
+			'ident' => array(
+				'name' => 'Identifier of Content',
+				'title' => 'Please give an CSS Class to identifie the Content with.',
+				'required' => true
+		),
+			'img-ident' => array(
+				'name' => 'Identifier of Image',
+				'title' => 'Sometimes, the Thumbnail is seperated from the Content<br> If that is the Case, use this.<br> Please use an CSS Class again.',
+		),
+			'img-src' => array(
+				'name' => 'Image source Attribute',
+				'title' => 'The Attribute src often doesnt work, but data-src, which isnt allways there, does. So please give that Attribute.',
+		)
+	));
+
+	public function collectData(){
+		$this->collectExpandableDatas($this->getInput('feed'));
+	}
+
+	protected function parseItem($feedItem){
+		$item = parent::parseItem($feedItem);
+		$articlepage = getSimpleHTMLDOM($item['uri']);
+		$article = $articlepage->find($this->getInput('ident'), 0);
+		$image = $articlepage->find($this->getInput('img-ident'), 0)->getAttribute($this->getInput('img-src'));
+		$item['content'] = '<img src="' . $image . '" />' . $article;
+		return $item;
+	}
+}

--- a/bridges/FeedArticleExpanderBridge.php
+++ b/bridges/FeedArticleExpanderBridge.php
@@ -24,6 +24,7 @@ class FeedArticleExpanderBridge extends FeedExpander {
 			'img-src' => array(
 				'name' => 'Image source Attribute',
 				'title' => 'The Attribute src often doesnt work, but data-src, which isnt allways there, does. So please give that Attribute.',
+				'defaultValue' => 'src'
 		)
 	));
 

--- a/bridges/FeedArticleExpanderBridge.php
+++ b/bridges/FeedArticleExpanderBridge.php
@@ -15,11 +15,14 @@ class FeedArticleExpanderBridge extends FeedExpander {
 			'ident' => array(
 				'name' => 'Identifier of Content',
 				'title' => 'Please give an CSS Class to identifie the Content with.',
+				'exampleValue' => '.wp-content',
 				'required' => true
 		),
 			'img-ident' => array(
 				'name' => 'Identifier of Image',
-				'title' => 'Sometimes, the Thumbnail is seperated from the Content<br> If that is the Case, use this.<br> Please use an CSS Class again.',
+				'title' => 'Sometimes, the Thumbnail is seperated from the Content.<br> If that is the Case, use this.<br> Please use an CSS Class again. If no Image is available, use *',
+				'defaultValue' => '*',
+				'required' => true,
 		),
 			'img-src' => array(
 				'name' => 'Image source Attribute',


### PR DESCRIPTION
This Bridge is capable of Expanding the Feed article to show Full Content in the Feed.
[Preview on my Bridge](https://dhusch.de/rss-bridge/#bridge-FeedArticleExpander)

### Example
I created a Feed for unbemerkt.eu/de a while ago using XPath.
That obviously doesn't show the full Content. Now it does.
#### Screens of Example
![grafik](https://user-images.githubusercontent.com/85834680/126672102-636a80ac-0949-4cea-abf3-10473564fe1b.png)
![grafik](https://user-images.githubusercontent.com/85834680/126672200-b65be158-54b9-426a-acd6-8a242707bdfb.png)

#### Inputs
Feed URL: `https://dhusch.de/rss-bridge/?action=display&bridge=XPath&url=https%3A%2F%2Fwww.unbemerkt.eu%2Fde%2Fblog%2F&item=%2Fhtml%5B1%5D%2Fbody%5B1%5D%2Fsection%5B1%5D%2Fsection%5B1%5D%2Fdiv%5B1%5D%2Fdiv%5B1%5D%2Fdiv%5B1%5D%2Fdiv%5B1%5D%2Fdiv%5B1%5D%2Fdiv%5B*%5D%2Farticle%5B1%5D&title=.%2F%2Fa%5B%40target%3D%22_self%22%5D&content=.%2F%2Fdiv%5B%40class%3D%22post-content%22%5D&uri=.%2F%2Fa%5B%40class%3D%22more-btn%22%5D%2F%40href&author=%2Fhtml%5B1%5D%2Fbody%5B1%5D%2Fsection%5B1%5D%2Fdiv%5B2%5D%2Fdiv%5B1%5D%2Fdiv%5B1%5D%2Fh1%5B1%5D&timestamp=.%2F%2Ftime%2F%40datetime&enclosures=.%2F%2Fimg%2F%40data-src&categories=.%2F%2F*%2Fli&format=Atom`
Content Identifier: `.archive .blog-post .post-content, .single .blog-post .post-content`
Image Identifier: `.wp-post-image`
Img Attribute: `data-src`

(Closes https://github.com/RSS-Bridge/rss-bridge/issues/2197)