### PR TITLE
[core] feat: render bridge card example values into default values

### DIFF
--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -78,6 +78,18 @@ This bridge is not fetching its content through a secure connection</div>';
 				if(!isset($inputEntry['defaultValue']))
 					$inputEntry['defaultValue'] = '';
 
+				/**
+				 * Copy over example value (placeholder) into default value (value)
+				 * but only if example value exists and the default value is empty
+				 *
+				 * Ideally, bridges should define a proper default value.
+				 *
+				 * So consider this a convenience.
+				 */
+				if ($inputEntry['exampleValue'] && !$inputEntry['defaultValue']) {
+					$inputEntry['defaultValue'] = $inputEntry['exampleValue'];
+				}
+
 				$idArg = 'arg-'
 					. urlencode($bridgeName)
 					. '-'


### PR DESCRIPTION
This change causes the bridge parameter example values
 (<input type="placeholder") to be rendered into default values
(<input type="value")

EDIT: This change causes all bridge forms to be filled with the example values. The prior behaviour was to only create a `<input placeholder="">` for them.