### PR TITLE
[WorldCosplayBridge] fix Cosplayer API response structure

### DIFF
--- a/bridges/WorldCosplayBridge.php
+++ b/bridges/WorldCosplayBridge.php
@@ -101,13 +101,15 @@ class WorldCosplayBridge extends BridgeAbstract {
 		$list = $json->list;
 
 		foreach($list as $img) {
-			$item = array();
-			$item['uri'] = self::URI . substr($img->photo->url, 1);
-			$item['title'] = $img->photo->subject;
-			$item['timestamp'] = $img->photo->created_at;
-			$item['author'] = $img->member->global_name;
-			$item['enclosures'] = array($img->photo->large_url);
-			$item['uid'] = $img->photo->id;
+			$image = isset($img->photo) ? $img->photo : $img;
+			$item = [
+				'uri' => self::URI . substr($image->url, 1),
+				'title' => $image->subject,
+				'timestamp' => $image->created_at,
+				'author' => $img->member->global_name,
+				'enclosures' => array($image->large_url),
+				'uid' => $image->id,
+			];
 			$item['content'] = sprintf(
 				self::CONTENT_HTML,
 				$item['uri'],

--- a/bridges/WorldCosplayBridge.php
+++ b/bridges/WorldCosplayBridge.php
@@ -102,14 +102,14 @@ class WorldCosplayBridge extends BridgeAbstract {
 
 		foreach($list as $img) {
 			$image = isset($img->photo) ? $img->photo : $img;
-			$item = [
+			$item = array(
 				'uri' => self::URI . substr($image->url, 1),
 				'title' => $image->subject,
 				'timestamp' => $image->created_at,
 				'author' => $img->member->global_name,
 				'enclosures' => array($image->large_url),
 				'uid' => $image->id,
-			];
+			);
 			$item['content'] = sprintf(
 				self::CONTENT_HTML,
 				$item['uri'],


### PR DESCRIPTION
issue #2278 identifies bridges that are partially broken. I try to fix some of them.

Cosplay API response has a slightly different structure of others responses.
"photo" information are not in a "photo" object but at the root of the response.

---

![image](https://user-images.githubusercontent.com/5741405/138614164-baf8eff5-4fbe-4869-a2d3-38b0d03fecb6.png)
