### PR TITLE
[GiteaBridge] Add Tags context

### DIFF
--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -13,6 +13,55 @@ class GiteaBridge extends GogsBridge {
 	const MAINTAINER = 'logmanoriginal';
 	const CACHE_TIMEOUT = 300; // 5 minutes
 
+	const PARAMETERS = array(
+		'global' => array(
+			'host' => array(
+				'name' => 'Host',
+				'exampleValue' => 'notabug.org',
+				'required' => true,
+				'title' => 'Host name without trailing slash',
+			),
+			'user' => array(
+				'name' => 'Username',
+				'exampleValue' => 'PDModdingCommunity',
+				'required' => true,
+				'title' => 'User name as it appears in the URL',
+			),
+			'project' => array(
+				'name' => 'Project name',
+				'exampleValue' => 'PD-Loader',
+				'required' => true,
+				'title' => 'Project name as it appears in the URL',
+			),
+		),
+		'Commits' => array(
+			'branch' => array(
+				'name' => 'Branch name',
+				'defaultValue' => 'master',
+				'required' => true,
+				'title' => 'Branch name as it appears in the URL',
+			),
+		),
+		'Issues' => array(
+			'include_description' => array(
+				'name' => 'Include issue description',
+				'type' => 'checkbox',
+				'title' => 'Activate to include the issue description',
+			),
+		),
+		'Single issue' => array(
+			'issue' => array(
+				'name' => 'Issue number',
+				'type' => 'number',
+				'exampleValue' => 100,
+				'required' => true,
+				'title' => 'Issue number from the issues list',
+			),
+		),
+		'Releases' => array(),
+	);
+
+
 	protected function collectReleasesData($html) {
 		$releases = $html->find('#release-list > li')
 			or returnServerError('Unable to find releases');

--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -62,6 +62,13 @@ class GiteaBridge extends GogsBridge {
 		'Tags' => array(),
 	);
 
+	public function getName() {
+		switch($this->queriedContext) {
+			case 'Tags': return 'Tags for ' . $this->title;
+			default: return parent::getName();
+		}
+	}
+
 	public function getURI() {
 		switch($this->queriedContext) {
 			case 'Tags': {


### PR DESCRIPTION
Following feedback in #2069, here is a new PR, with a more limited scope.

Add support for [tags](https://github.com/go-gitea/gitea/pull/12096) context.