### PR TITLE
[PixivBridge] [UnsplashBridge] Fix deprecated null

### DIFF
--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -86,7 +86,7 @@ class PixivBridge extends BridgeAbstract {
 		switch($this->queriedContext) {
 		// Tags context
 		case '':
-			$uri = static::URI . 'tags/' . urlencode($this->getInput('tag'));
+			$uri = static::URI . 'tags/' . urlencode($this->getInput('tag') ?? '');
 			break;
 		case 'User':
 			$uri = static::URI . 'users/' . $this->getInput('userid');

--- a/bridges/UnsplashBridge.php
+++ b/bridges/UnsplashBridge.php
@@ -103,7 +103,7 @@ class UnsplashBridge extends BridgeAbstract
 
 	public function getName()
 	{
-		$filteredUser = $this->getInput('u');
+		$filteredUser = $this->getInput('u') ?? '';
 		if (strlen($filteredUser) > 0) {
 			return $filteredUser . ' - ' . self::NAME;
 		} else {


### PR DESCRIPTION
Deprecations present in debug mode which are fixed by this PR:
```
Deprecated: urlencode(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/http/rss-bridge/bridges/PixivBridge.php on line 89

Deprecated: urlencode(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/http/rss-bridge/bridges/PixivBridge.php on line 89

Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/http/rss-bridge/bridges/UnsplashBridge.php on line 107
```