### PR TITLE
[GolemBridge] Add golem.de bridge

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -88,7 +88,7 @@ class GolemBridge extends FeedExpander {
 		$article = $page->find('article', 0);
 
 		// delete known bad elements
-		foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc') as $bad) {
+		foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc, .embedcontent') as $bad) {
 			$bad->remove();
 		}
 		// reload html, as remove() is buggy

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -94,8 +94,12 @@ class GolemBridge extends FeedExpander {
 		// reload html, as remove() is buggy
 		$article = str_get_html($article->outertext);
 
+		if ($pageHeader = $article->find('header.paged-cluster-header h1', 0)) {
+			$item .= $pageHeader;
+		}
+
 		$header = $article->find('header', 0);
-		foreach($header->find('p, figure, .paged-cluster-header h1') as $element) {
+		foreach($header->find('p, figure') as $element) {
 			$item .= $element;
 		}
 

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -91,8 +91,10 @@ class GolemBridge extends FeedExpander {
 		foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc, #table-jtoc,
 			.social-tools, #list-jtoc, div.tags, #breadcrumbs, .subscribe-newsletter, .clearfix, .teaser-widget,
 			script') as $bad) {
-			$bad->outertext = '';
+			$bad->remove();
 		}
+		// reload html, as remove() is buggy
+		$article = str_get_html($article->outertext);
 
 		$header = $article->find('header', 0);
 		foreach($header->find('p, figure, .paged-cluster-header h1') as $element) {

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -88,9 +88,7 @@ class GolemBridge extends FeedExpander {
 		$article = $page->find('article', 0);
 
 		// delete known bad elements
-		foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc, #table-jtoc,
-			.social-tools, #list-jtoc, div.tags, #breadcrumbs, .subscribe-newsletter, .clearfix, .teaser-widget,
-			script') as $bad) {
+		foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc') as $bad) {
 			$bad->remove();
 		}
 		// reload html, as remove() is buggy

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -72,6 +72,11 @@ class GolemBridge extends FeedExpander {
 			// URI without RSS feed reference
 			$item['uri'] = $articlePage->find('head meta[name="twitter:url"]', 0)->content;
 
+			$author = $articlePage->find('article header .authors .authors__name', 0);
+			if ($author) {
+				$item['author'] = $author->innertext;
+			}
+
 			$item['content'] .= $this->extractContent($articlePage);
 
 			// next page

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -1,0 +1,113 @@
+<?php
+
+class GolemBridge extends FeedExpander {
+	const MAINTAINER = 'Mynacol';
+	const NAME = 'Golem Bridge';
+	const URI = 'https://www.golem.de/';
+	const CACHE_TIMEOUT = 1800; // 30min
+	const DESCRIPTION = 'Returns the full articles instead of only the intro';
+	const PARAMETERS = array(array(
+		'category' => array(
+			'name' => 'Category',
+			'type' => 'list',
+			'values' => array(
+				'Alle News'
+				=> 'https://rss.golem.de/rss.php?feed=ATOM1.0',
+				'Audio/Video'
+				=> 'https://rss.golem.de/rss.php?ms=audio-video&feed=ATOM1.0',
+				'Auto'
+				=> 'https://rss.golem.de/rss.php?ms=auto&feed=ATOM1.0',
+				'Foto'
+				=> 'https://rss.golem.de/rss.php?ms=foto&feed=ATOM1.0',
+				'Games'
+				=> 'https://rss.golem.de/rss.php?ms=games&feed=ATOM1.0',
+				'Handy'
+				=> 'https://rss.golem.de/rss.php?ms=handy&feed=ATOM1.0',
+				'Internet'
+				=> 'https://rss.golem.de/rss.php?ms=internet&feed=ATOM1.0',
+				'Mobil'
+				=> 'https://rss.golem.de/rss.php?ms=mobil&feed=ATOM1.0',
+				'Open Source'
+				=> 'https://rss.golem.de/rss.php?ms=open-source&feed=ATOM1.0',
+				'Politik/Recht'
+				=> 'https://rss.golem.de/rss.php?ms=politik-recht&feed=ATOM1.0',
+				'Security'
+				=> 'https://rss.golem.de/rss.php?ms=security&feed=ATOM1.0',
+				'Desktop-Applikationen'
+				=> 'https://rss.golem.de/rss.php?ms=desktop-applikationen&feed=ATOM1.0',
+				'Software-Entwicklung'
+				=> 'https://rss.golem.de/rss.php?ms=softwareentwicklung&feed=ATOM1.0',
+				'Wirtschaft'
+				=> 'https://rss.golem.de/rss.php?ms=wirtschaft&feed=ATOM1.0',
+				'Wissenschaft'
+				=> 'https://rss.golem.de/rss.php?ms=wissenschaft&feed=ATOM1.0'
+			)
+		),
+		'limit' => array(
+			'name' => 'Limit',
+			'type' => 'number',
+			'required' => false,
+			'title' => 'Specify number of full articles to return',
+			'defaultValue' => 5
+		)
+	));
+	const LIMIT = 5;
+    const HEADERS = array('Cookie: golem_consent20=simple|220101;');
+
+	public function collectData() {
+		$this->collectExpandableDatas(
+			$this->getInput('category'),
+			$this->getInput('limit') ?: static::LIMIT
+		);
+	}
+
+	protected function parseItem($item) {
+		$item = parent::parseItem($item);
+        $item['content'] = $item['content'] ?? '';
+		$uri = $item['uri'];
+
+        while ($uri) {
+            $articlePage = getSimpleHTMLDOMCached($uri, static::CACHE_TIMEOUT, static::HEADERS);
+
+            // URI without RSS feed reference
+            $item['uri'] = $articlePage->find('head meta[name="twitter:url"]', 0)->content;
+
+            $item['content'] .= $this->extractContent($articlePage);
+
+            // next page
+            $nextUri = $articlePage->find('link[rel="next"]', 0);
+            $uri = $nextUri ? static::URI . $nextUri->href : null;
+        }
+
+		return $item;
+	}
+
+	private function extractContent($page) {
+        $item = '';
+
+        $article = $page->find('article', 0);
+
+        // delete known bad elements
+        foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc, #table-jtoc, .social-tools, #list-jtoc, div.tags, #breadcrumbs, .subscribe-newsletter, .clearfix, .teaser-widget, script') as $bad) {
+            $bad->outertext = '';
+        }
+
+        $header = $article->find('header', 0);
+        foreach($header->find('p, figure, .paged-cluster-header h1') as $element) {
+            $item .= $element;
+        }
+
+        $content = $article->find('div.formatted', 0);
+
+        // fix image galleries (empty src attribute), additionally full image quality
+        foreach($content->find('img[data-src-full]') as $img) {
+            $img->src = $img->getAttribute('data-src-full');
+        }
+
+        foreach($content->find('p, h1, h3, img') as $element) {
+            $item .= $element;
+        }
+
+        return $item;
+    }
+}

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -93,7 +93,8 @@ class GolemBridge extends FeedExpander {
 		$article = $page->find('article', 0);
 
 		// delete known bad elements
-		foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc, .embedcontent') as $bad) {
+		foreach($article->find('div[id*="adtile"], #job-market, #seminars,
+			div.gbox_affiliate, div.toc, .embedcontent') as $bad) {
 			$bad->remove();
 		}
 		// reload html, as remove() is buggy

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -52,7 +52,7 @@ class GolemBridge extends FeedExpander {
 		)
 	));
 	const LIMIT = 5;
-    const HEADERS = array('Cookie: golem_consent20=simple|220101;');
+	const HEADERS = array('Cookie: golem_consent20=simple|220101;');
 
 	public function collectData() {
 		$this->collectExpandableDatas(
@@ -63,51 +63,53 @@ class GolemBridge extends FeedExpander {
 
 	protected function parseItem($item) {
 		$item = parent::parseItem($item);
-        $item['content'] = $item['content'] ?? '';
+		$item['content'] = $item['content'] ?? '';
 		$uri = $item['uri'];
 
-        while ($uri) {
-            $articlePage = getSimpleHTMLDOMCached($uri, static::CACHE_TIMEOUT, static::HEADERS);
+		while ($uri) {
+			$articlePage = getSimpleHTMLDOMCached($uri, static::CACHE_TIMEOUT, static::HEADERS);
 
-            // URI without RSS feed reference
-            $item['uri'] = $articlePage->find('head meta[name="twitter:url"]', 0)->content;
+			// URI without RSS feed reference
+			$item['uri'] = $articlePage->find('head meta[name="twitter:url"]', 0)->content;
 
-            $item['content'] .= $this->extractContent($articlePage);
+			$item['content'] .= $this->extractContent($articlePage);
 
-            // next page
-            $nextUri = $articlePage->find('link[rel="next"]', 0);
-            $uri = $nextUri ? static::URI . $nextUri->href : null;
-        }
+			// next page
+			$nextUri = $articlePage->find('link[rel="next"]', 0);
+			$uri = $nextUri ? static::URI . $nextUri->href : null;
+		}
 
 		return $item;
 	}
 
 	private function extractContent($page) {
-        $item = '';
+		$item = '';
 
-        $article = $page->find('article', 0);
+		$article = $page->find('article', 0);
 
-        // delete known bad elements
-        foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc, #table-jtoc, .social-tools, #list-jtoc, div.tags, #breadcrumbs, .subscribe-newsletter, .clearfix, .teaser-widget, script') as $bad) {
-            $bad->outertext = '';
-        }
+		// delete known bad elements
+		foreach($article->find('div[id*="adtile"], #job-market, #seminars, div.gbox_affiliate, div.toc, #table-jtoc,
+			.social-tools, #list-jtoc, div.tags, #breadcrumbs, .subscribe-newsletter, .clearfix, .teaser-widget,
+			script') as $bad) {
+			$bad->outertext = '';
+		}
 
-        $header = $article->find('header', 0);
-        foreach($header->find('p, figure, .paged-cluster-header h1') as $element) {
-            $item .= $element;
-        }
+		$header = $article->find('header', 0);
+		foreach($header->find('p, figure, .paged-cluster-header h1') as $element) {
+			$item .= $element;
+		}
 
-        $content = $article->find('div.formatted', 0);
+		$content = $article->find('div.formatted', 0);
 
-        // fix image galleries (empty src attribute), additionally full image quality
-        foreach($content->find('img[data-src-full]') as $img) {
-            $img->src = $img->getAttribute('data-src-full');
-        }
+		// fix image galleries (empty src attribute), additionally full image quality
+		foreach($content->find('img[data-src-full]') as $img) {
+			$img->src = $img->getAttribute('data-src-full');
+		}
 
-        foreach($content->find('p, h1, h3, img') as $element) {
-            $item .= $element;
-        }
+		foreach($content->find('p, h1, h3, img') as $element) {
+			$item .= $element;
+		}
 
-        return $item;
-    }
+		return $item;
+	}
 }


### PR DESCRIPTION
I created a new bridge to provide full-text content from [golem.de](https://www.golem.de/).
It works surprisingly well, circumventing cookie banners and JavaScript.

This might be controversial, as golem.de [provides full-text rss feeds for paying customers](https://account.golem.de/product/subscription).

I will squash the commits if wanted.