### PR TITLE
[TwitterV2Bridge] Don't hide quote tweets

### DIFF
--- a/bridges/TwitterV2Bridge.php
+++ b/bridges/TwitterV2Bridge.php
@@ -330,11 +330,12 @@ EOD
 			}
 
 			// Check if Retweet or Reply
-			$retweetTypes = array('retweeted', 'quoted');
+			//$retweetTypes = array('retweeted', 'quoted');
 			$isRetweet = false;
 			$isReply = false;
 			if(isset($tweet->referenced_tweets)) {
-				if(in_array($tweet->referenced_tweets[0]->type, $retweetTypes)) {
+				//if(in_array($tweet->referenced_tweets[0]->type, $retweetTypes)) {
+				if($tweet->referenced_tweets[0]->type === 'retweeted') {
 					$isRetweet = true;
 				} elseif ($tweet->referenced_tweets[0]->type === 'replied_to') {
 					$isReply = true;


### PR DESCRIPTION
Quote Tweets were incorrectly being hidden when "Without Retweets" option was selected. This fixes #2695.

I will attempt to tackle #2697 next, to embed quoted tweets. Obviously a very related request, but I didn't want to delay in submitting this PR as I'm not sure how long it will take to complete the next part.