### PR TITLE
[contents] Add MIME type for mp3

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -369,7 +369,8 @@ function getMimeType($url) {
 			'jpg' => 'image/jpeg',
 			'gif' => 'image/gif',
 			'png' => 'image/png',
-			'image' => 'image/*'
+			'image' => 'image/*',
+			'mp3' => 'audio/mpeg',
 		);
 		// '@' is used to mute open_basedir warning, see issue #818
 		if (@is_readable('/etc/mime.types')) {


### PR DESCRIPTION
Without this, format tests fail on systems without `/etc/mime.types`.
