### PR TITLE
[lint] Fix PHP warning

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -161,6 +161,6 @@ EOD;
 	}
 
 	private function xml_encode($text){
-		return htmlspecialchars($text, ENT_XML1);
+		return htmlspecialchars($text ?? '', ENT_XML1);
 	}
 }


### PR DESCRIPTION
Not sure what PHP version this was introduced in, but I get the following warning using PHP 8.1.4.

`Deprecated:  htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated formats/AtomFormat.php on line 164`