### PR TITLE
[TwitterBridge] Added Media Timeline

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -83,6 +83,24 @@ EOD
 				'title' => 'Hide pinned tweet'
 			)
 		),
+		'By timeline' => array(
+			'u' => array(
+				'name' => 'username',
+				'required' => true,
+				'exampleValue' => 'sebsauvage',
+				'title' => 'Insert a user name'	
+			),
+			'timeline' => array(
+				'name' => 'Type',
+				'type' => 'list',
+				'values' => array(
+					'Tweets' => 'tweets',
+					'Media' => 'media'
+				),
+				'default_value' => 'tweets',
+				'title' => 'Tweets is the default timeline for a user.'
+			)
+		),
 		'By list' => array(
 			'user' => array(
 				'name' => 'User',
@@ -150,6 +168,14 @@ EOD
 			return $params;
 		}
 
+		//By timeline
+		$regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/([^\/?\n]+)\/([tweets|media]+)/';
+		if(preg_match($regex, $url, $matches) > 0) {
+			$params['u'] = urldecode($matches[3]);
+			$params['timeline'] = urldecode($matches[4]);
+			return $params;
+		}
+
 		return null;
 	}
 
@@ -163,6 +189,8 @@ EOD
 			$specific = '@';
 			$param = 'u';
 			break;
+		case 'By timeline':
+			return 'Twitter @' . $this->getInput('u') . " : " . $this->getInput('timeline'); 
 		case 'By list':
 			return $this->getInput('list') . ' - Twitter list by ' . $this->getInput('user');
 		case 'By list ID':
@@ -184,6 +212,10 @@ EOD
 			. urlencode($this->getInput('u'));
 			// Always return without replies!
 			// . ($this->getInput('norep') ? '' : '/with_replies');
+		case 'By timeline':
+			return self::URI
+			. urlencode($this->getInput('u'))
+			. urlencode($this->getInput('timeline'));
 		case 'By list':
 			return self::URI
 			. urlencode($this->getInput('user'))
@@ -221,6 +253,16 @@ EOD
 				. $this->getRestId($this->getInput('u'))
 				. '.json?tweet_mode=extended';
 			}
+		case 'By timeline':
+			if($this->getInput('timeline') == 'tweets')
+				$query = 'profile';
+			else 
+				$query = 'media';
+			return self::API_URI
+			. '/2/timeline/'
+			. urlencode($query) . '/'
+			. $this->getRestId($this->getInput('u'))
+			. '.json?tweet_mode=extended';
 		case 'By list':
 			return self::API_URI
 			. '/2/timeline/list.json?list_id='

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -214,7 +214,7 @@ EOD
 			// . ($this->getInput('norep') ? '' : '/with_replies');
 		case 'By timeline':
 			return self::URI
-			. urlencode($this->getInput('u'))
+			. urlencode($this->getInput('u')) . '/'
 			. urlencode($this->getInput('timeline'));
 		case 'By list':
 			return self::URI

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -88,7 +88,7 @@ EOD
 				'name' => 'username',
 				'required' => true,
 				'exampleValue' => 'sebsauvage',
-				'title' => 'Insert a user name'	
+				'title' => 'Insert a user name'
 			),
 			'timeline' => array(
 				'name' => 'Type',
@@ -190,7 +190,7 @@ EOD
 			$param = 'u';
 			break;
 		case 'By timeline':
-			return 'Twitter @' . $this->getInput('u') . " : " . $this->getInput('timeline'); 
+			return 'Twitter @' . $this->getInput('u') . ' : ' . $this->getInput('timeline');
 		case 'By list':
 			return $this->getInput('list') . ' - Twitter list by ' . $this->getInput('user');
 		case 'By list ID':
@@ -256,7 +256,7 @@ EOD
 		case 'By timeline':
 			if($this->getInput('timeline') == 'tweets')
 				$query = 'profile';
-			else 
+			else
 				$query = 'media';
 			return self::API_URI
 			. '/2/timeline/'


### PR DESCRIPTION
Closes #1401 and #591.

Although not exactly to their wording, adding the media timeline solves it in spirit.

The issue with following their wording exactly is that it would require using the search function in the api which only looks back a certain amount of tweets. This means that given a user who posts lots of text posts in between images, very few, if any, posts would actually be returned. The same is true for By keyword/hashtag and By list.

This can be explored by playing around with nitter's search options.

I can add the "filter:media" if desired though. I just think it's results are lackluster and not whats desired.