### PR TITLE
[ZoneTelechargementBridge] Fix SSL errors

### DIFF
--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -34,9 +34,9 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 	);
 
 	// This is an URL that is not protected by robot protection for Direct Download
-	const UNPROTECTED_URI = 'https://www.zone-telechargement.net/';
+	const UNPROTECTED_URI = 'https://zone-telechargement.net/';
 
-	// This is an URL that is not protected by robot protection for Streaming Links
+	// This is an URL that is not protected by robot protection for Streaming Links ; This domain has expired
 	const UNPROTECTED_URI_STREAMING = 'https://zone-telechargement.stream/';
 
 	// This function use curl library with curl as User Agent instead of
@@ -44,9 +44,29 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 	// request for other user agents
 	private function loadURL($url){
 		$header = array();
-		$opts = array(CURLOPT_USERAGENT => 'curl/7.64.0');
+		$opts = array(CURLOPT_USERAGENT => 'curl/7.64.0',
+				CURLOPT_RESOLVE => $this->getCurlResolve()
+			);
 		$html = getContents($url, $header, $opts);
 		return str_get_html($html);
+	}
+
+	// This function construct the array of string needed by CURLOPT_RESOLVE
+	// The Domain zone-telechargement.stream expired, but Cloudflare can still "host" the website
+	// We use the CURLOPT_RESOLVE option to tell curl to ask Cloudflare for the content, instead of the
+	// parking page
+	private function getCurlResolve()
+	{
+		// Extract the Host of the DDL URI
+		$ddlhost = parse_url(self::UNPROTECTED_URI, PHP_URL_HOST);
+		// Extract the Streaming URI
+		$streaminghost = parse_url(self::UNPROTECTED_URI_STREAMING, PHP_URL_HOST);
+		// Get the IP of the DDL URI
+		$ip = gethostbyname($ddlhost);
+
+		// Return the CURLOPT_RESOLVE array to use the DDL URI IP for the Streaming URI in HTTPS (443)
+		return array($streaminghost . ':443:' . $ip);
+
 	}
 
 	public function getIcon(){

--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -37,7 +37,7 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 	const UNPROTECTED_URI = 'https://zone-telechargement.net/';
 
 	// This is an URL that is not protected by robot protection for Streaming Links ; This domain has expired
-	const UNPROTECTED_URI_STREAMING = 'https://zone-telechargement.stream/';
+	const UNPROTECTED_URI_STREAMING = 'https://mail.zone-telechargement.cam/';
 
 	// This function use curl library with curl as User Agent instead of
 	// simple_html_dom to load the HTML content as the website has some captcha
@@ -45,28 +45,9 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 	private function loadURL($url){
 		$header = array();
 		$opts = array(CURLOPT_USERAGENT => 'curl/7.64.0',
-				CURLOPT_RESOLVE => $this->getCurlResolve()
 			);
 		$html = getContents($url, $header, $opts);
 		return str_get_html($html);
-	}
-
-	// This function construct the array of string needed by CURLOPT_RESOLVE
-	// The Domain zone-telechargement.stream expired, but Cloudflare can still "host" the website
-	// We use the CURLOPT_RESOLVE option to tell curl to ask Cloudflare for the content, instead of the
-	// parking page
-	private function getCurlResolve()
-	{
-		// Extract the Host of the DDL URI
-		$ddlhost = parse_url(self::UNPROTECTED_URI, PHP_URL_HOST);
-		// Extract the Streaming URI
-		$streaminghost = parse_url(self::UNPROTECTED_URI_STREAMING, PHP_URL_HOST);
-		// Get the IP of the DDL URI
-		$ip = gethostbyname($ddlhost);
-
-		// Return the CURLOPT_RESOLVE array to use the DDL URI IP for the Streaming URI in HTTPS (443)
-		return array($streaminghost . ':443:' . $ip);
-
 	}
 
 	public function getIcon(){

--- a/bridges/ZoneTelechargementBridge.php
+++ b/bridges/ZoneTelechargementBridge.php
@@ -98,7 +98,7 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 				$hoster = $this->findLinkHoster($element);
 
 				// Format the link and add the link to the corresponding episode table
-				$episodes[$epnumber]['ddl'][] = '<a href="' . $element->href . '">' . $hoster . ' - '
+				$episodes[$epnumber]['ddl'][] = '<a href="' . $this->rewriteProtectedLink($element->href) . '">' . $hoster . ' - '
 					. $this->showTitle . ' Episode ' . $epnumber . '</a>';
 
 			}
@@ -117,7 +117,7 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 				$epnumber = explode(' ', $elementstreaming->plaintext)[1];
 
 				// Format the link and add the link to the corresponding episode table
-				$episodes[$epnumber]['streaming'][] = '<a href="' . $elementstreaming->href . '">'
+				$episodes[$epnumber]['streaming'][] = '<a href="' . $this->rewriteProtectedLink($elementstreaming->href) . '">'
 					. $this->showTitle . ' Episode ' . $epnumber . '</a>';
 			}
 		}
@@ -181,5 +181,14 @@ class ZoneTelechargementBridge extends BridgeAbstract {
 		// Return the text of the div : it's the file hoster name !
 		return $element->find('div', 0)->plaintext;
 
+	}
+
+	// Rewrite the links to use the new URL Protection system
+	private function rewriteProtectedLink($url)
+	{
+		// Split the link using '/'
+		$parts = explode('/', $url);
+		// return the new URL using the new Link Protection system
+		return 'https://liens.onaregarde-pourvous.com/171-2/?link=' . end($parts);
 	}
 }


### PR DESCRIPTION
The streaming unprotected URI had some SSL issue because the domain is
now hosting a parking website. This URL is the only known URL that allows to
show streaming links without being protected by Cloudflare DDoS protection.

This URL still works if you ask Cloudflare for the content. Therefore,
to load this URL, this bridge kindly ask cURL to connect to the same IP
as the unproteced DDL URI to get the Streaming URI content, by using the
CURLOPT_RESOLVE option.

So we are still able to get streamingg links ! (fix for #2419)