### PR TITLE
[XPathAbstract.php] Use defaultLinkTo

### DIFF
--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -475,7 +475,7 @@ abstract class XPathAbstract extends BridgeAbstract {
 			return $value;
 		}
 
-		return urljoin($this->feedUri, $value);
+		return defaultLinkTo($value, $this->feedUri);
 	}
 
 	/**


### PR DESCRIPTION
This allows the bridge to be used without modification in cases where the feedUri is not at the root of the site. See #2451 for the workaround if this is not implemented:
```php
feedUri = 'https://groups.google.com/a/mozilla.org/g/announce'
value = './a/mozilla.org/g/announce/c/-az0PSv6rM4'
# desired result: https://groups.google.com/a/mozilla.org/g/announce/c/-az0PSv6rM4
# current result: https://groups.google.com/a/mozilla.org/g/a/mozilla.org/g/announce/c/-az0PSv6rM4
```