### PR TITLE
[ComicsKingdomBridge] Fix bridge by grabbing the last meta og:url instead of the first

### DIFF
--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -23,7 +23,7 @@ class ComicsKingdomBridge extends BridgeAbstract {
 		$author = $html->find('div.author p', 0);;
 
 		// Get current date/link
-		$link = $html->find('meta[property=og:url]', 0)->content;
+		$link = $html->find('meta[property=og:url]', -1)->content;
 		for($i = 0; $i < 3; $i++) {
 			$item = array();
 


### PR DESCRIPTION
The site has changed again which added a second meta og:url value from a WordPress SEO plugin at the top.  As such, there are now two og:url values on the page, and the first no longer contains the necessary date URL for the bridge to work.  By switching to finding the last og:url on the page, which does still contain the date, the bridge is restored to working order.