### PR TITLE
[GiteaBridge] Rewrite to decouple from Gogs and add contexts

### DIFF
--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -68,9 +68,9 @@ class GiteaBridge extends BridgeAbstract {
 		),
 		'Pull requests' => array(
 			'include_description' => array(
-				'name' => 'Include issue description',
+				'name' => 'Include pull request description',
 				'type' => 'checkbox',
-				'title' => 'Activate to include the issue description',
+				'title' => 'Activate to include the pull request description',
 			),
 		),
 		'Releases' => array(),

--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -256,13 +256,21 @@ class GiteaBridge extends BridgeAbstract {
 				continue;
 			}
 			$commentLink = $comment->find('a[href*="#issue"]', 0);
-			$this->items[] = array(
-				'uri' => $commentLink->href,
-				'title' => str_replace($commentLink->plaintext, '', $comment->find('span', 0)->plaintext),
+			$item = array(
 				'author' => $comment->find('a.author', 0)->plaintext,
-				'timestamp' => $comment->find('.time-since', 0)->title,
 				'content' => $comment->find('.render-content', 0),
 			);
+			if ($commentLink !== null) {
+				// Regular comment
+				$item['uri'] = $commentLink->href;
+				$item['title'] = str_replace($commentLink->plaintext, '', $comment->find('span', 0)->plaintext);
+				$item['timestamp'] = $comment->find('.time-since', 0)->title;
+			} else {
+				// Change request comment
+				$item['uri'] = $this->getURI() . '#' . $comment->getAttribute('id');
+				$item['title'] = $comment->find('.comment-header .text', 0)->plaintext;
+			}
+			$this->items[] = $item;
 		}
 
 		$this->items = array_reverse($this->items);

--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -259,7 +259,7 @@ class GiteaBridge extends BridgeAbstract {
 			$this->items[] = array(
 				'uri' => $commentLink->href,
 				'title' => str_replace($commentLink->plaintext, '', $comment->find('span', 0)->plaintext),
-				'author' => $comment->find('.author a', 0)->plaintext,
+				'author' => $comment->find('a.author', 0)->plaintext,
 				'timestamp' => $comment->find('.time-since', 0)->title,
 				'content' => $comment->find('.render-content', 0),
 			);

--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -88,10 +88,10 @@ class GiteaBridge extends BridgeAbstract {
 			case 'Commits':
 			case 'Issues':
 			case 'Pull requests':
-			case 'Releases': return $this->title . ' ' . $this->queriedContext;
-			case 'Single issue': return ' Issue ' . $this->getInput('issue') . ': ' . $this->title;
+			case 'Releases':
+			case 'Tags': return $this->title . ' ' . $this->queriedContext;
+			case 'Single issue': return 'Issue ' . $this->getInput('issue') . ': ' . $this->title;
 			case 'Single pull request': return 'Pull request ' . $this->getInput('pull_request') . ': ' . $this->title;
-			case 'Tags': return 'Tags for ' . $this->title;
 			default: return parent::getName();
 		}
 	}

--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -1,17 +1,144 @@
 <?php
 /**
- * Gitea is a fork of Gogs which may diverge in the future.
+ * Gitea is a community managed lightweight code hosting solution.
  * https://docs.gitea.io/en-us/
  */
-require_once 'GogsBridge.php';
 
-class GiteaBridge extends GogsBridge {
+class GiteaBridge extends BridgeAbstract {
 
 	const NAME = 'Gitea';
 	const URI = 'https://gitea.io';
 	const DESCRIPTION = 'Returns the latest issues, commits or releases';
-	const MAINTAINER = 'logmanoriginal';
+	const MAINTAINER = 'gileri';
 	const CACHE_TIMEOUT = 300; // 5 minutes
+
+	const PARAMETERS = array(
+		'global' => array(
+			'host' => array(
+				'name' => 'Host',
+				'exampleValue' => 'https://try.gitea.io',
+				'required' => true,
+				'title' => 'Host name with its protocol, without trailing slash',
+			),
+			'user' => array(
+				'name' => 'Username',
+				'exampleValue' => 'gitea',
+				'required' => true,
+				'title' => 'User name as it appears in the URL',
+			),
+			'project' => array(
+				'name' => 'Project name',
+				'exampleValue' => 'gitea',
+				'required' => true,
+				'title' => 'Project name as it appears in the URL',
+			),
+		),
+		'Commits' => array(
+			'branch' => array(
+				'name' => 'Branch name',
+				'defaultValue' => 'master',
+				'required' => true,
+				'title' => 'Branch name as it appears in the URL',
+			),
+		),
+		'Issues' => array(
+			'include_description' => array(
+				'name' => 'Include issue description',
+				'type' => 'checkbox',
+				'title' => 'Activate to include the issue description',
+			),
+		),
+		'Single issue' => array(
+			'issue' => array(
+				'name' => 'Issue number',
+				'type' => 'number',
+				'exampleValue' => 100,
+				'required' => true,
+				'title' => 'Issue number from the issues list',
+			),
+		),
+		'Releases' => array(),
+		'Tags' => array(),
+	);
+
+	private $title = '';
+
+	public function getIcon() {
+		return 'https://gitea.io/images/gitea.png';
+	}
+
+	public function getName() {
+		switch($this->queriedContext) {
+			case 'Commits':
+			case 'Issues':
+			case 'Releases': return $this->title . ' ' . $this->queriedContext;
+			case 'Single issue': return ' Issue ' . $this->getInput('issue') . ': ' . $this->title;
+			case 'Tags': return 'Tags for ' . $this->title;
+			default: return parent::getName();
+		}
+	}
+
+	public function getURI() {
+		switch($this->queriedContext) {
+			case 'Commits': {
+				return $this->getInput('host')
+				. '/' . $this->getInput('user')
+				. '/' . $this->getInput('project')
+				. '/commits/' . $this->getInput('branch');
+			} break;
+			case 'Issues': {
+				return $this->getInput('host')
+				. '/' . $this->getInput('user')
+				. '/' . $this->getInput('project')
+				. '/issues/';
+			} break;
+			case 'Single issue': {
+				return $this->getInput('host')
+				. '/' . $this->getInput('user')
+				. '/' . $this->getInput('project')
+				. '/issues/' . $this->getInput('issue');
+			} break;
+			case 'Releases': {
+				return $this->getInput('host')
+				. '/' . $this->getInput('user')
+				. '/' . $this->getInput('project')
+				. '/releases/';
+			} break;
+			case 'Tags': {
+				return $this->getInput('host')
+				. '/' . $this->getInput('user')
+				. '/' . $this->getInput('project')
+				. '/tags/';
+			} break;
+			default: return parent::getURI();
+		}
+	}
+
+	public function collectData() {
+		$html = getSimpleHTMLDOM($this->getURI())
+			or returnServerError('Could not request ' . $this->getURI());
+		$html = defaultLinkTo($html, $this->getURI());
+
+		$this->title = $html->find('[property="og:title"]', 0)->content;
+
+		switch($this->queriedContext) {
+			case 'Commits': {
+				$this->collectCommitsData($html);
+			} break;
+			case 'Issues': {
+				$this->collectIssuesData($html);
+			} break;
+			case 'Single issue': {
+				$this->collectSingleIssueData($html);
+			} break;
+			case 'Releases': {
+				$this->collectReleasesData($html);
+			} break;
+			case 'Tags': {
+				$this->collectTagsData($html);
+			} break;
+		}
+	}
 
 	protected function collectReleasesData($html) {
 		$releases = $html->find('#release-list > li')
@@ -19,9 +146,83 @@ class GiteaBridge extends GogsBridge {
 
 		foreach($releases as $release) {
 			$this->items[] = array(
+				'author' => $release->find('.author', 0)->plaintext,
 				'uri' => $release->find('a', 0)->href,
-				'title' => 'Release ' . $release->find('h3', 0)->plaintext,
+				'title' => 'Release ' . $release->find('h4', 0)->plaintext,
+				'timestamp' => $release->find('.time-since', 0)->title,
 			);
 		}
+	}
+
+	protected function collectTagsData($html) {
+		$tags = $html->find('table#tags-table > tbody > tr')
+			or returnServerError('Unable to find tags');
+
+		foreach($tags as $tag) {
+			$this->items[] = array(
+				'uri' => $tag->find('a', 0)->href,
+				'title' => 'Tag ' . $tag->find('.release-tag-name > a', 0)->plaintext,
+			);
+		}
+	}
+
+	protected function collectCommitsData($html) {
+		$commits = $html->find('#commits-table tbody tr')
+			or returnServerError('Unable to find commits');
+
+		foreach($commits as $commit) {
+			$this->items[] = array(
+				'uri' => $commit->find('a.sha', 0)->href,
+				'title' => $commit->find('.message span', 0)->plaintext,
+				'author' => $commit->find('.author', 0)->plaintext,
+				'timestamp' => $commit->find('.time-since', 0)->title,
+				'uid' => $commit->find('.sha', 0)->plaintext,
+			);
+		}
+	}
+
+	protected function collectIssuesData($html) {
+		$issues = $html->find('.issue.list li')
+			or returnServerError('Unable to find issues');
+
+		foreach($issues as $issue) {
+			$uri = $issue->find('a', 0)->href;
+
+			$item = array(
+				'uri' => $uri,
+				'title' => trim($issue->find('a.index', 0)->plaintext) . ' | ' . $issue->find('a.title', 0)->plaintext,
+				'author' => $issue->find('.desc a', 1)->plaintext,
+				'timestamp' => $issue->find('.time-since', 0)->title,
+			);
+
+			if($this->getInput('include_description')) {
+				$issue_html = getSimpleHTMLDOMCached($uri, 3600)
+					or returnServerError('Unable to load issue description');
+
+				$issue_html = defaultLinkTo($issue_html, $uri);
+
+				$item['content'] = $issue_html->find('.comment .markup', 0);
+			}
+
+			$this->items[] = $item;
+		}
+	}
+
+	protected function collectSingleIssueData($html) {
+		$comments = $html->find('.comment')
+			or returnServerError('Unable to find comments');
+
+		foreach($comments as $comment) {
+			$commentLink = $comment->find('a[href*="#issue"]', 0);
+			$this->items[] = array(
+				'uri' => $commentLink->href,
+				'title' => str_replace($commentLink->plaintext, '', $comment->find('span', 0)->plaintext),
+				'author' => $comment->find('.author a', 0)->plaintext,
+				'timestamp' => $comment->find('.time-since', 0)->title,
+				'content' => $comment->find('.render-content', 0),
+			);
+		}
+
+		$this->items = array_reverse($this->items);
 	}
 }

--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -16,7 +16,7 @@ class GiteaBridge extends BridgeAbstract {
 		'global' => array(
 			'host' => array(
 				'name' => 'Host',
-				'exampleValue' => 'https://try.gitea.io',
+				'exampleValue' => 'https://gitea.com',
 				'required' => true,
 				'title' => 'Host name with its protocol, without trailing slash',
 			),
@@ -28,7 +28,7 @@ class GiteaBridge extends BridgeAbstract {
 			),
 			'project' => array(
 				'name' => 'Project name',
-				'exampleValue' => 'gitea',
+				'exampleValue' => 'helm-chart',
 				'required' => true,
 				'title' => 'Project name as it appears in the URL',
 			),


### PR DESCRIPTION
Continuation of #2670.

This PR makes separates GiteaBridge from GogsBridge, and make it compatible with Gitea 1.0 and 1.17 (at least).
If a compatibility issue on a version between those two, I'd be happy to fix it.

It also implements the Tags, Pull Request, and Single pull request bridge context.