### PR TITLE
[HeiseBridge] Consistently use seite=all parameter

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -40,12 +40,12 @@ class HeiseBridge extends FeedExpander {
 
 	protected function parseItem($feedItem) {
 		$item = parent::parseItem($feedItem);
-		$uri = $item['uri'] . '&seite=all';
+		$item['uri'] = explode('?', $item['uri'])[0] . '?seite=all';
 
-		$article = getSimpleHTMLDOMCached($uri);
+		$article = getSimpleHTMLDOMCached($item['uri']);
 
 		if ($article) {
-			$article = defaultLinkTo($article, $uri);
+			$article = defaultLinkTo($article, $item['uri']);
 			$item = $this->addArticleToItem($item, $article);
 		}
 


### PR DESCRIPTION
This fixes clicking on a link and getting the multi-page article instead of the single-page one.

This also filters out the parameter wt_mc=rss.red.ho.ho.atom.beitrag.beitrag from the item URI. Works on links without this parameter as well, only breaks if a URI parameter is required in the future.