### PR TITLE
[Core] Add language search functionality

### DIFF
--- a/bridges/ABCNewsBridge.php
+++ b/bridges/ABCNewsBridge.php
@@ -24,10 +24,6 @@ class ABCNewsBridge extends BridgeAbstract {
 			)
 		)
 	);
-	const LANGUAGE = array(
-		'English',
-		'German'
-	);
 
 	public function collectData() {
 		$url = 'https://www.abc.net.au/news/' . $this->getInput('topic');

--- a/bridges/ABCNewsBridge.php
+++ b/bridges/ABCNewsBridge.php
@@ -24,6 +24,10 @@ class ABCNewsBridge extends BridgeAbstract {
 			)
 		)
 	);
+	const LANGUAGE = array(
+		'English',
+		'German'
+	);
 
 	public function collectData() {
 		$url = 'https://www.abc.net.au/news/' . $this->getInput('topic');

--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -97,6 +97,14 @@ class Arte7Bridge extends BridgeAbstract {
 			)
 		)
 	);
+	const LANGUAGE = array(
+		'French',
+		'German',
+		'English',
+		'Spanish',
+		'Polish',
+		'Italian'
+	);
 
 	public function collectData(){
 		switch($this->queriedContext) {

--- a/docs/05_Bridge_API/02_BridgeAbstract.md
+++ b/docs/05_Bridge_API/02_BridgeAbstract.md
@@ -59,6 +59,7 @@ const URI           // URI to the target website of the bridge (default: empty)
 const DESCRIPTION   // A brief description of the Bridge (default: "No description provided")
 const MAINTAINER    // Name of the maintainer, i.e. your name on GitHub (default: "No maintainer")
 const PARAMETERS    // (optional) Definition of additional parameters (default: empty)
+const LANGUAGE      // (optional) Definition of supported languages (default: empty)
 const CACHE_TIMEOUT // (optional) Defines the maximum duration for the cache in seconds (default: 3600)
 ```
 
@@ -71,6 +72,7 @@ class MyBridge extends BridgeAbstract {
 	const URI         = 'https://rss-bridge.github.io/rss-bridge/Bridge_API/BridgeAbstract.html';
 	const DESCRIPTION = 'Returns "Hello World!"';
 	const MAINTAINER  = 'ghost';
+	const LANGUAGE    = array('English', 'German');
 }
 // This line is empty (just imagine it!)
 ```
@@ -92,6 +94,7 @@ class MyBridge extends BridgeAbstract {
 	const URI         = 'https://rss-bridge.github.io/rss-bridge/Bridge_API/BridgeAbstract.html';
 	const DESCRIPTION = 'Returns "Hello World!"';
 	const MAINTAINER  = 'ghost';
+	const LANGUAGE    = array('English', 'German');
 
 	public function collectData() {
 		$item = array(); // Create an empty item
@@ -122,6 +125,7 @@ class MyBridge extends BridgeAbstract {
 	const DESCRIPTION = 'No description provided';
 	const MAINTAINER = 'No maintainer';
 	const PARAMETERS = array(); // Can be omitted!
+	const LANGUAGE = array('English', 'German'); // Can be omitted!
 	const CACHE_TIMEOUT = 3600; // Can be omitted!
 
 	public function collectData() {

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -83,6 +83,13 @@ abstract class BridgeAbstract implements BridgeInterface {
 	const PARAMETERS = array();
 
 	/**
+	 * Languages for the bridge
+	 *
+	 * Use {@see BridgeAbstract::getLanguage()} to read this parameter
+	 */
+	const LANGUAGE = array();
+
+	/**
 	 * Test cases for detectParameters for the bridge
 	 */
 	const TEST_DETECT_PARAMETERS = array();
@@ -366,6 +373,11 @@ abstract class BridgeAbstract implements BridgeInterface {
 	/** {@inheritdoc} */
 	public function getCacheTimeout(){
 		return static::CACHE_TIMEOUT;
+	}
+
+	/** {@inheritdoc} */
+	public function getLanguage(){
+		return static::LANGUAGE;
 	}
 
 	/** {@inheritdoc} */

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -300,7 +300,7 @@ This bridge is not fetching its content through a secure connection</div>';
 
 		$uri = $bridge->getURI();
 		$name = $bridge->getName();
-		$language = implode(' ',$bridge->getLanguage());
+		$language = implode(' ', $bridge->getLanguage());
 		$icon = $bridge->getIcon();
 		$description = $bridge->getDescription();
 		$parameters = $bridge->getParameters();

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -300,6 +300,7 @@ This bridge is not fetching its content through a secure connection</div>';
 
 		$uri = $bridge->getURI();
 		$name = $bridge->getName();
+		$language = $bridge->getLanguage();
 		$icon = $bridge->getIcon();
 		$description = $bridge->getDescription();
 		$parameters = $bridge->getParameters();
@@ -324,7 +325,7 @@ This bridge is not fetching its content through a secure connection</div>';
 		}
 
 		$card = <<<CARD
-			<section id="bridge-{$bridgeName}" data-ref="{$name}">
+			<section id="bridge-{$bridgeName}" data-ref="{$name}" language="{$language}">
 				<h2><a href="{$uri}">{$name}</a></h2>
 				<p class="description">{$description}</p>
 				<input type="checkbox" class="showmore-box" id="showmore-{$bridgeName}" />

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -300,7 +300,7 @@ This bridge is not fetching its content through a secure connection</div>';
 
 		$uri = $bridge->getURI();
 		$name = $bridge->getName();
-		$language = $bridge->getLanguage();
+		$language = implode(' ',$bridge->getLanguage());
 		$icon = $bridge->getIcon();
 		$description = $bridge->getDescription();
 		$parameters = $bridge->getParameters();

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -135,7 +135,7 @@ EOD;
 <section class="searchbar">
 	<h3>Search</h3>
 	<input type="text" name="searchfield"
-		id="searchfield" placeholder="Insert URL or bridge name"
+		id="searchfield" placeholder="Insert URL, bridge name or language"
 		onchange="search()" onkeyup="search()" value="{$query}">
 </section>
 EOD;

--- a/static/search.js
+++ b/static/search.js
@@ -23,6 +23,7 @@ function search() {
 	for(var i = 0; i < searchableElements.length; i++) {
 
 		var textValue = searchableElements[i].getAttribute('data-ref');
+		var languageValue = searchableElements[i].getAttribute('language');
 		var anchors = searchableElements[i].getElementsByTagName('a');
 
 		if(anchors != null && anchors.length > 0) {
@@ -40,6 +41,7 @@ function search() {
 
 			if(textValue.match(regexMatch) != null ||
 				uriValue.hostname.match(regexMatch) ||
+				languageValue.match(regexMatch) != null ||
 				searchTermUri != null &&
 				uriValue.hostname != 'localhost' && (
 					uriValue.href.match(regexMatch) != null ||


### PR DESCRIPTION
First implementation of an additional language filter for the search functionality (see #2659 ).

To use this, bridge maintainers only have to add a new const array LANGUAGE into their bridge with the supported languages. This should be done in english, not in their localized version ("French" instead of "Francais". Because otherwise people that search for "french" will not find the "francais" bridge).

If we add this functionality, a second step would be to add the languages to the current bridges.

Empty const will not cause any weird behavior.