### PR TITLE
[F-Secureblog] Limit number of returned items

### DIFF
--- a/bridges/FSecureBlogBridge.php
+++ b/bridges/FSecureBlogBridge.php
@@ -60,6 +60,10 @@ class FSecureBlogBridge extends BridgeAbstract {
 	private function collectCategory($category) {
 		$url = $this->getURI() . "/category/$category/";
 		while ($url) {
+			//Limit total amount of requests
+			if(count($this->items) >= 20) {
+				break;
+			}
 			$url = $this->collectListing($url);
 		}
 	}


### PR DESCRIPTION
Hi,

The fsecure blog bridge returns by default "every item ever" which will cause the bridge just to timeout if you call it without any parameters.

This limits the output to 20. Even looking at the no-filters-result, the last 10 posts cover the last 10 months, so I think it's safe to say that you will not miss a blog post because of the limit.