### PR TITLE
[NotAlways] fix: broken url

### DIFF
--- a/bridges/NotAlwaysBridge.php
+++ b/bridges/NotAlwaysBridge.php
@@ -12,7 +12,7 @@ class NotAlwaysBridge extends BridgeAbstract {
 						'type' => 'list',
 						'name' => 'Filter',
 						'values' => array(
-								'All' => 'all',
+								'All' => '',
 								'Right' => 'right',
 								'Working' => 'working',
 								'Romantic' => 'romantic',


### PR DESCRIPTION
The /all url now actually points to a specific item.
I think we want the frontpage for this.

Fixes:
Fatal error: Uncaught Error: Call to a member function find() on null in NotAlwaysBridge.php:37