### PR TITLE
[ScmbBridge] Fix error which only happens in php 8 (#2367)

### DIFF
--- a/bridges/ScmbBridge.php
+++ b/bridges/ScmbBridge.php
@@ -18,7 +18,10 @@ class ScmbBridge extends BridgeAbstract {
 			$item['title'] = $article->find('header h1 a', 0)->innertext;
 
 			// remove text "En savoir plus" from anecdote content
-			$article->find('span.read-more', 0)->outertext = '';
+			$readMoreButton = $article->find('span.read-more', 0);
+			if ($readMoreButton) {
+				$readMoreButton->outertext = '';
+			}
 			$content = $article->find('p.summary a', 0)->innertext;
 
 			// remove superfluous spaces at the end


### PR DESCRIPTION
Fix (#2367)

Attempting to write to a property of a non-object.
Previously this implicitly created an stdClass object for null, false and empty strings.
Now this triggers an Error exception.

This change modifies outertext only if the element exists.