### PR TITLE
[AtomFormat] Remove redundant fallback content

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -40,7 +40,7 @@ class AtomFormat extends FormatAbstract{
 		foreach($this->getItems() as $item) {
 			$entryTimestamp = $item->getTimestamp();
 			$entryTitle = $item->getTitle();
-			$entryContent = $item->getContent() ?? '';
+			$entryContent = $item->getContent();
 			$entryUri = $item->getURI();
 			$entryID = '';
 
@@ -63,6 +63,9 @@ class AtomFormat extends FormatAbstract{
 					$entryTitle = substr($entryTitle, 0, $wrapPos) . '...';
 				}
 			}
+
+			if (empty($entryContent))
+				$entryContent = ' ';
 
 			$entryAuthor = '';
 			if ($item->getAuthor()) {

--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -40,7 +40,7 @@ class AtomFormat extends FormatAbstract{
 		foreach($this->getItems() as $item) {
 			$entryTimestamp = $item->getTimestamp();
 			$entryTitle = $item->getTitle();
-			$entryContent = $item->getContent();
+			$entryContent = $item->getContent() ?? '';
 			$entryUri = $item->getURI();
 			$entryID = '';
 
@@ -63,9 +63,6 @@ class AtomFormat extends FormatAbstract{
 					$entryTitle = substr($entryTitle, 0, $wrapPos) . '...';
 				}
 			}
-
-			if (empty($entryContent))
-				$entryContent = $entryTitle;
 
 			$entryAuthor = '';
 			if ($item->getAuthor()) {

--- a/tests/samples/expectedAtomFormat/feed.emptyItems.xml
+++ b/tests/samples/expectedAtomFormat/feed.emptyItems.xml
@@ -17,14 +17,14 @@
 		<published>2000-01-01T12:00:00+00:00</published>
 		<updated>2000-01-01T12:00:00+00:00</updated>
 		<id>urn:sha1:29f59918d266c56a935da13e4122b524298e5a39</id>
-		<content type="html">Sample Item #1</content>
+		<content type="html"> </content>
 	</entry>
 	<entry>
 		<title type="html">Sample Item #2</title>
 		<published>2000-01-01T12:00:00+00:00</published>
 		<updated>2000-01-01T12:00:00+00:00</updated>
 		<id>urn:sha1:edf358cad1a7ae255d6bc97640dd9d27738f1b7b</id>
-		<content type="html">Sample Item #2</content>
+		<content type="html"> </content>
 	</entry>
 
 </feed>


### PR DESCRIPTION
Currently, the default content for an Atom feed is the title, which is redundant. This was added for compliance with [RFC 4287](https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.2), but this can also be solved by having an empty content element. The feed is still valid as tested by the [validator](https://validator.w3.org/feed/) at the top of the file.