### PR TITLE
[TwitterBridge] Don't decode HTML entities for feed content

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -466,8 +466,6 @@ EOD;
 </div>
 EOD;
 
-			$item['content'] = htmlspecialchars_decode($item['content'], ENT_QUOTES);
-
 			// put out
 			$this->items[] = $item;
 		}


### PR DESCRIPTION
Fixes https://github.com/RSS-Bridge/rss-bridge/issues/2468

@arnd-s, please make sure in [your PR](https://github.com/RSS-Bridge/rss-bridge/pull/2433) the issue above is not related. I tried to check, but "bypass cloudflare" returns empty feed for your PR.

git blame says @triatic 