### PR TITLE
add support for more media types as enclosures, handle result of /tex…

### DIFF
--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -344,7 +344,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	protected function provideFeedIcon(DOMXPath $xpath) {
 		$icon = $xpath->query($this->getParam('feed_icon'));
 		if(count($icon) === 1) {
-			return $this->cleanImageUrl($this->getItemValueOrNodeValue($icon));
+			return $this->cleanMediaUrl($this->getItemValueOrNodeValue($icon));
 		}
 	}
 
@@ -511,7 +511,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	 * @return array
 	 */
 	protected function formatItemEnclosures($value) {
-		return array($this->cleanImageUrl($value));
+		return array($this->cleanMediaUrl($value));
 	}
 
 	/**
@@ -527,12 +527,12 @@ abstract class XPathAbstract extends BridgeAbstract {
 	}
 
 	/**
-	 * @param $imageUrl
+	 * @param $mediaUrl
 	 * @return string|void
 	 */
-	protected function cleanImageUrl($imageUrl)
+	protected function cleanMediaUrl($mediaUrl)
 	{
-		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.]+\.(?:jpg|gif|png|jpeg|ico|mp3){1}~', $imageUrl, $matches);
+		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.]+\.(?:jpg|gif|png|jpeg|ico|mp3){1}~', $mediaUrl, $matches);
 		if(1 !== $result) {
 			return;
 		}

--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -532,7 +532,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	 */
 	protected function cleanImageUrl($imageUrl)
 	{
-		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.]+\.(?:jpg|gif|png|jpeg|ico){1}~', $imageUrl, $matches);
+		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.]+\.(?:jpg|gif|png|jpeg|ico|mp3){1}~', $imageUrl, $matches);
 		if(1 !== $result) {
 			return;
 		}
@@ -551,6 +551,8 @@ abstract class XPathAbstract extends BridgeAbstract {
 				return trim($item->nodeValue);
 			} elseif ($item instanceof DOMAttr) {
 				return trim($item->value);
+			} elseif ($item instanceof DOMText) {
+				return trim($item->wholeText);
 			}
 		} elseif(is_string($typedResult) && strlen($typedResult) > 0) {
 			return trim($typedResult);

--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -532,7 +532,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	 */
 	protected function cleanMediaUrl($mediaUrl)
 	{
-		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.]+\.(?:jpg|gif|png|jpeg|ico|mp3){1}~', $mediaUrl, $matches);
+		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.\%]+\.(?:jpg|gif|png|jpeg|ico|mp3){1}~i', $mediaUrl, $matches);
 		if(1 !== $result) {
 			return;
 		}

--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -532,7 +532,8 @@ abstract class XPathAbstract extends BridgeAbstract {
 	 */
 	protected function cleanMediaUrl($mediaUrl)
 	{
-		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.\%]+\.(?:jpg|gif|png|jpeg|ico|mp3){1}~i', $mediaUrl, $matches);
+		$pattern = '~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.\%]+\.(?:jpg|gif|png|jpeg|ico|mp3){1}~i';
+		$result = preg_match($pattern, $mediaUrl, $matches);
 		if(1 !== $result) {
 			return;
 		}


### PR DESCRIPTION
Hi @em92 
here come two small fixes for class XPathAbstract:
- support mp3 files in item enclosures (in addition to image formats)
- correctly deal with XPath expressions using `/text()` XPath function (they might return instanctes of `DOMText`)