### PR TITLE
[AnimeUltimeBridge] fix: convert strings from iso-8859-1 to utf8

### DIFF
--- a/bridges/AnimeUltimeBridge.php
+++ b/bridges/AnimeUltimeBridge.php
@@ -37,9 +37,11 @@ class AnimeUltimeBridge extends BridgeAbstract {
 		$processedOK = 0;
 		foreach (array($thismonth, $lastmonth) as $requestFilter) {
 
-			//Retrive page contents
 			$url = self::URI . 'history-0-1/' . $requestFilter;
-			$html = getSimpleHTMLDOM($url);
+			$html = getContents($url);
+			// Convert html from iso-8859-1 => utf8
+			$html = utf8_encode($html);
+			$html = str_get_html($html);
 
 			//Relases are sorted by day : process each day individually
 			foreach($html->find('div.history', 0)->find('h3') as $daySection) {
@@ -87,6 +89,8 @@ class AnimeUltimeBridge extends BridgeAbstract {
 
 							// Retrieve description from description page
 							$html_item = getContents($item_uri);
+							// Convert html from iso-8859-1 => utf8
+							$html_item = utf8_encode($html_item);
 							$item_description = substr(
 								$html_item,
 								strpos($html_item, 'class="principal_contain" align="center">') + 41


### PR DESCRIPTION
This fixes a bug with json_encode() being unable to produce output
because it expects utf8 strings.