### PR TITLE
[Core] Add internal port feature

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,9 +27,9 @@ done
 
 # This feature can set the internal port that apache uses to something else.
 # If docker is run on network:service mode, no two containers can use port 80
-# To use this, start the container with the additional environment variable "PORT"
-if [ ! -z ${PORT} ]; then
-	sed -i "s/80/$PORT/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+# To use this, start the container with the additional environment variable "HTTP_PORT"
+if [ ! -z ${HTTP_PORT} ]; then
+	sed -i "s/80/$HTTP_PORT/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
 fi
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,5 +25,13 @@ while IFS= read -r -d '' file; do
     esac
 done
 
+# This feature can set the internal port that apache uses to something else.
+# If docker is run on network:service mode, no two containers can use port 80
+# To use this, start the container with the additional environment variable "PORT"
+if [ ! -z ${PORT} ]; then
+	sed -i "s/80/$PORT/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+fi
+
+
 # Start apache
 apache2-foreground


### PR DESCRIPTION
This fixes #2270 

The addition of the feature does not change any behavior for current users. You have to manually add the environment variable "PORT" to the container to use this internal feature.

What it does:
If you add "PORT" to your docker container environment call, the script replaces the default port 80 in the config files to whichever port you assign.

I will add the how-to to the wiki as soon as it's merged.