### PR TITLE
[Core] Add debug file to config options

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,9 @@ while IFS= read -r -d '' file; do
     whitelist.txt)  yes | cp "$file" /app/ ;
                     chown www-data:www-data "/app/$file_name";
                     printf "Custom whitelist.txt added.\n";;
+    DEBUG)          yes | cp "$file" /app/ ;
+                    chown www-data:www-data "/app/$file_name";
+                    printf "DEBUG file added.\n";;
     esac
 done
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,5 +25,13 @@ while IFS= read -r -d '' file; do
     esac
 done
 
+# This feature can set the internal port that apache uses to something else.
+# If docker is run on network:service mode, no two containers can use port 80
+# To use this, start the container with the additional environment variable "PORT"
+if [ ! -z ${PORT} ]; then
+	sed -i "s/80/$PORT/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+fi
+
+
 # Start apache
 apache2-foreground


### PR DESCRIPTION
Hi,

Since it's possible to do custom bridges, whitelists and config.ini's, I think it makes sense to also add the debug functionality as described [here](https://github.com/RSS-Bridge/rss-bridge/wiki/Debug-mode).

This change just adds "DEBUG" as an option to the things you can configure using the mounted config folder.