### PR TITLE
[OtrkeyFinderBridge] Remove HTML in title

### DIFF
--- a/bridges/OtrkeyFinderBridge.php
+++ b/bridges/OtrkeyFinderBridge.php
@@ -155,8 +155,14 @@ class OtrkeyFinderBridge extends BridgeAbstract {
 
 		if ($file == null)
 			return null;
-		else
-			return trim($file->innertext);
+
+		// Sometimes there is HTML in the filename - we don't want that.
+		// To filter that out, enumerate to the node which contains the text only.
+		foreach($file->nodes as $node)
+			if ($node->nodetype == HDOM_TYPE_TEXT)
+				return trim($node->innertext);
+
+		return null;
 	}
 
 	private function buildContent(simple_html_dom_node $node) {

--- a/bridges/OtrkeyFinderBridge.php
+++ b/bridges/OtrkeyFinderBridge.php
@@ -10,7 +10,7 @@ class OtrkeyFinderBridge extends BridgeAbstract {
 		array(
 			'searchterm' => array(
 				'name' => 'Search term',
-				'exampleValue' => 'Terminator',
+				'exampleValue' => 'Tatort',
 				'title' => 'The search term is case-insensitive',
 			),
 			'station' => array(


### PR DESCRIPTION
The feed title contains HTML if the search term is omitted. This PR fixes that.

Also provide a better example that actually returns results. (see #2553)