### PR TITLE
[GroupBundNaturschutzBridge] Add bridge and adjust XPathAbstract

### DIFF
--- a/bridges/GroupBundNaturschutzBridge.php
+++ b/bridges/GroupBundNaturschutzBridge.php
@@ -3,6 +3,7 @@
 class GroupBundNaturschutzBridge extends XPathAbstract
 {
 	const NAME = 'BUND Naturschutz in Bayern e.V. - Kreisgruppen';
+	const URI = 'https://www.bund-naturschutz.de/ueber-uns/organisation/kreisgruppen-ortsgruppen';
 	const DESCRIPTION = 'Returns the latest news from specified BUND Naturschutz in Bayern e.V. local group (Germany)';
 	const MAINTAINER = 'dweipert';
 
@@ -11,7 +12,6 @@ class GroupBundNaturschutzBridge extends XPathAbstract
 			'group' => array(
 				'name' => 'Group',
 				'type' => 'list',
-				'required' => true,
 				'values' => array(
 					// 'Aichach-Friedberg' => 'bn-aic.de', # non-uniform page
 					'Altötting' => 'altoetting',
@@ -101,7 +101,7 @@ class GroupBundNaturschutzBridge extends XPathAbstract
 	const XPATH_EXPRESSION_ITEM_TIMESTAMP = './/*[@itemprop="datePublished"]/@datetime';
 	const XPATH_EXPRESSION_ITEM_ENCLOSURES = './/img/@src';
 
-	public function getSourceUrl() {
+	protected function getSourceUrl() {
 		return 'https://' . $this->getInput('group') . '.bund-naturschutz.de/aktuelles';
 	}
 }

--- a/bridges/GroupBundNaturschutzBridge.php
+++ b/bridges/GroupBundNaturschutzBridge.php
@@ -1,0 +1,107 @@
+<?php
+
+class GroupBundNaturschutzBridge extends XPathAbstract
+{
+	const NAME = 'BUND Naturschutz in Bayern e.V. - Kreisgruppen';
+	const DESCRIPTION = 'Returns the latest news from specified BUND Naturschutz in Bayern e.V. local group (Germany)';
+	const MAINTAINER = 'dweipert';
+
+	const PARAMETERS = array(
+		array(
+			'group' => array(
+				'name' => 'Group',
+				'type' => 'list',
+				'required' => true,
+				'values' => array(
+					// 'Aichach-Friedberg' => 'bn-aic.de', # non-uniform page
+					'Altötting' => 'altoetting',
+					'Amberg-Sulzbach' => 'amberg-sulzbach',
+					'Ansbach' => 'ansbach',
+					'Aschaffenburg' => 'aschaffenburg',
+					'Augsburg' => 'augsburg',
+					'Bad Kissingen' => 'bad-kissingen',
+					'Bad Tölz' => 'bad-toelz',
+					'Bamberg' => 'bamberg',
+					'Bayreuth' => 'bayreuth', # single entry # different layout
+					'Berchtesgadener Land' => 'berchtesgadener-land',
+					'Cham' => 'cham',
+					// 'Coburg' => 'coburg', # no real entries # different layout
+					'Dachau' => 'dachau',
+					'Deggendorf' => 'Deggendorf',
+					'Dillingen' => 'dillingen',
+					'Dingolfing-Landau' => 'dingolfing-landau',
+					'Donau-Ries' => 'donauries',
+					'Ebersberg' => 'ebersberg',
+					'Eichstätt' => 'eichstaett', # single entry since 2020
+					'Erding' => 'erding',
+					'Erlangen' => 'erlangen',
+					'Forchheim' => 'forchheim',
+					'Freising' => 'freising',
+					'Freyung-Grafenau' => 'freyung-grafenau',
+					'Fürstenfeldbruck' => 'fuerstenfeldbruck',
+					'Fürth-Land' => 'fuerth-land',
+					'Fürth-Stadt' => 'fuerth',
+					'Garmisch-Partenkirchen' => 'garmisch-partenkirchen',
+					'Günzburg' => 'guenzburg',
+					'Hassberge' => 'hassberge',
+					'Höchstadt-Herzogenaurach' => 'hoechstadt-herzogenaurach',
+					// 'Hof' => 'kreisgruppehof.bund-naturschutz.com', # non-uniform page
+					'Ingolstadt' => 'ingolstadt',
+					'Kelheim' => 'kelheim',
+					'Kempten' => 'kempten',
+					'Kitzingen' => 'kitzingen',
+					'Kronach' => 'kronach',
+					'Kulmbach' => 'kulmbach',
+					'Landsberg' => 'landsberg',
+					'Landshut' => 'landshut',
+					'Lichtenfeld' => 'lichtenfels',
+					'Lindau' => 'lindau',
+					'Main-Spessart' => 'main-spessart',
+					'Memmingen-Unterallgäu' => 'memmingen-unterallgaeu',
+					'Miesbach' => 'miesbach',
+					'Miltenberg' => 'miltenberg',
+					'Mühldorf am Inn' => 'muehldorf',
+					// 'München' => 'bn-muenchen.de', # non-uniform page
+					'Neu-Ulm' => 'neu-ulm',
+					'Neuburg-Schrobenhausen' => 'neuburg-schrobenhausen',
+					'Neumarkt' => 'neumarkt',
+					'Neustadt/Aisch-Bad Windsheim' => 'neustadt-aisch',
+					'Neustadt/Waldnaab-Weiden' => 'neustadt-weiden',
+					'Nürnberg Stadt' => 'nuernberg-stadt',
+					'Nürnberger Land' => 'nuernberger-land',
+					'Ostallgäu-Kaufbeuren' => 'Ostallgäu-Kaufbeuren',
+					'Passau' => 'passau',
+					'Pfaffenhofen/Ilm' => 'pfaffenhofen',
+					'Regen' => 'regen',
+					'Regensburg' => 'regensburg',
+					'Rhön-Grabfeld' => 'rhoen-grabfeld',
+					'Rosenheim' => 'rosenheim',
+					'Roth' => 'roth',
+					'Rottal-Inn' => 'rottal-inn',
+					'Schwabach' => 'schwabach',
+					'Schwandorf' => 'schwandorf',
+					'Schweinfurt' => 'schweinfurt',
+					'Starnberg' => 'starnberg',
+					'Straubing-Bogen' => 'straubing',
+					'Tirschenreuth' => 'tirschenreuth',
+					'Traunstein' => 'traunstein',
+					'Weilheim-Schongau' => 'weilheim-schongau',
+					'Weißenburg-Gunzenhausen' => 'weissenburg-gunzenhausen',
+					'Wunsiedel' => 'wunsiedel',
+					'Würzburg' => 'wuerzburg',
+				),
+			),
+		),
+	);
+
+	const XPATH_EXPRESSION_ITEM = '//div[@itemtype="http://schema.org/Article"]';
+	const XPATH_EXPRESSION_ITEM_TITLE = './/*[@itemprop="headline"]';
+	const XPATH_EXPRESSION_ITEM_CONTENT = './/*[@itemprop="description"]/text()';
+	const XPATH_EXPRESSION_ITEM_URI = './/a/@href';
+	const XPATH_EXPRESSION_ITEM_TIMESTAMP = './/*[@itemprop="datePublished"]/@datetime';
+	const XPATH_EXPRESSION_ITEM_ENCLOSURES = './/img/@src';
+
+	public function getSourceUrl() {
+		return 'https://' . $this->getInput('group') . '.bund-naturschutz.de/aktuelles';
+	}
+}

--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -532,7 +532,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	 */
 	protected function cleanImageUrl($imageUrl)
 	{
-		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.]+\.(?:jpg|gif|png|jpeg|ico){1}~', $imageUrl, $matches);
+		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.\%]+\.(?:jpg|gif|png|jpeg|ico){1}~i', $imageUrl, $matches);
 		if(1 !== $result) {
 			return;
 		}
@@ -547,7 +547,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	{
 		if($typedResult instanceof DOMNodeList) {
 			$item = $typedResult->item(0);
-			if ($item instanceof DOMElement) {
+			if ($item instanceof DOMElement || $item instanceof DOMText) {
 				return trim($item->nodeValue);
 			} elseif ($item instanceof DOMAttr) {
 				return trim($item->value);

--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -532,7 +532,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	 */
 	protected function cleanImageUrl($imageUrl)
 	{
-		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.\%]+\.(?:jpg|gif|png|jpeg|ico){1}~i', $imageUrl, $matches);
+		$result = preg_match('~(?:http(?:s)?:)?[\/a-zA-Z0-9\-_\.]+\.(?:jpg|gif|png|jpeg|ico){1}~', $imageUrl, $matches);
 		if(1 !== $result) {
 			return;
 		}
@@ -547,7 +547,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 	{
 		if($typedResult instanceof DOMNodeList) {
 			$item = $typedResult->item(0);
-			if ($item instanceof DOMElement || $item instanceof DOMText) {
+			if ($item instanceof DOMElement) {
 				return trim($item->nodeValue);
 			} elseif ($item instanceof DOMAttr) {
 				return trim($item->value);


### PR DESCRIPTION
This adds a bridge for the subdomains of https://bund-naturschutz.de.
The local groups with corresponding subdomains are listed here: https://www.bund-naturschutz.de/ueber-uns/organisation/kreisgruppen-ortsgruppen

I named the bridge `GroupBundNaturschutzBridge` because it doesn't actually get the news from bund-naturschutz.de, but from its groups. Where each group has its own subdomain.

All groups are working, except for the ones I commented out, mainly because they didn't use the subdomain pages and therefore had a different HTML layout.

I'm not sure about the exact name, description and parameter name regarding what should be written in english or german.
I guess the parameter name could be **Kreisgruppe**? Or should it stay **Group**?


@Niehztog I had to adjust the `XPathAbstract.php` in the process of creating this bridge.

Some images were named `$image.JPG`, so I added the case-insensitive modifier to the regex.
Other images had `%` encoded paths and didn't match the regex correctly, that's why I added the `\%` there as well.

I'm capturing a `DOMText` node with the XPath `text()` function, so I had to adjust the check when getting the value to include `DOMText` objects.
