### PR TITLE
[GelbooruBridge] + inheriting Bridges. Switch to using Gelbooru API

### DIFF
--- a/bridges/BooruprojectBridge.php
+++ b/bridges/BooruprojectBridge.php
@@ -1,16 +1,17 @@
 <?php
-require_once('GelbooruBridge.php');
+require_once('DanbooruBridge.php');
 
-class BooruprojectBridge extends GelbooruBridge {
+class BooruprojectBridge extends DanbooruBridge {
 
 	const MAINTAINER = 'mitsukarenai';
 	const NAME = 'Booruproject';
-	const URI = 'http://booru.org/';
+	const URI = 'https://booru.org/';
 	const DESCRIPTION = 'Returns images from given page of booruproject';
 	const PARAMETERS = array(
 		'global' => array(
 			'p' => array(
 				'name' => 'page',
+				'defaultValue' => 0,
 				'type' => 'number'
 			),
 			't' => array(
@@ -25,7 +26,29 @@ class BooruprojectBridge extends GelbooruBridge {
 		)
 	);
 
+	const PATHTODATA = '.thumb';
+	const IDATTRIBUTE = 'id';
+	const TAGATTRIBUTE = 'title';
 	const PIDBYPAGE = 20;
+
+	protected function getFullURI(){
+		return $this->getURI()
+		. 'index.php?page=post&s=list&pid='
+		. ($this->getInput('p') ? ($this->getInput('p') - 1) * static::PIDBYPAGE : '')
+		. '&tags=' . urlencode($this->getInput('t'));
+	}
+
+	protected function getTags($element){
+		$tags = parent::getTags($element);
+		$tags = explode(' ', $tags);
+
+		// Remove statistics from the tags list (identified by colon)
+		foreach($tags as $key => $tag) {
+			if(strpos($tag, ':') !== false) unset($tags[$key]);
+		}
+
+		return implode(' ', $tags);
+	}
 
 	public function getURI(){
 		if(!is_null($this->getInput('i'))) {

--- a/bridges/GelbooruBridge.php
+++ b/bridges/GelbooruBridge.php
@@ -76,6 +76,10 @@ class GelbooruBridge extends BridgeAbstract {
 			$posts = $posts->post;
 		}
 
+		if (is_null($posts)) {
+			returnServerError('No posts found.');
+		}
+
 		foreach($posts as $post) {
 			$this->items[] = $this->getItemFromElement($post);
 		}

--- a/bridges/GelbooruBridge.php
+++ b/bridges/GelbooruBridge.php
@@ -1,35 +1,83 @@
 <?php
-require_once('DanbooruBridge.php');
-
-class GelbooruBridge extends DanbooruBridge {
+class GelbooruBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'mitsukarenai';
 	const NAME = 'Gelbooru';
-	const URI = 'http://gelbooru.com/';
+	const URI = 'https://gelbooru.com/';
 	const DESCRIPTION = 'Returns images from given page';
 
-	const PATHTODATA = '.thumb';
-	const IDATTRIBUTE = 'id';
-	const TAGATTRIBUTE = 'title';
-
-	const PIDBYPAGE = 63;
+	const PARAMETERS = array(
+		'global' => array(
+			'p' => array(
+				'name' => 'page',
+				'defaultValue' => 0,
+				'type' => 'number'
+			),
+			't' => array(
+				'name' => 'tags',
+				'exampleValue' => 'pinup',
+				'title' => 'Tags to search for'
+			),
+			'l' => array(
+				'name' => 'limit',
+				'exampleValue' => 100,
+				'title' => 'How many posts to retrieve (hard limit of 1000)'
+			)
+		),
+		0 => array()
+	);
 
 	protected function getFullURI(){
 		return $this->getURI()
-		. 'index.php?page=post&s=list&pid='
-		. ($this->getInput('p') ? ($this->getInput('p') - 1) * static::PIDBYPAGE : '')
+		. 'index.php?&page=dapi&s=post&q=index&json=1&pid=' . $this->getInput('p')
+		. '&limit=' . $this->getInput('l')
 		. '&tags=' . urlencode($this->getInput('t'));
 	}
 
-	protected function getTags($element){
-		$tags = parent::getTags($element);
-		$tags = explode(' ', $tags);
+	/*
+	This function is superfluous for GelbooruBridge, but useful
+	for Bridges that inherit from it
+	*/
+	protected function buildThumbnailURI($element){
+		return $this->getURI() . 'thumbnails/' . $element->directory
+		. '/thumbnail_' . $element->md5 . '.jpg';
+	}
 
-		// Remove statistics from the tags list (identified by colon)
-		foreach($tags as $key => $tag) {
-			if(strpos($tag, ':') !== false) unset($tags[$key]);
+	protected function getItemFromElement($element){
+		$item = array();
+		$item['uri'] = $this->getURI() . 'index.php?page=post&s=view&id='
+		. $element->id;
+		$item['postid'] = $element->id;
+		$item['author'] = $element->owner;
+		$item['timestamp'] = date('d F Y H:i:s', $element->change);
+		$item['tags'] = $element->tags;
+		$item['title'] = $this->getName() . ' | ' . $item['postid'];
+
+		if (isset($element->preview_url)) {
+			$thumbnailUri = $element->preview_url;
+		} else{
+			$thumbnailUri = $this->buildThumbnailURI($element);
 		}
 
-		return implode(' ', $tags);
+		$item['content'] = '<a href="' . $item['uri'] . '"><img src="'
+		. $thumbnailUri	. '" /></a><br><br><b>Tags:</b> '
+		. $item['tags'] . '<br><br>' . $item['timestamp'];
+
+		return $item;
+	}
+
+	public function collectData(){
+		$content = getContents($this->getFullURI());
+
+		// Most other Gelbooru-based boorus put their content in the root of
+		// the JSON. This check is here for Bridges that inherit from this one
+		$posts = json_decode($content);
+		if (isset($posts->post)) {
+			$posts = $posts->post;
+		}
+
+		foreach($posts as $post) {
+			$this->items[] = $this->getItemFromElement($post);
+		}
 	}
 }

--- a/bridges/MspabooruBridge.php
+++ b/bridges/MspabooruBridge.php
@@ -5,8 +5,11 @@ class MspabooruBridge extends GelbooruBridge {
 
 	const MAINTAINER = 'mitsukarenai';
 	const NAME = 'Mspabooru';
-	const URI = 'http://mspabooru.com/';
+	const URI = 'https://mspabooru.com/';
 	const DESCRIPTION = 'Returns images from given page';
-	const PIDBYPAGE = 50;
 
+	protected function buildThumbnailURI($element){
+		return $this->getURI() . 'thumbnails/' . $element->directory
+		. '/thumbnail_' . $element->image;
+	}
 }

--- a/bridges/Rule34Bridge.php
+++ b/bridges/Rule34Bridge.php
@@ -1,8 +1,8 @@
 <?php
-class Rule34ApiBridge extends BridgeAbstract {
+class Rule34Bridge extends BridgeAbstract {
 
 	const MAINTAINER = 'mitsukarenai';
-	const NAME = 'Rule34Api';
+	const NAME = 'Rule34';
 	const URI = 'https://api.rule34.xxx/';
 	const DESCRIPTION = 'Returns images from given page';
 

--- a/bridges/Rule34Bridge.php
+++ b/bridges/Rule34Bridge.php
@@ -1,12 +1,71 @@
 <?php
-require_once('GelbooruBridge.php');
-
-class Rule34Bridge extends GelbooruBridge {
+class Rule34ApiBridge extends BridgeAbstract {
 
 	const MAINTAINER = 'mitsukarenai';
-	const NAME = 'Rule34';
-	const URI = 'https://rule34.xxx/';
+	const NAME = 'Rule34Api';
+	const URI = 'https://api.rule34.xxx/';
 	const DESCRIPTION = 'Returns images from given page';
 
-	const PIDBYPAGE = 50;
+	const PARAMETERS = array(
+		'global' => array(
+			'p' => array(
+				'name' => 'page',
+				'defaultValue' => 1,
+				'type' => 'number'
+			),
+			't' => array(
+				'name' => 'tags',
+				'exampleValue' => 'pinup',
+				'title' => 'Tags to search for'
+			),
+			'l' => array(
+				'name' => 'limit',
+				'defaultValue' => 100,
+				'exampleValue' => 100,
+				'title' => 'How many posts to retrieve (hard limit of 1000)'
+			)
+		),
+		0 => array()
+	);
+
+	protected function getFullURI(){
+		return $this->getURI()
+		. 'index.php?&page=dapi&s=post&q=index&json=1&pid=' . $this->getInput('p')
+		. '&limit=' . $this->getInput('l')
+		. '&tags=' . urlencode($this->getInput('t'));
+	}
+
+	protected function getItemFromElement($element){
+		//Debug::log('Element id: ' . $element->id);
+
+		$item = array();
+		$item['uri'] = 'https://rule34.xxx/index.php?page=post&s=view&id='
+		. $element->id;
+		$item['postid'] = $element->id;
+		$item['author'] = $element->owner;
+		$item['timestamp'] = date('d F Y H:i:s', $element->change);
+		$thumbnailUri = $element->preview_url;
+		$item['tags'] = $element->tags;
+		$item['title'] = $this->getName() . ' | ' . $item['postid'];
+
+		$item['content'] = '<a href="' . $item['uri'] . '"><img src="'
+		. $thumbnailUri	. '" /></a><br><br><b>Tags:</b> '
+		. $item['tags'] . '<br><br>' . $item['timestamp'];
+
+		return $item;
+	}
+
+	public function collectData(){
+		$content = getContents($this->getFullURI());
+
+		//Debug::log('$content ' . $content);
+
+		$posts = json_decode($content);
+
+		//Debug::log('$posts ' . $content);
+
+		foreach($posts as $post) {
+			$this->items[] = $this->getItemFromElement($post);
+		}
+	}
 }

--- a/bridges/Rule34Bridge.php
+++ b/bridges/Rule34Bridge.php
@@ -1,71 +1,11 @@
 <?php
-class Rule34Bridge extends BridgeAbstract {
+require_once('GelbooruBridge.php');
+
+class Rule34Bridge extends GelbooruBridge {
 
 	const MAINTAINER = 'mitsukarenai';
 	const NAME = 'Rule34';
-	const URI = 'https://api.rule34.xxx/';
+	const URI = 'https://rule34.xxx/';
 	const DESCRIPTION = 'Returns images from given page';
 
-	const PARAMETERS = array(
-		'global' => array(
-			'p' => array(
-				'name' => 'page',
-				'defaultValue' => 1,
-				'type' => 'number'
-			),
-			't' => array(
-				'name' => 'tags',
-				'exampleValue' => 'pinup',
-				'title' => 'Tags to search for'
-			),
-			'l' => array(
-				'name' => 'limit',
-				'defaultValue' => 100,
-				'exampleValue' => 100,
-				'title' => 'How many posts to retrieve (hard limit of 1000)'
-			)
-		),
-		0 => array()
-	);
-
-	protected function getFullURI(){
-		return $this->getURI()
-		. 'index.php?&page=dapi&s=post&q=index&json=1&pid=' . $this->getInput('p')
-		. '&limit=' . $this->getInput('l')
-		. '&tags=' . urlencode($this->getInput('t'));
-	}
-
-	protected function getItemFromElement($element){
-		//Debug::log('Element id: ' . $element->id);
-
-		$item = array();
-		$item['uri'] = 'https://rule34.xxx/index.php?page=post&s=view&id='
-		. $element->id;
-		$item['postid'] = $element->id;
-		$item['author'] = $element->owner;
-		$item['timestamp'] = date('d F Y H:i:s', $element->change);
-		$thumbnailUri = $element->preview_url;
-		$item['tags'] = $element->tags;
-		$item['title'] = $this->getName() . ' | ' . $item['postid'];
-
-		$item['content'] = '<a href="' . $item['uri'] . '"><img src="'
-		. $thumbnailUri	. '" /></a><br><br><b>Tags:</b> '
-		. $item['tags'] . '<br><br>' . $item['timestamp'];
-
-		return $item;
-	}
-
-	public function collectData(){
-		$content = getContents($this->getFullURI());
-
-		//Debug::log('$content ' . $content);
-
-		$posts = json_decode($content);
-
-		//Debug::log('$posts ' . $content);
-
-		foreach($posts as $post) {
-			$this->items[] = $this->getItemFromElement($post);
-		}
-	}
 }

--- a/bridges/SafebooruBridge.php
+++ b/bridges/SafebooruBridge.php
@@ -8,5 +8,9 @@ class SafebooruBridge extends GelbooruBridge {
 	const URI = 'https://safebooru.org/';
 	const DESCRIPTION = 'Returns images from given page';
 
-	const PIDBYPAGE = 40;
+	protected function buildThumbnailURI($element){
+		$regex = '/\.\w+$/';
+		return $this->getURI() . 'thumbnails/' . $element->directory
+		. '/thumbnail_' . preg_replace($regex, '.jpg', $element->image);
+	}
 }

--- a/bridges/TbibBridge.php
+++ b/bridges/TbibBridge.php
@@ -8,5 +8,8 @@ class TbibBridge extends GelbooruBridge {
 	const URI = 'https://tbib.org/';
 	const DESCRIPTION = 'Returns images from given page';
 
-	const PIDBYPAGE = 50;
+	protected function buildThumbnailURI($element){
+		return $this->getURI() . 'thumbnails/' . $element->directory
+		. '/thumbnail_' . substr($element->image, 0, -3) . 'jpg';
+	}
 }

--- a/bridges/TbibBridge.php
+++ b/bridges/TbibBridge.php
@@ -9,7 +9,8 @@ class TbibBridge extends GelbooruBridge {
 	const DESCRIPTION = 'Returns images from given page';
 
 	protected function buildThumbnailURI($element){
+		$regex = '/\.\w+$/';
 		return $this->getURI() . 'thumbnails/' . $element->directory
-		. '/thumbnail_' . substr($element->image, 0, -3) . 'jpg';
+		. '/thumbnail_' . preg_replace($regex, '.jpg', $element->image);
 	}
 }

--- a/bridges/XbooruBridge.php
+++ b/bridges/XbooruBridge.php
@@ -8,5 +8,8 @@ class XbooruBridge extends GelbooruBridge {
 	const URI = 'https://xbooru.com/';
 	const DESCRIPTION = 'Returns images from given page';
 
-	const PIDBYPAGE = 50;
+	protected function buildThumbnailURI($element){
+		return $this->getURI() . 'thumbnails/' . $element->directory
+		. '/thumbnail_' . $element->hash . '.jpg';
+	}
 }


### PR DESCRIPTION
Edit:
Instead of parsing HTML, use the available public Gelbooru API and get the data from the JSON response.

This modifies the GelbooruBridge, plus all the other Bridges for booru sites that run on Gelbooru: MspabooruBridge, Rule34Bridge, SafebooruBridge, TbibBridge, and XbooruBridge.

BooruprojectBridge had to be modified to inherit from DanbooruBridge instead of GelbooruBridge, since those sites are running an older version of Gelbooru which doesn't appear to include the API.

Benefits/changes:
- Defined 'Author' value: the user who created the post
- Unique per-item datestamp: Shows the date/time value from each item from the site, instead of all fetched items having the date/time of the feed fetch event
- Define the number of items to fetch: up to 1000, according to API doc