### PR TITLE
Fix NGINX regression Docker Expose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ COPY ./config/nginx.conf /etc/nginx/sites-enabled/default
 
 COPY --chown=www-data:www-data ./ /app/
 
+EXPOSE 80
+
 ENTRYPOINT ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
https://github.com/RSS-Bridge/rss-bridge/pull/2721 introduced a regression by not properly declaring the exposed port in Dockerfile.
The Apache version did it correctly:
https://github.com/docker-library/php/blob/faf8864e3845ced80780c03eefc66c022e2f9ac1/8.1/buster/apache/Dockerfile#L289

The consequence is that other systems, e.g. Traefik, could not know what port to route to.