### PR TITLE
[MangaDex] improve date handling

### DIFF
--- a/bridges/MangaDexBridge.php
+++ b/bridges/MangaDexBridge.php
@@ -94,7 +94,7 @@ class MangaDexBridge extends BridgeAbstract {
 			preg_match(self::TITLE_REGEX, $this->getInput('url'), $matches)
 				or returnClientError('Invalid URL Parameter');
 			$this->feedURI = self::URI . 'title/' . $matches['uuid'];
-			$params['order[updatedAt]'] = 'desc';
+			$params['order[readableAt]'] = 'desc';
 			if (!$this->getInput('external')) {
 				$params['includeFutureUpdates'] = '0';
 			}
@@ -105,7 +105,7 @@ class MangaDexBridge extends BridgeAbstract {
 			$params['chapter'] = $this->getInput('chapter');
 			$params['groups[]'] = $this->getInput('groups');
 			$params['uploader'] = $this->getInput('uploader');
-			$params['order[updatedAt]'] = 'desc';
+			$params['order[readableAt]'] = 'desc';
 			if (!$this->getInput('external')) {
 				$params['includeFutureUpdates'] = '0';
 			}
@@ -196,7 +196,7 @@ class MangaDexBridge extends BridgeAbstract {
 			}
 			$item['title'] .= ' [' . $chapter['attributes']['translatedLanguage'] . ']';
 
-			$item['timestamp'] = $chapter['attributes']['updatedAt'];
+			$item['timestamp'] = $chapter['attributes']['readableAt'];
 
 			$groups = array();
 			$users = array();


### PR DESCRIPTION
prioritizes new chapters rather than just edited ones.
should avoid batch-renaming drowning out new chapters, and existing items being re-sorted in the feed when they're edited.
documentation here: https://api.mangadex.org/docs/dates/