### PR TITLE
[GiphyBridge] use not rate limited public api key (error 403 fix)

### DIFF
--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -56,12 +56,15 @@ HTML
 
 	public function collectData() {
 		/**
-		 * This uses a public beta key which has severe rate limiting.
+		 * This uses Giphy's own undocumented public prod api key,
+		 * which should not have any rate limiting.
+		 * There is a documented public beta api key (dc6zaTOxFJmzC),
+		 * but it has severe rate limiting.
 		 *
 		 * https://giphy.api-docs.io/1.0/welcome/access-and-api-keys
 		 * https://giphy.api-docs.io/1.0/gifs/search-1
 		 */
-		$apiKey = 'dc6zaTOxFJmzC';
+		$apiKey = 'Gc7131jiJuvI7IdN0HZ1D7nh0ow5BU6g';
 		$limit = min($this->getInput('n') ?: 10, 50);
 		$endpoints = array();
 		if (empty($this->getInput('noGif'))) {


### PR DESCRIPTION
Since more than a week the Giphy bridge stopped working.
The bridge constantly returns 403 (e.g: https://bridge.easter.fr/?action=display&bridge=Giphy&s=%40fallguysgame&format=Json).
Calls to the Giphy API with the currently used public beta key constantly return 403 BANNED (e.g: https://api.giphy.com/v1/stickers/search?api_key=dc6zaTOxFJmzC&q=%40FallGuysGame).
This is probably due to the severe rate limiting of beta api keys.

I looked at the network traffic of Giphy.com and found that the website calls the API with this key: Gc7131jiJuvI7IdN0HZ1D7nh0ow5BU6g
It's probably Giphy's own prod api key and therefore not rate limited. From a quick google search it looks likes others already use that key and that it is around since more than a year.

This PR changes the public beta key "dc6zaTOxFJmzC" to Giphy's own prod api key "Gc7131jiJuvI7IdN0HZ1D7nh0ow5BU6g".
I tested this change on a private instance for couple of days and have not noticed any problem.
