### PR TITLE
[XPathBridge] Allow to define enclosure inside content

### DIFF
--- a/bridges/XPathBridge.php
+++ b/bridges/XPathBridge.php
@@ -125,11 +125,11 @@ EOL
                 'name' => 'Item image position',
                 'title' => 'You can specify if you want to embed the image inside the description (before/after) or as enclosure',
                 'values' => [
-                    'As enclosure' => 'Enclosures',
-                    'Before description' => 'BeforeContent',
-                    'After description' => 'AfterContent',
+                    'As enclosure' => 'enclosures',
+                    'Before description' => 'before_content',
+                    'After description' => 'after_content',
                 ],
-                'defaultValue' => 'Enclosures',
+                'defaultValue' => 'enclosures',
             ],
 
             'categories' => [
@@ -291,10 +291,11 @@ EOL
         return $uri;
     }
 
-    protected function setEnclosuresPosition($item)
+    private function setEnclosuresPosition($item)
     {
-        $enclosuresPosition = $this->getItemEnclosuresPosition();
-        $hasEnclosureInsideContent = str_contains($enclosuresPosition, 'Content');
+        $enclosuresPosition = static::getItemEnclosuresPosition();
+        $enclosuresContentPosition = ['before_content', 'after_content'];
+        $hasEnclosureInsideContent = in_array($enclosuresPosition, $enclosuresContentPosition);
 
         if ($hasEnclosureInsideContent) {
             $content = $item->getContent();
@@ -317,10 +318,10 @@ EOL
     {
         $enclosureHtml = $this->getEnclosuresAsHtml('image', $enclosuresUrl);
 
-        if ($enclosuresPosition === 'BeforeContent') {
+        if ($enclosuresPosition === 'before_content') {
             $content = $enclosureHtml . '<br/>' . $originalContent;
         }
-        if ($enclosuresPosition === 'AfterContent') {
+        if ($enclosuresPosition === 'after_content') {
             $content = $originalContent . '<br/>' . $enclosureHtml;
         }
 


### PR DESCRIPTION
Following my own request: https://github.com/RSS-Bridge/rss-bridge/issues/2843

Add a `enclosuresPosition` list parameter to define the enclosure as an enclosure or as an embed media inside the content.
Values can be: `Enclosures`, `BeforeContent`, `AfterContent`.

This feature follows the support of enclosures, which is limited to images only. I choose as well to use the plural of enclosure everywhere, as it is the case right now.