### PR TITLE
Fix wrong version string in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .git
+!.git/HEAD
+!.git/refs/heads/*
 .gitattributes
 .github/*
 .travis.yml


### PR DESCRIPTION
Closes https://github.com/RSS-Bridge/rss-bridge/issues/2496

This will exclude the `.git/HEAD` file and any file in the `.git/refs/heads` directory from the `.git` docker ignore rule and therefore include these files in the docker image.
The already existing `getVersion()` in [lib/Configuration.php](https://github.com/RSS-Bridge/rss-bridge/blob/master/lib/Configuration.php) will then be able to build an accurate version string which includes the git hash.