### PR TITLE
[BakaUpdatesMangaReleasesBridge] Fix description

### DIFF
--- a/bridges/BakaUpdatesMangaReleasesBridge.php
+++ b/bridges/BakaUpdatesMangaReleasesBridge.php
@@ -8,9 +8,12 @@ class BakaUpdatesMangaReleasesBridge extends BridgeAbstract {
 		'By series' => array(
 			'series_id' => array(
 				'name'		=> 'Series ID',
+				'title'		=> 'This is obtained from the "Search for all
+				releases of this series" link on the title page. For example:
+https://www.mangaupdates.com/releases.html?search=17360452316&stype=series',
 				'type'		=> 'number',
 				'required'	=> true,
-				'exampleValue'	=> '188066'
+				'exampleValue'	=> '17360452316'
 			)
 		),
 		'By list' => array(


### PR DESCRIPTION
See #2731

Separate from that issue: It looks like public lists now require log in to view. I think we should wait for a month or so and then remove the lists context if they are still private.