### PR TITLE
[Configuration.php] Update the version name to dev.2022-06-10

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -28,7 +28,7 @@ final class Configuration {
 	 *
 	 * @todo Replace this property by a constant.
 	 */
-	public static $VERSION = 'dev.2022-01-20';
+	public static $VERSION = 'dev.2022-06-10';
 
 	/**
 	 * Holds the configuration data.


### PR DESCRIPTION
The version name in `Configuration.php` wasn't updated in the [latest release](https://github.com/RSS-Bridge/rss-bridge/releases/tag/2022-06-10).