### PR TITLE
[Core] Define buster instead of default bullseye for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7-apache-buster
 
 LABEL description="RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for websites that don't have one."
 LABEL repository="https://github.com/RSS-Bridge/rss-bridge"


### PR DESCRIPTION
Fixes #2423 

Root cause and explanation: https://github.com/nextcloud/docker/issues/1574#issuecomment-913456545

Should be merged asap.