### PR TITLE
[FormatAbstract]: Ensure sanitizeHtml is given string

### DIFF
--- a/formats/JsonFormat.php
+++ b/formats/JsonFormat.php
@@ -49,7 +49,7 @@ class JsonFormat extends FormatAbstract {
 			$entryTitle = $item->getTitle();
 			$entryUri = $item->getURI();
 			$entryTimestamp = $item->getTimestamp();
-			$entryContent = $this->sanitizeHtml($item->getContent());
+			$entryContent = $item->getContent() ? $this->sanitizeHtml($item->getContent()) : '';
 			$entryEnclosures = $item->getEnclosures();
 			$entryCategories = $item->getCategories();
 

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -100,7 +100,7 @@ class MrssFormat extends FormatAbstract {
 			$itemTimestamp = $item->getTimestamp();
 			$itemTitle = $item->getTitle();
 			$itemUri = $item->getURI();
-			$itemContent = $this->sanitizeHtml($item->getContent());
+			$itemContent = $item->getContent() ? $this->sanitizeHtml($item->getContent()) : '';
 			$entryID = $item->getUid();
 			$isPermaLink = 'false';
 

--- a/lib/FormatAbstract.php
+++ b/lib/FormatAbstract.php
@@ -130,7 +130,7 @@ abstract class FormatAbstract implements FormatInterface {
 	 * @todo Maybe switch to http://htmlpurifier.org/
 	 * @todo Maybe switch to http://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/index.php
 	 */
-	protected function sanitizeHtml($html)
+	protected function sanitizeHtml(string $html): string
 	{
 		$html = str_replace('<script', '<&zwnj;script', $html); // Disable scripts, but leave them visible.
 		$html = str_replace('<iframe', '<&zwnj;iframe', $html);


### PR DESCRIPTION
Sometimes `Item::getContent` returns `null`, in which case `sanitizeHtml` would pass it to `str_replace`, which would raise `E_DEPRECATED` on PHP 8.1.
