### PR TITLE
Twitter error checks

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -224,7 +224,11 @@ class DisplayAction extends ActionAbstract {
 
 						$items[] = $item;
 					} elseif(Configuration::getConfig('error', 'output') === 'http') {
-						header('Content-Type: text/html', true, $this->get_return_code($e));
+						$code = $this->get_return_code($e);
+						if ($code == 503) {
+							header('Retry-After: 600', true);
+						}
+						header('Content-Type: text/html', true, $code);
 						die(buildTransformException($e, $bridge));
 					}
 				}

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -612,11 +612,11 @@ EOD;
 		// If we reach here, either we never got a guestToken (500), or the token was invalid (403),
 		// so return a meaningful error.
 		if ($lastCode == 500) {
-			returnError("Could not obtain a guest token", 503);
+			returnError('Could not obtain a guest token', 503);
 		} else if ($lastCode = 403) {
-			returnError("Our guest token is not valid", 503);
+			returnError('Our guest token is not valid', 503);
 		} else {
-			returnServerError("Unable to obtain contents");
+			returnServerError('Unable to obtain contents');
 		}
 	}
 

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -545,7 +545,7 @@ EOD;
 		$guestToken = null;
 		if($guestTokenUses === null || !is_array($guestTokenUses) || count($guestTokenUses) != 2
 		|| $guestTokenUses[0] <= 0 || (time() - $refresh) > self::GUEST_TOKEN_EXPIRY) {
-			$guestToken = $this->getGuestToken();
+			$guestToken = $this->getGuestToken($apiKey);
 			if ($guestToken === null) {
 				if($guestTokenUses === null) {
 					returnServerError('Could not parse guest token');
@@ -568,15 +568,17 @@ EOD;
 
 	// Get a guest token. This is different to an API key,
 	// and it seems to change more regularly than the API key.
-	private function getGuestToken() {
-		$pageContent = getContents('https://twitter.com', array(), array(), true);
+	private function getGuestToken($apiKey) {
+		$headers = array(
+			'authorization: Bearer ' . $apiKey,
+		);
+		$opts = array(
+			CURLOPT_POST => 1,
+		);
 
-		$guestTokenRegex = '/gt=([0-9]*)/m';
-		preg_match_all($guestTokenRegex, $pageContent['header'], $guestTokenMatches, PREG_SET_ORDER, 0);
-		if (!$guestTokenMatches)
-				preg_match_all($guestTokenRegex, $pageContent['content'], $guestTokenMatches, PREG_SET_ORDER, 0);
-		if (!$guestTokenMatches) return null;
-		$guestToken = $guestTokenMatches[0][1];
+		$pageContent = getContents('https://api.twitter.com/1.1/guest/activate.json', $headers, $opts, true);
+		$guestToken = json_decode($pageContent['content'])->guest_token;
+
 		return $guestToken;
 	}
 

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -576,9 +576,12 @@ EOD;
 			CURLOPT_POST => 1,
 		);
 
-		$pageContent = getContents('https://api.twitter.com/1.1/guest/activate.json', $headers, $opts, true);
-		$guestToken = json_decode($pageContent['content'])->guest_token;
-
+		try {
+			$pageContent = getContents('https://api.twitter.com/1.1/guest/activate.json', $headers, $opts, true);
+			$guestToken = json_decode($pageContent['content'])->guest_token;
+		} catch (Exception $e) {
+			$guestToken = null;
+		}
 		return $guestToken;
 	}
 


### PR DESCRIPTION
This builds on PR #2414 by arnd-s

Sometimes twitter invalidates our API key and/or guest token before expiry, and we need to delete the token we have and try again.

When this happens Twitter will return 403.  Treat the first occurrence of 403 as EAGAIN.  Do not retry infinitely.