### PR TITLE
[PepperBridge] fix and discussion

### DIFF
--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -2122,22 +2122,22 @@ class PepperBridgeAbstract extends BridgeAbstract {
 		// Get Cookies header to do the query
 		$cookies = $this->getCookies($url);
 
-		// Construct the GraphQL query string
-		$graphqlArray = array(
-			'query comments($filter:CommentFilter!,$limit:Int,$page:Int){comments(filter:$filter,limit:$li',
-			'mit,page:$page){items{...commentFields}pagination{...paginationFields}}}fragment commentField',
-			's on Comment{commentId threadId url preparedHtmlContent user{...userMediumAvatarFields...user',
-			'NameFields...userPersonaFields bestBadge{...badgeFields}}reactionCounts{type count}deletable ',
-			'currentUserReaction{type}reported reportable source status createdAt updatedAt ignored popula',
-			'r deletedBy{username}notes{content createdAt user{username}}lastEdit{reason timeAgo userId}}f',
-			'ragment userMediumAvatarFields on User{userId isDeletedOrPendingDeletion imageUrls(slot:"defa',
-			'ult",variations:["user_small_avatar"])}fragment userNameFields on User{userId username isUser',
-			'ProfileHidden isDeletedOrPendingDeletion}fragment userPersonaFields on User{persona{type text',
-			'}}fragment badgeFields on Badge{badgeId level{...badgeLevelFields}}fragment badgeLevelFields ',
-			'on BadgeLevel{key name description}fragment paginationFields on Pagination{count current last',
-			' next previous size order}'
-		);
-		$graphqlString = implode('', $graphqlArray);
+		// GraphQL String 
+		// This was extracted from https://www.dealabs.com/assets/js/modern/common_211b99.js
+		// This string was extracted during a Website visit, and minified using this neat tool :
+		// https://codepen.io/dangodev/pen/Baoqmoy
+		$graphqlString = <<<'HEREDOC'
+query comments($filter:CommentFilter!,$limit:Int,$page:Int){comments(filter:$filter,limit:$limit,page:$page){
+items{...commentFields}pagination{...paginationFields}}}fragment commentFields on Comment{commentId threadId url 
+preparedHtmlContent user{...userMediumAvatarFields...userNameFields...userPersonaFields bestBadge{...badgeFields}}
+reactionCounts{type count}deletable currentUserReaction{type}reported reportable source status createdAt updatedAt 
+ignored popular deletedBy{username}notes{content createdAt user{username}}lastEdit{reason timeAgo userId}}fragment 
+userMediumAvatarFields on User{userId isDeletedOrPendingDeletion imageUrls(slot:"default",variations:
+["user_small_avatar"])}fragment userNameFields on User{userId username isUserProfileHidden isDeletedOrPendingDeletion}
+fragment userPersonaFields on User{persona{type text}}fragment badgeFields on Badge{badgeId level{...badgeLevelFields}}
+fragment badgeLevelFields on BadgeLevel{key name description}fragment paginationFields on Pagination{count current last
+ next previous size order}
+HEREDOC;
 
 		// Construct the JSON object to send to the Website
 		$queryArray = array (

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1874,8 +1874,8 @@ class DealabsBridge extends PepperBridgeAbstract {
 				'type' => 'list',
 				'title' => 'Ordre de tri des deals',
 				'values' => array(
-					'Du deal le plus Hot au moins Hot' => '',
-					'Du deal le plus récent au plus ancien' => '-nouveaux',
+					'Du deal le plus Hot au moins Hot' => '-hot',
+					'Du deal le plus récent au plus ancien' => '',
 					'Du deal le plus commentés au moins commentés' => '-commentes'
 				)
 			)
@@ -2040,20 +2040,16 @@ class PepperBridgeAbstract extends BridgeAbstract {
 		} else {
 			foreach ($list as $deal) {
 				$item = array();
-				$item['uri'] = $deal->find('div[class*=threadGrid-title]', 0)->find('a', 0)->href;
-				$item['title'] = $deal->find('a[class*=' . $selectorLink . ']', 0
-				)->plaintext;
+				$item['uri'] = $this->getDealURI($deal);
+				$item['title'] = $this->GetTitle($deal);
 				$item['author'] = $deal->find('span.thread-username', 0)->plaintext;
+
 				$item['content'] = '<table><tr><td><a href="'
-					. $deal->find(
-						'a[class*=' . $selectorImageLink . ']', 0)->href
+					. $item['uri']
 						. '"><img src="'
 						. $this->getImage($deal)
-						. '"/></td><td><h2><a href="'
-						. $deal->find('a[class*=' . $selectorLink . ']', 0)->href
-						. '">'
-						. $deal->find('a[class*=' . $selectorLink . ']', 0)->innertext
-						. '</a></h2>'
+						. '"/></td><td>'
+						. $this->getHTMLTitle($item)
 						. $this->getPrice($deal)
 						. $this->getDiscount($deal)
 						. $this->getShipsFrom($deal)
@@ -2111,6 +2107,62 @@ class PepperBridgeAbstract extends BridgeAbstract {
 		} else {
 			return '';
 		}
+	}
+
+	/**
+	 * Get the Title from a Deal if it exists
+	 * @return string String of the deal title
+	 */
+	private function getTitle($deal)
+	{
+
+		$titleRoot  = $deal->find('div[class*=threadGrid-title]', 0);
+		$titleA = $titleRoot->find('a[class*=thread-link]', 0);
+		$titleFirstChild = $titleRoot->first_child();
+		if($titleA !== null) {
+			$title = $titleA->plaintext;
+		} else {
+		// Inb ssome case, expired deals have a different format
+			$title = $titleRoot->find('span', 0)->plaintext;
+		}
+
+		return $title;
+
+	}
+
+	/**
+	 * Get the HTML Title code from an item
+	 * @return string String of the deal title
+	 */
+	private function getHTMLTitle($item)
+	{
+		if($item['uri'] == '') {
+			$html = '<h2>' . $item['title'] . '</h2>';
+		} else {
+			$html = '<h2><a href="' . $item['uri'] . '">'
+				. $item['title'] . '</a></h2>';
+		}
+
+		return $html;
+
+	}
+
+	/**
+	 * Get the URI from a Deal if it exists
+	 * @return string String of the deal URI
+	 */
+	private function getDealURI($deal)
+	{
+
+		$uriA = $deal->find('div[class*=threadGrid-title]', 0)->find('a[class*=thread-link]', 0);
+		if($uriA === null) {
+			$uri = '';
+		} else 	{
+			$uri = $uriA->href;
+		}
+
+		return $uri;
+
 	}
 
 	/**

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1875,8 +1875,7 @@ class DealabsBridge extends PepperBridgeAbstract {
 				'title' => 'Ordre de tri des deals',
 				'values' => array(
 					'Du deal le plus Hot au moins Hot' => '-hot',
-					'Du deal le plus récent au plus ancien' => '',
-					'Du deal le plus commentés au moins commentés' => '-commentes'
+					'Du deal le plus récent au plus ancien' => '-nouveaux',
 				)
 			)
 		)

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -2122,7 +2122,7 @@ class PepperBridgeAbstract extends BridgeAbstract {
 		// Get Cookies header to do the query
 		$cookies = $this->getCookies($url);
 
-		// GraphQL String 
+		// GraphQL String
 		// This was extracted from https://www.dealabs.com/assets/js/modern/common_211b99.js
 		// This string was extracted during a Website visit, and minified using this neat tool :
 		// https://codepen.io/dangodev/pen/Baoqmoy

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1891,7 +1891,6 @@ class DealabsBridge extends PepperBridgeAbstract {
 			'only_with_url' => array(
 				'name' => 'Exclure les commentaires sans URL',
 				'type' => 'checkbox',
-				'required' => true,
 				'title' => 'Exclure les commentaires ne contenant pas d\'URL dans le flux',
 				'defaultValue' => false,
 				)

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -2171,8 +2171,7 @@ class PepperBridgeAbstract extends BridgeAbstract {
 				CURLOPT_POST => 1,
 				CURLOPT_POSTFIELDS => $queryJSON
 				);
-		$json = getContents($url, $header, $opts)
-			or returnServerError($this->i8n('request-error'));
+		$json = getContents($url, $header, $opts);
 		$objects = json_decode($json);
 		foreach($objects->data->comments->items as $comment) {
 			$item = array();

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -3243,8 +3243,7 @@ class HotUKDealsBridge extends PepperBridgeAbstract {
 				'title' => 'Sort order of deals',
 				'values' => array(
 					'From the most to the least hot deal' => '-hot',
-					'From the most recent deal to the oldest' => '',
-					'From the most commented deal to the least commented deal' => '-discussed'
+					'From the most recent deal to the oldest' => '-new',
 				)
 			)
 		)

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -3258,7 +3258,6 @@ class HotUKDealsBridge extends PepperBridgeAbstract {
 			'only_with_url' => array(
 				'name' => 'Exclude comments without URL',
 				'type' => 'checkbox',
-				'required' => true,
 				'title' => 'Exclude comments that does not contains URL in the feed',
 				'defaultValue' => false,
 				)

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -3246,7 +3246,25 @@ class HotUKDealsBridge extends PepperBridgeAbstract {
 					'From the most recent deal to the oldest' => '-new',
 				)
 			)
-		)
+		),
+		'Discussion Monitoring' => array(
+			'url' => array(
+				'name' => 'Discussion URL',
+				'type' => 'text',
+				'required' => true,
+				'title' => 'Discussion URL to monitor. Ex: https://www.hotukdeals.com/discussions/the-hukd-lego-thread-3599357',
+				'exampleValue' => 'https://www.hotukdeals.com/discussions/the-hukd-lego-thread-3599357',
+				),
+			'only_with_url' => array(
+				'name' => 'Exclude comments without URL',
+				'type' => 'checkbox',
+				'required' => true,
+				'title' => 'Exclude comments that does not contains URL in the feed',
+				'defaultValue' => false,
+				)
+			)
+
+
 	);
 
 	public $lang = array(
@@ -3254,8 +3272,10 @@ class HotUKDealsBridge extends PepperBridgeAbstract {
 		'bridge-name' => SELF::NAME,
 		'context-keyword' => 'Search by keyword(s))',
 		'context-group' => 'Deals per group',
+		'context-talk' => 'Discussion Monitoring',
 		'uri-group' => 'tag/',
 		'request-error' => 'Could not request HotUKDeals',
+		'thread-error' => 'Unable to determine the thread ID. Check the URL you entered',
 		'no-results' => 'Ooops, looks like we could',
 		'relative-date-indicator' => array(
 			'ago',
@@ -3266,6 +3286,7 @@ class HotUKDealsBridge extends PepperBridgeAbstract {
 		'discount' => 'Discount',
 		'title-keyword' => 'Search',
 		'title-group' => 'Group',
+		'title-talk' => 'Discussion Monitoring',
 		'local-months' => array(
 			'Jan',
 			'Feb',

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -1991,9 +1991,8 @@ class MydealsBridge extends PepperBridgeAbstract {
 				'type' => 'list',
 				'title' => 'Sortierung der deals',
 				'values' => array(
-					'Vom heißesten zum kältesten Deal' => '',
+					'Vom heißesten zum kältesten Deal' => '-hot',
 					'Vom jüngsten Deal zum ältesten' => '-new',
-					'Vom am meisten kommentierten Deal zum am wenigsten kommentierten Deal' => '-discussed'
 				)
 			)
 		)

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -2007,7 +2007,6 @@ class MydealsBridge extends PepperBridgeAbstract {
 			'only_with_url' => array(
 				'name' => 'Kommentare ohne URL ausschließen',
 				'type' => 'checkbox',
-				'required' => true,
 				'title' => 'Kommentare, die keine URL enthalten, im Feed ausschließen',
 				'defaultValue' => false,
 				)

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -1994,8 +1994,24 @@ class MydealsBridge extends PepperBridgeAbstract {
 					'Vom heißesten zum kältesten Deal' => '-hot',
 					'Vom jüngsten Deal zum ältesten' => '-new',
 				)
+			),
+		),
+		'Überwachung Diskussion' => array(
+			'url' => array(
+				'name' => 'URL der Diskussion',
+				'type' => 'text',
+				'required' => true,
+				'title' => 'URL-Diskussion zu überwachen:  https://www.mydealz.de/diskussion/title-123',
+				'exampleValue' => '://www.mydealz.de/diskussion/title-123',
+				),
+			'only_with_url' => array(
+				'name' => 'Kommentare ohne URL ausschließen',
+				'type' => 'checkbox',
+				'required' => true,
+				'title' => 'Kommentare, die keine URL enthalten, im Feed ausschließen',
+				'defaultValue' => false,
+				)
 			)
-		)
 	);
 
 	public $lang = array(
@@ -2003,8 +2019,10 @@ class MydealsBridge extends PepperBridgeAbstract {
 		'bridge-name' => SELF::NAME,
 		'context-keyword' => 'Suche nach Stichworten',
 		'context-group' => 'Deals pro Gruppen',
+		'context-talk' => 'Überwachung Diskussion',
 		'uri-group' => 'gruppe/',
 		'request-error' => 'Could not request mydeals',
+		'thread-error' => 'Die ID der Diskussion kann nicht ermittelt werden. Überprüfen Sie die eingegebene URL',
 		'no-results' => 'Ups, wir konnten keine Deals zu',
 		'relative-date-indicator' => array(
 			'vor',
@@ -2016,6 +2034,7 @@ class MydealsBridge extends PepperBridgeAbstract {
 		'discount' => 'Rabatte',
 		'title-keyword' => 'Suche',
 		'title-group' => 'Gruppe',
+		'title-talk' => 'Überwachung Diskussion',
 		'local-months' => array(
 			'Jan',
 			'Feb',


### PR DESCRIPTION
Some expired Deal does not have any URL and generated some PHP Notice. Now they won't generate any Notice.
Expired deal have a different format for the title : this is now handled too.

The "Most commented" sort order was removed from the Pepper Website, so it is removed from the bridge too.
Bridge using this sort order will break, but this is intended (as they are broken)

A new context allows to monitor a Discussion for new comments, and if needed, only show comment containing an URL.
This allows to close #2354 