### PR TITLE
[GitHubGistBridge] fix use the css selector "contains" to find gist comments

### DIFF
--- a/bridges/GitHubGistBridge.php
+++ b/bridges/GitHubGistBridge.php
@@ -56,12 +56,12 @@ class GitHubGistBridge extends BridgeAbstract {
 
 		$html = defaultLinkTo($html, $this->getURI());
 
-		$fileinfo = $html->find('[class="file-info"]', 0)
+		$fileinfo = $html->find('[class~="file-info"]', 0)
 			or returnServerError('Could not find file info!');
 
 		$this->filename = $fileinfo->plaintext;
 
-		$comments = $html->find('div[class="timeline-comment-wrapper"]');
+		$comments = $html->find('div[class~="TimelineItem"]');
 
 		if(is_null($comments)) { // no comments yet
 			return;
@@ -72,7 +72,7 @@ class GitHubGistBridge extends BridgeAbstract {
 			$uri = $comment->find('a[href*=#gistcomment]', 0)
 				or returnServerError('Could not find comment anchor!');
 
-			$title = $comment->find('div[class="unminimized-comment"] h3[class="timeline-comment-header-text"]', 0)
+			$title = $comment->find('div[class~="unminimized-comment"] h3[class~="timeline-comment-header-text"]', 0)
 				or returnServerError('Could not find comment header text!');
 
 			$datetime = $comment->find('[datetime]', 0)
@@ -81,7 +81,7 @@ class GitHubGistBridge extends BridgeAbstract {
 			$author = $comment->find('a.author', 0)
 				or returnServerError('Could not find author name!');
 
-			$message = $comment->find('[class="comment-body"]', 0)
+			$message = $comment->find('[class~="comment-body"]', 0)
 				or returnServerError('Could not find comment body!');
 
 			$item = array();


### PR DESCRIPTION
issue #2278 identifies bridges that are partially broken. I try to fix some of them.

GitHubGistBridge use css class selector to find gist comments.
Many utility classes surround the meaningful class: `class="timeline-comment-header-text f5 color-fg-muted text-normal text-italic"`
Fixed using css contain selector

---

![image](https://user-images.githubusercontent.com/5741405/138612569-30cbe58d-eb41-4368-844e-e35b48bb1ea5.png)
