### PR TITLE
refactor: switch to nginx in docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,7 @@ pip-log.txt
 /whitelist.txt
 DEBUG
 config.ini.php
+config/*
 
 ######################
 ## VisualStudioCode ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ RUN apt-get update && \
       zlib1g-dev \
       libmemcached-dev && \
     pecl install memcached && \
-    docker-php-ext-enable memcached
-
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+    docker-php-ext-enable memcached \
+    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY ./config/nginx.conf /etc/nginx/sites-enabled/default
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,21 @@
-FROM php:7-apache-buster
+FROM php:7.4.29-fpm
 
 LABEL description="RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for websites that don't have one."
 LABEL repository="https://github.com/RSS-Bridge/rss-bridge"
 LABEL website="https://github.com/RSS-Bridge/rss-bridge"
 
-ENV APACHE_DOCUMENT_ROOT=/app
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+      nginx \
+      zlib1g-dev \
+      libmemcached-dev && \
+    pecl install memcached && \
+    docker-php-ext-enable memcached
 
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
-	&& apt-get --yes update \
-	&& apt-get --yes --no-install-recommends install \
-		zlib1g-dev \
-		libmemcached-dev \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& pecl install memcached \
-	&& docker-php-ext-enable memcached \
-	&& sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
-	&& sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
-	&& sed -ri -e 's/(MinProtocol\s*=\s*)TLSv1\.2/\1None/' /etc/ssl/openssl.cnf \
-	&& sed -ri -e 's/(CipherString\s*=\s*DEFAULT)@SECLEVEL=2/\1/' /etc/ssl/openssl.cnf
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+COPY ./config/nginx.conf /etc/nginx/sites-enabled/default
 
 COPY --chown=www-data:www-data ./ /app/
 
-CMD ["/app/docker-entrypoint.sh"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
       zlib1g-dev \
       libmemcached-dev && \
     pecl install memcached && \
-    docker-php-ext-enable memcached \
+    docker-php-ext-enable memcached && \
     mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY ./config/nginx.conf /etc/nginx/sites-enabled/default

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80 default_server;
+    root /app;
+    access_log /var/log/nginx/rssbridge.access.log;
+    error_log /var/log/nginx/rssbridge.error.log;
+    index index.php;
+
+    location ~ /(\.|vendor|tests) {
+        deny all;
+        return 403; # Forbidden
+    }
+
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass 127.0.0.1:9000;
+    }
+}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,9 +32,11 @@ done
 # If docker is run on network:service mode, no two containers can use port 80
 # To use this, start the container with the additional environment variable "HTTP_PORT"
 if [ ! -z ${HTTP_PORT} ]; then
-	sed -i "s/80/$HTTP_PORT/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+	sed -i "s/80/$HTTP_PORT/g" /etc/nginx/sites-enabled/default
 fi
 
+# nginx will daemonize
+nginx
 
-# Start apache
-apache2-foreground
+# php-fpm will not
+php-fpm


### PR DESCRIPTION
TLDR: nginx is better.

Also I (we?) are more familiar with nginx so it becomes easier to introduce a new document root while not breaking BC.

Removed some TLS cruft. They are not used.