### PR TITLE
[GiphyBridge] include bundle parameter in api calls to reduce bandwidth

### DIFF
--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -62,9 +62,10 @@ HTML
 		 * but it has severe rate limiting.
 		 *
 		 * https://giphy.api-docs.io/1.0/welcome/access-and-api-keys
-		 * https://giphy.api-docs.io/1.0/gifs/search-1
+		 * https://developers.giphy.com/branch/master/docs/api/endpoint/#search
 		 */
 		$apiKey = 'Gc7131jiJuvI7IdN0HZ1D7nh0ow5BU6g';
+		$bundle = 'low_bandwidth';
 		$limit = min($this->getInput('n') ?: 10, 50);
 		$endpoints = array();
 		if (empty($this->getInput('noGif'))) {
@@ -76,10 +77,11 @@ HTML
 
 		foreach ($endpoints as $endpoint) {
 			$uri = sprintf(
-				'https://api.giphy.com/v1/%s/search?q=%s&limit=%s&api_key=%s',
+				'https://api.giphy.com/v1/%s/search?q=%s&limit=%s&bundle=%s&api_key=%s',
 				$endpoint,
 				rawurlencode($this->getInput('s')),
 				$limit,
+				$bundle,
 				$apiKey
 			);
 


### PR DESCRIPTION
This PR adds the `bundle` parameter with value `low_bandwidth` to Giphy API calls.
It will reduce the used bandwith of each API call by around 40%.

By default the Giphy API responds with all supported image formats and sizes.
The `bundle` parameter tells the API to respond with a limited set of image formats and sizes.

Example without it (~215KB): https://api.giphy.com/v1/gifs/search?q=bird&api_key=Gc7131jiJuvI7IdN0HZ1D7nh0ow5BU6g
Example with it (~125KB): https://api.giphy.com/v1/gifs/search?q=bird&api_key=Gc7131jiJuvI7IdN0HZ1D7nh0ow5BU6g&bundle=low_bandwidth

This parameter is not mentioned in the API doc from the code comments: https://giphy.api-docs.io/1.0/gifs/search-1.
It is only mentioned on this API doc: https://developers.giphy.com/branch/master/docs/api/endpoint/#search