### PR TITLE
[HeiseBridge] Properly extract authors

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -53,8 +53,9 @@ class HeiseBridge extends FeedExpander {
 	}
 
 	private function addArticleToItem($item, $article) {
-		if($author = $article->find('[itemprop="author"]', 0))
-			$item['author'] = $author->plaintext;
+		$authors = $article->find('.a-creator__names', 0)->find('.a-creator__name');
+		if ($authors)
+			$item['author'] = implode(', ', array_map(function ($e) { return $e->plaintext; }, $authors ));
 
 		$content = $article->find('div[class*="article-content"]', 0);
 


### PR DESCRIPTION
Fixes extracting author information.
If there are multiple authors, they are concatenated with ", ", similar to heise.de