### PR TITLE
[MrssFormat] Add 'itunes:duration' tag for items with duration

### DIFF
--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -140,6 +140,7 @@ class Arte7Bridge extends BridgeAbstract {
 
 			$item['timestamp'] = strtotime($element['videoRightsBegin']);
 			$item['title'] = $element['title'];
+			$item['duration'] = (int) $durationSeconds;
 
 			if(!empty($element['subtitle']))
 				$item['title'] = $element['title'] . ' | ' . $element['subtitle'];

--- a/docs/05_Bridge_API/02_BridgeAbstract.md
+++ b/docs/05_Bridge_API/02_BridgeAbstract.md
@@ -372,6 +372,7 @@ $item['title']      // Title of the item
 $item['timestamp']  // Timestamp of the item in numeric or text format (compatible for strtotime())
 $item['author']     // Name of the author for this item
 $item['content']    // Content in HTML format
+$item['duration']   // Duration of the media in the URI (if any), in seconds (used for podcast Mrss feeds)
 $item['enclosures'] // Array of URIs to an attachments (pictures, files, etc...)
 $item['categories'] // Array of categories / tags / topics
 $item['uid']        // A unique ID to identify the current item

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -29,6 +29,7 @@ class MrssFormat extends FormatAbstract {
 
 	protected const ATOM_NS = 'http://www.w3.org/2005/Atom';
 	protected const MRSS_NS = 'http://search.yahoo.com/mrss/';
+	protected const ITUNES_NS = 'http://www.itunes.com/dtds/podcast-1.0.dtd';
 
 	const ALLOWED_IMAGE_EXT = array(
 		'.gif', '.jpg', '.png'
@@ -52,6 +53,7 @@ class MrssFormat extends FormatAbstract {
 		$feed->setAttribute('version', '2.0');
 		$feed->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:atom', self::ATOM_NS);
 		$feed->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:media', self::MRSS_NS);
+		$feed->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:itunes', self::ITUNES_NS);
 
 		$channel = $document->createElement('channel');
 		$feed->appendChild($channel);
@@ -101,6 +103,7 @@ class MrssFormat extends FormatAbstract {
 			$itemTitle = $item->getTitle();
 			$itemUri = $item->getURI();
 			$itemContent = $this->sanitizeHtml($item->getContent());
+			$itemDuration = $item->getDuration();
 			$entryID = $item->getUid();
 			$isPermaLink = 'false';
 
@@ -142,6 +145,12 @@ class MrssFormat extends FormatAbstract {
 				$entryDescription = $document->createElement('description');
 				$entry->appendChild($entryDescription);
 				$entryDescription->appendChild($document->createTextNode($itemContent));
+			}
+
+			if ($itemDuration !== null) {
+				$entryDuration = $document->createElementNS(self::ITUNES_NS, 'itunes:duration');
+				$entryDuration->appendChild($document->createTextNode((string)$itemDuration));
+				$entry->appendChild($entryDuration);
 			}
 
 			foreach($item->getEnclosures() as $enclosure) {

--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -23,6 +23,7 @@
  * - **Timestamp**: A timestamp of when the item was first released
  * - **Author**: Name of the author
  * - **Content**: Body of the feed, as text or HTML
+ * - **Duration**: Duration of the media in the URI (if any), in seconds
  * - **Enclosures**: A list of links to media objects (images, videos, etc...)
  * - **Categories**: A list of category names or tags to categorize the item
  *
@@ -48,6 +49,9 @@ class FeedItem {
 
 	/** @var string|null Body of the feed */
 	protected $content = null;
+
+	/** @var int|null Duration of the linked media in seconds */
+	protected $duration = null;
 
 	/** @var array List of links to media objects */
 	protected $enclosures = array();
@@ -429,6 +433,35 @@ class FeedItem {
 	}
 
 	/**
+	 * Get duration (for items where the link points to media)
+	 *
+	 * Use {@see FeedItem::setDuration()} to set the duration.
+	 *
+	 * @return ?int Duration in seconds.
+	 */
+	public function getDuration(): ?int {
+		return $this->duration;
+	}
+
+	/**
+	 * Set duration (for items where the link points to media)
+	 *
+	 * Use {@see FeedItem::getDuration()} to get the duration.
+	 *
+	 * @param int $duration Duration of the media in seconds
+	 * @return self
+	 */
+	public function setDuration(?int $duration): self {
+		if($duration !== null && $duration < 0) {
+			Debug::log('Duration must be a non-negative integer!');
+		} else {
+			$this->duration = $duration;
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Add miscellaneous elements to the item.
 	 *
 	 * @param string $key Name of the element.
@@ -461,6 +494,7 @@ class FeedItem {
 				'timestamp' => $this->timestamp,
 				'author' => $this->author,
 				'content' => $this->content,
+				'duration' => $this->duration,
 				'enclosures' => $this->enclosures,
 				'categories' => $this->categories,
 				'uid' => $this->uid,
@@ -490,6 +524,7 @@ class FeedItem {
 			case 'timestamp': $this->setTimestamp($value); break;
 			case 'author': $this->setAuthor($value); break;
 			case 'content': $this->setContent($value); break;
+			case 'duration': $this->setDuration($value); break;
 			case 'enclosures': $this->setEnclosures($value); break;
 			case 'categories': $this->setCategories($value); break;
 			case 'uid': $this->setUid($value); break;
@@ -513,6 +548,7 @@ class FeedItem {
 			case 'timestamp': return $this->getTimestamp();
 			case 'author': return $this->getAuthor();
 			case 'content': return $this->getContent();
+			case 'duration': return $this->getDuration();
 			case 'enclosures': return $this->getEnclosures();
 			case 'categories': return $this->getCategories();
 			case 'uid': return $this->getUid();


### PR DESCRIPTION
Some bridges have items which are links to media. The media linked typically has a duration. Add a 'duration' property for FeedItems and use its contents (if not empty) to add an 'itunes:duration' tag to Mrss output. This allows feed readers (podcast clients) to read the duration of the episode, and allows sorting and searching episodes by their length.

Patch Arte7Bridge to add the duration to items as an example. I'm sure there are also other bridges which can use this property.