### PR TITLE
[core] feat: improve date rendering in html formatter

### DIFF
--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -45,13 +45,14 @@ class HtmlFormat extends FormatAbstract {
 			$entryTitle = $this->sanitizeHtml(strip_tags($item->getTitle()));
 			$entryUri = $item->getURI() ?: $uri;
 
-			$entryTimestamp = '';
+			$entryDate = '';
 			if($item->getTimestamp()) {
-				$entryTimestamp = '<time datetime="'
-				. date(DATE_ATOM, $item->getTimestamp())
-				. '">'
-				. date(DATE_ATOM, $item->getTimestamp())
-				. '</time>';
+
+				$entryDate = sprintf(
+					'<time datetime="%s">%s</time>',
+					date('Y-m-d H:i:s', $item->getTimestamp()),
+					date('Y-m-d H:i:s', $item->getTimestamp())
+				);
 			}
 
 			$entryContent = '';
@@ -96,7 +97,7 @@ class HtmlFormat extends FormatAbstract {
 
 <section class="feeditem">
 	<h2><a class="itemtitle" href="{$entryUri}">{$entryTitle}</a></h2>
-	{$entryTimestamp}
+	{$entryDate}
 	{$entryAuthor}
 	{$entryContent}
 	{$entryEnclosures}


### PR DESCRIPTION
This change will cause feed item dates to be
rendered as

2022-03-20 19:03:30

instead of

2022-03-20T19:03:30-00:00

This applies only for the html output format.