### PR TITLE
fix: don't bork upstream with http status code -1

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,6 +28,9 @@ try {
 	}
 } catch(\Exception $e) {
 	error_log($e);
-	header('Content-Type: text/plain', true, $e->getCode());
+	$code = $e->getCode();
+	if ($code !== -1) {
+		header('Content-Type: text/plain', true, $code);
+	}
 	die($e->getMessage());
 }


### PR DESCRIPTION
When passing -1 to upstream e.g. php-fpm it errors out because -1 is an illegal http status code.