### PR TITLE
[lib/contents.php] Use variable name 'retVal' instead of 'retval' as …

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -265,7 +265,7 @@ function getContents($url, $header = array(), $opts = array(), $returnHeader = f
 				throw new GetContentsException('cURL error: ' . $curlError . ' (' . $curlErrno . ')');
 			}
 
-			throw new UnexpectedResponseException($retval['content'], $retval['header'], $errorCode);
+			throw new UnexpectedResponseException($retVal['content'], $retVal['header'], $errorCode);
 	}
 
 	return ($returnHeader === true) ? $retVal : $retVal['content'];


### PR DESCRIPTION
This pull request fixes a small issue introduced by the changes in #2447.

As variable names in PHP are case-sensitive, the identifier `$retVal` must be used instead of `$retval` throughout the file `lib/contents.php`.