### PR TITLE
[contents.php] fix UnexpectedResponseException.getResponseBody

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -74,7 +74,7 @@ class UnexpectedResponseException extends \GetContentsException {
 	}
 
 	public function getResponseBody() {
-		return $this->responseBody();
+		return $this->responseBody;
 	}
 }
 


### PR DESCRIPTION
fixes incorrect reference to UnexpectedResponseException's responseBody.