### PR TITLE
[ActionFactory] Prevent leaking working directory

### DIFF
--- a/lib/ActionFactory.php
+++ b/lib/ActionFactory.php
@@ -24,7 +24,7 @@ class ActionFactory extends FactoryAbstract {
 		$filePath = $this->buildFilePath($name);
 
 		if(!file_exists($filePath)) {
-			throw new \Exception('File ' . $filePath . ' does not exist!');
+			throw new \Exception('Action ' . $name . ' does not exist!');
 		}
 
 		require_once $filePath;


### PR DESCRIPTION
Previous behavior leaks the working directory path if the action is not found.
Test: Try the /?action=badaction endpoint on any public host.

Before:
File /var/www/rss-bridge/actions/BadactionAction.php does not exist!
Now:
Action badaction does not exist!