### PR TITLE
[MozillaBugTrackerBridge] Fix incorrect newlines in feed title

### DIFF
--- a/bridges/MozillaBugTrackerBridge.php
+++ b/bridges/MozillaBugTrackerBridge.php
@@ -65,7 +65,7 @@ class MozillaBugTrackerBridge extends BridgeAbstract {
 		defaultLinkTo($html, self::URI);
 
 		// Store header information into private members
-		$this->bugid = $html->find('#field-value-bug_id', 0)->plaintext;
+		$this->bugid = trim($html->find('#field-value-bug_id', 0)->plaintext);
 		$this->bugdesc = $html->find('h1#field-value-short_desc', 0)->plaintext;
 
 		// Get and limit comments


### PR DESCRIPTION
Due to changes in Bugzilla, plaintext returns the bug id with extra whitespace at either end. This can be either by making a narrower (and more brittle) selector or by trimming the plaintext. I chose the latter for this PR.

Test: http://rssbridge/?action=display&bridge=MozillaBugTracker&context=Bug+comments&id=668576&limit=-1&sorting=lf&format=Atom

Old output: 
```
        ...
        <title type="text">
        Bug 668577
       - registerProtocolHandler notification should provide a &amp;quot;don't ask me again&amp;quot; button - Mozilla Bug Tracker</title>
        ...
```
New output:
```
        ...
        <title type="text">Bug 668577 - registerProtocolHandler notification should provide a &amp;quot;don't ask me again&amp;quot; button - Mozilla Bug Tracker</title>
        ...
```
