### PR TITLE
[KilledByGoogle] fix: broken enclosure url

### DIFF
--- a/bridges/KilledbyGoogleBridge.php
+++ b/bridges/KilledbyGoogleBridge.php
@@ -45,7 +45,7 @@ class KilledbyGoogleBridge extends BridgeAbstract {
 			$item['timestamp'] = strtotime($tombstone['dateClose']);
 
 			$item['content'] = <<<EOD
-<p>{$tombstone['description']}</p><p><a href="{$tombstone['link']}">{$tombstone['link']}</p>
+<p>{$tombstone['description']}</p><p><a href="{$tombstone['link']}">{$tombstone['link']}</a></p>
 EOD;
 
 			$item['enclosures'][] = 'https://static.killedbygoogle.com/com/tombstone.svg';

--- a/bridges/KilledbyGoogleBridge.php
+++ b/bridges/KilledbyGoogleBridge.php
@@ -41,13 +41,14 @@ class KilledbyGoogleBridge extends BridgeAbstract {
 
 			$item['title'] = $tombstone['name'] . ' (' . $yearOpened . ' - ' . $yearClosed . ')';
 			$item['uid'] = $tombstone['slug'];
+			$item['uri'] = $tombstone['link'];
 			$item['timestamp'] = strtotime($tombstone['dateClose']);
 
 			$item['content'] = <<<EOD
 <p>{$tombstone['description']}</p><p><a href="{$tombstone['link']}">{$tombstone['link']}</p>
 EOD;
 
-			$item['enclosures'][] = self::URI . '/assets/tombstone.svg';
+			$item['enclosures'][] = 'https://static.killedbygoogle.com/com/tombstone.svg';
 
 			$this->items[] = $item;
 		}


### PR DESCRIPTION
The previous enclosure url was HTTP 404.

Also add link to items.