### PR TITLE
replace wiki links with documentation links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,49 +1,7 @@
 ### Pull request policy
 
-* [Fix one issue per pull request](https://github.com/RSS-Bridge/rss-bridge/wiki/Pull-request-policy#fix-one-issue-per-pull-request)
-* [Respect the coding style policy](https://github.com/RSS-Bridge/rss-bridge/wiki/Pull-request-policy#respect-the-coding-style-policy)
-* [Properly name your commits](https://github.com/RSS-Bridge/rss-bridge/wiki/Pull-request-policy#properly-name-your-commits)
-  * When fixing a bridge (located in the `bridges` directory), write `[BridgeName] Feature` <br>(i.e. `[YoutubeBridge] Fix typo in video titles`).
-  * When fixing other files, use `[FileName] Feature` <br>(i.e. `[index.php] Add multilingual support`).
-  * When fixing a general problem that applies to multiple files, write `category: feature` <br>(i.e. `bridges: Fix various typos`).
-
-Note that all pull-requests must pass all tests before they can be merged.
+See the [Pull request policy page on the documentation](https://rss-bridge.github.io/rss-bridge/For_Developers/Pull_Request_policy.html) for more information on the pull request policy.
 
 ### Coding style
 
-* [Whitespace](https://github.com/RSS-Bridge/rss-bridge/wiki/Whitespace)
-  * [Add a new line at the end of a file](https://github.com/RSS-Bridge/rss-bridge/wiki/Whitespace#add-a-new-line-at-the-end-of-a-file)
-  * [Do not add a whitespace before a semicolon](https://github.com/RSS-Bridge/rss-bridge/wiki/Whitespace#add-a-new-line-at-the-end-of-a-file)
-  * [Do not add whitespace at start or end of a file or end of a line](https://github.com/RSS-Bridge/rss-bridge/wiki/Whitespace#do-not-add-whitespace-at-start-or-end-of-a-file-or-end-of-a-line)
-* [Indentation](https://github.com/RSS-Bridge/rss-bridge/wiki/Indentation)
-  * [Use tabs for indentation](https://github.com/RSS-Bridge/rss-bridge/wiki/Indentation#use-tabs-for-indentation)
-* [Maximum line length](https://github.com/RSS-Bridge/rss-bridge/wiki/Maximum-line-length)
-  * [The maximum line length should not exceed 80 characters](https://github.com/RSS-Bridge/rss-bridge/wiki/Maximum-line-length#the-maximum-line-length-should-not-exceed-80-characters)
-* [Strings](https://github.com/RSS-Bridge/rss-bridge/wiki/Strings)
-  * [Whenever possible use single quoted strings](https://github.com/RSS-Bridge/rss-bridge/wiki/Strings#whenever-possible-use-single-quote-strings)
-  * [Add spaces around the concatenation operator](https://github.com/RSS-Bridge/rss-bridge/wiki/Strings#add-spaces-around-the-concatenation-operator)
-  * [Use a single string instead of concatenating](https://github.com/RSS-Bridge/rss-bridge/wiki/Strings#use-a-single-string-instead-of-concatenating)
-* [Constants](https://github.com/RSS-Bridge/rss-bridge/wiki/Constants)
-  * [Use UPPERCASE for constants](https://github.com/RSS-Bridge/rss-bridge/wiki/Constants#use-uppercase-for-constants)
-* [Keywords](https://github.com/RSS-Bridge/rss-bridge/wiki/Keywords)
-  * [Use lowercase for `true`, `false` and `null`](https://github.com/RSS-Bridge/rss-bridge/wiki/Keywords#use-lowercase-for-true-false-and-null)
-* [Operators](https://github.com/RSS-Bridge/rss-bridge/wiki/Operators)
-  * [Operators must have a space around them](https://github.com/RSS-Bridge/rss-bridge/wiki/Operators#operators-must-have-a-space-around-them)
-* [Functions](https://github.com/RSS-Bridge/rss-bridge/wiki/Functions)
-  * [Parameters with default values must appear last in functions](https://github.com/RSS-Bridge/rss-bridge/wiki/Functions#parameters-with-default-values-must-appear-last-in-functions)
-  * [Calling functions](https://github.com/RSS-Bridge/rss-bridge/wiki/Functions#calling-functions)
-  * [Do not add spaces after opening or before closing bracket](https://github.com/RSS-Bridge/rss-bridge/wiki/Functions#do-not-add-spaces-after-opening-or-before-closing-bracket)
-* [Structures](https://github.com/RSS-Bridge/rss-bridge/wiki/Structures)
-  * [Structures must always be formatted as multi-line blocks](https://github.com/RSS-Bridge/rss-bridge/wiki/Structures#structures-must-always-be-formatted-as-multi-line-blocks)
-* [If-Statement](https://github.com/RSS-Bridge/rss-bridge/wiki/if-Statement)
-  * [Use `elseif` instead of `else if`](https://github.com/RSS-Bridge/rss-bridge/wiki/if-Statement#use-elseif-instead-of-else-if)
-  * [Do not write empty statements](https://github.com/RSS-Bridge/rss-bridge/wiki/if-Statement#do-not-write-empty-statements)
-  * [Do not write unconditional if-statements](https://github.com/RSS-Bridge/rss-bridge/wiki/if-Statement#do-not-write-unconditional-if-statements)
-* [Classes](https://github.com/RSS-Bridge/rss-bridge/wiki/Classes)
-  * [Use PascalCase for class names](https://github.com/RSS-Bridge/rss-bridge/wiki/Classes#use-pascalcase-for-class-names)
-  * [Do not use final statements inside final classes](https://github.com/RSS-Bridge/rss-bridge/wiki/Classes#do-not-use-final-statements-inside-final-classes)
-  * [Do not override methods to call their parent](https://github.com/RSS-Bridge/rss-bridge/wiki/Classes#do-not-override-methods-to-call-their-parent)
-  * [abstract and final declarations MUST precede the visibility declaration](https://github.com/RSS-Bridge/rss-bridge/wiki/Classes#abstract-and-final-declarations-must-precede-the-visibility-declaration)
-  * [static declaration MUST come after the visibility declaration](https://github.com/RSS-Bridge/rss-bridge/wiki/Classes#static-declaration-must-come-after-the-visibility-declaration)
-* [Casting](https://github.com/RSS-Bridge/rss-bridge/wiki/Casting)
-  * [Do not add spaces when casting](https://github.com/RSS-Bridge/rss-bridge/wiki/Casting#do-not-add-spaces-when-casting)
+See the [Coding style policy page on the documentation](https://rss-bridge.github.io/rss-bridge/For_Developers/Coding_style_policy.html) for more information on the coding style of the project.

--- a/.github/ISSUE_TEMPLATE/bridge-request.md
+++ b/.github/ISSUE_TEMPLATE/bridge-request.md
@@ -60,5 +60,5 @@ Please describe what you expect from the bridge. Whenever possible provide sampl
 
 Keep in mind that opening a request does not guarantee the bridge being implemented! That depends entirely on the interest and time of others to make the bridge for you.
 
-You can also implement your own bridge (with support of the community if needed). Find more information in the [RSS-Bridge Wiki](https://github.com/RSS-Bridge/rss-bridge/wiki/For-developers) developer section.
+You can also implement your own bridge (with support of the community if needed). Find more information in the [RSS-Bridge Documentation](https://rss-bridge.github.io/rss-bridge/For_Developers/index.html) developer section.
 -->

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ RSS-Bridge is capable of producing several output formats:
 * `Mrss` : MRSS feed, for use in feed readers
 * `Plaintext` : Raw text, for consumption by other applications
 
-You can extend RSS-Bridge with your own format, using the [Format API](https://github.com/RSS-Bridge/rss-bridge/wiki/Format-API)!
+You can extend RSS-Bridge with your own format, using the [Format API](https://rss-bridge.github.io/rss-bridge/Format_API/index.html)!
 
 Screenshot
 ===
@@ -73,16 +73,16 @@ RSS-Bridge requires PHP 7.1 or higher with following extensions enabled:
   - [`filter`](https://secure.php.net/manual/en/book.filter.php)
   - [`sqlite3`](http://php.net/manual/en/book.sqlite3.php) (only when using SQLiteCache)
 
-Find more information on our [Wiki](https://github.com/rss-bridge/rss-bridge/wiki)
+Find more information on our [Documentation](https://rss-bridge.github.io/rss-bridge/index.html)
 
 Enable / Disable bridges
 ===
 
 RSS-Bridge allows you to take full control over which bridges are displayed to the user. That way you can host your own RSS-Bridge service with your favorite collection of bridges!
 
-Find more information on the [Wiki](https://github.com/RSS-Bridge/rss-bridge/wiki/Whitelisting)
+Find more information on the [Documentation](https://rss-bridge.github.io/rss-bridge/For_Hosts/Whitelisting.html)
 
-**Notice**: By default, RSS-Bridge will only show a small subset of bridges. Make sure to read up on [whitelisting](https://github.com/RSS-Bridge/rss-bridge/wiki/Whitelisting) to unlock the full potential of RSS-Bridge!
+**Notice**: By default, RSS-Bridge will only show a small subset of bridges. Make sure to read up on [whitelisting](https://rss-bridge.github.io/rss-bridge/For_Hosts/Whitelisting.html) to unlock the full potential of RSS-Bridge!
 
 Deploy
 ===
@@ -104,7 +104,7 @@ There are many ways for you to getting involved with RSS-Bridge. Here are a few 
 - Request new features or suggest ideas (via [Issues](https://github.com/RSS-Bridge/rss-bridge/issues))
 - Discuss bugs, features, ideas or [issues](https://github.com/RSS-Bridge/rss-bridge/issues)
 - Add new bridges or improve the API
-- Improve the [Wiki](https://github.com/RSS-Bridge/rss-bridge/wiki)
+- Improve the [Documentation](https://rss-bridge.github.io/rss-bridge/)
 - Host an instance of RSS-Bridge for your personal use or make it available to the community :sparkling_heart:
 
 Authors
@@ -326,8 +326,8 @@ Technical notes
 ===
 
   * RSS-Bridge uses caching to prevent services from banning your server for repeatedly updating feeds. The specific cache duration can be different between bridges. Cached files are deleted automatically after 24 hours.
-  * You can implement your own bridge, [following these instructions](https://github.com/RSS-Bridge/rss-bridge/wiki/Bridge-API).
-  * You can enable debug mode to disable caching. Find more information on the [Wiki](https://github.com/RSS-Bridge/rss-bridge/wiki/Debug-mode)
+  * You can implement your own bridge, [following these instructions](https://rss-bridge.github.io/rss-bridge/Bridge_API/index.html).
+  * You can enable debug mode to disable caching. Find more information on the [Wiki](https://rss-bridge.github.io/rss-bridge/For_Developers/Debug_mode.html)
 
 Rant
 ===

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "license": "UNLICENSE",
     "support": {
         "issues": "https://github.com/rss-bridge/rss-bridge/issues/",
-        "wiki": "https://github.com/rss-bridge/rss-bridge/wiki/",
+        "docs": "https://rss-bridge.github.io/rss-bridge/",
         "source": "https://github.com/rss-bridge/rss-bridge/",
         "rss": "https://github.com/RSS-Bridge/rss-bridge/commits/master.atom"
     },

--- a/docs/05_Bridge_API/02_BridgeAbstract.md
+++ b/docs/05_Bridge_API/02_BridgeAbstract.md
@@ -6,10 +6,10 @@
 
 You need four basic steps in order to create a new bridge:
 
-[**Step 1**](#step-1---create-a-new-file) - Create a new file  
-[**Step 2**](#step-2---add-a-class-extending-bridgeabstract) - Add a class, extending `BridgeAbstract`  
-[**Step 3**](#step-3---add-general-constants-to-the-class) - Add general constants to the class  
-[**Step 4**](#step-4---implement-a-function-to-collect-feed-data) - Implement a function to collect feed data 
+[**Step 1**](#step-1---create-a-new-file) - Create a new file
+[**Step 2**](#step-2---add-a-class-extending-bridgeabstract) - Add a class, extending `BridgeAbstract`
+[**Step 3**](#step-3---add-general-constants-to-the-class) - Add general constants to the class
+[**Step 4**](#step-4---implement-a-function-to-collect-feed-data) - Implement a function to collect feed data
 
 These steps are described in more detail below. At the end of this document you'll find a complete [template](#template) based on these instructions. The pictures below show an example based on these instructions:
 
@@ -68,7 +68,7 @@ const CACHE_TIMEOUT // (optional) Defines the maximum duration for the cache in 
 <?PHP
 class MyBridge extends BridgeAbstract {
 	const NAME        = 'My Bridge';
-	const URI         = 'https://github.com/RSS-Bridge/rss-bridge/wiki/BridgeAbstract';
+	const URI         = 'https://rss-bridge.github.io/rss-bridge/Bridge_API/BridgeAbstract.html';
 	const DESCRIPTION = 'Returns "Hello World!"';
 	const MAINTAINER  = 'ghost';
 }
@@ -89,7 +89,7 @@ In order for RSS-Bridge to collect data, you must implement the **public** funct
 <?PHP
 class MyBridge extends BridgeAbstract {
 	const NAME        = 'My Bridge';
-	const URI         = 'https://github.com/RSS-Bridge/rss-bridge/wiki/BridgeAbstract';
+	const URI         = 'https://rss-bridge.github.io/rss-bridge/Bridge_API/BridgeAbstract.html';
 	const DESCRIPTION = 'Returns "Hello World!"';
 	const MAINTAINER  = 'ghost';
 
@@ -162,7 +162,7 @@ class MyBridge extends BridgeAbstract {
 
 Parameters are organized in two levels:
 
-[**Level 1**](##level-1---context) - Context  
+[**Level 1**](##level-1---context) - Context
 [**Level 2**](##level-2---parameter) - Parameter
 
 ## Level 1 - Context
@@ -277,7 +277,7 @@ List values are defined in an associative array where keys are the string displa
 
 If a more complex organization is required to display the values, the above key/value can be used to set a title as a key and another array as a value:
 ```PHP
-... 
+...
     'type' => 'list',
     'values' => array(
         'Item A' => 'itemA',


### PR DESCRIPTION
Replace links to the wiki with links to the documentation website. 
Related to https://github.com/RSS-Bridge/rss-bridge/issues/2624.

I replaced the CONTRIBUTING.md content with links to the corresponding pages on the documentation to avoid duplication of the content.