### PR TITLE
phpcs: allow short array syntax

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -100,6 +100,4 @@
   <rule ref="Squiz.Strings.DoubleQuoteUsage">
     <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
   </rule>
-  <!-- Always use the long array syntax -->
-  <rule ref="Generic.Arrays.DisallowShortArraySyntax" />
 </ruleset>


### PR DESCRIPTION
Short array syntax was added to PHP in PHP 5.4 (2012) and replaces array() with [].