### PR TITLE
[PhoronixBridge] support multipage and embed benchmarks

### DIFF
--- a/bridges/PhoronixBridge.php
+++ b/bridges/PhoronixBridge.php
@@ -17,7 +17,8 @@ class PhoronixBridge extends FeedExpander {
 		'svgAsImg' => array(
 			'name' => 'SVG in "image" tag',
 			'type' => 'checkbox',
-			'title' => 'Some benchmarks are exported as SVG with "object" tag, but some RSS readers don\'t support this. "img" tag are supported by most browsers',
+			'title' => 'Some benchmarks are exported as SVG with "object" tag,
+but some RSS readers don\'t support this. "img" tag are supported by most browsers',
 			'defaultValue' => false
 		),
 	));

--- a/bridges/PhoronixBridge.php
+++ b/bridges/PhoronixBridge.php
@@ -6,9 +6,18 @@ class PhoronixBridge extends FeedExpander {
 	const URI = 'https://www.phoronix.com';
 	const CACHE_TIMEOUT = 3600;
 	const DESCRIPTION = 'RSS feed for Linux news website Phoronix';
+	const PARAMETERS = array(array(
+		'n' => array(
+			'name' => 'Limit',
+			'type' => 'number',
+			'required' => false,
+			'title' => 'Maximum number of items to return',
+			'defaultValue' => 10
+		)
+	));
 
 	public function collectData(){
-		$this->collectExpandableDatas('https://www.phoronix.com/rss.php', 15);
+		$this->collectExpandableDatas('https://www.phoronix.com/rss.php', $this->getInput('n'));
 	}
 
 	protected function parseItem($newsItem){

--- a/bridges/PhoronixBridge.php
+++ b/bridges/PhoronixBridge.php
@@ -31,6 +31,7 @@ but some RSS readers don\'t support this. "img" tag are supported by most browse
 		$item = parent::parseItem($newsItem);
 		// $articlePage gets the entire page's contents
 		$articlePage = getSimpleHTMLDOM($newsItem->link);
+		$articlePage = defaultLinkTo($articlePage, $this->getURI());
 		// Extract final link. From Facebook's like plugin.
 		parse_str(parse_url($articlePage->find('iframe[src^=//www.facebook.com/plugins]', 0), PHP_URL_QUERY), $facebookQuery);
 		if (array_key_exists('href', $facebookQuery)) {

--- a/bridges/PhoronixBridge.php
+++ b/bridges/PhoronixBridge.php
@@ -13,7 +13,13 @@ class PhoronixBridge extends FeedExpander {
 			'required' => false,
 			'title' => 'Maximum number of items to return',
 			'defaultValue' => 10
-		)
+		),
+		'svgAsImg' => array(
+			'name' => 'SVG in "image" tag',
+			'type' => 'checkbox',
+			'title' => 'Some benchmarks are exported as SVG with "object" tag, but some RSS readers don\'t support this. "img" tag are supported by most browsers',
+			'defaultValue' => false
+		),
 	));
 
 	public function collectData(){
@@ -45,7 +51,11 @@ class PhoronixBridge extends FeedExpander {
 		$objects = $content->find('script[src^=//openbenchmarking.org]');
 		foreach ($objects as $object) {
 			$objectSrc = preg_replace('/p=0/', 'p=2', $object->src);
-			$object->outertext = '<object data="' . $objectSrc . '" type="image/svg+xml"></object>';
+			if ($this->getInput('svgAsImg')) {
+				$object->outertext = '<a href="' . $objectSrc . '"><img src="' . $objectSrc . '"/></a>';
+			} else {
+				$object->outertext = '<object data="' . $objectSrc . '" type="image/svg+xml"></object>';
+			}
 		}
 		$content = stripWithDelimiters($content, '<script', '</script>');
 		return $content;


### PR DESCRIPTION
The bridge now supports multipage article. In those article, benchmarks from OpenBenchmarking.com are now embedded, either as SVG in `<object>` tag or as `<img>`. The second option is useful for feed readers like TT-RSS that disable `<object>` or `<svg>` tags for security reasons.