### PR TITLE
[GQMagazineBridge] fix retrieve the content of an article at a given url

### DIFF
--- a/bridges/GQMagazineBridge.php
+++ b/bridges/GQMagazineBridge.php
@@ -117,7 +117,7 @@ class GQMagazineBridge extends BridgeAbstract
 	 */
 	private function loadFullArticle($uri){
 		$html = getSimpleHTMLDOMCached($uri);
-		return $html->find('section[data-test-id=MainContentWrapper]', 0);
+		return $html->find('article', 0);
 	}
 
 	/**

--- a/bridges/GQMagazineBridge.php
+++ b/bridges/GQMagazineBridge.php
@@ -77,8 +77,6 @@ class GQMagazineBridge extends BridgeAbstract
 		// Since GQ don't want simple class scrapping, let's do it the hard way and ... discover content !
 		$main = $html->find('main', 0);
 		foreach ($main->find('a') as $link) {
-			if(strpos($link, $this->getInput('page')))
-				continue;
 			$uri = $link->href;
 			$date = $link->parent()->find('time', 0);
 


### PR DESCRIPTION
issue #2278 identifies bridges that are partially broken. I try to fix some of them.

GQMagazineBridge is partially broken because: 
1. GQMagazine change its HTML structure. `section[data-test-id=MainContentWrapper]` is now `article`
2. a test prevent listing the children urls of the url being processed

---

![image](https://user-images.githubusercontent.com/5741405/138611220-a672f8d7-2d3f-4f93-90fc-4ffe7dd64587.png)
