### PR TITLE
[Mastodon] Use ActivityPub outbox for Mastodon (et al.) feed

### DIFF
--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -65,11 +65,9 @@ class MastodonBridge extends FeedExpander {
 				'Content-Type: application/jrd+json'
 			);
 			$webfinger = json_decode(getContents($webfingerUrl, $webfingerHeader), true);
-			if ($webfinger['subject'] == $resource) {
-				foreach ($webfinger['links'] as $link) {
-					if ($link['type'] == 'application/activity+json')
-						return $link['href'] . '/outbox?page=true';
-				}
+			foreach ($webfinger['links'] as $link) {
+				if ($link['type'] == 'application/activity+json')
+					return $link['href'];
 			}
 		}
 
@@ -77,7 +75,7 @@ class MastodonBridge extends FeedExpander {
 	}
 
 	public function collectData(){
-		$url = $this->getURI();
+		$url = $this->getURI() . '/outbox?page=true';
 		$content = json_decode(getContents($url, self::AP_HEADER), true);
 		if ($content['id'] == $url) {
 			foreach ($content['orderedItems'] as $status) {

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -10,7 +10,7 @@ class MastodonBridge extends FeedExpander {
 	const MAINTAINER = 'Austin Huang';
 	const NAME = 'Mastodon Bridge';
 	const CACHE_TIMEOUT = 900; // 15mn
-	const DESCRIPTION = 'Returns recent statuses for a Mastodon account. May support other ActivityPub-compatible accounts.';
+	const DESCRIPTION = 'Returns recent statuses. May support other ActivityPub-compatible accounts.';
 	const URI = 'https://mastodon.social';
 
 	const PARAMETERS = array(array(
@@ -83,8 +83,7 @@ class MastodonBridge extends FeedExpander {
 			foreach ($content['orderedItems'] as $status) {
 				$this->items[] = $this->parseItem($status);
 			}
-		}
-		else returnServerError('Unexpected response from server.');
+		} else returnServerError('Unexpected response from server.');
 	}
 
 	protected function parseItem($content) {
@@ -120,13 +119,14 @@ class MastodonBridge extends FeedExpander {
 	protected function parseObject($object, $item) {
 		$item['content'] = $object['content'];
 		if (strlen(strip_tags($object['content'])) > 75) {
-			$item['title'] = $item['title'] . substr(strip_tags($object['content']), 0, strpos(wordwrap(strip_tags($object['content']), 75), "\n")) . '...';
-		}
-		else $item['title'] = $item['title'] . strip_tags($object['content']);
+			$item['title'] = $item['title'] .
+							 substr(strip_tags($object['content']), 0, strpos(wordwrap(strip_tags($object['content']), 75), "\n")) . '...';
+		} else $item['title'] = $item['title'] . strip_tags($object['content']);
 		$item['uri'] = $object['id'];
 		foreach ($object['attachment'] as $attachment) {
 			// Only process REMOTE pictures (prevent xss)
-			if (preg_match('/^image\//', $attachment['mediaType'], $match) && preg_match('/^http(s|):\/\//', $attachment['url'], $match)) {
+			if (preg_match('/^image\//', $attachment['mediaType'], $match) &&
+				preg_match('/^http(s|):\/\//', $attachment['url'], $match)) {
 				$item['content'] = $item['content'] . '<br /><img ';
 				if ($attachment['name']) $item['content'] = $item['content'] . 'alt="' . $attachment['name'] . '" ';
 				$item['content'] = $item['content'] . 'src="' . $attachment['url'] . '" />';

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -2,15 +2,16 @@
 
 class MastodonBridge extends BridgeAbstract {
 	// This script attempts to imitiate the behaviour of a read-only ActivityPub server
-	// to read the outbox.
+	// to read the outbox. This does not support instances that require HTTP signatures
+	// for ActivityPub endpoints.
 
 	// Note: Most PixelFed instances have ActivityPub outbox disabled,
-	// use the official feed: https://pixelfed.instance/users/username.atom (Posts only)
+	// so use the official feed: https://pixelfed.instance/users/username.atom (Posts only)
 
 	const MAINTAINER = 'Austin Huang';
-	const NAME = 'Mastodon Bridge';
+	const NAME = 'ActivityPub Bridge';
 	const CACHE_TIMEOUT = 900; // 15mn
-	const DESCRIPTION = 'Returns recent statuses. May support other ActivityPub-compatible accounts.';
+	const DESCRIPTION = 'Returns recent statuses. Supports ActivityPub-compatible platforms, including Mastodon, Pleroma and Misskey.';
 	const URI = 'https://mastodon.social';
 
 	const PARAMETERS = array(array(
@@ -80,14 +81,15 @@ class MastodonBridge extends BridgeAbstract {
 		$content = json_decode(getContents($url, self::AP_HEADER), true);
 		if ($content['id'] === $url) {
 			foreach ($content['orderedItems'] as $status) {
-				$this->items[] = $this->parseItem($status);
+				$users = array();
+				$this->items[] = $this->parseItem($status, $users);
 			}
 		} else {
 			throw new \Exception('Unexpected response from server.');
 		}
 	}
 
-	protected function parseItem($content) {
+	protected function parseItem($content, &$users) {
 		$item = array();
 		switch ($content['type']) {
 			case 'Announce': // boost
@@ -97,21 +99,31 @@ class MastodonBridge extends BridgeAbstract {
 				// We fetch the boosted content.
 				try {
 					$rtContent = json_decode(getContents($content['object'], self::AP_HEADER), true);
-					// We fetch the author, since we cannot always assume the format of the URL.
-					$user = json_decode(getContents($rtContent['attributedTo'], self::AP_HEADER), true);
-					preg_match('/http(|s):\/\/([a-z0-9-\.]{0,})\//', $rtContent['attributedTo'], $matches);
-					$rtUser = '@' . $user['preferredUsername'] . '@' . $matches[2];
-					$item['author'] = $rtUser;
-					$item['title'] = 'Shared a status by ' . $rtUser . ': ';
-					$item = $this->parseObject($rtContent, $item);
-				} catch (Throwable $th) {
+					if ($rtContent['attributedTo'] && isset($users[$rtContent['attributedTo']])) {
+						$item['author'] = $users[$rtContent['attributedTo']];
+						$item['title'] = 'Shared a status by ' . $item['author'] . ': ';
+						$item = $this->parseObject($rtContent, $item);
+					} else {
+						// We fetch the author, since we cannot always assume the format of the URL.
+						$user = json_decode(getContents($rtContent['attributedTo'], self::AP_HEADER), true);
+						preg_match('/http(|s):\/\/([a-z0-9-\.]{0,})\//', $rtContent['attributedTo'], $matches);
+						// We assume that the server name as indicated by the path is the actual server name,
+						// since using webfinger to delegate domains is not officially supported, and it only
+						// seems to work in one way.
+						$rtUser = '@' . $user['preferredUsername'] . '@' . $matches[2];
+						$users[$rtContent['attributedTo']] = $rtUser;
+						$item['author'] = $rtUser;
+						$item['title'] = 'Shared a status by ' . $rtUser . ': ';
+						$item = $this->parseObject($rtContent, $item);
+					}
+				} catch (UnexpectedResponseException $th) {
 					$item['title'] = 'Shared an unreachable status: ' . $content['object'];
 					$item['content'] = $content['object'];
 					$item['uri'] = $content['object'];
 				}
 				break;
 			case 'Create':
-				if ($this->getInput('norep') && $content['object']['inReplyTo']) {
+				if ($this->getInput('norep') && isset($content['object']['inReplyTo'])) {
 					return null;
 				}
 				$item['author'] = $this->getInput('canusername');

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -10,7 +10,9 @@ class MastodonBridge extends BridgeAbstract {
 	const MAINTAINER = 'Austin Huang';
 	const NAME = 'ActivityPub Bridge';
 	const CACHE_TIMEOUT = 900; // 15mn
-	const DESCRIPTION = 'Returns recent statuses. Supports Mastodon, Pleroma and Misskey, among others.';
+	const DESCRIPTION = 'Returns recent statuses. Supports Mastodon, Pleroma and Misskey, among others. Access to
+	instances that have Authorized Fetch enabled requires
+	<a href="https://rss-bridge.github.io/rss-bridge/Bridge_Specific/ActivityPub_(Mastodon).html">configuration</a>.';
 	const URI = 'https://mastodon.social';
 
 	// Some Mastodon instances use Secure Mode which requires all requests to be signed.

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -8,9 +8,9 @@ class MastodonBridge extends FeedExpander {
 	// use the official feed: https://pixelfed.instance/users/username.atom (Posts only)
 
 	const MAINTAINER = 'Austin Huang';
-	const NAME = 'ActivityPub (Mastodon, Pleroma, Misskey...) Bridge';
+	const NAME = 'Mastodon Bridge';
 	const CACHE_TIMEOUT = 900; // 15mn
-	const DESCRIPTION = 'Returns recent statuses for an ActivityPub-compatible account.';
+	const DESCRIPTION = 'Returns recent statuses for a Mastodon account. May support other ActivityPub-compatible accounts.';
 	const URI = 'https://mastodon.social';
 
 	const PARAMETERS = array(array(

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -22,13 +22,13 @@ class MastodonBridge extends FeedExpander {
 		'norep' => array(
 			'name' => 'Without replies',
 			'type' => 'checkbox',
-			'title' => 'Only return initial statuses'
+			'title' => 'Only return statuses that are not replies, as determined by relations (not mentions).'
 		),
 		'noboost' => array(
 			'name' => 'Without boosts',
 			'required' => false,
 			'type' => 'checkbox',
-			'title' => 'Hide boosts'
+			'title' => 'Hide boosts. Note that RSS-Bridge will fetch the original status from other federated instances.'
 			)
 		));
 
@@ -102,7 +102,9 @@ class MastodonBridge extends FeedExpander {
 					$item['title'] = 'Shared a status by ' . $rtUser . ': ';
 					$item = $this->parseObject($rtContent, $item);
 				} catch (Throwable $th) {
-					return null;
+					$item['title'] = 'Shared an unreachable status: ' . $content['object'];
+					$item['content'] = $content['object'];
+					$item['uri'] = $content['object'];
 				}
 				break;
 			case 'Create':
@@ -125,7 +127,7 @@ class MastodonBridge extends FeedExpander {
 		$item['uri'] = $object['id'];
 		foreach ($object['attachment'] as $attachment) {
 			// Only process REMOTE pictures (prevent xss)
-			if (preg_match('/^image\//', $attachment['mediaType'], $match) &&
+			if ($attachment['mediaType'] && preg_match('/^image\//', $attachment['mediaType'], $match) &&
 				preg_match('/^http(s|):\/\//', $attachment['url'], $match)) {
 				$item['content'] = $item['content'] . '<br /><img ';
 				if ($attachment['name']) $item['content'] = $item['content'] . 'alt="' . $attachment['name'] . '" ';

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -11,7 +11,7 @@ class MastodonBridge extends BridgeAbstract {
 	const MAINTAINER = 'Austin Huang';
 	const NAME = 'ActivityPub Bridge';
 	const CACHE_TIMEOUT = 900; // 15mn
-	const DESCRIPTION = 'Returns recent statuses. Supports ActivityPub-compatible platforms, including Mastodon, Pleroma and Misskey.';
+	const DESCRIPTION = 'Returns recent statuses. Supports Mastodon, Pleroma and Misskey, among others.';
 	const URI = 'https://mastodon.social';
 
 	const PARAMETERS = array(array(

--- a/docs/10_Bridge_Specific/ActivityPub_(Mastodon).md
+++ b/docs/10_Bridge_Specific/ActivityPub_(Mastodon).md
@@ -2,7 +2,7 @@
 
 Certain ActivityPub implementations, such as [Mastodon](https://docs.joinmastodon.org/spec/security/#http) and [Pleroma](https://docs-develop.pleroma.social/backend/configuration/cheatsheet/#activitypub), allow instances to require requests to ActivityPub endpoints to be signed. RSS-Bridge can handle the HTTP signature header if a private key is provided, while the ActivityPub instance must be able to know the corresponding public key.
 
-You do **not** need to configure this if their usage is limited to accessing ActivityPub instances that do not have such requirements.
+You do **not** need to configure this if the usage on your RSS-Bridge instance is limited to accessing ActivityPub instances that do not have such requirements. While the majority of ActivityPub instances don't have them at the time of writing, the situation may change in the future.
 
 ## Configuration
 
@@ -27,7 +27,7 @@ $ openssl rsa -in private.pem -outform PEM -pubout -out public.pem
 	}]
 }
 ```
-5. Serve the following page at `https://DOMAIN/actor`, replacing the value of `publicKeyPem` with the contents of the `public.pem` file in step 2:
+5. Serve the following page at `https://DOMAIN/actor`, replacing the value of `publicKeyPem` with the contents of the `public.pem` file in step 2, with all line breaks substituted with `\n`:
 ```json
 {
     "@context": [
@@ -54,4 +54,4 @@ key_id = "https://DOMAIN/actor#main-key"
 
 ## Considerations
 
-Any ActivityPub instance your users requested content from will be able to identify requests from your RSS-Bridge instance by the domain you specified in the configuration. This also means that an ActivityPub instance may choose to block this domain should they judge your instance's usage excessive. Therefore, public instance operators may need to monitor for abuse and communicate with ActivityPub instance admins when necessary.
+Any ActivityPub instance your users requested content from will be able to identify requests from your RSS-Bridge instance by the domain you specified in the configuration. This also means that an ActivityPub instance may choose to block this domain should they judge your instance's usage excessive. Therefore, public instance operators should monitor for abuse and prepare to communicate with ActivityPub instance admins when necessary. You may also leave contact information as the `summary` value in the actor JSON (step 5).

--- a/docs/10_Bridge_Specific/ActivityPub_(Mastodon).md
+++ b/docs/10_Bridge_Specific/ActivityPub_(Mastodon).md
@@ -1,0 +1,57 @@
+# MastodonBridge (aka. ActivityPub Bridge)
+
+Certain ActivityPub implementations, such as [Mastodon](https://docs.joinmastodon.org/spec/security/#http) and [Pleroma](https://docs-develop.pleroma.social/backend/configuration/cheatsheet/#activitypub), allow instances to require requests to ActivityPub endpoints to be signed. RSS-Bridge can handle the HTTP signature header if a private key is provided, while the ActivityPub instance must be able to know the corresponding public key.
+
+You do **not** need to configure this if their usage is limited to accessing ActivityPub instances that do not have such requirements.
+
+## Configuration
+
+[This article](https://blog.joinmastodon.org/2018/06/how-to-implement-a-basic-activitypub-server/) is referenced.
+
+1. Select a domain. It may, but does not need to, be the one RSS-Bridge is on. For all subsequent steps, replace `DOMAIN` with this domain.
+2. Run the following commands on your machine:
+```bash
+$ openssl genrsa -out private.pem 2048
+$ openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+```
+3. Place `private.pem` in an appropriate location and note down its absolute path.
+4. Serve the following page at `https://DOMAIN/.well-known/webfinger`:
+```json
+{
+	"subject": "acct:DOMAIN@DOMAIN",
+	"aliases": ["https://DOMAIN/actor"],
+	"links": [{
+		"rel": "self",
+		"type": "application/activity+json",
+		"href": "https://DOMAIN/actor"
+	}]
+}
+```
+5. Serve the following page at `https://DOMAIN/actor`, replacing the value of `publicKeyPem` with the contents of the `public.pem` file in step 2:
+```json
+{
+    "@context": [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/v1"
+    ],
+    "id": "https://DOMAIN/actor",
+    "type": "Application",
+    "inbox": "https://DOMAIN/actor/inbox",
+    "preferredUsername": "DOMAIN",
+    "publicKey": {
+        "id": "https://DOMAIN/actor#main-key",
+        "owner": "https://DOMAIN/actor",
+        "publicKeyPem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n"
+    }
+}
+```
+6. Add the following configuration in `config.ini.php` in your RSS-Bridge folder, replacing the path with the one from step 3:
+```ini
+[MastodonBridge]
+private_key = "/absolute/path/to/your/private.pem"
+key_id = "https://DOMAIN/actor#main-key"
+```
+
+## Considerations
+
+Any ActivityPub instance your users requested content from will be able to identify requests from your RSS-Bridge instance by the domain you specified in the configuration. This also means that an ActivityPub instance may choose to block this domain should they judge your instance's usage excessive. Therefore, public instance operators may need to monitor for abuse and communicate with ActivityPub instance admins when necessary.


### PR DESCRIPTION
Closes #2754.

In theory this supports all ActivityPub-compatible software[^1]. This may warrant renaming the bridge (not included in PR).

Example: https://rssbridge.bus-hit.me/?action=display&bridge=Mastodon&canusername=%40austin%40ieji.de&format=Html

[^1]: I have tested it on [Pleroma](https://pleroma.social) and [Misskey](https://misskey-hub.net/) instances. AFAIK it supports certain [Pixelfed](https://pixelfed.org/) instances, but [the official one has ActivityPub outbox disabled](https://github.com/pixelfed/pixelfed/issues/1850#issuecomment-560225625).