### PR TITLE
[InstagramBridge] Fix incorrect cache timeout calculation

### DIFF
--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -70,7 +70,10 @@ class InstagramBridge extends BridgeAbstract {
 
 	public function getCacheTimeout() {
 		$customTimeout = $this->getOption('cache_timeout');
-		return $customTimeout || parent::getCacheTimeout();
+		if ($customTimeout) {
+			return $customTimeout;
+		}
+		return parent::getCacheTimeout();
 	}
 
 	protected function getContents($uri) {


### PR DESCRIPTION
It is expected that getCacheTimeout returns integer. In fact
it returned boolean value which lead to situation, where Instagram feeds
were not cached.