### PR TITLE
[DaveRamseyBlogBridge] Repair broken bridge

### DIFF
--- a/bridges/DaveRamseyBlogBridge.php
+++ b/bridges/DaveRamseyBlogBridge.php
@@ -9,16 +9,13 @@ class DaveRamseyBlogBridge extends BridgeAbstract {
 
 	public function collectData()
 	{
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request daveramsey.com.');
-
-		foreach ($html->find('.Post') as $element) {
-			$this->items[] = array(
-				'uri' => 'https://www.daveramsey.com' . $element->find('header > a', 0)->href,
-				'title' => $element->find('header > h2 > a', 0)->plaintext,
-				'tags' => $element->find('.Post-topic', 0)->plaintext,
-				'content' => $element->find('.Post-body', 0)->plaintext,
-			);
-		}
+		$this->items[] = array(
+			'uri'		=> 'https://www.ramseysolutions.com/articles',
+			'title' 	=> self::NAME,
+			'content'	=> <<<'CONTENT'
+The blog https://www.daveramsey.com/blog is retired. <br><br>
+See https://www.ramseysolutions.com/articles
+CONTENT
+		);
 	}
 }


### PR DESCRIPTION
This change gives indication to users that the blog is
retired and that the content is available at a new url.

This is a much better user experience than simply removing
the bridge.

There is actually a feed at
https://www.ramseysolutions.com/rss
but it is huge (5MB) and contains invalid xml.