### PR TITLE
Change getGuestToken to use Twitter-API V1.1 guest/activate for reque…

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -545,7 +545,7 @@ EOD;
 		$guestToken = null;
 		if($guestTokenUses === null || !is_array($guestTokenUses) || count($guestTokenUses) != 2
 		|| $guestTokenUses[0] <= 0 || (time() - $refresh) > self::GUEST_TOKEN_EXPIRY) {
-			$guestToken = $this->getGuestToken();
+			$guestToken = $this->getGuestToken($apiKey);
 			if ($guestToken === null) {
 				if($guestTokenUses === null) {
 					returnServerError('Could not parse guest token');
@@ -568,15 +568,17 @@ EOD;
 
 	// Get a guest token. This is different to an API key,
 	// and it seems to change more regularly than the API key.
-	private function getGuestToken() {
-		$pageContent = getContents('https://twitter.com', array(), array(), true);
+	private function getGuestToken($apiKey) {
+		$headers = array(
+			'authorization: Bearer ' . $apiKey,
+		);
+		$opts = array(
+			CURLOPT_POST => 1,
+		);
 
-		$guestTokenRegex = '/gt=([0-9]*)/m';
-		preg_match_all($guestTokenRegex, $pageContent['header'], $guestTokenMatches, PREG_SET_ORDER, 0);
-		if (!$guestTokenMatches)
-				preg_match_all($guestTokenRegex, $pageContent['content'], $guestTokenMatches, PREG_SET_ORDER, 0);
-		if (!$guestTokenMatches) return null;
-		$guestToken = $guestTokenMatches[0][1];
+		$pageContent = getContents('https://api.twitter.com/1.1/guest/activate.json', $headers, $opts, true);
+		$guestToken = json_decode($pageContent['content'])->guest_token;
+
 		return $guestToken;
 	}
 

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -576,9 +576,12 @@ EOD;
 			CURLOPT_POST => 1,
 		);
 
-		$pageContent = getContents('https://api.twitter.com/1.1/guest/activate.json', $headers, $opts, true);
-		$guestToken = json_decode($pageContent['content'])->guest_token;
-
+		try {
+			$pageContent = getContents('https://api.twitter.com/1.1/guest/activate.json', $headers, $opts, true);
+			$guestToken = json_decode($pageContent['content'])->guest_token;
+		} catch (Exception $e) {
+			$guestToken = null;
+		}
 		return $guestToken;
 	}
 


### PR DESCRIPTION
Change getGuestToken to use Twitter-API V1.1 guest/activate for requesting new guest tokens

Instead of searching inside base html page for the guest token, this patch instead uses the Twitter REST API V1.1 to aquire the nessecary guest tokens.