### PR TITLE
Properly remove script/link tags & turn iframes into clickable links

### DIFF
--- a/lib/FormatAbstract.php
+++ b/lib/FormatAbstract.php
@@ -175,10 +175,29 @@ abstract class FormatAbstract implements FormatInterface {
 	 */
 	protected function sanitizeHtml($html)
 	{
-		$html = str_replace('<script', '<&zwnj;script', $html); // Disable scripts, but leave them visible.
-		$html = str_replace('<iframe', '<&zwnj;iframe', $html);
-		$html = str_replace('<link', '<&zwnj;link', $html);
-		// We leave alone object and embed so that videos can play in RSS readers.
+		//create HTML dom object
+		$html_obj = str_get_html($html);
+
+		//remove script, link
+		foreach ($html_obj->find('script, link') as $remove) {
+			$remove->outertext = '';
+		}
+
+		//turn <iframe>s into <a>s, usefull for embedded YouTube videos
+		foreach($html_obj->find('iframe') as $found) {
+			$iframeUrl = $found->getAttribute('src');
+
+			if ($iframeUrl) {
+				$found->outertext = '<a href="' . $iframeUrl . '">' . $iframeUrl . '</a>';
+			} else {
+				$found->outertext = '';
+			}
+		}
+
+		//We leave alone object and embed so that videos can play in RSS readers.
+
+		//turn it back into a string
+		$html = $html_obj;
 		return $html;
 	}
 

--- a/lib/FormatAbstract.php
+++ b/lib/FormatAbstract.php
@@ -178,6 +178,12 @@ abstract class FormatAbstract implements FormatInterface {
 		//create HTML dom object
 		$html_obj = str_get_html($html);
 
+		//$html was empty or exceeded the max file size.
+		//explicitly return empty string to avoid large file escaping sanitation
+		if($html_obj == false){
+			return "";
+		}
+
 		//remove script, link
 		foreach ($html_obj->find('script, link') as $remove) {
 			$remove->outertext = '';


### PR DESCRIPTION
The current sanitizeHtml function disables <script> <iframe> and <link> tags, but leaves them visible visible in the RSS items content. Wouldn't it be better to remove the text completely? I cannot think of any situations where I would want HTML code in the middle of my RSS feed articles.
<iframe>s are often used to embed YouTube videos in articles so they should not be removed. Instead I propose to turn them into clickable links (<a>) so users can still watch the videos.  


What do you think? Do you agree with these changes?

edit: okay, looks like the code still needs some work. But do you agree with what I'm trying to do?