### PR TITLE
[ReutersBridge] Updated 'Top News' feed, some fix

### DIFF
--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -578,7 +578,7 @@ EOD;
 			}
 
 			$this->addStories($title, $content, $timestamp, $author, $url, $category);
-			
+
 		}
 	}
 }

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -344,7 +344,7 @@ class ReutersBridge extends BridgeAbstract
 		$images = '';
 		$meta_items = $html->find('meta');
 		foreach($meta_items as $meta) {
-			switch ($meta->type) {
+			switch ($meta->name) {
 				case 'description':
 					$description = $meta->content;
 					break;
@@ -352,7 +352,8 @@ class ReutersBridge extends BridgeAbstract
 				case 'twitter:creator':
 					$author = $meta->content;
 					break;
-				case 'og:image':
+				case 'twitter:image:src':
+				case 'twitter:image':
 					$url = $meta->content;
 					$images = "<img src=$url" . '>';
 					break;
@@ -364,7 +365,8 @@ class ReutersBridge extends BridgeAbstract
 			'author' => $author,
 			'category' => '',
 			'images' => $images,
-			'published_at' => ''
+			'published_at' => '',
+			'status' => 'redirected'
 		);
 	}
 
@@ -521,7 +523,11 @@ EOD;
 			$story_data = $this->getArticle($story['url']);
 			$title = $story['caption'];
 			$url = self::URI . $story['url'];
-			$article_body = defaultLinkTo($story_data['content'], $this->getURI());
+			if(isset($story_data['status']) && $story_data['status'] != 'redirected') {
+				$article_body = defaultLinkTo($story_data['content'], $this->getURI());
+			} else {
+				$article_body = $story_data['content'];
+			}
 			$content = $article_body . $story_data['images'];
 			$timestamp = $story_data['published_at'];
 			$category = $story_data['category'];

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -292,7 +292,7 @@ class ReutersBridge extends BridgeAbstract
 		$rawData = $this->getJson($url);
 
 		if(json_last_error() != JSON_ERROR_NONE) { // Checking whether a valid JSON or not
-			return handleRedirectedArticle($url);
+			return $this->handleRedirectedArticle($url);
 		}
 
 		$article_content = '';

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -287,7 +287,6 @@ class ReutersBridge extends BridgeAbstract
 
 	private function getArticle($feed_uri, $is_article_uid = false)
 	{
-		print_r($feed_uri . '<br>');
 		// This will make another request to API to get full detail of article and author's name.
 		$url = $this->getAPIURL($feed_uri, 'article', $is_article_uid);
 		$rawData = $this->getJson($url);


### PR DESCRIPTION
- Replace API endpoint for 'Top News' feed.
- Add new function to get all related stories from 'Top News' feed.
- Add new function to add item to RSS feed.
- Function getArticle() and getAPIURL() now accept article ID from API
  as long as setting is_article_uid in second parameter to true.