### PR TITLE
[Core] Change version display behavior

### DIFF
--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -31,9 +31,6 @@ def testBridges(bridges,status):
                 # if an example or default value is missing for a required attribute, it will throw an error
                 # any non-required fields are not tested!!!
                 for parameter in parameters:
-                    if parameter.get('type') == 'hidden' and parameter.get('name') == 'context':
-                        cleanvalue = parameter.get('value').replace(" ","+")
-                        formstring = formstring + '&' + parameter.get('name') + '=' + cleanvalue
                     if parameter.get('type') == 'number' or parameter.get('type') == 'text':
                         if parameter.has_attr('required'):
                             if parameter.get('placeholder') == '':

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -31,6 +31,9 @@ def testBridges(bridges,status):
                 # if an example or default value is missing for a required attribute, it will throw an error
                 # any non-required fields are not tested!!!
                 for parameter in parameters:
+                    if parameter.get('type') == 'hidden' and parameter.get('name') == 'context':
+                        cleanvalue = parameter.get('value').replace(" ","+")
+                        formstring = formstring + '&' + parameter.get('name') + '=' + cleanvalue
                     if parameter.get('type') == 'number' or parameter.get('type') == 'text':
                         if parameter.has_attr('required'):
                             if parameter.get('placeholder') == '':

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -378,7 +378,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 * @param int $duration Cache duration (optional, default: 24 hours)
 	 * @return mixed Cached value or null if the key doesn't exist or has expired
 	 */
-	protected function loadCacheValue($key, $duration = 86400){
+	public function loadCacheValue($key, $duration = 86400){
 		$cacheFac = new CacheFactory();
 		$cacheFac->setWorkingDir(PATH_LIB_CACHES);
 		$cache = $cacheFac->create(Configuration::getConfig('cache', 'type'));
@@ -395,7 +395,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 * @param string $key Key name
 	 * @param mixed $value Value to cache
 	 */
-	protected function saveCacheValue($key, $value){
+	public function saveCacheValue($key, $value){
 		$cacheFac = new CacheFactory();
 		$cacheFac->setWorkingDir(PATH_LIB_CACHES);
 		$cache = $cacheFac->create(Configuration::getConfig('cache', 'type'));

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -157,11 +157,6 @@ EOD;
 
 		if (substr($version, 0, 3) == 'git') {
 			$version = substr($version, -7);
-			$githubcurl = curl_init('https://api.github.com/repos/rss-bridge/rss-bridge/commits/master');
-			curl_setopt($githubcurl,
-				CURLOPT_HTTPHEADER,
-				array('Accept: application/vnd.github.VERSION.sha','user-agent: rss-bridge'));
-			$version = substr(curl_exec($githubcurl), 0, 7);
 		}
 
 		if($remoteversion !== $version) {

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -155,19 +155,19 @@ EOD;
 		$version = Configuration::getVersion();
 		$remoteversion = Configuration::getRemoteVersion();
 
-		if (substr($version,0,3) == "git") {
+		if (substr($version, 0, 3) == 'git') {
 			$version = substr($version, -7);
-			$githubcurl = curl_init("https://api.github.com/repos/rss-bridge/rss-bridge/commits/master");
+			$githubcurl = curl_init('https://api.github.com/repos/rss-bridge/rss-bridge/commits/master');
 			curl_setopt($githubcurl, CURLOPT_HTTPHEADER, array('Accept: application/vnd.github.VERSION.sha'));
-			return substr(curl_exec($githubcurl),0,7);
+			return substr(curl_exec($githubcurl), 0, 7);
 		}
 
 		if($remoteversion !== $version) {
-			$badgestate = "Update_Available";
-			$badgecolor = "red";
+			$badgestate = 'Update_Available';
+			$badgecolor = 'red';
 		} else {
-			$badgestate = "Version_Up--To--Date";
-			$badgecolor = "green";
+			$badgestate = 'Version_Up--To--Date';
+			$badgecolor = 'green';
 		}
 
 		$email = Configuration::getConfig('admin', 'email');

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -181,7 +181,8 @@ EOD;
 		return <<<EOD
 <section class="footer">
 	<a href="https://github.com/rss-bridge/rss-bridge">RSS-Bridge ~ Public Domain</a><br>
-	<p class="version">{$version}</p>
+	<p><img src="https://img.shields.io/badge/installed-{$version}-yellowgreen"></p>
+	<p><img src="https://img.shields.io/docker/v/rssbridge/rss-bridge?label=current"></p>
 	{$totalActiveBridges}/{$totalBridges} active bridges.<br>
 	{$inactive}
 	{$admininfo}

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -181,8 +181,8 @@ EOD;
 		return <<<EOD
 <section class="footer">
 	<a href="https://github.com/rss-bridge/rss-bridge">RSS-Bridge ~ Public Domain</a><br>
-	<p><img src="https://img.shields.io/badge/installed-{$version}-yellowgreen"></p>
-	<p><img src="https://img.shields.io/docker/v/rssbridge/rss-bridge?label=current"></p>
+	<p><img src="https://img.shields.io/badge/installed-{$version}-yellowgreen">
+	<img src="https://img.shields.io/docker/v/rssbridge/rss-bridge?label=current"></p>
 	{$totalActiveBridges}/{$totalBridges} active bridges.<br>
 	{$inactive}
 	{$admininfo}

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -158,8 +158,10 @@ EOD;
 		if (substr($version, 0, 3) == 'git') {
 			$version = substr($version, -7);
 			$githubcurl = curl_init('https://api.github.com/repos/rss-bridge/rss-bridge/commits/master');
-			curl_setopt($githubcurl, CURLOPT_HTTPHEADER, array('Accept: application/vnd.github.VERSION.sha'));
-			return substr(curl_exec($githubcurl), 0, 7);
+			curl_setopt($githubcurl,
+				CURLOPT_HTTPHEADER,
+				array('Accept: application/vnd.github.VERSION.sha','user-agent: rss-bridge'));
+			$version = substr(curl_exec($githubcurl), 0, 7);
 		}
 
 		if($remoteversion !== $version) {

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -153,6 +153,22 @@ EOD;
 	 */
 	private static function getFooter($totalBridges, $totalActiveBridges, $showInactive) {
 		$version = Configuration::getVersion();
+		$remoteversion = Configuration::getRemoteVersion();
+
+		if (substr($version,0,3) == "git") {
+			$version = substr($version, -7);
+			$githubcurl = curl_init("https://api.github.com/repos/rss-bridge/rss-bridge/commits/master");
+			curl_setopt($githubcurl, CURLOPT_HTTPHEADER, array('Accept: application/vnd.github.VERSION.sha'));
+			return substr(curl_exec($githubcurl),0,7);
+		}
+
+		if($remoteversion !== $version) {
+			$badgestate = "Update_Available";
+			$badgecolor = "red";
+		} else {
+			$badgestate = "Version_Up--To--Date";
+			$badgecolor = "green";
+		}
 
 		$email = Configuration::getConfig('admin', 'email');
 		$admininfo = '';
@@ -181,8 +197,7 @@ EOD;
 		return <<<EOD
 <section class="footer">
 	<a href="https://github.com/rss-bridge/rss-bridge">RSS-Bridge ~ Public Domain</a><br>
-	<p><img src="https://img.shields.io/badge/installed-{$version}-yellowgreen">
-	<img src="https://img.shields.io/docker/v/rssbridge/rss-bridge?label=current"></p>
+	<p><img src="https://img.shields.io/badge/{$badgestate}-{$version}-{$badgecolor}"></p>
 	{$totalActiveBridges}/{$totalBridges} active bridges.<br>
 	{$inactive}
 	{$admininfo}

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -278,7 +278,7 @@ final class Configuration {
 
 		$remotecache = BridgeAbstract::loadCacheValue(REMOTEVERSION);
 
-		if (isset($remotecache)){
+		if (isset($remotecache)) {
 			return $remotecache;
 		}
 
@@ -296,9 +296,9 @@ final class Configuration {
 		} else {
 			$ghcontent = getContents('https://api.github.com/repos/rss-bridge/rss-bridge/releases/latest');
 			$githubjson = json_decode($ghcontent, true);
-			$remoteversion =  $githubjson['tag_name'];
+			$remoteversion = $githubjson['tag_name'];
 		}
-		
+
 		BridgeAbstract::saveCacheValue(REMOTEVERSION, $remoteversion);
 		return $remoteversion;
 	}

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -256,7 +256,7 @@ final class Configuration {
 			if(isset($parts[3])) {
 				$branchName = $parts[3];
 				if(file_exists($revisionHashFile)) {
-					return 'sha-' . substr(file_get_contents($revisionHashFile), 0, 7);
+					return 'sha--' . substr(file_get_contents($revisionHashFile), 0, 7);
 				}
 			}
 		}

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -286,10 +286,12 @@ final class Configuration {
 			curl_setopt($githubcurl,
 				CURLOPT_HTTPHEADER,
 				array('Accept: application/vnd.github.VERSION.sha','user-agent: rss-bridge'));
+			curl_setopt($githubcurl, CURLOPT_RETURNTRANSFER, true);
 			return substr(curl_exec($githubcurl), 0, 7);
 		} else {
 			$githubcurl = curl_init('https://api.github.com/repos/rss-bridge/rss-bridge/releases/latest');
 			curl_setopt($githubcurl, CURLOPT_HTTPHEADER, array('user-agent: rss-bridge'));
+			curl_setopt($githubcurl, CURLOPT_RETURNTRANSFER, true);
 			$githubjson = json_decode(curl_exec($githubcurl), true);
 			return $githubjson['tag_name'];
 		}

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -280,13 +280,15 @@ final class Configuration {
 
 		// If the version starts with 'git', its commit based, otherwise its release based
 		// We only need to transform the git based string, not the release based
-		if (substr($localversion,0,3) == "git") {
+		if (substr($localversion, 0, 3) == 'git') {
 			$localversion = substr($localversion, -7);
-			$githubcurl = curl_init("https://api.github.com/repos/rss-bridge/rss-bridge/commits/master");
-			curl_setopt($githubcurl, CURLOPT_HTTPHEADER, array('Accept: application/vnd.github.VERSION.sha','user-agent: rss-bridge'));
-			return substr(curl_exec($githubcurl),0,7);
+			$githubcurl = curl_init('https://api.github.com/repos/rss-bridge/rss-bridge/commits/master');
+			curl_setopt($githubcurl,
+				CURLOPT_HTTPHEADER,
+				array('Accept: application/vnd.github.VERSION.sha','user-agent: rss-bridge'));
+			return substr(curl_exec($githubcurl), 0, 7);
 		} else {
-			$githubcurl = curl_init("https://api.github.com/repos/rss-bridge/rss-bridge/releases/latest");
+			$githubcurl = curl_init('https://api.github.com/repos/rss-bridge/rss-bridge/releases/latest');
 			curl_setopt($githubcurl, CURLOPT_HTTPHEADER, array('user-agent: rss-bridge'));
 			$githubjson = json_decode(curl_exec($githubcurl), true);
 			return $githubjson['tag_name'];

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -276,7 +276,7 @@ final class Configuration {
 	 */
 	public static function getRemoteVersion() {
 
-		$remotecache = BridgeAbstract::loadCacheValue(REMOTEVERSION);
+		$remotecache = BridgeAbstract::loadCacheValue('REMOTEVERSION');
 
 		if (isset($remotecache)) {
 			return $remotecache;
@@ -299,7 +299,7 @@ final class Configuration {
 			$remoteversion = $githubjson['tag_name'];
 		}
 
-		BridgeAbstract::saveCacheValue(REMOTEVERSION, $remoteversion);
+		BridgeAbstract::saveCacheValue('REMOTEVERSION', $remoteversion);
 		return $remoteversion;
 	}
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -256,7 +256,7 @@ final class Configuration {
 			if(isset($parts[3])) {
 				$branchName = $parts[3];
 				if(file_exists($revisionHashFile)) {
-					return 'git.' . $branchName . '.' . substr(file_get_contents($revisionHashFile), 0, 7);
+					return 'sha-' . substr(file_get_contents($revisionHashFile), 0, 7);
 				}
 			}
 		}


### PR DESCRIPTION
Hi,

this fixes #2434 .

In BridgeList view, a remoteVersion request is done to get either the latest commit sha or the latest release version (based on the currently used deployment method). A badge will be created if the installation is up-to-date or if an update is available.