### PR TITLE
[Economist] Fix if no article image present

### DIFF
--- a/bridges/EconomistBridge.php
+++ b/bridges/EconomistBridge.php
@@ -100,8 +100,12 @@ class EconomistBridge extends FeedExpander {
 			or returnServerError('Could not request Site: ' . $item['title']);
 		// before the article can be added, it needs to be cleaned up, thus, the extra function
 		$item['content'] = $this->cleanContent($article);
-		// only the article lead image is retained
-		$item['enclosures'][] = $article->find('div.article__lead-image', 0)->find('img', 0)->getAttribute('src');
+		// only the article lead image is retained if it's there
+		if (!is_null($article->find('div.article__lead-image', 0))) {
+			$item['enclosures'][] = $article->find('div.article__lead-image', 0)->find('img', 0)->getAttribute('src');
+		} else {
+			$item['enclosures'][] = '';
+		}
 
 		return $item;
 	}


### PR DESCRIPTION
Fixes #2325 

Some articles (like graphic-detail) don't have article lead images.