### PR TITLE
[Core] Debug option for config folder

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,9 @@ while IFS= read -r -d '' file; do
     whitelist.txt)  yes | cp "$file" /app/ ;
                     chown www-data:www-data "/app/$file_name";
                     printf "Custom whitelist.txt added.\n";;
+    DEBUG)          yes | cp "$file" /app/ ;
+                    chown www-data:www-data "/app/$file_name";
+                    printf "DEBUG file added.\n";;
     esac
 done
 


### PR DESCRIPTION
Hi,

Since it's possible to do custom bridges, whitelists and config.ini's, I think it makes sense to also add the debug functionality as described [here](https://github.com/RSS-Bridge/rss-bridge/wiki/Debug-mode).

This change just adds "DEBUG" as an option to the things you can configure using the mounted config folder.