### PR TITLE
[core] Update pr html generator

### DIFF
--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -75,7 +75,7 @@ now = datetime.now()
 date_time = now.strftime("%Y-%m-%d, %H:%M:%S")
 
 with open(os.getcwd() + '/comment.txt', 'w+') as file:
-    file.write(''' ## Generated Views
+    file.write(''' ## Pull request artifacts
 | file | last change |
 | ---- | ------ |''')
 

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -1,7 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
-import random
-import json
+from datetime import datetime
 import os.path
 
 # This script is specifically written to be used in automation for https://github.com/RSS-Bridge/rss-bridge
@@ -49,18 +48,36 @@ def testBridges(bridges,status):
                     formstring = formstring + '&' + list.get('name') + '=' + list.contents[0].get('value')
                 if not errormessages:
                     # if all example/default values are present, form the full request string, run the request, replace the static css
-                    # file with the url of em's public instance and then write it all to file.
+                    # file with the url of em's public instance and then upload it to termpad.com, a pastebin-like-site.
                     r = requests.get(URL + bridgestring + formstring)
                     pagetext = r.text.replace('static/HtmlFormat.css','https://feed.eugenemolotov.ru/static/HtmlFormat.css')
-                    with open(os.getcwd() + "/results/" + bridgeid + '-' + status + '-context' + str(formid) + '.html', 'w+') as file:
-                        file.write(pagetext)
+                    pagetext = pagetext.encode("utf_8")
+                    termpad = requests.post(url="https://termpad.com/", data=pagetext)
+                    termpadurl = termpad.text
+                    termpadurl = termpadurl.replace('termpad.com/','termpad.com/raw/')
+                    termpadurl = termpadurl.replace('\n','')
+                    with open(os.getcwd() + '/comment.txt', 'a+') as file:
+                        file.write("\n")
+                        file.write("| [`" + bridgeid + '-' + status + '-context' + str(formid) + "`](" + termpadurl + ") | " + date_time + " |")
                 else:
                     # if there are errors (which means that a required value has no example or default value), log out which error appeared
-                    with open(os.getcwd() + "/results/" + bridgeid + '-' + status + '-context' + str(formid) + '.html', 'w+') as file:
-                        file.write(str(errormessages))
+                    termpad = requests.post(url="https://termpad.com/", data=str(errormessages))
+                    termpadurl = termpad.text
+                    termpadurl = termpadurl.replace('termpad.com/','termpad.com/raw/')
+                    termpadurl = termpadurl.replace('\n','')
+                    with open(os.getcwd() + '/comment.txt', 'a+') as file:
+                        file.write("\n")
+                        file.write("| [`" + bridgeid + '-' + status + '-context' + str(formid) + "`](" + termpadurl + ") | " + date_time + " |")
                 formid += 1
 
 gitstatus = ["current", "pr"]
+now = datetime.now()
+date_time = now.strftime("%Y-%m-%d, %H:%M:%S")
+
+with open(os.getcwd() + '/comment.txt', 'w+') as file:
+    file.write(''' ## Generated Views
+| file | last change |
+| ---- | ------ |''')
 
 for status in gitstatus: # run this twice, once for the current version, once for the PR version
     if status == "current":

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -40,21 +40,27 @@ jobs:
           cd $GITHUB_WORKSPACE
           pip install -r requirements.txt
       - name: Run bridge tests
+        id: testrun
         run: |
           mkdir results;
-          python prtester.py
-      - name: Find result files
-        uses: tj-actions/glob@v7.10
-        id: artifacts
+          python prtester.py;
+          body="$(cat comment.txt)";
+          body="${body//'%'/'%25'}";
+          body="${body//$'\n'/'%0A'}";
+          body="${body//$'\r'/'%0D'}";
+          echo "::set-output name=body::$body"
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
         with:
-          files: |
-            ./results/*.html
-      - name: Upload results to PR
-        uses: yamanq/pull-request-artifacts@v1.3.1
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Generated Views
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v2
         with:
-          commit: ${{ github.event.pull_request.head.sha }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts-branch: artifacts
-          artifacts-prefix-url: "https://htmlpreview.github.io/?"
-          artifacts: |
-            ${{ steps.artifacts.outputs.paths }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ${{ steps.testrun.outputs.body }}
+          edit-mode: replace

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Generated Views
+          body-includes: Pull request artifacts
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v2
         with:


### PR DESCRIPTION
Hi,

this reworks the way the posting is made.

Before:
- Files are generated as html files on the action runner
- Files are picked up by the artifacts-action, uploaded to the "artifacts" branch of rss-bridge and linked to the PR
- Comment is made/updated with the current files and links

Now:
- File content is generated and instead of saving to file, directly uploaded to termpad.com, a pastebin like website
- Comment string is prepared right in the python code and saved as textfile to action runner
- Comment body is picked up by a commenting action that will either create or update the comment

Benefits:
- No more uploading files to the artifacts branch, so no more additional files in the repo and no notifications on uploaded files
- No more "bot linked commit XY to this pr" spam in the conversation view. The only interaction with the conversation view is the single comment by the bot
- The termpad raw link already renders the html code, so no intermediary solution like before needed
- No custom action needed (@yamanq actually customized a previous action to get the preview link correct)

Downsides:
- Termpad only keeps data for 120 days. PRs that take longer than that will need a new commit to update the previews. Hopefully, new PRs dont even stay open that long, but if it does, a single dummy commit by the maintainers (add an empty comment line somewhere, the commit can be reverted afterwards) will trigger a new upload.

Examples: This is working in my test-repo [here](https://github.com/Bockiii/dmxprbldr/pull/4) (ignore all the testing :) )