### PR TITLE
bridges: remove redundant "or returnServerError" after getContents/getSimpleHTMLDom/getSimpleHTMLDomCached

### DIFF
--- a/bridges/AO3Bridge.php
+++ b/bridges/AO3Bridge.php
@@ -37,8 +37,7 @@ class AO3Bridge extends BridgeAbstract {
 	// Feed for lists of works (e.g. recent works, search results, filtered tags,
 	// bookmarks, series, collections).
 	private function collectList($url) {
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('could not request AO3');
+		$html = getSimpleHTMLDOM($url);
 		$html = defaultLinkTo($html, self::URI);
 
 		foreach($html->find('.index.group > li') as $element) {
@@ -65,8 +64,7 @@ class AO3Bridge extends BridgeAbstract {
 	// Feed for recent chapters of a specific work.
 	private function collectWork($id) {
 		$url = self::URI . "/works/$id/navigate";
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('could not request AO3');
+		$html = getSimpleHTMLDOM($url);
 		$html = defaultLinkTo($html, self::URI);
 
 		$this->title = $html->find('h2 a', 0)->plaintext;

--- a/bridges/ASRockNewsBridge.php
+++ b/bridges/ASRockNewsBridge.php
@@ -10,8 +10,7 @@ class ASRockNewsBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM(self::URI . '/news/index.asp')
-			or returnServerError('Could not request: ' . self::URI . '/news/index.asp');
+		$html = getSimpleHTMLDOM(self::URI . '/news/index.asp');
 
 		$html = defaultLinkTo($html, self::URI . '/news/');
 
@@ -20,8 +19,7 @@ class ASRockNewsBridge extends BridgeAbstract {
 
 			$articlePath = $a->href;
 
-			$articlePageHtml = getSimpleHTMLDOMCached($articlePath, self::CACHE_TIMEOUT)
-				or returnServerError('Could not request: ' . $articlePath);
+			$articlePageHtml = getSimpleHTMLDOMCached($articlePath, self::CACHE_TIMEOUT);
 
 			$articlePageHtml = defaultLinkTo($articlePageHtml, self::URI);
 

--- a/bridges/AlbionOnlineBridge.php
+++ b/bridges/AlbionOnlineBridge.php
@@ -42,8 +42,7 @@ class AlbionOnlineBridge extends BridgeAbstract {
 		// Example: https://albiononline.com/en/changelog/1/5
 		$url = $api . $this->getInput('language') . '/changelog/1/' . $this->getInput('postcount');
 
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Unable to get changelog data from "' . $url . '"!');
+		$html = getSimpleHTMLDOM($url);
 
 		foreach ($html->find('li') as $data) {
 			$item = array();
@@ -66,8 +65,7 @@ class AlbionOnlineBridge extends BridgeAbstract {
 	}
 
 	private function getFullChangelog($url) {
-		$html = getSimpleHTMLDOMCached($url)
-			or returnServerError('Unable to load changelog post from "' . $url . '"!');
+		$html = getSimpleHTMLDOMCached($url);
 		$html = defaultLinkTo($html, self::URI);
 		return $html->find('div.small-12.columns', 1)->innertext;
 	}

--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -77,8 +77,7 @@ class AllocineFRBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request ' . $this->getURI() . ' !');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$category = array_search(
 				$this->getInput('category'),

--- a/bridges/AmazonBridge.php
+++ b/bridges/AmazonBridge.php
@@ -61,8 +61,7 @@ class AmazonBridge extends BridgeAbstract {
 		$uri = 'https://www.amazon.' . $this->getInput('tld') . '/';
 		$uri .= 's/?field-keywords=' . urlencode($this->getInput('q')) . '&sort=' . $this->getInput('sort');
 
-		$html = getSimpleHTMLDOM($uri)
-			or returnServerError('Could not request Amazon.');
+		$html = getSimpleHTMLDOM($uri);
 
 		foreach($html->find('li.s-result-item') as $element) {
 

--- a/bridges/AnidexBridge.php
+++ b/bridges/AnidexBridge.php
@@ -142,8 +142,7 @@ class AnidexBridge extends BridgeAbstract {
 		$opt[CURLOPT_SSL_VERIFYPEER] = 0;
 
 		// Retrieve torrent listing from search results, which does not contain torrent description
-		$html = getSimpleHTMLDOM($search_url, $headers, $opt)
-		or returnServerError('Could not request Anidex: ' . $search_url);
+		$html = getSimpleHTMLDOM($search_url, $headers, $opt);
 		$links = $html->find('a');
 		$results = array();
 		foreach ($links as $link)

--- a/bridges/AnimeUltimeBridge.php
+++ b/bridges/AnimeUltimeBridge.php
@@ -39,8 +39,7 @@ class AnimeUltimeBridge extends BridgeAbstract {
 
 			//Retrive page contents
 			$url = self::URI . 'history-0-1/' . $requestFilter;
-			$html = getSimpleHTMLDOM($url)
-				or returnServerError('Could not request Anime-Ultime: ' . $url);
+			$html = getSimpleHTMLDOM($url);
 
 			//Relases are sorted by day : process each day individually
 			foreach($html->find('div.history', 0)->find('h3') as $daySection) {
@@ -87,8 +86,7 @@ class AnimeUltimeBridge extends BridgeAbstract {
 						if(!empty($item_uri)) {
 
 							// Retrieve description from description page
-							$html_item = getContents($item_uri)
-								or returnServerError('Could not request Anime-Ultime: ' . $item_uri);
+							$html_item = getContents($item_uri);
 							$item_description = substr(
 								$html_item,
 								strpos($html_item, 'class="principal_contain" align="center">') + 41

--- a/bridges/AppleMusicBridge.php
+++ b/bridges/AppleMusicBridge.php
@@ -32,8 +32,7 @@ class AppleMusicBridge extends BridgeAbstract {
 			. '&entity=album&limit='
 			. $limit .
 			'&sort=recent';
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request: ' . $url);
+		$html = getSimpleHTMLDOM($url);
 
 		$json = json_decode($html);
 

--- a/bridges/ArtStationBridge.php
+++ b/bridges/ArtStationBridge.php
@@ -39,15 +39,13 @@ class ArtStationBridge extends BridgeAbstract {
 		);
 
 		$jsonSearchURL = self::URI . '/api/v2/search/projects.json';
-		$jsonSearchStr = getContents($jsonSearchURL, $header, $opts)
-			or returnServerError('Could not fetch JSON for search query.');
+		$jsonSearchStr = getContents($jsonSearchURL, $header, $opts);
 		return json_decode($jsonSearchStr);
 	}
 
 	private function fetchProject($hashID) {
 		$jsonProjectURL = self::URI . '/projects/' . $hashID . '.json';
-		$jsonProjectStr = getContents($jsonProjectURL)
-			or returnServerError('Could not fetch JSON for project.');
+		$jsonProjectStr = getContents($jsonProjectURL);
 		return json_decode($jsonProjectStr);
 	}
 

--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -91,8 +91,7 @@ class Arte7Bridge extends BridgeAbstract {
 			'Authorization: Bearer ' . self::API_TOKEN
 		);
 
-		$input = getContents($url, $header)
-			or returnServerError('Could not request ARTE.');
+		$input = getContents($url, $header);
 		$input_json = json_decode($input, true);
 
 		foreach($input_json['videos'] as $element) {

--- a/bridges/AsahiShimbunAJWBridge.php
+++ b/bridges/AsahiShimbunAJWBridge.php
@@ -36,8 +36,7 @@ class AsahiShimbunAJWBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getSectionURI($this->getInput('section')))
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM($this->getSectionURI($this->getInput('section')));
 
 		foreach($html->find('#MainInner li a') as $element) {
 			if ($element->parent()->class == 'HeadlineTopImage-S') {

--- a/bridges/AskfmBridge.php
+++ b/bridges/AskfmBridge.php
@@ -16,8 +16,7 @@ class AskfmBridge extends BridgeAbstract {
 	);
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Requested username can\'t be found.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$html = defaultLinkTo($html, self::URI);
 

--- a/bridges/AtmoNouvelleAquitaineBridge.php
+++ b/bridges/AtmoNouvelleAquitaineBridge.php
@@ -29,8 +29,7 @@ class AtmoNouvelleAquitaineBridge extends BridgeAbstract {
 	public function collectData() {
 		$uri = self::URI . '/monair/commune/' . $this->getInput('cities');
 
-		$html = getSimpleHTMLDOM($uri)
-				or returnServerError('Could not request ' . $uri);
+		$html = getSimpleHTMLDOM($uri);
 
 		$this->dom = $html->find('#block-system-main .city-prevision-map', 0);
 

--- a/bridges/AtmoOccitanieBridge.php
+++ b/bridges/AtmoOccitanieBridge.php
@@ -16,8 +16,7 @@ class AtmoOccitanieBridge extends BridgeAbstract {
 	public function collectData() {
 		$uri = self::URI . $this->getInput('city');
 
-		$html = getSimpleHTMLDOM($uri)
-				or returnServerError('Could not request ' . $uri);
+		$html = getSimpleHTMLDOM($uri);
 
 		$generalMessage = $html->find('.landing-ville .city-banner .iqa-avertissement', 0)->innertext;
 		$recommendationsDom = $html->find('.landing-ville .recommandations', 0);

--- a/bridges/AwwwardsBridge.php
+++ b/bridges/AwwwardsBridge.php
@@ -18,8 +18,7 @@ class AwwwardsBridge extends BridgeAbstract {
 
 	private function fetchSites() {
 		Debug::log('Fetching all sites');
-		$sites = getSimpleHTMLDOM(self::SITESURI)
-			or returnServerError('Could not fetch JSON for sites.');
+		$sites = getSimpleHTMLDOM(self::SITESURI);
 
 		Debug::log('Parsing all JSON data');
 		foreach($sites->find('li[data-model]') as $site) {

--- a/bridges/BadDragonBridge.php
+++ b/bridges/BadDragonBridge.php
@@ -220,8 +220,7 @@ class BadDragonBridge extends BridgeAbstract {
 	public function collectData() {
 		switch($this->queriedContext) {
 		case 'Sales':
-			$sales = json_decode(getContents(self::URI . 'api/sales'))
-				or returnServerError('Failed to query BD API');
+			$sales = json_decode(getContents(self::URI . 'api/sales'));
 
 			foreach($sales as $sale) {
 				$item = array();
@@ -274,12 +273,10 @@ class BadDragonBridge extends BridgeAbstract {
 			}
 			break;
 		case 'Clearance':
-			$toyData = json_decode(getContents($this->inputToURL(true)))
-				or returnServerError('Failed to query BD API');
+			$toyData = json_decode(getContents($this->inputToURL(true)));
 
 			$productList = json_decode(getContents(self::URI
-				. 'api/inventory-toy/product-list'))
-				or returnServerError('Failed to query BD API');
+				. 'api/inventory-toy/product-list'));
 
 			foreach($toyData->toys as $toy) {
 				$item = array();

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -110,8 +110,7 @@ class BandcampBridge extends BridgeAbstract {
 				CURLOPT_CUSTOMREQUEST => 'POST',
 				CURLOPT_POSTFIELDS => $data
 			);
-			$content = getContents($url, $header, $opts)
-				or returnServerError('Could not complete request to: ' . $url);
+			$content = getContents($url, $header, $opts);
 
 			$json = json_decode($content);
 
@@ -300,8 +299,7 @@ class BandcampBridge extends BridgeAbstract {
 
 	private function apiGet($endpoint, $query_data) {
 		$url = self::URI . 'api/' . $endpoint . '?' . http_build_query($query_data);
-		$data = json_decode(getContents($url))
-			or returnServerError('API request to "' . $url . '" failed.');
+		$data = json_decode(getContents($url));
 		return $data;
 	}
 

--- a/bridges/BastaBridge.php
+++ b/bridges/BastaBridge.php
@@ -8,8 +8,7 @@ class BastaBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the newest articles.';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI . 'spip.php?page=backend')
-			or returnServerError('Could not request Bastamag.');
+		$html = getSimpleHTMLDOM(self::URI . 'spip.php?page=backend');
 
 		$limit = 0;
 

--- a/bridges/BinanceBridge.php
+++ b/bridges/BinanceBridge.php
@@ -35,8 +35,7 @@ class BinanceBridge extends BridgeAbstract {
 	}
 
 	protected function collectBlogData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not fetch Binance blog data.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$appData = $html->find('script[id="__APP_DATA"]');
 		$appDataJson = json_decode($appData[0]->innertext);
@@ -64,8 +63,7 @@ class BinanceBridge extends BridgeAbstract {
 	}
 
 	protected function collectAnnouncementData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not fetch Zendesk announcement data.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('a.article-list-link') as $a) {
 			$title = $a->innertext;

--- a/bridges/BlaguesDeMerdeBridge.php
+++ b/bridges/BlaguesDeMerdeBridge.php
@@ -13,8 +13,7 @@ class BlaguesDeMerdeBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request BDM.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('div.blague') as $element) {
 

--- a/bridges/BrutBridge.php
+++ b/bridges/BrutBridge.php
@@ -44,8 +44,7 @@ class BrutBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$results = $html->find('div.results', 0);
 
@@ -54,8 +53,7 @@ class BrutBridge extends BridgeAbstract {
 
 			$videoPath = self::URI . $li->children(0)->href;
 
-			$videoPageHtml = getSimpleHTMLDOMCached($videoPath, 3600)
-				or returnServerError('Could not request: ' . $videoPath);
+			$videoPageHtml = getSimpleHTMLDOMCached($videoPath, 3600);
 
 			$this->videoImage = $videoPageHtml->find('meta[name="twitter:image"]', 0)->content;
 

--- a/bridges/BukowskisBridge.php
+++ b/bridges/BukowskisBridge.php
@@ -186,8 +186,7 @@ class BukowskisBridge extends BridgeAbstract
 		if ($sort_order)
 			$url = $url . '/sort/' . $sort_order;
 
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request: ' . $url);
+		$html = getSimpleHTMLDOM($url);
 
 		$this->title = htmlspecialchars_decode($html->find('title', 0)->innertext);
 

--- a/bridges/BundesbankBridge.php
+++ b/bridges/BundesbankBridge.php
@@ -41,8 +41,7 @@ class BundesbankBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('No response for ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$html = defaultLinkTo($html, $this->getURI());
 

--- a/bridges/CNETBridge.php
+++ b/bridges/CNETBridge.php
@@ -53,8 +53,7 @@ class CNETBridge extends BridgeAbstract {
 
 		// Retrieve webpage
 		$pageUrl = self::URI . (empty($topic) ? 'news/' : $topic . '/');
-		$html = getSimpleHTMLDOM($pageUrl)
-		or returnServerError('Could not request CNET: ' . $pageUrl);
+		$html = getSimpleHTMLDOM($pageUrl);
 
 		// Process articles
 		foreach($html->find('div.assetBody, div.riverPost') as $element) {

--- a/bridges/CVEDetailsBridge.php
+++ b/bridges/CVEDetailsBridge.php
@@ -55,8 +55,7 @@ class CVEDetailsBridge extends BridgeAbstract {
 	// Make the actual request to cvedetails.com and stores the response
 	// (HTML) for later use and extract vendor and product from it.
 	private function _fetchContent() {
-		$html = getSimpleHTMLDOM($this->_buildURL())
-			or returnServerError('Request failed: ' . $this->_buildURL());
+		$html = getSimpleHTMLDOM($this->_buildURL());
 		$this->html = defaultLinkTo($html, self::URI);
 
 		$vendor = $html->find('#contentdiv > h1 > a', 0);

--- a/bridges/CeskaTelevizeBridge.php
+++ b/bridges/CeskaTelevizeBridge.php
@@ -46,8 +46,7 @@ class CeskaTelevizeBridge extends BridgeAbstract {
 		$category = isset($match[4]) ? $match[4] : 'nove';
 		$fixedUrl = "{$match[1]}dily/{$category}/";
 
-		$html = getSimpleHTMLDOM($fixedUrl)
-			or returnServerError('Could not request Česká televize');
+		$html = getSimpleHTMLDOM($fixedUrl);
 
 		$this->feedUri = $fixedUrl;
 		$this->feedName = str_replace('Přehled dílů — ', '', $this->fixChars($html->find('title', 0)->plaintext));

--- a/bridges/CodebergBridge.php
+++ b/bridges/CodebergBridge.php
@@ -130,8 +130,7 @@ class CodebergBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$html = defaultLinkTo($html, $this->getURI());
 
@@ -246,8 +245,7 @@ class CodebergBridge extends BridgeAbstract {
 			$item['author'] = $li->find('p.desc', 0)->find('a', 0)->plaintext;
 
 			// Fetch issue page
-			$issuePage = getSimpleHTMLDOMCached($item['uri'], 3600)
-				or returnServerError('Could not request: ' . $item['uri']);
+			$issuePage = getSimpleHTMLDOMCached($item['uri'], 3600);
 
 			$issuePage = defaultLinkTo($issuePage, self::URI);
 
@@ -301,8 +299,7 @@ class CodebergBridge extends BridgeAbstract {
 			$item['author'] = $li->find('p.desc', 0)->find('a', 0)->plaintext;
 
 			// Fetch pull request page
-			$pullRequestPage = getSimpleHTMLDOMCached($item['uri'], 3600)
-				or returnServerError('Could not request: ' . $item['uri']);
+			$pullRequestPage = getSimpleHTMLDOMCached($item['uri'], 3600);
 
 			$pullRequestPage = defaultLinkTo($pullRequestPage, self::URI);
 

--- a/bridges/CollegeDeFranceBridge.php
+++ b/bridges/CollegeDeFranceBridge.php
@@ -34,8 +34,7 @@ class CollegeDeFranceBridge extends BridgeAbstract {
 		 * </li>
 		 */
 		$html = getSimpleHTMLDOM(self::URI
-		. 'components/search-audiovideo.jsp?fulltext=&siteid=1156951719600&lang=FR&type=all')
-			or returnServerError('Could not request CollegeDeFrance.');
+		. 'components/search-audiovideo.jsp?fulltext=&siteid=1156951719600&lang=FR&type=all');
 
 		foreach($html->find('a[data-target]') as $element) {
 			$item = array();

--- a/bridges/ComboiosDePortugalBridge.php
+++ b/bridges/ComboiosDePortugalBridge.php
@@ -7,8 +7,7 @@ class ComboiosDePortugalBridge extends BridgeAbstract {
 	const MAINTAINER = 'somini';
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI() . '/consultar-horarios/avisos')
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM($this->getURI() . '/consultar-horarios/avisos');
 
 		foreach($html->find('.warnings-table a') as $element) {
 			$item = array();

--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -15,20 +15,17 @@ class ComicsKingdomBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI(), array(), array(), true, false)
-			or returnServerError('Could not request Comics Kingdom: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI(), array(), array(), true, false);
 
 		// Get author from first page
-		$author = $html->find('div.author p', 0)->plaintext
-			or returnServerError('Comics Kingdom comic does not exist: ' . $this->getURI());;
+		$author = $html->find('div.author p', 0);;
 
 		// Get current date/link
 		$link = $html->find('meta[property=og:url]', 0)->content;
 		for($i = 0; $i < 5; $i++) {
 			$item = array();
 
-			$page = getSimpleHTMLDOM($link)
-				or returnServerError('Could not request Comics Kingdom: ' . $link);
+			$page = getSimpleHTMLDOM($link);
 
 			$imagelink = $page->find('meta[property=og:image]', 0)->content;
 			$prevSlug = $page->find('slider-arrow[:is-left-arrow=true]', 0);

--- a/bridges/ContainerLinuxReleasesBridge.php
+++ b/bridges/ContainerLinuxReleasesBridge.php
@@ -26,8 +26,7 @@ class ContainerLinuxReleasesBridge extends BridgeAbstract {
 	);
 
 	private function getReleaseFeed($jsonUrl) {
-		$json = getContents($jsonUrl)
-			or returnServerError('Could not request Core OS Website.');
+		$json = getContents($jsonUrl);
 		return json_decode($json, true);
 	}
 

--- a/bridges/CopieDoubleBridge.php
+++ b/bridges/CopieDoubleBridge.php
@@ -8,8 +8,7 @@ class CopieDoubleBridge extends BridgeAbstract {
 	const DESCRIPTION = 'CopieDouble';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request CopieDouble.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$table = $html->find('table table', 2);
 

--- a/bridges/CryptomeBridge.php
+++ b/bridges/CryptomeBridge.php
@@ -17,8 +17,7 @@ class CryptomeBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request Cryptome.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$number = $this->getInput('n');
 

--- a/bridges/CuriousCatBridge.php
+++ b/bridges/CuriousCatBridge.php
@@ -19,8 +19,7 @@ class CuriousCatBridge extends BridgeAbstract {
 
 		$url = self::URI . '/api/v2/profile?username=' . urlencode($this->getInput('username'));
 
-		$apiJson = getContents($url)
-			or returnServerError('Could not request: ' . $url);
+		$apiJson = getContents($url);
 
 		$apiData = json_decode($apiJson, true);
 

--- a/bridges/DailymotionBridge.php
+++ b/bridges/DailymotionBridge.php
@@ -46,8 +46,7 @@ class DailymotionBridge extends BridgeAbstract {
 
 		if ($this->queriedContext === 'By username' || $this->queriedContext === 'By playlist id') {
 
-			$apiJson = getContents($this->getApiUrl())
-				or returnServerError('Could not request: ' . $this->getApiUrl());
+			$apiJson = getContents($this->getApiUrl());
 
 			$apiData = json_decode($apiJson, true);
 
@@ -72,8 +71,7 @@ class DailymotionBridge extends BridgeAbstract {
 
 		if ($this->queriedContext === 'From search results') {
 
-			$html = getSimpleHTMLDOM($this->getURI())
-				or returnServerError('Could not request Dailymotion.');
+			$html = getSimpleHTMLDOM($this->getURI());
 
 			foreach($html->find('div.media a.preview_link') as $element) {
 				$item = array();
@@ -180,8 +178,7 @@ class DailymotionBridge extends BridgeAbstract {
 
 		$url = self::URI . 'playlist/' . $id;
 
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request: ' . $url);
+		$html = getSimpleHTMLDOM($url);
 
 		$title = $html->find('meta[property=og:title]', 0)->getAttribute('content');
 		return $title;

--- a/bridges/DanbooruBridge.php
+++ b/bridges/DanbooruBridge.php
@@ -57,8 +57,7 @@ class DanbooruBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-		$content = getContents($this->getFullURI())
-			or returnServerError('Could not request ' . $this->getName());
+		$content = getContents($this->getFullURI());
 
 		$html = Fix_Simple_Html_Dom::str_get_html($content);
 

--- a/bridges/DansTonChatBridge.php
+++ b/bridges/DansTonChatBridge.php
@@ -9,8 +9,7 @@ class DansTonChatBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM(self::URI . 'latest.html')
-			or returnServerError('Could not request DansTonChat.');
+		$html = getSimpleHTMLDOM(self::URI . 'latest.html');
 
 		foreach($html->find('div.item') as $element) {
 			$item = array();

--- a/bridges/DarkReadingBridge.php
+++ b/bridges/DarkReadingBridge.php
@@ -53,8 +53,7 @@ class DarkReadingBridge extends FeedExpander {
 
 	protected function parseItem($newsItem){
 		$item = parent::parseItem($newsItem);
-		$article = getSimpleHTMLDOMCached($item['uri'])
-			or returnServerError('Could not request Dark Reading: ' . $item['uri']);
+		$article = getSimpleHTMLDOMCached($item['uri']);
 		$item['content'] = $this->extractArticleContent($article);
 		$item['enclosures'] = array(); //remove author profile picture
 		$image = $article->find('meta[property="og:image"]', 0);

--- a/bridges/DaveRamseyBlogBridge.php
+++ b/bridges/DaveRamseyBlogBridge.php
@@ -9,8 +9,7 @@ class DaveRamseyBlogBridge extends BridgeAbstract {
 
 	public function collectData()
 	{
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request daveramsey.com.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach ($html->find('.Post') as $element) {
 			$this->items[] = array(

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1980,8 +1980,7 @@ class PepperBridgeAbstract extends BridgeAbstract {
 	 * Get the Deal data using the given URL
 	 */
 	protected function collectDeals($url){
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError($this->i8n('request-error'));
+		$html = getSimpleHTMLDOM($url);
 		$list = $html->find('article[id]');
 
 		// Deal Image Link CSS Selector

--- a/bridges/DerpibooruBridge.php
+++ b/bridges/DerpibooruBridge.php
@@ -76,7 +76,8 @@ class DerpibooruBridge extends BridgeAbstract {
 			. 'api/v1/json/search/images?filter_id='
 			. urlencode($this->getInput('f'))
 			. '&q='
-			. urlencode($this->getInput('q'));
+			. urlencode($this->getInput('q'))
+		));
 
 		foreach($queryJson->images as $post) {
 			$item = array();

--- a/bridges/DerpibooruBridge.php
+++ b/bridges/DerpibooruBridge.php
@@ -76,8 +76,7 @@ class DerpibooruBridge extends BridgeAbstract {
 			. 'api/v1/json/search/images?filter_id='
 			. urlencode($this->getInput('f'))
 			. '&q='
-			. urlencode($this->getInput('q'))
-		)) or returnServerError('Failed to query Derpibooru');
+			. urlencode($this->getInput('q'));
 
 		foreach($queryJson->images as $post) {
 			$item = array();

--- a/bridges/DesoutterBridge.php
+++ b/bridges/DesoutterBridge.php
@@ -155,8 +155,7 @@ class DesoutterBridge extends BridgeAbstract {
 		}
 		*/
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$html = defaultLinkTo($html, $this->getURI());
 
@@ -184,8 +183,7 @@ class DesoutterBridge extends BridgeAbstract {
 	}
 
 	private function getFullNewsArticle($uri) {
-		$html = getSimpleHTMLDOMCached($uri)
-			or returnServerError('Unable to load full article!');
+		$html = getSimpleHTMLDOMCached($uri);
 
 		$html = defaultLinkTo($html, $this->getURI());
 
@@ -199,8 +197,7 @@ class DesoutterBridge extends BridgeAbstract {
 	 * @return void
 	 */
 	private function extractNewsLanguages() {
-		$html = getSimpleHTMLDOMCached('https://www.desouttertools.com/about-desoutter/news-events')
-			or returnServerError('Error loading news!');
+		$html = getSimpleHTMLDOMCached('https://www.desouttertools.com/about-desoutter/news-events');
 
 		$html = defaultLinkTo($html, static::URI);
 
@@ -225,8 +222,7 @@ class DesoutterBridge extends BridgeAbstract {
 	 * @return void
 	 */
 	private function extractIndustryLanguages() {
-		$html = getSimpleHTMLDOMCached('https://www.desouttertools.com/industry-4-0/news')
-			or returnServerError('Error loading news!');
+		$html = getSimpleHTMLDOMCached('https://www.desouttertools.com/industry-4-0/news');
 
 		$html = defaultLinkTo($html, static::URI);
 

--- a/bridges/DevToBridge.php
+++ b/bridges/DevToBridge.php
@@ -45,8 +45,7 @@ apple-icon-5c6fa9f2bce280428589c6195b7f1924206a53b782b371cfe2d02da932c8c173.png'
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOMCached($this->getURI())
-			or returnServerError('Could not request ' . $this->getURI());
+		$html = getSimpleHTMLDOMCached($this->getURI());
 
 		$html = defaultLinkTo($html, static::URI);
 
@@ -95,8 +94,7 @@ EOD;
 	}
 
 	private function getFullArticle($url) {
-		$html = getSimpleHTMLDOMCached($url)
-			or returnServerError('Unable to load article from "' . $url . '"!');
+		$html = getSimpleHTMLDOMCached($url);
 
 		$html = defaultLinkTo($html, static::URI);
 

--- a/bridges/DiarioDeNoticiasBridge.php
+++ b/bridges/DiarioDeNoticiasBridge.php
@@ -56,8 +56,7 @@ class DiarioDeNoticiasBridge extends BridgeAbstract {
 
 	public function collectData() {
 		$archives = self::getURI();
-		$html = getSimpleHTMLDOMCached($archives)
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOMCached($archives);
 
 		foreach($html->find('article') as $element) {
 			$item = array();

--- a/bridges/DiarioDoAlentejoBridge.php
+++ b/bridges/DiarioDoAlentejoBridge.php
@@ -27,8 +27,7 @@ class DiarioDoAlentejoBridge extends BridgeAbstract {
 
 	public function collectData(){
 		/* This is slow as molasses (>30s!), keep the cache timeout high to avoid killing the host */
-		$html = getSimpleHTMLDOMCached($this->getURI() . '/pt/noticias-listagem.aspx')
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOMCached($this->getURI() . '/pt/noticias-listagem.aspx');
 
 		foreach($html->find('.list_news .item') as $element) {
 			$item = array();

--- a/bridges/DiceBridge.php
+++ b/bridges/DiceBridge.php
@@ -97,8 +97,7 @@ class DiceBridge extends BridgeAbstract {
 			$uri .= '&telecommute=true';
 		}
 
-		$html = getSimpleHTMLDOM($uri)
-			or returnServerError('Could not request Dice.');
+		$html = getSimpleHTMLDOM($uri);
 		foreach($html->find('div.complete-serp-result-div') as $element) {
 			$item = array();
 			// Title

--- a/bridges/DilbertBridge.php
+++ b/bridges/DilbertBridge.php
@@ -9,8 +9,7 @@ class DilbertBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request Dilbert: ' . self::URI);
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('section.comic-item') as $element) {
 

--- a/bridges/DiscogsBridge.php
+++ b/bridges/DiscogsBridge.php
@@ -44,13 +44,11 @@ class DiscogsBridge extends BridgeAbstract {
 			if(!empty($this->getInput('artistid'))) {
 				$data = getContents('https://api.discogs.com/artists/'
 						. $this->getInput('artistid')
-						. '/releases?sort=year&sort_order=desc')
-						or returnServerError('Unable to query discogs !');
+						. '/releases?sort=year&sort_order=desc');
 			} elseif(!empty($this->getInput('labelid'))) {
 				$data = getContents('https://api.discogs.com/labels/'
 						. $this->getInput('labelid')
-						. '/releases?sort=year&sort_order=desc')
-						or returnServerError('Unable to query discogs !');
+						. '/releases?sort=year&sort_order=desc');
 			}
 
 			$jsonData = json_decode($data, true);
@@ -76,8 +74,7 @@ class DiscogsBridge extends BridgeAbstract {
 			if(!empty($this->getInput('username_wantlist'))) {
 				$data = getContents('https://api.discogs.com/users/'
 						. $this->getInput('username_wantlist')
-						. '/wants?sort=added&sort_order=desc')
-						or returnServerError('Unable to query discogs !');
+						. '/wants?sort=added&sort_order=desc');
 				$jsonData = json_decode($data, true)['wants'];
 
 			} elseif(!empty($this->getInput('username_folder'))) {
@@ -85,8 +82,7 @@ class DiscogsBridge extends BridgeAbstract {
 						. $this->getInput('username_folder')
 						. '/collection/folders/'
 						. $this->getInput('folderid')
-						. '/releases?sort=added&sort_order=desc')
-						or returnServerError('Unable to query discogs !');
+						. '/releases?sort=added&sort_order=desc');
 				$jsonData = json_decode($data, true)['releases'];
 			}
 			foreach($jsonData as $element) {

--- a/bridges/DockerHubBridge.php
+++ b/bridges/DockerHubBridge.php
@@ -57,8 +57,7 @@ class DockerHubBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$json = getContents($this->getApiUrl())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$json = getContents($this->getApiUrl());
 
 		$data = json_decode($json, false);
 

--- a/bridges/DonnonsBridge.php
+++ b/bridges/DonnonsBridge.php
@@ -40,8 +40,7 @@ class DonnonsBridge extends BridgeAbstract {
 	private function collectDataByPage($page) {
 		$uri = $this->getPageURI($page);
 
-		$html = getSimpleHTMLDOM($uri)
-			or returnServerError('No results for this query.');
+		$html = getSimpleHTMLDOM($uri);
 
 		$searchDiv = $html->find('div[id=search]', 0);
 

--- a/bridges/DribbbleBridge.php
+++ b/bridges/DribbbleBridge.php
@@ -13,8 +13,7 @@ favicon-63b2904a073c89b52b19aa08cebc16a154bcf83fee8ecc6439968b1e6db569c7.ico';
 	}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$json = $this->loadEmbeddedJsonData($html);
 

--- a/bridges/DuckDuckGoBridge.php
+++ b/bridges/DuckDuckGoBridge.php
@@ -28,8 +28,7 @@ class DuckDuckGoBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI . 'html/?kd=-1&q=' . $this->getInput('u') . $this->getInput('sort'))
-			or returnServerError('Could not request DuckDuckGo.');
+		$html = getSimpleHTMLDOM(self::URI . 'html/?kd=-1&q=' . $this->getInput('u') . $this->getInput('sort'));
 
 		foreach($html->find('div.results_links') as $element) {
 			$item = array();

--- a/bridges/ETTVBridge.php
+++ b/bridges/ETTVBridge.php
@@ -107,8 +107,7 @@ class ETTVBridge extends BridgeAbstract {
 
 		// Get results page
 		$this->results_link = self::URI . $query_str;
-		$html = getSimpleHTMLDOM($this->results_link)
-			or returnServerError('Could not request ' . $this->getName());
+		$html = getSimpleHTMLDOM($this->results_link);
 
 		// Loop on each entry
 		foreach($html->find('table.table tr') as $element) {
@@ -117,8 +116,7 @@ class ETTVBridge extends BridgeAbstract {
 
 			// retrieve result page to get more details
 			$link = rtrim(self::URI, '/') . $entry->href;
-			$page = getSimpleHTMLDOM($link)
-				or returnServerError('Could not request page ' . $link);
+			$page = getSimpleHTMLDOM($link);
 
 			// get details & download links
 			$details = $page->find('fieldset.download table', 0); // WHAT?? It should be the second one…

--- a/bridges/EZTVBridge.php
+++ b/bridges/EZTVBridge.php
@@ -35,8 +35,7 @@ on EZTV. Get showID from URLs in https://eztv.ch/shows/showID/show-full-name.';
 		foreach($showList as $showID) {
 
 			// Get show page
-			$html = getSimpleHTMLDOM(self::URI . 'shows/' . rawurlencode($showID) . '/')
-				or returnServerError('Could not request EZTV for id "' . $showID . '"');
+			$html = getSimpleHTMLDOM(self::URI . 'shows/' . rawurlencode($showID) . '/');
 
 			// Loop on each element that look like an episode entry...
 			foreach($html->find('.forum_header_border') as $element) {

--- a/bridges/EconomistBridge.php
+++ b/bridges/EconomistBridge.php
@@ -96,8 +96,7 @@ class EconomistBridge extends FeedExpander {
 	protected function parseItem($feedItem){
 		$item = parent::parseItem($feedItem);
 
-		$article = getSimpleHTMLDOM($item['uri'])
-			or returnServerError('Could not request Site: ' . $item['title']);
+		$article = getSimpleHTMLDOM($item['uri']);
 		// before the article can be added, it needs to be cleaned up, thus, the extra function
 		$item['content'] = $this->cleanContent($article);
 		// only the article lead image is retained

--- a/bridges/EliteDangerousGalnetBridge.php
+++ b/bridges/EliteDangerousGalnetBridge.php
@@ -25,8 +25,7 @@ class EliteDangerousGalnetBridge extends BridgeAbstract {
 		$language = $this->getInput('language');
 		$url = 'https://community.elitedangerous.com/';
 		$url = $url . $language . '/galnet';
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM($url);
 
 		foreach($html->find('div.article') as $element) {
 			$item = array();

--- a/bridges/ElsevierBridge.php
+++ b/bridges/ElsevierBridge.php
@@ -63,8 +63,7 @@ class ElsevierBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$uri = self::URI . $this->getInput('j') . '/recent-articles/';
-		$html = getSimpleHTMLDOM($uri)
-			or returnServerError('No results for Elsevier journal ' . $this->getInput('j'));
+		$html = getSimpleHTMLDOM($uri);
 
 		foreach($html->find('.pod-listing') as $article) {
 			$item = array();

--- a/bridges/EpicgamesBridge.php
+++ b/bridges/EpicgamesBridge.php
@@ -50,10 +50,8 @@ class EpicgamesBridge extends BridgeAbstract {
 		// Example: https://store-content.ak.epicgames.com/api/ru/content/blog?limit=25
 		$urlBlog = $api . $this->getInput('language') . '/content/blog?limit=' . $this->getInput('postcount');
 
-		$dataSticky = getContents($urlSticky)
-			or returnServerError('Unable to get the sticky posts from epicgames.com!');
-		$dataBlog = getContents($urlBlog)
-			or returnServerError('Unable to get the news posts from epicgames.com!');
+		$dataSticky = getContents($urlSticky);
+		$dataBlog = getContents($urlBlog);
 
 		// Merge data
 		$decodedData = array_merge(json_decode($dataSticky), json_decode($dataBlog));

--- a/bridges/EsquerdaNetBridge.php
+++ b/bridges/EsquerdaNetBridge.php
@@ -42,8 +42,7 @@ class EsquerdaNetBridge extends FeedExpander {
 		$item = parent::parseItem($newsItem);
 		# Include all the content
 		$uri = $item['uri'];
-		$html = getSimpleHTMLDOMCached($uri)
-			or returnServerError('Could not load content for ' . $uri);
+		$html = getSimpleHTMLDOMCached($uri);
 		$content = $html->find('div#content div.content', 0);
 		## Fix author
 		$authorHTML = $html->find('.field-name-field-op-author a', 0);

--- a/bridges/EstCeQuonMetEnProdBridge.php
+++ b/bridges/EstCeQuonMetEnProdBridge.php
@@ -8,8 +8,7 @@ class EstCeQuonMetEnProdBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Should we put a website in production today? (French)';
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request EstCeQuonMetEnProd: ' . self::URI);
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$item = array();
 		$item['uri'] = $this->getURI() . '#' . date('Y-m-d');

--- a/bridges/EtsyBridge.php
+++ b/bridges/EtsyBridge.php
@@ -33,8 +33,7 @@ class EtsyBridge extends BridgeAbstract {
 	);
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Failed to receive ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$results = $html->find('li.block-grid-item');
 

--- a/bridges/ExtremeDownloadBridge.php
+++ b/bridges/ExtremeDownloadBridge.php
@@ -26,8 +26,7 @@ class ExtremeDownloadBridge extends BridgeAbstract {
 		);
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI . $this->getInput('url'))
-			or returnServerError('Could not request Extreme Download.');
+		$html = getSimpleHTMLDOM(self::URI . $this->getInput('url'));
 
 		$filter = $this->getInput('filter');
 

--- a/bridges/FDroidBridge.php
+++ b/bridges/FDroidBridge.php
@@ -24,8 +24,7 @@ class FDroidBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$url = self::URI;
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request F-Droid.');
+		$html = getSimpleHTMLDOM($url);
 
 		// targetting the corresponding widget based on user selection
 		// "updated" is the 5th widget on the page, "added" is the 6th

--- a/bridges/FM4Bridge.php
+++ b/bridges/FM4Bridge.php
@@ -36,8 +36,7 @@ class FM4Bridge extends BridgeAbstract
 
 		$uri = $uri . '?page=' . $page;
 
-		$html = getSimpleHTMLDOM($uri)
-		or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM($uri);
 
 		$page_items = array();
 
@@ -50,8 +49,7 @@ class FM4Bridge extends BridgeAbstract
 			$item['timestamp'] = strtotime($article->find('p[class*=time]', 0)->plaintext);
 
 			if ($this->getInput('loadcontent')) {
-				$item['content'] = getSimpleHTMLDOM($item['uri'])->find('div[class=storyText]', 0)->innertext
-				or returnServerError('Error while downloading the full article');
+				$item['content'] = getSimpleHTMLDOM($item['uri'])->find('div[class=storyText]', 0);
 			}
 
 			$page_items[] = $item;

--- a/bridges/FabriceBellardBridge.php
+++ b/bridges/FabriceBellardBridge.php
@@ -6,8 +6,7 @@ class FabriceBellardBridge extends BridgeAbstract {
 	const MAINTAINER = 'somini';
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach ($html->find('p') as $obj) {
 			$item = array();

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -181,8 +181,7 @@ class FacebookBridge extends BridgeAbstract {
 			$this->getURI()
 		);
 
-		$html = getSimpleHTMLDOM($touchURI, $header)
-			or returnServerError('Failed loading facebook page: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($touchURI, $header);
 
 		if(!$this->isPublicGroup($html)) {
 			returnClientError('This group is not public! RSS-Bridge only supports public groups!');
@@ -534,8 +533,7 @@ EOD;
 					CURLOPT_POSTFIELDS => http_build_query($captcha_fields)
 				);
 
-				$html = getSimpleHTMLDOM($captcha_action, $header, $opts)
-					or returnServerError('Failed to submit captcha response back to Facebook');
+				$html = getSimpleHTMLDOM($captcha_action, $header, $opts);
 
 				return $html;
 			}
@@ -560,8 +558,7 @@ EOD;
 				$header = array();
 			}
 
-			$html = getSimpleHTMLDOM($this->getURI(), $header)
-				or returnServerError('No results for this query.');
+			$html = getSimpleHTMLDOM($this->getURI(), $header);
 
 		}
 

--- a/bridges/FicbookBridge.php
+++ b/bridges/FicbookBridge.php
@@ -77,8 +77,7 @@ class FicbookBridge extends BridgeAbstract {
 
 		$header = array('Accept-Language: en-US');
 
-		$html = getSimpleHTMLDOM($this->getURI(), $header)
-			or returnServerError('Could not request ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI(), $header);
 
 		$html = defaultLinkTo($html, self::URI);
 

--- a/bridges/FirefoxAddonsBridge.php
+++ b/bridges/FirefoxAddonsBridge.php
@@ -35,8 +35,7 @@ class FirefoxAddonsBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$this->feedName = $html->find('h1[class="AddonTitle"] > a', 0)->innertext;
 		$author = $html->find('span.AddonTitle-author > a', 0)->plaintext;

--- a/bridges/FirstLookMediaTechBridge.php
+++ b/bridges/FirstLookMediaTechBridge.php
@@ -14,8 +14,7 @@ class FirstLookMediaTechBridge extends BridgeAbstract {
 	);
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		if ($this->getInput('projects')) {
 			$top_projects = $html->find('.PromoList-ul', 0);

--- a/bridges/FlickrBridge.php
+++ b/bridges/FlickrBridge.php
@@ -83,21 +83,18 @@ class FlickrBridge extends BridgeAbstract {
 
 		case 'Explore':
 			$filter = 'photo-lite-models';
-			$html = getSimpleHTMLDOM($this->getURI())
-				or returnServerError('Could not request Flickr.');
+			$html = getSimpleHTMLDOM($this->getURI());
 			break;
 
 		case 'By keyword':
 			$filter = 'photo-lite-models';
-			$html = getSimpleHTMLDOM($this->getURI())
-				or returnServerError('No results for this query.');
+			$html = getSimpleHTMLDOM($this->getURI());
 			break;
 
 		case 'By username':
 			//$filter = 'photo-models';
 			$filter = 'photo-lite-models';
-			$html = getSimpleHTMLDOM($this->getURI())
-				or returnServerError('Requested username can\'t be found.');
+			$html = getSimpleHTMLDOM($this->getURI());
 
 				$this->username = $this->getInput('u');
 

--- a/bridges/FootitoBridge.php
+++ b/bridges/FootitoBridge.php
@@ -7,8 +7,7 @@ class FootitoBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Footito';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request Footito.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('div.post') as $element) {
 			$item = array();

--- a/bridges/FourchanBridge.php
+++ b/bridges/FourchanBridge.php
@@ -29,8 +29,7 @@ class FourchanBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request 4chan, thread not found');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('div.postContainer') as $element) {
 			$item = array();

--- a/bridges/FurAffinityUserBridge.php
+++ b/bridges/FurAffinityUserBridge.php
@@ -28,8 +28,7 @@ class FurAffinityUserBridge extends BridgeAbstract {
 		$cookies = self::login();
 		$url = self::URI . '/gallery/' . $this->getInput('searchUsername');
 
-		$html = getSimpleHTMLDOM($url, $cookies)
-			or returnServerError('Could not load the user\'s galary page.');
+		$html = getSimpleHTMLDOM($url, $cookies);
 
 		$submissions = $html->find('section[id=gallery-gallery]', 0)->find('figure');
 		foreach($submissions as $submission) {

--- a/bridges/FuturaSciencesBridge.php
+++ b/bridges/FuturaSciencesBridge.php
@@ -86,8 +86,7 @@ class FuturaSciencesBridge extends FeedExpander {
 	protected function parseItem($newsItem){
 		$item = parent::parseItem($newsItem);
 		$item['uri'] = str_replace('#xtor%3DRSS-8', '', $item['uri']);
-		$article = getSimpleHTMLDOMCached($item['uri'])
-			or returnServerError('Could not request Futura-Sciences: ' . $item['uri']);
+		$article = getSimpleHTMLDOMCached($item['uri']);
 		$item['content'] = $this->extractArticleContent($article);
 		$author = $this->extractAuthor($article);
 		if (!empty($author))

--- a/bridges/GBAtempBridge.php
+++ b/bridges/GBAtempBridge.php
@@ -76,8 +76,7 @@ class GBAtempBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request GBAtemp.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		switch($this->getInput('type')) {
 		case 'N':
@@ -97,8 +96,7 @@ class GBAtempBridge extends BridgeAbstract {
 				$url = self::URI . $reviewItem->find('a', 0)->href;
 				$img = $this->getURI() . extractFromDelimiters($reviewItem->find('a', 0)->style, 'image:url(', ')');
 				$title = $reviewItem->find('span.review_title', 0)->plaintext;
-				$content = getSimpleHTMLDOM($url)
-					or returnServerError('Could not request GBAtemp: ' . $uri);
+				$content = getSimpleHTMLDOM($url);
 				$author = $content->find('a.username', 0)->plaintext;
 				$time = $this->findItemDate($content);
 				$intro = '<p><b>' . ($content->find('div#review_intro', 0)->plaintext) . '</b></p>';

--- a/bridges/GOGBridge.php
+++ b/bridges/GOGBridge.php
@@ -8,8 +8,7 @@ class GOGBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$values = getContents('https://www.gog.com/games/ajax/filtered?limit=25&sort=new')
-			or returnServerError('Unable to get the news pages from GOG !');
+		$values = getContents('https://www.gog.com/games/ajax/filtered?limit=25&sort=new');
 		$decodedValues = json_decode($values);
 
 		$limit = 0;
@@ -38,8 +37,7 @@ class GOGBridge extends BridgeAbstract {
 
 	private function buildGameContentPage($game) {
 
-		$gameDescriptionText = getContents('https://api.gog.com/products/' . $game->id . '?expand=description')
-			or returnServerError('Unable to get game description from GOG !');
+		$gameDescriptionText = getContents('https://api.gog.com/products/' . $game->id . '?expand=description');
 
 		$gameDescriptionValue = json_decode($gameDescriptionText);
 

--- a/bridges/GQMagazineBridge.php
+++ b/bridges/GQMagazineBridge.php
@@ -72,7 +72,7 @@ class GQMagazineBridge extends BridgeAbstract
 
 	public function collectData()
 	{
-		$html = getSimpleHTMLDOM($this->getURI()) or returnServerError('Could not request ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		// Since GQ don't want simple class scrapping, let's do it the hard way and ... discover content !
 		$main = $html->find('main', 0);

--- a/bridges/GenshinImpactBridge.php
+++ b/bridges/GenshinImpactBridge.php
@@ -27,15 +27,13 @@ class GenshinImpactBridge extends BridgeAbstract {
 
 		$url = 'https://genshin.mihoyo.com/content/yuanshen/getContentList';
 		$url = $url . '?pageSize=3&pageNum=1&channelId=' . $category;
-		$api_response = getContents($url)
-			or returnServerError('Error while downloading the website content');
+		$api_response = getContents($url);
 		$json_list = json_decode($api_response, true);
 
 		foreach($json_list['data']['list'] as $json_item) {
 			$article_url = 'https://genshin.mihoyo.com/content/yuanshen/getContent';
 			$article_url = $article_url . '?contentId=' . $json_item['contentId'];
-			$article_res = getContents($article_url)
-				or returnServerError('Error while downloading the website content');
+			$article_res = getContents($article_url);
 			$article_json = json_decode($article_res, true);
 			$article_time = $article_json['data']['start_time'];
 			$timezone = 'Asia/Shanghai';

--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -36,8 +36,7 @@ class GiphyBridge extends BridgeAbstract {
 			$apiKey
 		);
 
-		$result = json_decode(getContents($uri))
-			or returnServerError('Unable to fetch and decode json');
+		$result = json_decode(getContents($uri));
 
 		foreach($result->data as $entry) {
 			$createdAt = new \DateTime($entry->import_datetime);

--- a/bridges/GitHubGistBridge.php
+++ b/bridges/GitHubGistBridge.php
@@ -51,8 +51,7 @@ class GitHubGistBridge extends BridgeAbstract {
 		DEFAULT_TARGET_CHARSET,
 		false, // Do NOT remove line breaks
 		DEFAULT_BR_TEXT,
-		DEFAULT_SPAN_TEXT)
-			or returnServerError('Could not request ' . $this->getURI());
+		DEFAULT_SPAN_TEXT);
 
 		$html = defaultLinkTo($html, $this->getURI());
 

--- a/bridges/GithubIssueBridge.php
+++ b/bridges/GithubIssueBridge.php
@@ -177,10 +177,7 @@ class GithubIssueBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError(
-				'No results for ' . static::NAME . ' ' . $this->getURI()
-			);
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		switch($this->queriedContext) {
 		case static::BRIDGE_OPTIONS[1]: // Issue comments

--- a/bridges/GithubSearchBridge.php
+++ b/bridges/GithubSearchBridge.php
@@ -21,8 +21,7 @@ class GithubSearchBridge extends BridgeAbstract {
 										'type' => 'Repositories');
 		$url = self::URI . 'search?' . http_build_query($params);
 
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM($url);
 
 		foreach($html->find('li.repo-list-item') as $element) {
 			$item = array();

--- a/bridges/GithubTrendingBridge.php
+++ b/bridges/GithubTrendingBridge.php
@@ -600,8 +600,7 @@ class GithubTrendingBridge extends BridgeAbstract {
 		$params = array('since' => urlencode($this->getInput('date_range')));
 		$url = self::URI . '/' . $this->getInput('language') . '?' . http_build_query($params);
 
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM($url);
 
 		$this->items = array();
 		foreach($html->find('.Box-row') as $element) {

--- a/bridges/GizmodoBridge.php
+++ b/bridges/GizmodoBridge.php
@@ -10,8 +10,7 @@ class GizmodoBridge extends FeedExpander {
 	protected function parseItem($item) {
 		$item = parent::parseItem($item);
 
-		$html = getSimpleHTMLDOMCached($item['uri'])
-			or returnServerError('Could not request: ' . $item['uri']);
+		$html = getSimpleHTMLDOMCached($item['uri']);
 
 		$html = defaultLinkTo($html, $this->getURI());
 		$this->stripTags($html);

--- a/bridges/GlassdoorBridge.php
+++ b/bridges/GlassdoorBridge.php
@@ -86,8 +86,7 @@ class GlassdoorBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Failed loading contents!');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$this->host = $html->find('link[rel="canonical"]', 0)->href;
 
@@ -122,8 +121,7 @@ class GlassdoorBridge extends BridgeAbstract {
 
 			// optionally load full articles
 			if($this->getInput(self::PARAM_BLOG_FULL)) {
-				$full_html = getSimpleHTMLDOMCached($item['uri'])
-					or returnServerError('Unable to load full article!');
+				$full_html = getSimpleHTMLDOMCached($item['uri']);
 
 				$full_html = defaultLinkTo($full_html, $this->host);
 

--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -15,8 +15,7 @@ class GoComicsBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request GoComics: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		//Get info from first page
 		$author = preg_replace('/By /', '', $html->find('.media-subheading', 0)->plaintext);
@@ -26,8 +25,7 @@ class GoComicsBridge extends BridgeAbstract {
 
 			$item = array();
 
-			$page = getSimpleHTMLDOM($link)
-				or returnServerError('Could not request GoComics: ' . $link);
+			$page = getSimpleHTMLDOM($link);
 			$imagelink = $page->find('.comic.container', 0)->getAttribute('data-image');
 			$date = explode('/', $link);
 

--- a/bridges/GogsBridge.php
+++ b/bridges/GogsBridge.php
@@ -108,8 +108,7 @@ class GogsBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$html = defaultLinkTo($html, $this->getURI());
 

--- a/bridges/GoogleSearchBridge.php
+++ b/bridges/GoogleSearchBridge.php
@@ -25,8 +25,7 @@ class GoogleSearchBridge extends BridgeAbstract {
 	public function collectData(){
 		$html = '';
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('No results for this query.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$emIsRes = $html->find('div[id=res]', 0);
 

--- a/bridges/GrandComicsDatabaseBridge.php
+++ b/bridges/GrandComicsDatabaseBridge.php
@@ -17,8 +17,7 @@ class GrandComicsDatabaseBridge extends BridgeAbstract {
 	public function collectData(){
 
 		$url = self::URI . 'series/' . $this->getInput('series') . '/details/timeline/';
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM($url);
 
 		$table = $html->find('table', 0);
 		$list = array_reverse($table->find('[class^=row_even]'));

--- a/bridges/HDWallpapersBridge.php
+++ b/bridges/HDWallpapersBridge.php
@@ -33,8 +33,7 @@ class HDWallpapersBridge extends BridgeAbstract {
 
 		for($page = 1; $page <= $lastpage; $page++) {
 			$link = self::URI . $category . '/page/' . $page;
-			$html = getSimpleHTMLDOM($link)
-				or returnServerError('No results for this query.');
+			$html = getSimpleHTMLDOM($link);
 
 			if($page === 1) {
 				preg_match('/page\/(\d+)$/', $html->find('.pagination a', -2)->href, $matches);

--- a/bridges/HackerNewsUserThreadsBridge.php
+++ b/bridges/HackerNewsUserThreadsBridge.php
@@ -17,7 +17,7 @@ class HackerNewsUserThreadsBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$url = 'https://news.ycombinator.com/threads?id=' . $this->getInput('user');
-		$html = getSimpleHTMLDOM($url) or returnServerError('Could not request HN.');
+		$html = getSimpleHTMLDOM($url);
 		Debug::log('queried ' . $url);
 		Debug::log('found ' . $html);
 

--- a/bridges/HaveIBeenPwnedBridge.php
+++ b/bridges/HaveIBeenPwnedBridge.php
@@ -31,8 +31,7 @@ class HaveIBeenPwnedBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM(self::URI . '/PwnedWebsites')
-			or returnServerError('Could not request: ' . self::URI . '/PwnedWebsites');
+		$html = getSimpleHTMLDOM(self::URI . '/PwnedWebsites');
 
 		$breaches = array();
 

--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -42,8 +42,7 @@ class HeiseBridge extends FeedExpander {
 		$item = parent::parseItem($feedItem);
 		$uri = $item['uri'] . '&seite=all';
 
-		$article = getSimpleHTMLDOMCached($uri)
-			or returnServerError('Could not open article: ' . $uri);
+		$article = getSimpleHTMLDOMCached($uri);
 
 		if ($article) {
 			$article = defaultLinkTo($article, $uri);

--- a/bridges/HentaiHavenBridge.php
+++ b/bridges/HentaiHavenBridge.php
@@ -8,8 +8,7 @@ class HentaiHavenBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns releases from Hentai Haven';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request Hentai Haven.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('div.zoe-grid') as $element) {
 			$item = array();

--- a/bridges/IKWYDBridge.php
+++ b/bridges/IKWYDBridge.php
@@ -60,8 +60,7 @@ class IKWYDBridge extends BridgeAbstract {
 	public function collectData() {
 		$ip = $this->getInput('ip');
 		$root = self::URI . 'en/peer/?ip=' . $ip;
-		$html = getSimpleHTMLDOM($root)
-			or returnServerError('Could not request ' . self::URI);
+		$html = getSimpleHTMLDOM($root);
 
 		$this->name = 'IKWYD: ' . $ip;
 		$this->uri = $root;

--- a/bridges/IPBBridge.php
+++ b/bridges/IPBBridge.php
@@ -59,8 +59,7 @@ class IPBBridge extends FeedExpander {
 		}
 
 		// No valid feed, so do it the hard way
-		$html = getSimpleHTMLDOM($uri)
-			or returnServerError('Could not request ' . $this->getInput('uri') . '!');
+		$html = getSimpleHTMLDOM($uri);
 
 		$limit = $this->getInput('limit');
 

--- a/bridges/IdenticaBridge.php
+++ b/bridges/IdenticaBridge.php
@@ -15,8 +15,7 @@ class IdenticaBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Requested username can\'t be found.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('li.major') as $dent) {
 			$item = array();

--- a/bridges/IndeedBridge.php
+++ b/bridges/IndeedBridge.php
@@ -137,8 +137,7 @@ class IndeedBridge extends BridgeAbstract {
 
 		do {
 
-			$html = getSimpleHTMLDOM($url)
-				or returnServerError('Could not request ' . $url);
+			$html = getSimpleHTMLDOM($url);
 
 			$html = defaultLinkTo($html, $url);
 

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -239,8 +239,7 @@ class InstagramBridge extends BridgeAbstract {
 
 		} else {
 
-			$html = getContents($uri)
-				or returnServerError('Could not request Instagram.');
+			$html = getContents($uri);
 			$scriptRegex = '/window\._sharedData = (.*);<\/script>/';
 
 			preg_match($scriptRegex, $html, $matches, PREG_OFFSET_CAPTURE, 0);

--- a/bridges/InstructablesBridge.php
+++ b/bridges/InstructablesBridge.php
@@ -237,8 +237,7 @@ class InstructablesBridge extends BridgeAbstract {
 		// Enable the following line to get the category list (dev mode)
 		// $this->listCategories();
 
-		$html = getSimpleHTMLDOM($this->getURI())
-				or returnServerError('Error loading category ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 		$html = defaultLinkTo($html, $this->getURI());
 
 		$covers = $html->find('

--- a/bridges/InternetArchiveBridge.php
+++ b/bridges/InternetArchiveBridge.php
@@ -65,8 +65,7 @@ class InternetArchiveBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$html = defaultLinkTo($html, $this->getURI());
 
@@ -277,8 +276,7 @@ EOD;
 
 			$postDate = $tr->find('td', 4)->children(0)->plaintext;
 
-			$postPageHtml = getSimpleHTMLDOMCached($item['uri'], 3600)
-				or returnServerError('Could not request: ' . $item['uri']);
+			$postPageHtml = getSimpleHTMLDOMCached($item['uri'], 3600);
 
 			$postPageHtml = defaultLinkTo($postPageHtml, $this->getURI());
 

--- a/bridges/ItchioBridge.php
+++ b/bridges/ItchioBridge.php
@@ -16,8 +16,7 @@ class ItchioBridge extends BridgeAbstract {
 
 	public function collectData() {
 		$url = $this->getInput('url');
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request: ' . $url);
+		$html = getSimpleHTMLDOM($url);
 
 		$title = $html->find('.game_title', 0)->innertext;
 

--- a/bridges/IvooxBridge.php
+++ b/bridges/IvooxBridge.php
@@ -108,8 +108,7 @@ class IvooxBridge extends BridgeAbstract {
 			returnClientError('Not valid mode at IvooxBridge');
 		}
 
-		$dom = getSimpleHTMLDOM($url_feed)
-			or returnServerError('Could not request ' . $url_feed);
+		$dom = getSimpleHTMLDOM($url_feed);
 		$this->ivBridgeParseHtmlListing($dom);
 
 		// restore locale

--- a/bridges/JapanExpoBridge.php
+++ b/bridges/JapanExpoBridge.php
@@ -25,8 +25,7 @@ class JapanExpoBridge extends BridgeAbstract {
 			}
 		};
 
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request JapanExpo: ' . self::URI);
+		$html = getSimpleHTMLDOM(self::URI);
 		$fullcontent = $this->getInput('mode');
 		$count = 0;
 
@@ -44,8 +43,7 @@ class JapanExpoBridge extends BridgeAbstract {
 					break;
 				}
 
-				$article_html = getSimpleHTMLDOMCached($url)
-				or returnServerError('Could not request JapanExpo: ' . $url);
+				$article_html = getSimpleHTMLDOMCached($url);
 				$header = $article_html->find('header.pageHeadBox', 0);
 				$timestamp = strtotime($header->find('time', 0)->datetime);
 				$title_html = $header->find('div.section', 0)->next_sibling();

--- a/bridges/JustETFBridge.php
+++ b/bridges/JustETFBridge.php
@@ -46,8 +46,7 @@ class JustETFBridge extends BridgeAbstract {
 	);
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Failed loading contents from ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		defaultLinkTo($html, static::URI);
 

--- a/bridges/KhinsiderBridge.php
+++ b/bridges/KhinsiderBridge.php
@@ -10,7 +10,7 @@ class KhinsiderBridge extends BridgeAbstract
 
 	public function collectData()
 	{
-		$html = getSimpleHTMLDOM(self::URI) or returnServerError('Could not request Khinsider.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$dates = $html->find('#EchoTopic h3');
 		foreach ($dates as $date) {

--- a/bridges/KununuBridge.php
+++ b/bridges/KununuBridge.php
@@ -95,8 +95,7 @@ class KununuBridge extends BridgeAbstract {
 		$full = $this->getInput('full');
 
 		// Load page
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Unable to receive data from ' . $this->getURI() . '!');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$html = defaultLinkTo($html, static::URI);
 

--- a/bridges/LWNprevBridge.php
+++ b/bridges/LWNprevBridge.php
@@ -35,8 +35,7 @@ class LWNprevBridge extends BridgeAbstract{
 	public function collectData(){
 		// Because the LWN page is written in loose HTML and not XHTML,
 		// Simple HTML Dom is not accurate enough for the job
-		$content = getContents($this->getURI())
-			or returnServerError('No results for LWNprev');
+		$content = getContents($this->getURI());
 
 		$contents = explode('<b>Page editor</b>', $content);
 

--- a/bridges/LaCentraleBridge.php
+++ b/bridges/LaCentraleBridge.php
@@ -443,8 +443,7 @@ class LaCentraleBridge extends BridgeAbstract {
 			'sortBy' => $this->getInput('sort')
 		);
 		$url = self::URI . 'listing?' . http_build_query($params);
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request LaCentrale.');
+		$html = getSimpleHTMLDOM($url);
 
 		foreach($html->find('.linkAd') as $element) {
 

--- a/bridges/LeBonCoinBridge.php
+++ b/bridges/LeBonCoinBridge.php
@@ -370,8 +370,7 @@ class LeBonCoinBridge extends BridgeAbstract {
 
 		);
 
-		$content = getContents($url, $header, $opts)
-			or returnServerError('Could not request LeBonCoin. Tried: ' . $url);
+		$content = getContents($url, $header, $opts);
 
 		$json = json_decode($content);
 

--- a/bridges/LeMondeInformatiqueBridge.php
+++ b/bridges/LeMondeInformatiqueBridge.php
@@ -12,8 +12,7 @@ class LeMondeInformatiqueBridge extends FeedExpander {
 
 	protected function parseItem($newsItem){
 		$item = parent::parseItem($newsItem);
-		$article_html = getSimpleHTMLDOMCached($item['uri'])
-			or returnServerError('Could not request LeMondeInformatique: ' . $item['uri']);
+		$article_html = getSimpleHTMLDOMCached($item['uri']);
 
 		//Deduce thumbnail URL from article image URL
 		$item['enclosures'] = array(

--- a/bridges/LesJoiesDuCodeBridge.php
+++ b/bridges/LesJoiesDuCodeBridge.php
@@ -8,8 +8,7 @@ class LesJoiesDuCodeBridge extends BridgeAbstract {
 	const DESCRIPTION = 'LesJoiesDuCode';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request LesJoiesDuCode.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('article.blog-post') as $element) {
 			$item = array();

--- a/bridges/MallTvBridge.php
+++ b/bridges/MallTvBridge.php
@@ -23,8 +23,7 @@ class MallTvBridge extends BridgeAbstract {
 	}
 
 	private function getUploadTimeFromUrl($url) {
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request MALL.TV detail page');
+		$html = getSimpleHTMLDOM($url);
 
 		$scriptLdJson = $html->find('script[type="application/ld+json"]', 0)->innertext;
 		if (!preg_match('/[\'"]uploadDate[\'"]\s*:\s*[\'"](\d{4}-\d{2}-\d{2})[\'"]/', $scriptLdJson, $match)) {
@@ -41,8 +40,7 @@ class MallTvBridge extends BridgeAbstract {
 			returnServerError('Invalid url');
 		}
 
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request MALL.TV');
+		$html = getSimpleHTMLDOM($url);
 
 		$this->feedUri = $url;
 		$this->feedName = $this->fixChars($html->find('title', 0)->plaintext);

--- a/bridges/MarktplaatsBridge.php
+++ b/bridges/MarktplaatsBridge.php
@@ -76,7 +76,7 @@ class MarktplaatsBridge extends BridgeAbstract {
 			}
 		}
 		$url = 'https://www.marktplaats.nl/lrp/api/search?query=' . urlencode($this->getInput('q')) . $query;
-		$jsonString = getSimpleHTMLDOM($url, 900) or returnServerError('No contents received!');
+		$jsonString = getSimpleHTMLDOM($url, 900);
 		$jsonObj = json_decode($jsonString);
 		foreach($jsonObj->listings as $listing) {
 			if(!$excludeGlobal || $listing->location->distanceMeters >= 0) {

--- a/bridges/MediapartBlogsBridge.php
+++ b/bridges/MediapartBlogsBridge.php
@@ -20,8 +20,7 @@ class MediapartBlogsBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::BASE_URI . '/' . $this->getInput('slug') . '/blog')
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM(self::BASE_URI . '/' . $this->getInput('slug') . '/blog');
 
 		foreach($html->find('ul.post-list li') as $element) {
 			$item = array();

--- a/bridges/MixCloudBridge.php
+++ b/bridges/MixCloudBridge.php
@@ -26,8 +26,7 @@ class MixCloudBridge extends BridgeAbstract {
 	public function collectData(){
 		ini_set('user_agent', 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0');
 
-		$html = getSimpleHTMLDOM(self::URI . '/' . $this->getInput('u'))
-			or returnServerError('Could not request MixCloud.');
+		$html = getSimpleHTMLDOM(self::URI . '/' . $this->getInput('u'));
 
 		foreach($html->find('section.card') as $element) {
 

--- a/bridges/ModelKarteiBridge.php
+++ b/bridges/ModelKarteiBridge.php
@@ -20,8 +20,7 @@ class ModelKarteiBridge extends BridgeAbstract {
 		if (empty($model_id))
 			returnServerError('Invalid model ID');
 
-		$html = getSimpleHTMLDOM(self::URI . 'sedcards/model/' . $model_id . '/')
-			or returnServerError('Model not found');
+		$html = getSimpleHTMLDOM(self::URI . 'sedcards/model/' . $model_id . '/');
 
 		$objTitle = $html->find('.sTitle', 0);
 		if ($objTitle)

--- a/bridges/MoebooruBridge.php
+++ b/bridges/MoebooruBridge.php
@@ -27,8 +27,7 @@ class MoebooruBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getFullURI())
-			or returnServerError('Could not request ' . $this->getName());
+		$html = getSimpleHTMLDOM($this->getFullURI());
 
 		$input_json = explode('Post.register(', $html);
 		foreach($input_json as $element)

--- a/bridges/MoinMoinBridge.php
+++ b/bridges/MoinMoinBridge.php
@@ -76,8 +76,7 @@ class MoinMoinBridge extends BridgeAbstract {
 		 *     <a class="interwiki" href="/GPL" title="MoinMoin">GNU GPL license</a>.
 		 * ...
 		 */
-		$html = getSimpleHTMLDOM($this->getInput('source'))
-			or returnServerError('Could not load ' . $this->getInput('source'));
+		$html = getSimpleHTMLDOM($this->getInput('source'));
 
 		// Some anchors link to local sites or local IDs (both don't work well
 		// in feeds)

--- a/bridges/MondeDiploBridge.php
+++ b/bridges/MondeDiploBridge.php
@@ -12,8 +12,7 @@ class MondeDiploBridge extends BridgeAbstract {
 		}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request MondeDiplo. for : ' . self::URI);
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('div.unarticle') as $article) {
 			$element = $article->parent();

--- a/bridges/MozillaSecurityBridge.php
+++ b/bridges/MozillaSecurityBridge.php
@@ -9,8 +9,7 @@ class MozillaSecurityBridge extends BridgeAbstract {
 	const WEBROOT = 'https://www.mozilla.org';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request MSA.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$html = defaultLinkTo($html, self::WEBROOT);
 

--- a/bridges/MsnMondeBridge.php
+++ b/bridges/MsnMondeBridge.php
@@ -17,8 +17,7 @@ class MsnMondeBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request MsnMonde.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$limit = 0;
 		foreach($html->find('.smalla') as $article) {

--- a/bridges/N26Bridge.php
+++ b/bridges/N26Bridge.php
@@ -15,8 +15,7 @@ class N26Bridge extends BridgeAbstract
 
 	public function collectData()
 	{
-		$html = getSimpleHTMLDOM(self::URI . '/en-eu/blog-archive')
-			or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM(self::URI . '/en-eu/blog-archive');
 
 		foreach($html->find('div[class="ag ah ai aj bs bt dx ea fo gx ie if ih ii ij ik s"]') as $article) {
 			$item = array();
@@ -24,8 +23,7 @@ class N26Bridge extends BridgeAbstract
 			$item['uri'] = self::URI . $article->find('h2 a', 0)->href;
 			$item['title'] = $article->find('h2 a', 0)->plaintext;
 
-			$fullArticle = getSimpleHTMLDOM($item['uri'])
-				or returnServerError('Error while downloading the full article');
+			$fullArticle = getSimpleHTMLDOM($item['uri']);
 
 			$dateElement = $fullArticle->find('time', 0);
 			$item['timestamp'] = strtotime($dateElement->plaintext);

--- a/bridges/NFLRUSBridge.php
+++ b/bridges/NFLRUSBridge.php
@@ -43,8 +43,7 @@ class NFLRUSBridge extends BridgeAbstract {
 	}
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Unable to get any articles from NFLRUS');
+		$html = getSimpleHTMLDOM(self::URI);
 		$html = defaultLinkTo($html, self::URI);
 
 		foreach($html->find('article') as $article) {

--- a/bridges/NasaApodBridge.php
+++ b/bridges/NasaApodBridge.php
@@ -9,8 +9,7 @@ class NasaApodBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM(self::URI . 'archivepix.html')
-			or returnServerError('Error while downloading the website content');
+		$html = getSimpleHTMLDOM(self::URI . 'archivepix.html');
 
 		// Start at 1 to skip the "APOD Full Archive" on top of the page
 		for($i = 1; $i < 4; $i++) {

--- a/bridges/NationalGeographicBridge.php
+++ b/bridges/NationalGeographicBridge.php
@@ -252,8 +252,7 @@ EOD;
 	}
 
 	private function getFullArticle($uri) {
-		$html = getContents($uri)
-			or returnServerError('Could not load ' . $uri);
+		$html = getContents($uri);
 
 		$scriptRegex = '/window\[\'__natgeo__\'\]=(.*);<\/script>/';
 

--- a/bridges/NewOnNetflixBridge.php
+++ b/bridges/NewOnNetflixBridge.php
@@ -22,8 +22,7 @@ class NewOnNetflixBridge extends BridgeAbstract {
 
 	public function collectData() {
 		$baseURI = 'https://' . $this->getInput('country') . '.newonnetflix.info';
-		$html = getSimpleHTMLDOMCached($baseURI . '/lastchance', self::CACHE_TIMEOUT)
-			or returnServerError('Could not request NewOnNetflix (U FAILED LOL).');
+		$html = getSimpleHTMLDOMCached($baseURI . '/lastchance', self::CACHE_TIMEOUT);
 
 		foreach($html->find('article.oldpost') as $element) {
 			$title = $element->find('a.infopop[title]', 0);

--- a/bridges/NotAlwaysBridge.php
+++ b/bridges/NotAlwaysBridge.php
@@ -30,8 +30,7 @@ class NotAlwaysBridge extends BridgeAbstract {
 		}
 
 		public function collectData(){
-				$html = getSimpleHTMLDOM($this->getURI())
-						or returnServerError('Could not request NotAlways.');
+				$html = getSimpleHTMLDOM($this->getURI());
 				foreach($html->find('.post') as $post) {
 						#print_r($post);
 						$item = array();

--- a/bridges/NovelUpdatesBridge.php
+++ b/bridges/NovelUpdatesBridge.php
@@ -25,8 +25,7 @@ class NovelUpdatesBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-		$fullhtml = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request NovelUpdates, novel "' . $this->getInput('n') . '" not found');
+		$fullhtml = getSimpleHTMLDOM($this->getURI());
 
 		$this->seriesTitle = $fullhtml->find('h4.seriestitle', 0)->plaintext;
 		// dirty fix for nasty simpledom bug: https://github.com/sebsauvage/rss-bridge/issues/259

--- a/bridges/OpenClassroomsBridge.php
+++ b/bridges/OpenClassroomsBridge.php
@@ -34,8 +34,7 @@ class OpenClassroomsBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request OpenClassrooms.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('.courseListItem') as $element) {
 				$item = array();

--- a/bridges/OpenwhydBridge.php
+++ b/bridges/OpenwhydBridge.php
@@ -25,18 +25,15 @@ class OpenwhydBridge extends BridgeAbstract {
 		if(strlen(preg_replace('/[^0-9a-f]/', '', $this->getInput('u'))) == 24) {
 			// is input the userid ?
 			$html = getSimpleHTMLDOM(
-				self::URI . '/u/' . preg_replace('/[^0-9a-f]/', '', $this->getInput('u'))
-			) or returnServerError('No results for this query.');
+				self::URI . '/u/' . preg_replace('/[^0-9a-f]/', '', $this->getInput('u'));
 		} else { // input may be the username
 			$html = getSimpleHTMLDOM(
-				self::URI . '/search?q=' . urlencode($this->getInput('u'))
-			) or returnServerError('No results for this query.');
+				self::URI . '/search?q=' . urlencode($this->getInput('u'));
 
 			for($j = 0; $j < 5; $j++) {
 				if(strtolower($html->find('div.user', $j)->find('a', 0)->plaintext) == strtolower($this->getInput('u'))) {
 					$html = getSimpleHTMLDOM(
-						self::URI . $html->find('div.user', $j)->find('a', 0)->getAttribute('href')
-					) or returnServerError('No results for this query');
+						self::URI . $html->find('div.user', $j)->find('a', 0)->getAttribute('href';
 					break;
 				}
 			}

--- a/bridges/OpenwhydBridge.php
+++ b/bridges/OpenwhydBridge.php
@@ -33,7 +33,7 @@ class OpenwhydBridge extends BridgeAbstract {
 			for($j = 0; $j < 5; $j++) {
 				if(strtolower($html->find('div.user', $j)->find('a', 0)->plaintext) == strtolower($this->getInput('u'))) {
 					$html = getSimpleHTMLDOM(
-						self::URI . $html->find('div.user', $j)->find('a', 0)->getAttribute('href';
+						self::URI . $html->find('div.user', $j)->find('a', 0)->getAttribute('href');
 					break;
 				}
 			}

--- a/bridges/OpenwhydBridge.php
+++ b/bridges/OpenwhydBridge.php
@@ -25,10 +25,12 @@ class OpenwhydBridge extends BridgeAbstract {
 		if(strlen(preg_replace('/[^0-9a-f]/', '', $this->getInput('u'))) == 24) {
 			// is input the userid ?
 			$html = getSimpleHTMLDOM(
-				self::URI . '/u/' . preg_replace('/[^0-9a-f]/', '', $this->getInput('u'));
+				self::URI . '/u/' . preg_replace('/[^0-9a-f]/', '', $this->getInput('u'))
+			);
 		} else { // input may be the username
 			$html = getSimpleHTMLDOM(
-				self::URI . '/search?q=' . urlencode($this->getInput('u'));
+				self::URI . '/search?q=' . urlencode($this->getInput('u'))
+			);
 
 			for($j = 0; $j < 5; $j++) {
 				if(strtolower($html->find('div.user', $j)->find('a', 0)->plaintext) == strtolower($this->getInput('u'))) {

--- a/bridges/OpenwhydBridge.php
+++ b/bridges/OpenwhydBridge.php
@@ -35,7 +35,8 @@ class OpenwhydBridge extends BridgeAbstract {
 			for($j = 0; $j < 5; $j++) {
 				if(strtolower($html->find('div.user', $j)->find('a', 0)->plaintext) == strtolower($this->getInput('u'))) {
 					$html = getSimpleHTMLDOM(
-						self::URI . $html->find('div.user', $j)->find('a', 0)->getAttribute('href');
+						self::URI . $html->find('div.user', $j)->find('a', 0)->getAttribute('href')
+					);
 					break;
 				}
 			}

--- a/bridges/OpenwrtSecurityBridge.php
+++ b/bridges/OpenwrtSecurityBridge.php
@@ -9,8 +9,7 @@ class OpenwrtSecurityBridge extends BridgeAbstract {
 
 	public function collectData() {
 		$item = array();
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request entries');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$advisories = $html->find('div[class=plugin_nspages]', 0);
 

--- a/bridges/OsmAndBlogBridge.php
+++ b/bridges/OsmAndBlogBridge.php
@@ -6,8 +6,7 @@ class OsmAndBlogBridge extends BridgeAbstract {
 	const MAINTAINER = 'fulmeek';
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::URI . 'blog')
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM(self::URI . 'blog');
 
 		foreach($html->find('div.article') as $element) {
 			$item = array();

--- a/bridges/OtrkeyFinderBridge.php
+++ b/bridges/OtrkeyFinderBridge.php
@@ -69,8 +69,7 @@ class OtrkeyFinderBridge extends BridgeAbstract {
 		for($page = 1; $page <= $pages; $page++) {
 			$uri = $this->buildUri($page);
 
-			$html = getSimpleHTMLDOMCached($uri, self::CACHE_TIMEOUT)
-				or returnServerError('Could not request ' . $uri);
+			$html = getSimpleHTMLDOMCached($uri, self::CACHE_TIMEOUT);
 
 			$keys = $html->find('div.otrkey');
 

--- a/bridges/ParuVenduImmoBridge.php
+++ b/bridges/ParuVenduImmoBridge.php
@@ -26,8 +26,7 @@ class ParuVenduImmoBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request paruvendu.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('div.annonce a') as $element) {
 

--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -15,8 +15,7 @@ class PatreonBridge extends BridgeAbstract {
 	));
 
 	public function collectData(){
-		$html = getSimpleHTMLDOMCached($this->getURI(), 86400)
-			or returnServerError('Failed to load creator page at ' . $this->getURI());
+		$html = getSimpleHTMLDOMCached($this->getURI(), 86400);
 		$regex = '#/api/campaigns/([0-9]+)#';
 		if(preg_match($regex, $html->save(), $matches) > 0) {
 			$campaign_id = $matches[1];
@@ -168,8 +167,7 @@ class PatreonBridge extends BridgeAbstract {
 			))
 		);
 
-		$data = json_decode(getContents($url, $header, $opts))
-			or returnServerError('API request to "' . $url . '" failed.');
+		$data = json_decode(getContents($url, $header, $opts));
 
 		return $data;
 	}

--- a/bridges/PickyWallpapersBridge.php
+++ b/bridges/PickyWallpapersBridge.php
@@ -35,8 +35,7 @@ class PickyWallpapersBridge extends BridgeAbstract {
 		$resolution = $this->getInput('r'); // Wide wallpaper default
 
 		for($page = 1; $page <= $lastpage; $page++) {
-			$html = getSimpleHTMLDOM($this->getURI() . '/page-' . $page . '/')
-				or returnServerError('No results for this query.');
+			$html = getSimpleHTMLDOM($this->getURI() . '/page-' . $page . '/');
 
 			if($page === 1) {
 				preg_match('/page-(\d+)\/$/', $html->find('.pages li a', -2)->href, $matches);

--- a/bridges/PillowfortBridge.php
+++ b/bridges/PillowfortBridge.php
@@ -205,8 +205,7 @@ EOD;
 	 * to the Twitter bridge for formatting.
 	 */
 	public function collectData() {
-		$jsonSite = getContents($this -> getJSONURI())
-			or returnServerError('Could not get the feed of' . $this->getUsername());
+		$jsonSite = getContents($this -> getJSONURI());
 
 		$jsonFile = json_decode($jsonSite, true);
 		$posts = $jsonFile['posts'];

--- a/bridges/PirateCommunityBridge.php
+++ b/bridges/PirateCommunityBridge.php
@@ -50,8 +50,7 @@ class PirateCommunityBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not retrieve topic page at ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$this->feedName = $html->find('head title', 0)->plaintext;
 

--- a/bridges/PlantUMLReleasesBridge.php
+++ b/bridges/PlantUMLReleasesBridge.php
@@ -46,7 +46,7 @@ class PlantUMLReleasesBridge extends BridgeAbstract
 
 	public function collectData()
 	{
-		$html = getSimpleHTMLDOM($this->getURI()) or returnServerError('Could not request ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		// Since GQ don't want simple class scrapping, let's do it the hard way and ... discover content !
 		$main = $html->find('div[id=root]', 0);

--- a/bridges/PokemonTVBridge.php
+++ b/bridges/PokemonTVBridge.php
@@ -44,8 +44,7 @@ class PokemonTVBridge extends BridgeAbstract {
 	public function collectData(){
 		$link = 'https://www.pokemon.com/api/pokemontv/v2/channels/' . $this->getInput('language');
 
-		$html = getSimpleHTMLDOM($link)
-			or returnServerError('Could not request Channels for : ' . $link);
+		$html = getSimpleHTMLDOM($link);
 		$parsed_json = json_decode($html);
 
 		$filtername = $this->getInput('filtername');

--- a/bridges/PornhubBridge.php
+++ b/bridges/PornhubBridge.php
@@ -62,8 +62,7 @@ class PornhubBridge extends BridgeAbstract {
 
 		$show_images = $this->getInput('show_images');
 
-		$html = getSimpleHTMLDOM($uri)
-			or returnServerError('Could not request PornHub.');
+		$html = getSimpleHTMLDOM($uri);
 
 		foreach($html->find('div.videoUList ul.videos li.videoblock') as $element) {
 

--- a/bridges/QPlayBridge.php
+++ b/bridges/QPlayBridge.php
@@ -39,8 +39,7 @@ class QPlayBridge extends BridgeAbstract {
 	public function getName() {
 		switch ($this->queriedContext) {
 			case 'Program':
-				$html = getSimpleHTMLDOMCached($this->getURI())
-					or returnServerError('Could not load content');
+				$html = getSimpleHTMLDOMCached($this->getURI());
 
 				return $html->find('h1.program--title', 0)->innertext;
 			case 'Catalog':
@@ -55,8 +54,7 @@ class QPlayBridge extends BridgeAbstract {
 		switch ($this->queriedContext) {
 		case 'Program':
 			$program = $this->getInput('program');
-			$html = getSimpleHTMLDOMCached($this->getURI())
-				or returnServerError('Could not load content');
+			$html = getSimpleHTMLDOMCached($this->getURI());
 
 			foreach($html->find('.cce--thumbnails-video-chapter') as $element) {
 				$cid = $element->getAttribute('data-id');
@@ -67,8 +65,7 @@ class QPlayBridge extends BridgeAbstract {
 
 				/* TODO: Suport login credentials? */
 				/* # Get direct video URL */
-				/* $json_source = getContents(self::URI . '/chapters/' . $cid, array('Cookie: _uscreen2_session=???;')) */
-				/* 	or returnServerError('Could not request chapter JSON'); */
+				/* $json_source = getContents(self::URI . '/chapters/' . $cid, array('Cookie: _uscreen2_session=???;')); */
 				/* $json = json_decode($json_source); */
 
 				/* $item['enclosures'] = [$json->fallback]; */
@@ -78,8 +75,7 @@ class QPlayBridge extends BridgeAbstract {
 
 			break;
 		case 'Catalog':
-			$json_raw = getContents($this->getCatalogURI(1))
-				or returnServerError('Could not load catalog content');
+			$json_raw = getContents($this->getCatalogURI(1));
 
 			$json = json_decode($json_raw);
 			$total_pages = $json->total_pages;
@@ -90,8 +86,7 @@ class QPlayBridge extends BridgeAbstract {
 
 			if ($this->getInput('all_pages') === true) {
 				foreach(range(2, $total_pages) as $page) {
-					$json_raw = getContents($this->getCatalogURI($page))
-						or returnServerError('Could not load catalog content (all pages)');
+					$json_raw = getContents($this->getCatalogURI($page));
 
 					$json = json_decode($json_raw);
 

--- a/bridges/RTBFBridge.php
+++ b/bridges/RTBFBridge.php
@@ -19,8 +19,7 @@ class RTBFBridge extends BridgeAbstract {
 		$limit = 10;
 		$count = 0;
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request RTBF.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('section[id!=widget-ml-avoiraussi-] .rtbf-media-grid article') as $element) {
 			if($count >= $limit) {

--- a/bridges/RaceDepartmentBridge.php
+++ b/bridges/RaceDepartmentBridge.php
@@ -13,8 +13,7 @@ class RaceDepartmentBridge extends FeedExpander {
 		$item = parent::parseRSS_2_0_Item($feedItem);
 
 		//fetch page
-		$articlePage = getSimpleHTMLDOMCached($feedItem->link)
-			or returnServerError('Could not retrieve ' . $feedItem->link);
+		$articlePage = getSimpleHTMLDOMCached($feedItem->link);
 
 		$coverImage = $articlePage->find('img.js-articleCoverImage', 0);
 		#relative url -> absolute url

--- a/bridges/RadioMelodieBridge.php
+++ b/bridges/RadioMelodieBridge.php
@@ -10,8 +10,7 @@ class RadioMelodieBridge extends BridgeAbstract {
 	}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI . '/actu/')
-			or returnServerError('Could not request Radio Melodie.');
+		$html = getSimpleHTMLDOM(self::URI . '/actu/');
 		$list = $html->find('div[class=listArticles]', 0)->children();
 
 		foreach($list as $element) {

--- a/bridges/RainbowSixSiegeBridge.php
+++ b/bridges/RainbowSixSiegeBridge.php
@@ -14,7 +14,7 @@ class RainbowSixSiegeBridge extends BridgeAbstract {
 	public function collectData(){
 		$dlUrl = 'https://www.ubisoft.com/api/updates/items?locale=en-us&categoriesFilter=all';
 		$dlUrl = $dlUrl . '&limit=6&mediaFilter=news&skip=0&startIndex=undefined&tags=BR-rainbow-six%20GA-siege';
-		$jsonString = getContents($dlUrl) or returnServerError('Error while downloading the website content');
+		$jsonString = getContents($dlUrl);
 
 		$json = json_decode($jsonString, true);
 		$json = $json['items'];

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -137,8 +137,7 @@ class RedditBridge extends BridgeAbstract {
 					. $name
 					. '&sort='
 					. $this->getInput('d')
-					. '&include_over_18=on')
-			or returnServerError('Unable to fetch posts!');
+					. '&include_over_18=on');
 			$decodedValues = json_decode($values);
 
 			foreach ($decodedValues->data->children as $post) {

--- a/bridges/Releases3DSBridge.php
+++ b/bridges/Releases3DSBridge.php
@@ -13,8 +13,7 @@ class Releases3DSBridge extends BridgeAbstract {
 
 	protected function collectDataUrl($dataUrl){
 
-		$xml = getContents($dataUrl)
-			or returnServerError('Could not request URL: ' . $dataUrl);
+		$xml = getContents($dataUrl);
 		$limit = 0;
 
 		foreach(array_reverse(explode('<release>', $xml)) as $element) {

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -22,8 +22,7 @@ class ReporterreBridge extends BridgeAbstract {
 		}
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI . 'spip.php?page=backend')
-			or returnServerError('Could not request Reporterre.');
+		$html = getSimpleHTMLDOM(self::URI . 'spip.php?page=backend');
 		$limit = 0;
 
 		foreach($html->find('item') as $element) {

--- a/bridges/RobinhoodSnacksBridge.php
+++ b/bridges/RobinhoodSnacksBridge.php
@@ -9,8 +9,7 @@ class RobinhoodSnacksBridge extends BridgeAbstract {
 
 	public function collectData()
 	{
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request snacks.robinhood.com.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach ($html->find('#root > div > div > div > div > div > a') as $element) {
 			if ($element->href === 'https://snacks.robinhood.com/newsletters/page/2/') {

--- a/bridges/RoosterTeethBridge.php
+++ b/bridges/RoosterTeethBridge.php
@@ -66,8 +66,7 @@ class RoosterTeethBridge extends BridgeAbstract {
 				. '&order=' . $this->getInput('sort')
 				. '&page=1';
 
-			$htmlJSON = getSimpleHTMLDOM($uri)
-			or returnServerError('Could not contact Rooster Teeth: ' . $uri);
+			$htmlJSON = getSimpleHTMLDOM($uri);
 		} else {
 			$uri = self::API
 				. '/api/v1/episodes?per_page='
@@ -76,8 +75,7 @@ class RoosterTeethBridge extends BridgeAbstract {
 				. $this->getInput('sort')
 				. '&page=1';
 
-			$htmlJSON = getSimpleHTMLDOM($uri)
-			or returnServerError('Could not contact Rooster Teeth: ' . $uri);
+			$htmlJSON = getSimpleHTMLDOM($uri);
 		}
 
 		$htmlArray = json_decode($htmlJSON, true);

--- a/bridges/Rue89Bridge.php
+++ b/bridges/Rue89Bridge.php
@@ -8,8 +8,7 @@ class Rue89Bridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$jsonArticles = getContents('https://appdata.nouvelobs.com/rue89/feed.json')
-				or returnServerError('Unable to query Rue89 !');
+		$jsonArticles = getContents('https://appdata.nouvelobs.com/rue89/feed.json');
 		$articles = json_decode($jsonArticles)->items;
 		foreach($articles as $article) {
 			$this->items[] = $this->getArticle($article);
@@ -19,8 +18,7 @@ class Rue89Bridge extends BridgeAbstract {
 
 	private function getArticle($articleInfo) {
 
-		$articleJson = getContents($articleInfo->json_url)
-			or returnServerError('Unable to get article !');
+		$articleJson = getContents($articleInfo->json_url);
 		$article = json_decode($articleJson);
 		$item = array();
 		$item['title'] = $article->title;

--- a/bridges/SIMARBridge.php
+++ b/bridges/SIMARBridge.php
@@ -15,8 +15,7 @@ class SIMARBridge extends BridgeAbstract {
 	);
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::getURI())
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM(self::getURI());
 		$e_home = $html->find('#home', 0)
 			or returnServerError('Invalid site structure');
 

--- a/bridges/ScmbBridge.php
+++ b/bridges/ScmbBridge.php
@@ -9,8 +9,7 @@ class ScmbBridge extends BridgeAbstract {
 
 	public function collectData(){
 		$html = '';
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request Se Coucher Moins Bete.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('article') as $article) {
 			$item = array();

--- a/bridges/ScoopItBridge.php
+++ b/bridges/ScoopItBridge.php
@@ -18,8 +18,7 @@ class ScoopItBridge extends BridgeAbstract {
 		$this->request = $this->getInput('u');
 		$link = self::URI . 'search?q=' . urlencode($this->getInput('u'));
 
-		$html = getSimpleHTMLDOM($link)
-			or returnServerError('Could not request ScoopIt. for : ' . $link);
+		$html = getSimpleHTMLDOM($link);
 
 		foreach($html->find('div.post-view') as $element) {
 			$item = array();

--- a/bridges/ScribdBridge.php
+++ b/bridges/ScribdBridge.php
@@ -21,8 +21,7 @@ class ScribdBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$header = $html->find('div.header', 0);
 		$this->feedName = $header->find('a', 0)->plaintext;
@@ -36,8 +35,7 @@ class ScribdBridge extends BridgeAbstract {
 			//$item['timestamp'] =
 			$item['uid'] = $li->find('a', 0)->href;
 
-			$pageHtml = getSimpleHTMLDOMCached($item['uri'], 3600)
-				or returnServerError('Could not request: ' . $item['uri']);
+			$pageHtml = getSimpleHTMLDOMCached($item['uri'], 3600);
 
 			$image = $pageHtml->find('meta[property="og:image"]', 0)->content;
 			$description = $pageHtml->find('meta[property="og:description"]', 0)->content;

--- a/bridges/SensCritiqueBridge.php
+++ b/bridges/SensCritiqueBridge.php
@@ -47,8 +47,7 @@ class SensCritiqueBridge extends BridgeAbstract {
 				case 'mu': $uri .= 'musique/actualite';
 				break;
 				}
-				$html = getSimpleHTMLDOM($uri)
-					or returnServerError('No results for this query.');
+				$html = getSimpleHTMLDOM($uri);
 				$list = $html->find('ul.elpr-list', 0);
 
 				$this->extractDataFromList($list);

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -80,20 +80,14 @@ class ShanaprojectBridge extends BridgeAbstract {
 	// Returns an html object for the Season Anime List (latest season)
 	private function loadSeasonAnimeList(){
 
-		$html = getSimpleHTMLDOM(self::URI . '/seasons')
-			or returnServerError('Could not load \'seasons\' page!');
+		$html = getSimpleHTMLDOM(self::URI . '/seasons');
 
 		$html = defaultLinkTo($html, self::URI . '/seasons');
 
 		$season = $html->find('div.follows_menu > a', 1)
 			or returnServerError('Could not find \'Season Anime List\'!');
 
-		$html = getSimpleHTMLDOM($season->href)
-			or returnServerError(
-				'Could not load \'Season Anime List\' from \''
-				. $season->innertext
-				. '\'!'
-			);
+		$html = getSimpleHTMLDOM($season->href);
 
 		$this->uri = $season->href;
 

--- a/bridges/SkimfeedBridge.php
+++ b/bridges/SkimfeedBridge.php
@@ -531,8 +531,7 @@ class SkimfeedBridge extends BridgeAbstract {
 		// $this->exportBoxChannels(); die;
 		// $this->exportTechChannels(); die;
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Request to ' . $this->getURI() . ' failed!');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		defaultLinkTo($html, static::URI);
 

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -39,8 +39,7 @@ class SoundCloudBridge extends BridgeAbstract {
 	private $widgetRegex = '/widget-.+?\.js/';
 
 	public function collectData() {
-		$res = $this->getUser($this->getInput('u'))
-			or returnServerError('No results for this query');
+		$res = $this->getUser($this->getInput('u'));
 
 		$this->feedTitle = $res->username;
 		$this->feedIcon = $res->avatar_url;
@@ -136,8 +135,7 @@ HTML;
 	private function refreshClientID(){
 		$this->initClientIDCache();
 
-		$playerHTML = getContents($this->playerUrl)
-			or returnServerError('Unable to get player page.');
+		$playerHTML = getContents($this->playerUrl);
 
 		// Extract widget JS filenames from player page
 		if(preg_match_all($this->widgetRegex, $playerHTML, $matches) == false)
@@ -149,8 +147,7 @@ HTML;
 		foreach ($matches[0] as $widgetFile) {
 			$widgetURL = $this->widgetUrl . $widgetFile;
 
-			$widgetJS = getContents($widgetURL)
-				or returnServerError('Unable to get widget JS page.');
+			$widgetJS = getContents($widgetURL);
 
 			if(preg_match($this->clientIdRegex, $widgetJS, $matches)) {
 				$clientID = $matches[1];

--- a/bridges/SplCenterBridge.php
+++ b/bridges/SplCenterBridge.php
@@ -23,8 +23,7 @@ class SplCenterBridge extends FeedExpander {
 	protected function parseItem($item) {
 		$item = parent::parseItem($item);
 
-		$articleHtml = getSimpleHTMLDOMCached($item['uri'])
-			or returnServerError('Could not request: ' . $item['uri']);
+		$articleHtml = getSimpleHTMLDOMCached($item['uri']);
 
 		foreach ($articleHtml->find('.file') as $index => $media) {
 			$articleHtml->find('div.file', $index)->outertext = '<em>' . $media->outertext . '</em>';

--- a/bridges/SteamBridge.php
+++ b/bridges/SteamBridge.php
@@ -29,8 +29,7 @@ class SteamBridge extends BridgeAbstract {
 		$sourceUrl = self::URI . 'wishlist/profiles/' . $userid . '/wishlistdata?p=0';
 		$sort = array();
 
-		$json = getContents($sourceUrl)
-			or returnServerError('Could not get content from wishlistdata (' . $sourceUrl . ')');
+		$json = getContents($sourceUrl);
 
 		$appsData = json_decode($json);
 

--- a/bridges/SteamCommunityBridge.php
+++ b/bridges/SteamCommunityBridge.php
@@ -33,8 +33,7 @@ class SteamCommunityBridge extends BridgeAbstract {
 
 	protected function getMainPage() {
 		$category = $this->getInput('category');
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not fetch Steam data.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		return $html;
 	}

--- a/bridges/StripeAPIChangeLogBridge.php
+++ b/bridges/StripeAPIChangeLogBridge.php
@@ -7,8 +7,7 @@ class StripeAPIChangeLogBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the changes made to the stripe.com API';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('No results for Stripe API Changelog');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		foreach($html->find('h3') as $change) {
 			$item = array();

--- a/bridges/SupInfoBridge.php
+++ b/bridges/SupInfoBridge.php
@@ -20,11 +20,9 @@ class SupInfoBridge extends BridgeAbstract {
 	public function collectData() {
 
 		if(empty($this->getInput('tag'))) {
-			$html = getSimpleHTMLDOM(self::URI . '/articles/')
-				or returnServerError('Unable to fetch articles !');
+			$html = getSimpleHTMLDOM(self::URI . '/articles/');
 		} else {
-			$html = getSimpleHTMLDOM(self::URI . '/articles/tag/' . $this->getInput('tag'))
-				or returnServerError('Unable to fetch articles !');
+			$html = getSimpleHTMLDOM(self::URI . '/articles/tag/' . $this->getInput('tag'));
 		}
 		$content = $html->find('#latest', 0)->find('ul[class=courseContent]', 0);
 
@@ -37,8 +35,7 @@ class SupInfoBridge extends BridgeAbstract {
 
 	private function fetchArticle($link) {
 
-		$articleHTML = getSimpleHTMLDOM(self::URI . $link)
-			or returnServerError('Unable to fetch article !');
+		$articleHTML = getSimpleHTMLDOM(self::URI . $link);
 
 		$article = $articleHTML->find('div[id=courseDocZero]', 0);
 		$item = array();

--- a/bridges/SuperSmashBlogBridge.php
+++ b/bridges/SuperSmashBlogBridge.php
@@ -10,7 +10,7 @@ class SuperSmashBlogBridge extends BridgeAbstract {
 	public function collectData(){
 		$dlUrl = 'https://www.smashbros.com/data/bs/en_US/json/en_US.json';
 
-		$jsonString = getContents($dlUrl) or returnServerError('Error while downloading the website content');
+		$jsonString = getContents($dlUrl);
 		$json = json_decode($jsonString, true);
 
 		foreach($json as $article) {

--- a/bridges/SymfonyCastsBridge.php
+++ b/bridges/SymfonyCastsBridge.php
@@ -8,8 +8,7 @@ class SymfonyCastsBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 3600;
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM('https://symfonycasts.com/updates/find')
-			or returnServerError('Unable to get page.');
+		$html = getSimpleHTMLDOM('https://symfonycasts.com/updates/find');
 		$dives = $html->find('div');
 
 		/* @var simple_html_dom $div */

--- a/bridges/TagBoardBridge.php
+++ b/bridges/TagBoardBridge.php
@@ -21,8 +21,7 @@ class TagBoardBridge extends BridgeAbstract {
 	public function collectData(){
 		$link = 'https://post-cache.tagboard.com/search/' . $this->getInput('u');
 
-		$html = getSimpleHTMLDOM($link)
-			or returnServerError('Could not request TagBoard for : ' . $link);
+		$html = getSimpleHTMLDOM($link);
 		$parsed_json = json_decode($html);
 
 		foreach($parsed_json->{'posts'} as $element) {

--- a/bridges/TebeoBridge.php
+++ b/bridges/TebeoBridge.php
@@ -27,8 +27,7 @@ class TebeoBridge extends FeedExpander {
 
 	public function collectData(){
 		$url = self::URI . '/le-replay/' . $this->getInput('cat');
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError('Could not request Tébéo.');
+		$html = getSimpleHTMLDOM($url);
 
 		foreach($html->find('div[id=items_replay] div.replay') as $element) {
 			$item = array();

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -41,8 +41,7 @@ class TelegramBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$channelTitle = htmlspecialchars_decode(
 			$html->find('div.tgme_channel_info_header_title span', 0)->plaintext,

--- a/bridges/TheFarSideBridge.php
+++ b/bridges/TheFarSideBridge.php
@@ -9,8 +9,7 @@ class TheFarSideBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 3600; // 1 hour
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request: ' . self::URI);
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$div = $html->find('div.tfs-page-container__cows', 0);
 
@@ -25,8 +24,7 @@ class TheFarSideBridge extends BridgeAbstract {
 			$imageUrl = $image->attr['data-src'];
 
 			// Images are downloaded to bypass the hotlink protection.
-			$image = getContents($imageUrl, array('Referer: ' . self::URI))
-				or returnServerError('Could not request: ' . $imageUrl);
+			$image = getContents($imageUrl, array('Referer: ' . self::URI));
 
 			// Encode image as base64
 			$imageBase64 = base64_encode($image);

--- a/bridges/TheHackerNewsBridge.php
+++ b/bridges/TheHackerNewsBridge.php
@@ -8,8 +8,7 @@ class TheHackerNewsBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request TheHackerNews: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 		$limit = 0;
 
 		foreach($html->find('div.body-post') as $element) {

--- a/bridges/ThePirateBayBridge.php
+++ b/bridges/ThePirateBayBridge.php
@@ -57,7 +57,7 @@ class ThePirateBayBridge extends BridgeAbstract {
 						'search/' .
 						rawurlencode($keywords) .
 						'/0/3/0'
-					) or returnServerError('Could not request TPB.');
+					);
 				} else {
 					$html = getSimpleHTMLDOM(
 						self::URI .
@@ -65,7 +65,7 @@ class ThePirateBayBridge extends BridgeAbstract {
 						rawurlencode($keywords) .
 						'/0/3/' .
 						rawurlencode($catNum)
-						) or returnServerError('Could not request TPB.');
+						);
 				}
 				break;
 			case 'cat':
@@ -74,7 +74,7 @@ class ThePirateBayBridge extends BridgeAbstract {
 					'browse/' .
 					rawurlencode($keywords) .
 					'/0/3/0'
-				) or returnServerError('Could not request TPB.');
+				);
 				break;
 			case 'usr':
 				$html = getSimpleHTMLDOM(
@@ -82,7 +82,7 @@ class ThePirateBayBridge extends BridgeAbstract {
 					'user/' .
 					rawurlencode($keywords) .
 					'/0/3/0'
-				) or returnServerError('Could not request TPB.');
+				);
 				break;
 			}
 

--- a/bridges/TheWhiteboardBridge.php
+++ b/bridges/TheWhiteboardBridge.php
@@ -8,7 +8,7 @@ class TheWhiteboardBridge extends BridgeAbstract {
 	public function collectData() {
 		$item = array();
 
-		$html = getSimpleHTMLDOM(self::URI) or returnServerError('Could not load The Whiteboard.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$image = $html->find('center', 1)->find('img', 0);
 		$image->src = self::URI . '/' . $image->src;

--- a/bridges/TheYeteeBridge.php
+++ b/bridges/TheYeteeBridge.php
@@ -9,8 +9,7 @@ class TheYeteeBridge extends BridgeAbstract {
 
 	public function collectData(){
 
-		$html = getSimpleHTMLDOM(self::URI)
-			or returnServerError('Could not request The Yetee.');
+		$html = getSimpleHTMLDOM(self::URI);
 
 		$div = $html->find('.module_timed-item.is--full');
 		foreach($div as $element) {

--- a/bridges/ThingiverseBridge.php
+++ b/bridges/ThingiverseBridge.php
@@ -125,8 +125,7 @@ class ThingiverseBridge extends BridgeAbstract {
 	);
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Failed to receive ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$results = $html->find('div.thing-card');
 

--- a/bridges/TinyLetterBridge.php
+++ b/bridges/TinyLetterBridge.php
@@ -33,8 +33,7 @@ class TinyLetterBridge extends BridgeAbstract {
 
 	public function collectData() {
 		$archives = self::getURI() . '/archive';
-		$html = getSimpleHTMLDOMCached($archives)
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOMCached($archives);
 
 		foreach($html->find('.message-list li') as $element) {
 			$item = array();

--- a/bridges/TorrentGalaxyBridge.php
+++ b/bridges/TorrentGalaxyBridge.php
@@ -55,8 +55,7 @@ class TorrentGalaxyBridge extends BridgeAbstract {
 			. '/torrents.php?search=' . urlencode($this->getInput('search'))
 			. '&lang=' . $this->getInput('lang')
 			. '&sort=id&order=desc';
-		$html = getSimpleHTMLDOM($url)
-			or returnServerError("Error querying the server at $url");
+		$html = getSimpleHTMLDOM($url);
 
 		foreach($html->find('div.tgxtablerow') as $result) {
 			$identity = $result->find('div.tgxtablecell', 3)->find('div a', 0);

--- a/bridges/TrelloBridge.php
+++ b/bridges/TrelloBridge.php
@@ -553,8 +553,7 @@ class TrelloBridge extends BridgeAbstract {
 		$data = json_decode(getContents('https://trello.com/1/'
 			. $path
 			. '?'
-			. http_build_query($params)))
-			or returnServerError('Failed to query trello API');
+			. http_build_query($params)));
 		return $data;
 	}
 

--- a/bridges/TwitScoopBridge.php
+++ b/bridges/TwitScoopBridge.php
@@ -87,8 +87,7 @@ class TwitScoopBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 900; // 15 mins
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$updated = $html->find('time', 0)->datetime;
 		$trends = $html->find('div.trends', 0);

--- a/bridges/TwitchBridge.php
+++ b/bridges/TwitchBridge.php
@@ -213,8 +213,7 @@ EOD;
 		Debug::log("Sending GraphQL variables:\n"
 			. json_encode($variables, JSON_PRETTY_PRINT));
 
-		$response = json_decode(getContents(self::API_ENDPOINT, $header, $opts))
-			or returnServerError('API request to "' . self::API_ENDPOINT . '" failed.');
+		$response = json_decode(getContents(self::API_ENDPOINT, $header, $opts));
 
 		Debug::log("Got GraphQL response:\n"
 			. json_encode($response, JSON_PRETTY_PRINT));

--- a/bridges/UnraidCommunityApplicationsBridge.php
+++ b/bridges/UnraidCommunityApplicationsBridge.php
@@ -12,8 +12,7 @@ class UnraidCommunityApplicationsBridge extends BridgeAbstract {
 
 	private function fetchApps() {
 		Debug::log('Fetching all applications/plugins');
-		$this->apps = getContents(self::APPSURI)
-			or returnServerError('Could not fetch JSON for apps.');
+		$this->apps = getContents(self::APPSURI);
 		$this->apps = json_decode($this->apps, true)['applist'];
 	}
 

--- a/bridges/UnsplashBridge.php
+++ b/bridges/UnsplashBridge.php
@@ -30,8 +30,7 @@ class UnsplashBridge extends BridgeAbstract {
 		$max = $this->getInput('m');
 		$quality = $this->getInput('q');
 
-		$api_response = getContents('https://unsplash.com/napi/photos?page=1&per_page=' . $max)
-			or returnServerError('Could not request Unsplash API.');
+		$api_response = getContents('https://unsplash.com/napi/photos?page=1&per_page=' . $max);
 		$json = json_decode($api_response, true);
 
 		foreach ($json as $json_item) {

--- a/bridges/ViadeoCompanyBridge.php
+++ b/bridges/ViadeoCompanyBridge.php
@@ -19,8 +19,7 @@ class ViadeoCompanyBridge extends BridgeAbstract {
 		$html = '';
 		$link = self::URI . 'fr/company/' . $this->getInput('c');
 
-		$html = getSimpleHTMLDOM($link)
-			or returnServerError('Could not request Viadeo.');
+		$html = getSimpleHTMLDOM($link);
 
 		foreach($html->find('//*[@id="company-newsfeed"]/ul/li') as $element) {
 			$title = $element->find('p', 0)->innertext;

--- a/bridges/VieDeMerdeBridge.php
+++ b/bridges/VieDeMerdeBridge.php
@@ -22,8 +22,7 @@ class VieDeMerdeBridge extends BridgeAbstract {
 			$limit = 20;
 		}
 
-		$html = getSimpleHTMLDOM(self::URI, array())
-			or returnServerError('Could not request VieDeMerde.');
+		$html = getSimpleHTMLDOM(self::URI, array());
 
 		$quotes = $html->find('article.article-panel');
 		if(sizeof($quotes) === 0) {

--- a/bridges/VimeoBridge.php
+++ b/bridges/VimeoBridge.php
@@ -48,8 +48,7 @@ class VimeoBridge extends BridgeAbstract {
 			$target_charset = DEFAULT_TARGET_CHARSET,
 			$stripRN = false, // We want to keep newline characters
 			$defaultBRText = DEFAULT_BR_TEXT,
-			$defaultSpanText = DEFAULT_SPAN_TEXT)
-			or returnServerError('Could not request ' . $this->getURI());
+			$defaultSpanText = DEFAULT_SPAN_TEXT);
 
 		$json = null; // Holds the JSON data
 

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -51,8 +51,7 @@ class VkBridge extends BridgeAbstract
 
 	public function collectData()
 	{
-		$text_html = $this->getContents()
-		or returnServerError('No results for group or user name "' . $this->getInput('u') . '".');
+		$text_html = $this->getContents();
 
 		$text_html = iconv('windows-1251', 'utf-8//ignore', $text_html);
 		// makes album link generating work correctly

--- a/bridges/WallmineNewsBridge.php
+++ b/bridges/WallmineNewsBridge.php
@@ -9,8 +9,7 @@ class WallmineNewsBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 900; // 15 mins
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI() . '/news/')
-			or returnServerError('Could not request: ' . $this->getURI() . '/news/');
+		$html = getSimpleHTMLDOM($this->getURI() . '/news/');
 
 		$html = defaultLinkTo($html, self::URI);
 
@@ -20,8 +19,7 @@ class WallmineNewsBridge extends BridgeAbstract {
 
 			$image = $div->find('img.img-fluid', 0)->src;
 
-			$page = getSimpleHTMLDOMCached($item['uri'], 7200)
-				or returnServerError('Could not request: ' . $item['uri']);
+			$page = getSimpleHTMLDOMCached($item['uri'], 7200);
 
 			$article = $page->find('div.container.article-container', 0);
 

--- a/bridges/WallpaperStopBridge.php
+++ b/bridges/WallpaperStopBridge.php
@@ -45,8 +45,7 @@ class WallpaperStopBridge extends BridgeAbstract {
 			. $page
 			. '.html';
 
-			$html = getSimpleHTMLDOM($link)
-				or returnServerError('No results for this query.');
+			$html = getSimpleHTMLDOM($link);
 
 			if($page === 1) {
 				preg_match('/-(\d+)\.html$/', $html->find('.pagination > .last', 0)->href, $matches);

--- a/bridges/WiredBridge.php
+++ b/bridges/WiredBridge.php
@@ -47,8 +47,7 @@ class WiredBridge extends FeedExpander {
 
 	protected function parseItem($newsItem){
 		$item = parent::parseItem($newsItem);
-		$article = getSimpleHTMLDOMCached($item['uri'])
-			or returnServerError('Could not request WIRED: ' . $item['uri']);
+		$article = getSimpleHTMLDOMCached($item['uri']);
 		$item['content'] = $this->extractArticleContent($article);
 
 		$headline = strval($newsItem->description);

--- a/bridges/WordPressPluginUpdateBridge.php
+++ b/bridges/WordPressPluginUpdateBridge.php
@@ -21,8 +21,7 @@ class WordPressPluginUpdateBridge extends BridgeAbstract {
 		$request = str_replace('/', '', $this->getInput('pluginUrl'));
 		$page = self::URI . $request . '/changelog/';
 
-		$html = getSimpleHTMLDOM($page)
-			or returnServerError('No results for this query.');
+		$html = getSimpleHTMLDOM($page);
 
 		$content = $html->find('.block-content', 0);
 

--- a/bridges/WorldCosplayBridge.php
+++ b/bridges/WorldCosplayBridge.php
@@ -93,8 +93,7 @@ class WorldCosplayBridge extends BridgeAbstract {
 		}
 		$url = self::URI . sprintf($url, $id, $limit);
 
-		$json = json_decode(getContents($url))
-			or returnServerError(sprintf(self::ERR_QUERY, $url));
+		$json = json_decode(getContents($url));
 		if($json->has_error) {
 			returnServerError($json->message);
 		}

--- a/bridges/WosckerBridge.php
+++ b/bridges/WosckerBridge.php
@@ -9,8 +9,7 @@ class WosckerBridge extends BridgeAbstract {
 	const CACHE_TIMEOUT = 1800; // 30 mins
 
 	public function collectData() {
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not request: ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$date = $html->find('h1', 0)->plaintext;
 		$timestamp = $html->find('span.dateFont', 0)->plaintext . ' ' . $html->find('span.dateFont', 1)->plaintext;

--- a/bridges/XenForoBridge.php
+++ b/bridges/XenForoBridge.php
@@ -110,8 +110,7 @@ class XenForoBridge extends BridgeAbstract {
 
 		}
 
-		$html = getSimpleHTMLDOMCached($this->threadurl)
-			or returnServerError('Failed loading data from "' . $this->threadurl . '"!');
+		$html = getSimpleHTMLDOMCached($this->threadurl);
 
 		$html = defaultLinkTo($html, $this->threadurl);
 

--- a/bridges/YGGTorrentBridge.php
+++ b/bridges/YGGTorrentBridge.php
@@ -101,8 +101,7 @@ class YGGTorrentBridge extends BridgeAbstract {
 					. $category
 					. '&sub_category='
 					. $subcategory
-					. '&do=search&order=desc&sort=publish_date')
-					or returnServerError('Unable to query Yggtorrent !');
+					. '&do=search&order=desc&sort=publish_date');
 
 		$count = 0;
 		$results = $html->find('.results', 0);
@@ -136,7 +135,7 @@ class YGGTorrentBridge extends BridgeAbstract {
 		$url_full[5] = urlencode($url_full[5]);
 		$url_full[6] = urlencode($url_full[6]);
 		$url = implode('/', $url_full);
-		$page = getSimpleHTMLDOMCached($url) or returnServerError('Unable to query Yggtorrent page !');
+		$page = getSimpleHTMLDOMCached($url);
 		$author = $page->find('.informations', 0)->find('a', 4)->plaintext;
 		$content = $page->find('.default', 1);
 		return array('author' => $author, 'content' => $content);

--- a/bridges/YahtzeeDevDiaryBridge.php
+++ b/bridges/YahtzeeDevDiaryBridge.php
@@ -6,8 +6,7 @@ class YahtzeeDevDiaryBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Yahtzee’s Dev Diary Series';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Could not load content');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('blockquote.wp-embedded-content a') as $element) {
 			$item = array();

--- a/bridges/YeggiBridge.php
+++ b/bridges/YeggiBridge.php
@@ -47,8 +47,7 @@ class YeggiBridge extends BridgeAbstract {
 	);
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('Failed to receive ' . $this->getURI());
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		$results = $html->find('div.item_1_A');
 

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -347,8 +347,7 @@ class YoutubeBridge extends BridgeAbstract {
 			$this->request = $this->getInput('p');
 			$url_feed = self::URI . 'feeds/videos.xml?playlist_id=' . urlencode($this->request);
 			$url_listing = self::URI . 'playlist?list=' . urlencode($this->request);
-			$html = $this->ytGetSimpleHTMLDOM($url_listing)
-				or returnServerError("Could not request YouTube. Tried:\n - $url_listing");
+			$html = $this->ytGetSimpleHTMLDOM($url_listing);
 			$jsonData = $this->getJSONData($html);
 			// TODO: this method returns only first 100 video items
 			// if it has more videos, playlistVideoListRenderer will have continuationItemRenderer as last element
@@ -377,8 +376,7 @@ class YoutubeBridge extends BridgeAbstract {
 			. urlencode($this->request)
 			. '&sp=CAI%253D';
 
-			$html = $this->ytGetSimpleHTMLDOM($url_listing)
-				or returnServerError("Could not request YouTube. Tried:\n - $url_listing");
+			$html = $this->ytGetSimpleHTMLDOM($url_listing);
 
 			$jsonData = $this->getJSONData($html);
 			$jsonData = $jsonData->contents->twoColumnSearchResultsRenderer->primaryContents;

--- a/bridges/ZenodoBridge.php
+++ b/bridges/ZenodoBridge.php
@@ -7,8 +7,7 @@ class ZenodoBridge extends BridgeAbstract {
 	const DESCRIPTION = 'Returns the newest content of Zenodo';
 
 	public function collectData(){
-		$html = getSimpleHTMLDOM($this->getURI())
-			or returnServerError('zenodo.org not reachable.');
+		$html = getSimpleHTMLDOM($this->getURI());
 
 		foreach($html->find('div.record-elem') as $element) {
 			$item = array();

--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -45,8 +45,7 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 	private function loadURL($url){
 		$header = array();
 		$opts = array(CURLOPT_USERAGENT => 'curl/7.64.0');
-		$html = getContents($url, $header, $opts)
-			or returnServerError('Could not request Zone Telechargement.');
+		$html = getContents($url, $header, $opts);
 		return str_get_html($html);
 	}
 


### PR DESCRIPTION
When fetching website contents, exceptions already raise on fetching error