### PR TITLE
[Arte7Bridge] Exclude trailers and sort by

### DIFF
--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -15,8 +15,9 @@ class Arte7Bridge extends BridgeAbstract {
 				'type' => 'list',
 				'name' => 'Sort by',
 				'required' => false,
-				'defaultValue' => 'broadcastBegin',
+				'defaultValue' => null,
 				'values' => array(
+					'Default' => null,
 					'Video rights start date' => 'videoRightsBegin',
 					'Video rights end date' => 'videoRightsEnd',
 					'Brodcast date' => 'broadcastBegin',


### PR DESCRIPTION
- Replace `video_duration_filter` by `exclude trailers` option (according to https://github.com/RSS-Bridge/rss-bridge/issues/662#issuecomment-1099145809) which is simpler and filter videos from a category using metadata
- Replace default sorting `lastModified` by none and add a sorting option. Since a couple of months, I've tried the change on my instance, and it works much better. On some TV shows, using a sort option create some weird behaviour.
- Set myself as a maintainer. It appears that no one want to be a maintainer. I'm not a PHP expert, but I do use daily this bridge.