### PR TITLE
[GiphyBridge] include search text in feed name

### DIFF
--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -31,6 +31,15 @@ class GiphyBridge extends BridgeAbstract {
 		)
 	));
 
+	public function getName()
+	{
+		if (!is_null($this->getInput('s'))) {
+			return $this->getInput('s') . ' - ' . parent::getName();
+		}
+
+		return parent::getName();
+	}
+
 	protected function getGiphyItems($entries){
 		foreach($entries as $entry) {
 			$createdAt = new \DateTime($entry->import_datetime);


### PR DESCRIPTION
Currently the feed name/title is always "Giphy Bridge".

This PR will include the search text/account name in the feed name/title like this examples:
Search: "bird - Giphy Bridge"
Account: "@fallguysgame - Giphy Bridge"