### PR TITLE
fix: incorrect encoding

### DIFF
--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -165,6 +165,6 @@ EOD;
 	}
 
 	private function xml_encode($text){
-		return htmlspecialchars($text, ENT_XML1);
+		return htmlspecialchars($text);
 	}
 }

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -95,6 +95,7 @@ class MrssFormat extends FormatAbstract {
 
 			$entryCategories = '';
 			foreach($item->getCategories() as $category) {
+				$category = $this->xml_encode($category);
 				$entryCategories .= '<category>'
 				. $category . '</category>'
 				. PHP_EOL;


### PR DESCRIPTION
This change makes sure that rss categories are encoded too.

Also fixes a problem in atom where " was not encoded.