### PR TITLE
core: Add item testing

### DIFF
--- a/actions/ConnectivityAction.php
+++ b/actions/ConnectivityAction.php
@@ -59,7 +59,7 @@ class ConnectivityAction extends ActionAbstract {
 
 		$retVal = array_merge(
 			['bridge' => $bridgeName],
-			$this->testBridgeConnectivity($bridge),
+			$this->testBridgeConnectivity($bridge)
 		);
 		if (isset($this->userData['check_items'])) {
 			$retVal = array_merge($retVal, $this->testBridgeItems($bridge));

--- a/actions/ConnectivityAction.php
+++ b/actions/ConnectivityAction.php
@@ -106,6 +106,7 @@ class ConnectivityAction extends ActionAbstract {
 			}
 		} catch(Exception $e) {
 			$retVal['successful'] = false;
+			$retVal['http_code'] = $e->getCode();
 		}
 
 		return $retVal;
@@ -124,9 +125,15 @@ class ConnectivityAction extends ActionAbstract {
 		$bridge = $bridgeFac->create($bridgeName);
 		$params = $bridge->getTestParameters();
 		foreach($params as $set) {
+			$failed = false;
 			$bridge->setDatas($set);
-			$bridge->collectData();
-			if (!$bridge->checkItems()) {
+			try {
+				$bridge->collectData();
+			} catch (Exception $e) {
+				$failed = true;
+			}
+
+			if ($failed or !$bridge->checkItems()) {
 				$retVal['valid_items'] = false;
 				$retVal['failed_on'] = $set;
 				break;

--- a/actions/ConnectivityAction.php
+++ b/actions/ConnectivityAction.php
@@ -56,13 +56,16 @@ class ConnectivityAction extends ActionAbstract {
 		}
 
 		$bridge = $bridgeFac->create($bridgeName);
+		if (!$bridge) {
+			generateReport(['bridge' => null]);
+		}
 
 		$retVal = array_merge(
 			['bridge' => $bridgeName],
-			$this->testBridgeConnectivity($bridge)
+			$this->testBridgeConnectivity($bridgeName)
 		);
 		if (isset($this->userData['check_items'])) {
-			$retVal = array_merge($retVal, $this->testBridgeItems($bridge));
+			$retVal = array_merge($retVal, $this->testBridgeItems($bridgeName));
 		}
 		$this->generateReport($retVal);
 
@@ -76,10 +79,12 @@ class ConnectivityAction extends ActionAbstract {
 	/**
 	 * Gets information on bridge connectivity status
 	 *
-	 * @param string $bridge instance of the bridge to generate the report for
+	 * @param string $bridgeName Name of the bridge to test connectivity
 	 * @return array
 	 */
-	private function testBridgeConnectivity($bridge) {
+	private function testBridgeConnectivity($bridgeName) {
+		$bridgeFac = new \BridgeFactory();
+		$bridge = $bridgeFac->create($bridgeName);
 
 		$retVal = array(
 			'successful' => false,
@@ -106,8 +111,17 @@ class ConnectivityAction extends ActionAbstract {
 		return $retVal;
 	}
 
-	private function testBridgeItems($bridge) {
+	/**
+	 * Gets information on bridge's returned items
+	 * Uses overridable getTestParameters and checkItems.
+	 *
+	 * @param string $bridgeName Name of the bridge to test returned items
+	 * @return array
+	 */
+	private function testBridgeItems($bridgeName) {
 		$retVal = ['valid_items' => true];
+		$bridgeFac = new \BridgeFactory();
+		$bridge = $bridgeFac->create($bridgeName);
 		$params = $bridge->getTestParameters();
 		foreach($params as $set) {
 			$bridge->setDatas($set);
@@ -117,7 +131,7 @@ class ConnectivityAction extends ActionAbstract {
 				$retVal['failed_on'] = $set;
 				break;
 			}
-			$bridge->clearDatas();
+			$bridge = $bridgeFac->create($bridgeName);
 		}
 		return $retVal;
 	}

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -268,15 +268,6 @@ abstract class BridgeAbstract implements BridgeInterface {
 	}
 
 	/**
-	 * Resets bridge internal state (items, inputs, context)
-	 */
-	public function clearDatas(){
-		$this->items = array();
-		$this->inputs = array();
-		$this->queriedContext = '';
-	}
-
-	/**
 	 * Loads configuration for the bridge
 	 *
 	 * Returns errors and aborts execution if the provided configuration is
@@ -432,7 +423,8 @@ abstract class BridgeAbstract implements BridgeInterface {
 			$ret[] = $values;
 
 			// Reset internal state for next iteration
-			$this->clearDatas();
+			$this->inputs = array();
+			$this->queriedContext = '';
 		}
 
 		return $ret;

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -269,7 +269,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 
 	/**
 	 * Resets bridge internal state (items, inputs, context)
- 	 */
+	 */
 	public function clearDatas(){
 		$this->items = array();
 		$this->inputs = array();
@@ -448,7 +448,7 @@ abstract class BridgeAbstract implements BridgeInterface {
 	 * @return bool true if valid, false otherwise
 	 */
 	public function checkItems(){
-		if !empty($this->getItems());
+		return !empty($this->getItems());
 	}
 
 	/**


### PR DESCRIPTION
This is a step towards achieving #2280 and related issues. It adds two functions that bridge authors can override:
- `getTestParameters`: This should return a list of inputs to be tested on the bridge. By default returns default values of each context.
- `checkItems`: This function checks if bridge items are valid. Currently, the default is just to check that any items exist, but we can make this more strict, for example testing that items exist AND they all have titles.

These functions are accessible through the ConnectivityAction when check_items is passed.

Things to do:
- [ ] Document all of this
- [ ] Add this the javascript UI. For now, it can be accessed through the same way (passing check_items), but in future PRs, this UI can be improved to allow the user/instance maintainer to select a subset of bridges to test.
- [ ] Future PRs can work on implementing these functions for each bridge
- [ ] Please review and/or test this if you can :)