### PR TITLE
[XenForoBridge] Fix error if message is < 70 chars

### DIFF
--- a/bridges/XenForoBridge.php
+++ b/bridges/XenForoBridge.php
@@ -269,7 +269,7 @@ class XenForoBridge extends BridgeAbstract {
 			$item['uri'] = $url . '#' . $post->getAttribute('id');
 
 			$title = $post->find('div[class~="message-content"] article', 0)->plaintext;
-			$end = strpos($title, ' ', 70);
+			$end = strpos($title, ' ', min(70, strlen($title)));
 			$item['title'] = substr($title, 0, $end);
 
 			if ($post->find('time[datetime]', 0)) {


### PR DESCRIPTION
Using php 8.1.
Don't know how to make the change prettier.

At the time of writing, this occurs on the following thread:
https://forum.xda-developers.com/t/optimized-lineageos19-1-v4-0-23apr.4426575/

Fixes the following error:
ValueError: strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack) in ./rss-bridge/bridges/XenForoBridge.php:272
Stack trace:
0 ./rss-bridge/bridges/XenForoBridge.php(272): strpos()
1 ./rss-bridge/bridges/XenForoBridge.php(146): XenForoBridge->extractThreadPostsV2()
2 ./rss-bridge/actions/DisplayAction.php(134): XenForoBridge->collectData()
3 ./rss-bridge/index.php(24): DisplayAction->execute()
4 {main}