### PR TITLE
[GolemBridge] Remove image galleries

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -111,12 +111,12 @@ class GolemBridge extends FeedExpander {
 
 		$content = $article->find('div.formatted', 0);
 
-		// fix image galleries (empty src attribute), additionally full image quality
-		foreach($content->find('img[data-src-full]') as $img) {
+		// full image quality
+		foreach($content->find('img[data-src-full][src*="."]') as $img) {
 			$img->src = $img->getAttribute('data-src-full');
 		}
 
-		foreach($content->find('p, h1, h3, img') as $element) {
+		foreach($content->find('p, h1, h3, img[src*="."]') as $element) {
 			$item .= $element;
 		}
 


### PR DESCRIPTION
Do not add all images of the image gallery, but only the preselected one.

Often, the same gallery is used multiple times with different preselected
images. The previous implementation always added all images of the
gallery, cluttering the article. This patch only adds the preselected one.

The no-js link wrapping around the gallery leads to a 403 Forbidden
page, so linking that doesn't work to really support galleries.