### PR TITLE
[MozillaSecurity] Limit items

### DIFF
--- a/bridges/MozillaSecurityBridge.php
+++ b/bridges/MozillaSecurityBridge.php
@@ -18,6 +18,10 @@ class MozillaSecurityBridge extends BridgeAbstract {
 		$articles = $html->find('div[id="main-content"] h2');
 
 		foreach ($articles as $element) {
+			//Limit total amount of requests
+			if(count($this->items) >= 20) {
+				break;
+			}
 			$item['title'] = $element->innertext;
 			$item['timestamp'] = strtotime($element->innertext);
 			$item['content'] = $element->next_sibling()->innertext;


### PR DESCRIPTION
The mozilla security bridge retrieves all items ever by default. That means 260+ entries on a single bridge retrieval.

This limits the returned articles to a more sensible 20, in line with many other bridges that limit the returns to 10-20.