### PR TITLE
[Docker] force unix line ending on bash files to prevent docker run failing on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sh text eol=lf
 
 # Custom for Visual Studio
 *.cs     diff=csharp


### PR DESCRIPTION
When you checkout this project on a Windows system, then build the dockerfile and run the created image it will fail with this message: `/usr/bin/env: 'bash\r': No such file or directory`

Git checks out every text file with the Windows line ending, also the `docker-entrypoint.sh` file. The file then gets included in the docker image with Windows line endings. The linux based docker environment can not handle it.

This PR forces git to checkout every `.sh` file with linux line endings.
It could also be fixed by just doing this for `docker-entrypoint.sh`, but `*.sh` ensures it will not break in case more bash files get added in the future. There is no reason for a `.sh` file to ever have Windows line endings.