### PR TITLE
[DerpibooruBridge] Fix parsing of title

### DIFF
--- a/bridges/DerpibooruBridge.php
+++ b/bridges/DerpibooruBridge.php
@@ -85,7 +85,7 @@ class DerpibooruBridge extends BridgeAbstract {
 			$postUri = self::URI . $post->id;
 
 			$item['uri'] = $postUri;
-			$item['title'] = $post->id;
+			$item['title'] = $post->name;
 			$item['timestamp'] = strtotime($post->created_at);
 			$item['author'] = $post->uploader;
 			$item['enclosures'] = array($post->view_url);


### PR DESCRIPTION
The previous value was an int and was not accepted
by rss-bridge as a title. This change uses the image
name instead which fixes the problem and is a better
title than the image id.