### PR TITLE
[ComicsKingdomBridge] Fixes to accomodate new layout and site changes

### DIFF
--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -28,8 +28,6 @@ class ComicsKingdomBridge extends BridgeAbstract {
 			$page = getSimpleHTMLDOM($link);
 
 			$imagelink = $page->find('meta[property=og:image]', 0)->content;
-			$link = $page->find('div.comic-viewer-inline a', 0)->href;
-			if (empty($link)) break; // site only goes back 3 comics (appears to be a new bug on their end)
 
 			$date = explode('/', $link);
 
@@ -41,6 +39,8 @@ class ComicsKingdomBridge extends BridgeAbstract {
 			$item['content'] = '<img src="' . $imagelink . '" />';
 
 			$this->items[] = $item;
+			$link = $page->find('div.comic-viewer-inline a', 0)->href;
+			if (empty($link)) break; // site only goes back 3 comics (appears to be a new bug on their end)
 		}
 	}
 

--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -24,7 +24,7 @@ class ComicsKingdomBridge extends BridgeAbstract {
 
 		// Get current date/link
 		$link = $html->find('meta[property=og:url]', 0)->content;
-		for($i = 0; $i < 5; $i++) {
+		for($i = 0; $i < 3; $i++) {
 			$item = array();
 
 			$page = getSimpleHTMLDOM($link);
@@ -42,7 +42,7 @@ class ComicsKingdomBridge extends BridgeAbstract {
 
 			$this->items[] = $item;
 			$link = $page->find('div.comic-viewer-inline a', 0)->href;
-			if (empty($link)) break; // site only goes back 3 comics (appears to be a new bug on their end)
+			if (empty($link)) break; // allow bridge to continue if there's less than 3 comics
 		}
 	}
 

--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -3,7 +3,7 @@ class ComicsKingdomBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'stjohnjohnson';
 	const NAME = 'Comics Kingdom Unofficial RSS';
-	const URI = 'https://www.comicskingdom.com/';
+	const URI = 'https://comicskingdom.com/';
 	const CACHE_TIMEOUT = 21600; // 6h
 	const DESCRIPTION = 'Comics Kingdom Unofficial RSS';
 	const PARAMETERS = array( array(

--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -28,8 +28,8 @@ class ComicsKingdomBridge extends BridgeAbstract {
 			$page = getSimpleHTMLDOM($link);
 
 			$imagelink = $page->find('meta[property=og:image]', 0)->content;
-			$prevSlug = $page->find('slider-arrow[:is-left-arrow=true]', 0);
-			$link = $this->getURI() . '/' . $prevSlug->getAttribute('date-slug');
+			$link = $page->find('div.comic-viewer-inline a', 0)->href;
+			if (empty($link)) break; // site only goes back 3 comics (appears to be a new bug on their end)
 
 			$date = explode('/', $link);
 

--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -10,6 +10,8 @@ class ComicsKingdomBridge extends BridgeAbstract {
 		'comicname' => array(
 			'name' => 'comicname',
 			'type' => 'text',
+			'exampleValue' => 'mutts',
+			'title' => 'The name of the comic in the URL after https://comicskingdom.com/',
 			'required' => true
 		)
 	));


### PR DESCRIPTION
ComicsKingdomBridge started failing a few days ago with "Call to a member function getAttribute() on null", as the site layout has changed significantly, making the prior method of obtaining the previous days comics obsolete.  The ComicsKingdom new site also has a new name, which is also changed in this PR to avoid unnecessary redirects.

Note: This PR does not address that the new site's SSL certificate is not fully configured resulting in, "cUrl error: SSL certificate problem: unable to get local issuer certificate" on some systems.  That can be solved by installing the "GoDaddy Secure Server Certificate (Intermediate Certificate) - G2" into your local machine's CA store. 