### PR TITLE
ci: Install PHPUnit as a Composer dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-      - run: composer global require phpunit/phpunit ^8
-      - run: phpunit --configuration=phpunit.xml --include-path=lib/
+      - run: composer install
+      - run: composer test


### PR DESCRIPTION
Now that we dropped support for deprecated PHP versions, we can use the same PHPUnit version on all supported PHP version.
Let’s install it as a Composer dependency to have the same PHPUnit version on the CI as on developers’ computers.
