### PR TITLE
[GithubTrendingBridge] fix: the description selector was broken

### DIFF
--- a/bridges/GithubTrendingBridge.php
+++ b/bridges/GithubTrendingBridge.php
@@ -613,7 +613,7 @@ class GithubTrendingBridge extends BridgeAbstract {
 			$item['title'] = str_replace('  ', '', trim(strip_tags($element->find('h1 a', 0)->plaintext)));
 
 			// Description
-			$item['content'] = trim(strip_tags($element->find('p.text-gray', 0)->innertext));
+			$item['content'] = trim(strip_tags($element->find('p', 0)->innertext));
 
 			// Time
 			$item['timestamp'] = time();


### PR DESCRIPTION
There is only one <p> node so this is fine for now.