### PR TITLE
[CourrierInternationalBridge] fix: don't break on unusual feed items #2570

### DIFF
--- a/bridges/CourrierInternationalBridge.php
+++ b/bridges/CourrierInternationalBridge.php
@@ -19,7 +19,9 @@ class CourrierInternationalBridge extends FeedExpander {
 		if(!$content) {
 			$content = $articlePage->find('.depeche-text', 0);
 		}
-
+		if (!$content) {
+			return $item;
+		}
 		$item['content'] = sanitize($content);
 
 		return $item;

--- a/bridges/CourrierInternationalBridge.php
+++ b/bridges/CourrierInternationalBridge.php
@@ -15,10 +15,7 @@ class CourrierInternationalBridge extends FeedExpander {
 		$item = parent::parseItem($feedItem);
 
 		$articlePage = getSimpleHTMLDOMCached($feedItem->link);
-		$content = $articlePage->find('.article-text', 0);
-		if(!$content) {
-			$content = $articlePage->find('.depeche-text', 0);
-		}
+		$content = $articlePage->find('.article-text, depeche-text', 0);
 		if (!$content) {
 			return $item;
 		}


### PR DESCRIPTION
Some items don't contain content. E.g. horoscopes.