### PR TITLE
chore: bump required php version to 7.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.4']
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.1', '7.4']
+        php-versions: ['7.4']
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,24 +7,11 @@ on:
     branches: [ master ]
 
 jobs:
-  phpunit7:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        php-versions: ['7.1', '7.2', '7.3']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-      - run: composer global require phpunit/phpunit ^7
-      - run: phpunit --configuration=phpunit.xml --include-path=lib/
-
   phpunit8:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -349,7 +349,6 @@ RSS-Bridge uses third party libraries with their own license:
   * [`Parsedown`](https://github.com/erusev/parsedown) licensed under the [MIT License](https://opensource.org/licenses/MIT)
   * [`PHP Simple HTML DOM Parser`](https://simplehtmldom.sourceforge.io/docs/1.9/index.html) licensed under the [MIT License](https://opensource.org/licenses/MIT)
   * [`php-urljoin`](https://github.com/fluffy-critter/php-urljoin) licensed under the [MIT License](https://opensource.org/licenses/MIT)
-  * [php polyfills](https://github.com/symfony/polyfill) licensed under the [MIT License](https://opensource.org/licenses/MIT)
   * [`Laravel framework`](https://github.com/laravel/framework/) licensed under the [MIT License](https://opensource.org/licenses/MIT)
 
 Technical notes

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ RSS-Bridge hashtag (#rss-bridge) search on Twitter, in Atom format (as displayed
 Requirements
 ===
 
-RSS-Bridge requires PHP 7.1 or higher with following extensions enabled:
+RSS-Bridge requires PHP 7.4 or higher with following extensions enabled:
 
   - [`openssl`](https://secure.php.net/manual/en/book.openssl.php)
   - [`libxml`](https://secure.php.net/manual/en/book.libxml.php)

--- a/bridges/BandcampDailyBridge.php
+++ b/bridges/BandcampDailyBridge.php
@@ -148,8 +148,7 @@ class BandcampDailyBridge extends BridgeAbstract {
 			case 'Best of':
 			case 'Genres':
 			case 'Franchises':
-				// TODO Switch to array_key_first once php >= 7.3
-				$contentKey = key(self::PARAMETERS[$this->queriedContext]);
+				$contentKey = array_key_first(self::PARAMETERS[$this->queriedContext]);
 				$contentValues = array_flip(self::PARAMETERS[$this->queriedContext][$contentKey]['values']);
 
 				return $contentValues[$this->getInput($contentKey)] . ' - Bandcamp Daily';

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "rss": "https://github.com/RSS-Bridge/rss-bridge/commits/master.atom"
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.4",
         "ext-mbstring": "*",
         "ext-curl": "*",
         "ext-openssl": "*",

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -79,9 +79,9 @@ final class Configuration {
 	public static function verifyInstallation() {
 
 		// Check PHP version
-		if(version_compare(PHP_VERSION, '7.1.0') === -1)
-			self::reportError('RSS-Bridge requires at least PHP version 7.1.0!');
-
+		if(version_compare(PHP_VERSION, '7.4.0') === -1) {
+			self::reportError('RSS-Bridge requires at least PHP version 7.4.0!');
+		}
 		// extensions check
 		if(!extension_loaded('openssl'))
 			self::reportError('"openssl" extension not loaded. Please check "php.ini"');

--- a/lib/php8backports.php
+++ b/lib/php8backports.php
@@ -50,37 +50,3 @@ if (!function_exists('str_contains')) {
 		return $needle !== '' && mb_strpos($haystack, $needle) !== false;
 	}
 }
-
-// php 7.3 https://github.com/symfony/polyfill/blob/main/src/Php73/bootstrap.php
-//
-// Copyright (c) 2018-2019 Fabien Potencier
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is furnished
-// to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-if (!function_exists('array_key_first')) {
-	function array_key_first(array $array) {
-		foreach ($array as $key => $value) {
-			return $key;
-		}
-	}
-}
-if (!function_exists('array_key_last')) {
-	function array_key_last(array $array) {
-		return key(array_slice($array, -1, 1, true));
-	}
-}

--- a/phpcompatibility.xml
+++ b/phpcompatibility.xml
@@ -8,7 +8,7 @@
   <!--
 
   -->
-  <config name="testVersion" value="7.1-"/>
+  <config name="testVersion" value="7.4-"/>
   <rule ref="PHPCompatibility">
   </rule>
 


### PR DESCRIPTION
I suggest we bump to `7.4`. It's the oldest version that still get updates.

The primary benefit is we don't have to worry about the software working on `7.1`, `7.2` and `7.3`. Also it's nice to be able to use more recent language features.

The biggest downside is that some users must upgrade their servers.
E.g. Debian 10 (buster) is on `7.3` and Ubuntu 18.04 is on `7.2`.

[0] https://www.php.net/supported-versions.php
[1] https://wiki.debian.org/PHP