### PR TITLE
[CraigslistBridge] Fix notice with nearby results

### DIFF
--- a/bridges/CraigslistBridge.php
+++ b/bridges/CraigslistBridge.php
@@ -74,6 +74,7 @@ class CraigslistBridge extends BridgeAbstract {
 		foreach($results as $post) {
 
 			// Skip "nearby results" banner and results
+			// This only appears when searchNearby is not specified
 			if ($post->tag == 'h4') {
 				break;
 			}
@@ -86,7 +87,8 @@ class CraigslistBridge extends BridgeAbstract {
 			$item['timestamp'] = $post->find('.result-date', 0)->datetime;
 			$item['uid'] = $heading->id;
 			$item['content'] = $post->find('.result-price', 0)->plaintext . ' '
-							 . $post->find('.result-hood', 0)->plaintext;
+							 // Find the location (local and nearby results if searchNearby=1)
+							 . $post->find('.result-hood, span.nearby', 0)->plaintext;
 
 			$images = $post->find('.result-image[data-ids]', 0);
 			if (!is_null($images)) {


### PR DESCRIPTION
If the search query includes searchNearby=1, nearby results do not have .result-hood to indicate location, instead using .nearby.

Example Query:
`http://rssbridge/?action=display&bridge=Craigslist&region=sfbay&search=ata%3Fquery%3Dnew%2Bguinea%2Bmask%26searchNearby%3D1%26nearbyArea%3D373%26nearbyArea%3D285%26nearbyArea%3D96%26nearbyArea%3D102%26nearbyArea%3D12%26nearbyArea%3D97&limit=25&format=Html`

Note the location on the listing from Modesto:
(After)
![image](https://user-images.githubusercontent.com/8166212/161188372-ebea9a0d-b118-42f0-bcaf-5cc0e8c32693.png)
(Before)
![image](https://user-images.githubusercontent.com/8166212/161188464-791a2e59-f201-4fc5-95f4-a4d6e1350c02.png)

