### PR TITLE
fix: deprecate functions returnClientError etc

### DIFF
--- a/bridges/KilledbyGoogleBridge.php
+++ b/bridges/KilledbyGoogleBridge.php
@@ -10,9 +10,10 @@ class KilledbyGoogleBridge extends BridgeAbstract {
 
 	public function collectData() {
 
-		$json = getContents(self::URI . '/graveyard.json')
-			or returnServerError('Could not request: ' . self::URI . '/graveyard.json');
-
+		$json = getContents(self::URI . '/graveyard.json');
+		if (! $json) {
+			throw new \Exception('Could not request: ' . self::URI . '/graveyard.json');
+		}
 		$this->handleJson($json);
 		$this->orderItems();
 		$this->limitItems();

--- a/lib/error.php
+++ b/lib/error.php
@@ -14,6 +14,7 @@
 /**
  * Throws an exception when called.
  *
+ * @deprecated Explicitly throw an exception instead of calling this
  * @throws \Exception when called
  * @param string $message The error message
  * @param int $code The HTTP error code
@@ -27,6 +28,7 @@ function returnError($message, $code){
 /**
  * Returns HTTP Error 400 (Bad Request) when called.
  *
+ * @deprecated Explicitly throw an exception instead of calling this
  * @param string $message The error message
  */
 function returnClientError($message){
@@ -36,6 +38,7 @@ function returnClientError($message){
 /**
  * Returns HTTP Error 500 (Internal Server Error) when called.
  *
+ * @deprecated Explicitly throw an exception instead of calling this
  * @param string $message The error message
  */
 function returnServerError($message){


### PR DESCRIPTION
This is a suggestion.

Bridges should not be concerned whether the client code is coming from an http context or not. Also it's confusing to have functions named `returnClientError` because they don't actually return anything. Also it's doubly confusing to use the `or` operator together with these functions so I suggest we stop doing that too.