### PR TITLE
[GogsBridge|GiteaBridge] Require protocol in host input in order to make defaultLinkTo to work

### DIFF
--- a/bridges/GogsBridge.php
+++ b/bridges/GogsBridge.php
@@ -11,9 +11,9 @@ class GogsBridge extends BridgeAbstract {
 		'global' => array(
 			'host' => array(
 				'name' => 'Host',
-				'exampleValue' => 'notabug.org',
+				'exampleValue' => 'https://notabug.org',
 				'required' => true,
-				'title' => 'Host name without trailing slash',
+				'title' => 'Host name with its protocol, without trailing slash',
 			),
 			'user' => array(
 				'name' => 'Username',


### PR DESCRIPTION
Without a protocol, the relative links (items URIs for example) are not replaced.

Example : `/?action=display&bridge=Gitea&context=Releases&host=notabug.org&user=kensanata&project=oddmuse&format=Html`