### PR TITLE
Fix AppleAppStoreBridge

### DIFF
--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -94,6 +94,7 @@ class AppleAppStoreBridge extends BridgeAbstract {
 
 		$headers = array(
 			"Authorization: Bearer $token",
+			'Origin: https://apps.apple.com',
 		);
 
 		$json = json_decode(getContents($uri, $headers), true);


### PR DESCRIPTION
Returns a 401 error unless the Origin is specified

- Fixes #2587