### PR TITLE
[Docker] Debug addition fixed

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@
 # This will overwrite previous configs and bridges of same name
 # If there are no matching files, rss-bridge works like default.
 
-find /config/ -type f -name '*.*' -print0 | 
+find /config/ -type f -name '*' -print0 | 
 while IFS= read -r -d '' file; do
     file_name="$(basename "$file")" # Strip leading path
     if [[ $file_name = *" "* ]]; then


### PR DESCRIPTION
Before debug, the "find *.*" was working fine, but since the DEBUG file doesnt have a suffix, it wouldnt pick it up.

This fixes that. Now, containers can be run in debug mode (also the automated tester).