### PR TITLE
[LichessBridge] Repair broken bridge

### DIFF
--- a/bridges/LichessBridge.php
+++ b/bridges/LichessBridge.php
@@ -3,7 +3,7 @@ class LichessBridge  extends FeedExpander {
 
 	const MAINTAINER = 'AmauryCarrade';
 	const NAME = 'Lichess Blog';
-	const URI = 'http://fr.lichess.org/blog';
+	const URI = 'https://lichess.org/blog';
 	const DESCRIPTION = 'Returns the 5 newest posts from the Lichess blog (full text)';
 
 	public function collectData(){
@@ -18,9 +18,9 @@ class LichessBridge  extends FeedExpander {
 
 	private function retrieveLichessPost($blog_post_uri){
 		$blog_post_html = getSimpleHTMLDOMCached($blog_post_uri);
-		$blog_post_div  = $blog_post_html->find('#lichess_blog', 0);
+		$blog_post_div  = $blog_post_html->find('.blog.page-menu__content', 0);
 
-		$post_chapo = $blog_post_div->find('.shortlede', 0)->innertext;
+		$post_chapo = $blog_post_div->find('.headline', 0)->innertext;
 		$post_content = $blog_post_div->find('.body', 0)->innertext;
 
 		$content = '<p><em>' . $post_chapo . '</em></p>';


### PR DESCRIPTION
Changed the URI and two css selectors.

Looks like to me that the atom feed at https://lichess.org/blog.atom
now actually delivers entire post contents such that this bridge is
redundant.