### PR TITLE
ci: Fix PHPCompatibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
       - run: composer global require dealerdirect/phpcodesniffer-composer-installer
+      - run: composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
       - run: composer global require phpcompatibility/php-compatibility
       - run: ~/.composer/vendor/bin/phpcs . --standard=phpcompatibility.xml --warning-severity=0 --extensions=php -p
 


### PR DESCRIPTION
> For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins
> You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.

Oops, it is July now.
