### PR TITLE
Accepting additional "Successful" 2xx status codes

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -160,7 +160,9 @@ function getContents($url, $header = array(), $opts = array(), $returnHeader = f
 	}
 
 	switch($errorCode) {
-		case 200: // Contents received
+		case 200: // Contents OK
+		case 201: // Contents Created
+		case 202: // Contents Accepted
 			Debug::log('New contents received');
 			$data = substr($data, $headerSize);
 			// Disable caching if the server responds with "Cache-Control: no-cache"


### PR DESCRIPTION
In case a bridge does a http 'POST' to get additional data, some services/servers (for example servicenow.com) return a "201 Created" instead of a "200 OK" http status, which currently causes rss-bridge to throw an error.
I added 'support' for 201 and 202 status codes, which might make sense in the rss-bridge context,

Fixes #2311 