### PR TITLE
[NFLRUSBridge] Remove byte-order-mark

### DIFF
--- a/bridges/NFLRUSBridge.php
+++ b/bridges/NFLRUSBridge.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 class NFLRUSBridge extends BridgeAbstract {
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,6 +15,8 @@
   <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
   <!-- Do not override methods to call their parent -->
   <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+  <!-- Do not allow UTF-8 byte-order mark -->
+  <rule ref="Generic.Files.ByteOrderMark"/>
   <!-- Make sure the concatenation operator has spaces around it -->
   <rule ref="Squiz.Strings.ConcatenationSpacing">
     <properties>


### PR DESCRIPTION
With UTF-8 byte-order mark in the file, the `ListActionTest::testOutput` would fail after converting tests to [PSR-4 namespaces](https://github.com/RSS-Bridge/rss-bridge/pull/2771):

    invalid JSON output: Syntax error
    Failed asserting that null is not null.

This is because ListAction::execute tries to create the bridge objects and, when the files containing the bridge classes are not loaded yet, the autoloader starts including them. Since this happens after output buffering has begun, any text in the PHP file before the `<?php` tag such as the BOM will end up in the buffer to be parsed by `json_decode`.

Previously, it worked by chance thanks to some other test including the file before `ListActionTest`. With the restructuring, `Actions\ListActionTest` will run sooner and become responsible for triggering the autoloader.

To prevent this in the future, I also disallowed BOM in the coding style.
