### PR TITLE
add erlangen to nordbayern

### DIFF
--- a/bridges/NordbayernBridge.php
+++ b/bridges/NordbayernBridge.php
@@ -16,6 +16,7 @@ class NordbayernBridge extends BridgeAbstract {
 			'values' => array(
 				'Nürnberg' => 'nuernberg',
 				'Fürth' => 'fuerth',
+				'Erlangen' => 'erlangen',
 				'Altdorf' => 'altdorf',
 				'Ansbach' => 'ansbach',
 				'Bad Windsheim' => 'bad-windsheim',


### PR DESCRIPTION
add the city of Erlangen to Nordbayern bridge.