### PR TITLE
[BandcampBridge] Add support for labels

### DIFF
--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -38,6 +38,30 @@ class BandcampBridge extends BridgeAbstract {
 				'defaultValue' => 5
 			)
 		),
+		'By label' => array(
+			'label' => array(
+				'name' => 'label',
+				'type' => 'text',
+				'title' => 'label name as seen in the label page URL',
+				'required' => true
+			),
+			'type' => array(
+				'name' => 'Articles are',
+				'type' => 'list',
+				'values' => array(
+					'Releases' => 'releases',
+					'Releases, new one when track list changes' => 'changes',
+					'Individual tracks' => 'tracks'
+				),
+				'defaultValue' => 'changes'
+			),
+			'limit' => array(
+				'name' => 'limit',
+				'type' => 'number',
+				'title' => 'Number of releases to return',
+				'defaultValue' => 5
+			)
+		),
 		'By album' => array(
 			'band' => array(
 				'name' => 'band',
@@ -122,6 +146,7 @@ class BandcampBridge extends BridgeAbstract {
 			}
 			break;
 		case 'By band':
+		case 'By label':
 		case 'By album':
 			$html = getSimpleHTMLDOMCached($this->getURI(), 86400);
 
@@ -139,6 +164,7 @@ class BandcampBridge extends BridgeAbstract {
 			$tralbums = array();
 			switch($this->queriedContext) {
 			case 'By band':
+			case 'By label':
 				$query_data = array(
 					'band_id' => $band_id
 				);
@@ -289,6 +315,13 @@ class BandcampBridge extends BridgeAbstract {
 				. '?sort_field=date';
 			}
 			break;
+		case 'By label':
+			if(!is_null($this->getInput('label'))) {
+				return 'https://'
+					. $this->getInput('label')
+					. '.bandcamp.com/music';
+			}
+			break;
 		case 'By band':
 			if(!is_null($this->getInput('band'))) {
 				return 'https://'
@@ -321,6 +354,13 @@ class BandcampBridge extends BridgeAbstract {
 				return $this->feedName . ' - Bandcamp Band';
 			} elseif(!is_null($this->getInput('band'))) {
 				return $this->getInput('band') . ' - Bandcamp Band';
+			}
+			break;
+		case 'By label':
+			if(isset($this->feedName)) {
+				return $this->feedName . ' - Bandcamp Label';
+			} elseif(!is_null($this->getInput('label'))) {
+				return $this->getInput('label') . ' - Bandcamp Label';
 			}
 			break;
 		case 'By album':


### PR DESCRIPTION
The bridge technically already supports labels via the `By band` context. This pr adds a context (`By label`) just for record labels.

Label example: `lexrecords`

Closes #2244