### PR TITLE
fix: type error in function call

### DIFF
--- a/bridges/MarktplaatsBridge.php
+++ b/bridges/MarktplaatsBridge.php
@@ -77,7 +77,7 @@ class MarktplaatsBridge extends BridgeAbstract {
 			}
 		}
 		$url = 'https://www.marktplaats.nl/lrp/api/search?query=' . urlencode($this->getInput('q')) . $query;
-		$jsonString = getSimpleHTMLDOM($url, 900);
+		$jsonString = getSimpleHTMLDOM($url);
 		$jsonObj = json_decode($jsonString);
 		foreach($jsonObj->listings as $listing) {
 			if(!$excludeGlobal || $listing->location->distanceMeters >= 0) {


### PR DESCRIPTION
Fixes:
Argument 2 passed to getContents() must be of the type array, int given

This bug was introduced when refactoring the http client. The original intent was probably to cache the item for 900s.