### PR TITLE
Fix coding style missed by phpbcf

### DIFF
--- a/actions/ConnectivityAction.php
+++ b/actions/ConnectivityAction.php
@@ -80,7 +80,7 @@ class ConnectivityAction implements ActionInterface
         }
 
         $curl_opts = [
-            CURLOPT_CONNECTTIMEOUT => 5
+            CURLOPT_CONNECTTIMEOUT => 5,
         ];
 
         try {
@@ -102,35 +102,35 @@ class ConnectivityAction implements ActionInterface
     private function returnEntryPage()
     {
         echo <<<EOD
-<!DOCTYPE html>
+            <!DOCTYPE html>
 
-<html>
-	<head>
-		<link rel="stylesheet" href="static/bootstrap.min.css">
-		<link
-			rel="stylesheet"
-			href="https://use.fontawesome.com/releases/v5.6.3/css/all.css"
-			integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/"
-			crossorigin="anonymous">
-		<link rel="stylesheet" href="static/connectivity.css">
-		<script src="static/connectivity.js" type="text/javascript"></script>
-	</head>
-	<body>
-		<div id="main-content" class="container">
-			<div class="progress">
-				<div class="progress-bar" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
-			</div>
-			<div id="status-message" class="sticky-top alert alert-primary alert-dismissible fade show" role="alert">
-				<i id="status-icon" class="fas fa-sync"></i>
-				<span>...</span>
-				<button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="stopConnectivityChecks()">
-					<span aria-hidden="true">&times;</span>
-				</button>
-			</div>
-			<input type="text" class="form-control" id="search" onkeyup="search()" placeholder="Search for bridge..">
-		</div>
-	</body>
-</html>
-EOD;
+            <html>
+            	<head>
+            		<link rel="stylesheet" href="static/bootstrap.min.css">
+            		<link
+            			rel="stylesheet"
+            			href="https://use.fontawesome.com/releases/v5.6.3/css/all.css"
+            			integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/"
+            			crossorigin="anonymous">
+            		<link rel="stylesheet" href="static/connectivity.css">
+            		<script src="static/connectivity.js" type="text/javascript"></script>
+            	</head>
+            	<body>
+            		<div id="main-content" class="container">
+            			<div class="progress">
+            				<div class="progress-bar" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+            			</div>
+            			<div id="status-message" class="sticky-top alert alert-primary alert-dismissible fade show" role="alert">
+            				<i id="status-icon" class="fas fa-sync"></i>
+            				<span>...</span>
+            				<button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="stopConnectivityChecks()">
+            					<span aria-hidden="true">&times;</span>
+            				</button>
+            			</div>
+            			<input type="text" class="form-control" id="search" onkeyup="search()" placeholder="Search for bridge..">
+            		</div>
+            	</body>
+            </html>
+            EOD;
     }
 }

--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -77,7 +77,7 @@ class DisplayAction implements ActionInterface
                     'format',
                     '_noproxy',
                     '_cache_timeout',
-                    '_error_time'
+                    '_error_time',
                 ],
                 ''
             )
@@ -92,7 +92,7 @@ class DisplayAction implements ActionInterface
                     'format',
                     '_noproxy',
                     '_cache_timeout',
-                    '_error_time'
+                    '_error_time',
                 ],
                 ''
             )
@@ -156,9 +156,9 @@ class DisplayAction implements ActionInterface
 
                 $infos = [
                     'name' => $bridge->getName(),
-                    'uri'  => $bridge->getURI(),
-                    'donationUri'  => $bridge->getDonationURI(),
-                    'icon' => $bridge->getIcon()
+                    'uri' => $bridge->getURI(),
+                    'donationUri' => $bridge->getDonationURI(),
+                    'icon' => $bridge->getIcon(),
                 ];
             } catch (\Throwable $e) {
                 error_log($e);
@@ -199,7 +199,7 @@ class DisplayAction implements ActionInterface
                 'items' => array_map(function ($i) {
                     return $i->toArray();
                 }, $items),
-                'extraInfos' => $infos
+                'extraInfos' => $infos,
             ]);
         }
 

--- a/actions/ListAction.php
+++ b/actions/ListAction.php
@@ -27,7 +27,7 @@ class ListAction implements ActionInterface
 
             if ($bridge === false) { // Broken bridge, show as inactive
                 $list->bridges[$bridgeName] = [
-                    'status' => 'inactive'
+                    'status' => 'inactive',
                 ];
 
                 continue;
@@ -43,7 +43,7 @@ class ListAction implements ActionInterface
                 'icon' => $bridge->getIcon(),
                 'parameters' => $bridge->getParameters(),
                 'maintainer' => $bridge->getMaintainer(),
-                'description' => $bridge->getDescription()
+                'description' => $bridge->getDescription(),
             ];
         }
 

--- a/bridges/ABCNewsBridge.php
+++ b/bridges/ABCNewsBridge.php
@@ -21,10 +21,10 @@ class ABCNewsBridge extends BridgeAbstract
                     'SA' => 'sa',
                     'TAS' => 'tas',
                     'VIC' => 'vic',
-                    'WA' => 'wa'
+                    'WA' => 'wa',
                 ],
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/AO3Bridge.php
+++ b/bridges/AO3Bridge.php
@@ -31,7 +31,7 @@ class AO3Bridge extends BridgeAbstract
                 // Example: latest chapters from A Better Past by LysSerris
                 'exampleValue' => '18181853',
             ],
-        ]
+        ],
     ];
 
     // Feed for lists of works (e.g. recent works, search results, filtered tags,

--- a/bridges/ARDMediathekBridge.php
+++ b/bridges/ARDMediathekBridge.php
@@ -47,9 +47,9 @@ class ARDMediathekBridge extends BridgeAbstract
                 'name' => 'Show Link or ID',
                 'required' => true,
                 'title' => 'Link to the show page or just its alphanumeric suffix',
-                'defaultValue' => 'https://www.ardmediathek.de/sendung/45-min/Y3JpZDovL25kci5kZS8xMzkx/'
-            ]
-        ]
+                'defaultValue' => 'https://www.ardmediathek.de/sendung/45-min/Y3JpZDovL25kci5kZS8xMzkx/',
+            ],
+        ],
     ];
 
     public function collectData()
@@ -84,7 +84,7 @@ class ARDMediathekBridge extends BridgeAbstract
             $item['title'] = $video->longTitle;
             // in the test, aspect16x9 was the only child of images, not sure whether that is always true
             $item['enclosures'] = [
-                str_replace(self::IMAGEWIDTHPLACEHOLDER, self::IMAGEWIDTH, $video->images->aspect16x9->src)
+                str_replace(self::IMAGEWIDTHPLACEHOLDER, self::IMAGEWIDTH, $video->images->aspect16x9->src),
             ];
             $item['content'] = '<img src="' . $item['enclosures'][0] . '" /><p>';
             $item['timestamp'] = $video->broadcastedOn;

--- a/bridges/AcrimedBridge.php
+++ b/bridges/AcrimedBridge.php
@@ -14,8 +14,8 @@ class AcrimedBridge extends FeedExpander
                 'name' => 'limit',
                 'type' => 'number',
                 'defaultValue' => -1,
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/AirBreizhBridge.php
+++ b/bridges/AirBreizhBridge.php
@@ -18,10 +18,10 @@ class AirBreizhBridge extends BridgeAbstract
                     'Information' => 'information',
                     'Autres documents' => 'autres-documents',
                     'Plan Régional de Surveillance de la qualité de l’air' => 'prsqa',
-                    'Transport' => 'transport'
-                ]
-            ]
-        ]
+                    'Transport' => 'transport',
+                ],
+            ],
+        ],
     ];
 
     public function getIcon()

--- a/bridges/AlbionOnlineBridge.php
+++ b/bridges/AlbionOnlineBridge.php
@@ -35,7 +35,7 @@ class AlbionOnlineBridge extends BridgeAbstract
             'name' => 'Full changelog',
             'type' => 'checkbox',
             'required' => false,
-            'title' => 'Enable to receive the full changelog post for each item'
+            'title' => 'Enable to receive the full changelog post for each item',
         ],
     ]];
 

--- a/bridges/AlfaBankByBridge.php
+++ b/bridges/AlfaBankByBridge.php
@@ -16,16 +16,16 @@ class AlfaBankByBridge extends BridgeAbstract
 					" клиентов физ. лиц либо для клиентов-юридических лиц и ИП',
                 'values' => [
                     'Новости' => 'news',
-                    'Новости бизнеса' => 'newsBusiness'
+                    'Новости бизнеса' => 'newsBusiness',
                 ],
-                'defaultValue' => 'news'
+                'defaultValue' => 'news',
             ],
             'fullContent' => [
                 'name' => 'Включать содержимое',
                 'type' => 'checkbox',
-                'title' => 'Если выбрано, содержимое уведомлений вставляется в поток (работает медленно)'
-            ]
-        ]
+                'title' => 'Если выбрано, содержимое уведомлений вставляется в поток (работает медленно)',
+            ],
+        ],
     ];
 
     public function collectData()
@@ -78,10 +78,10 @@ class AlfaBankByBridge extends BridgeAbstract
     {
         $ruMonths = [
             'Января', 'Февраля', 'Марта', 'Апреля', 'Мая', 'Июня',
-            'Июля', 'Августа', 'Сентября', 'Октября', 'Ноября', 'Декабря' ];
+            'Июля', 'Августа', 'Сентября', 'Октября', 'Ноября', 'Декабря', ];
         $enMonths = [
             'January', 'February', 'March', 'April', 'May', 'June',
-            'July', 'August', 'September', 'October', 'November', 'December' ];
+            'July', 'August', 'September', 'October', 'November', 'December', ];
         return str_replace($ruMonths, $enMonths, $date);
     }
 }

--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -28,8 +28,8 @@ class AllocineFRBridge extends BridgeAbstract
                 'Complètement...' => 'completement',
                 '#Fun Facts' => 'fun-facts',
                 'Origin Story' => 'origin-story',
-            ]
-        ]
+            ],
+        ],
     ]];
 
     public function getURI()
@@ -50,7 +50,7 @@ class AllocineFRBridge extends BridgeAbstract
                 'cliches' => '/video/programme-24834/',
                 'completement' => '/video/programme-23859/',
                 'fun-facts' => '/video/programme-23040/',
-                'origin-story' => '/video/programme-25667/'
+                'origin-story' => '/video/programme-25667/',
             ];
 
             $category = $this->getInput('category');

--- a/bridges/AmazonPriceTrackerBridge.php
+++ b/bridges/AmazonPriceTrackerBridge.php
@@ -11,36 +11,36 @@ class AmazonPriceTrackerBridge extends BridgeAbstract
     const PARAMETERS = [
         [
         'asin' => [
-            'name'          => 'ASIN',
-            'required'      => true,
-            'exampleValue'  => 'B071GB1VMQ',
+            'name' => 'ASIN',
+            'required' => true,
+            'exampleValue' => 'B071GB1VMQ',
             // https://stackoverflow.com/a/12827734
-            'pattern'       => 'B[\dA-Z]{9}|\d{9}(X|\d)',
+            'pattern' => 'B[\dA-Z]{9}|\d{9}(X|\d)',
         ],
         'tld' => [
             'name' => 'Country',
             'type' => 'list',
             'values' => [
-                'Australia'         => 'com.au',
-                'Brazil'        => 'com.br',
-                'Canada'        => 'ca',
-                'China'         => 'cn',
-                'France'        => 'fr',
-                'Germany'       => 'de',
-                'India'         => 'in',
-                'Italy'         => 'it',
-                'Japan'         => 'co.jp',
-                'Mexico'        => 'com.mx',
-                'Netherlands'       => 'nl',
-                'Spain'         => 'es',
-                'Sweden'        => 'se',
-                'Turkey'        => 'com.tr',
-                'United Kingdom'    => 'co.uk',
-                'United States'     => 'com',
+                'Australia' => 'com.au',
+                'Brazil' => 'com.br',
+                'Canada' => 'ca',
+                'China' => 'cn',
+                'France' => 'fr',
+                'Germany' => 'de',
+                'India' => 'in',
+                'Italy' => 'it',
+                'Japan' => 'co.jp',
+                'Mexico' => 'com.mx',
+                'Netherlands' => 'nl',
+                'Spain' => 'es',
+                'Sweden' => 'se',
+                'Turkey' => 'com.tr',
+                'United Kingdom' => 'co.uk',
+                'United States' => 'com',
             ],
             'defaultValue' => 'com',
         ],
-        ]];
+        ], ];
 
     const PRICE_SELECTORS = [
         '#priceblock_ourprice',
@@ -134,8 +134,8 @@ class AmazonPriceTrackerBridge extends BridgeAbstract
         $image = $image ?: 'https://placekitten.com/200/300';
 
         return <<<EOT
-<img width="300" style="max-width:300;max-height:300" src="$image" alt="{$this->title}" />
-EOT;
+            <img width="300" style="max-width:300;max-height:300" src="$image" alt="{$this->title}" />
+            EOT;
     }
 
     /**
@@ -158,9 +158,9 @@ EOT;
         //  data-asin-currency-code="USD" data-substitute-count="-1" ... />
         if ($asinData) {
             return [
-                'price'     => $asinData->getAttribute('data-asin-price'),
-                'currency'  => $asinData->getAttribute('data-asin-currency-code'),
-                'shipping'  => $asinData->getAttribute('data-asin-shipping')
+                'price' => $asinData->getAttribute('data-asin-price'),
+                'currency' => $asinData->getAttribute('data-asin-currency-code'),
+                'shipping' => $asinData->getAttribute('data-asin-shipping'),
             ];
         }
 
@@ -207,9 +207,9 @@ EOT;
 
         if ($price != null && $currency != null) {
             return [
-                'price'     => $price,
-                'currency'  => $currency,
-                'shipping'  => '0'
+                'price' => $price,
+                'currency' => $currency,
+                'shipping' => '0',
             ];
         }
 
@@ -245,11 +245,11 @@ EOT;
         $data = $this->scrapePriceGeneric($html);
 
         $item = [
-            'title'     => $this->title,
-            'uri'       => $this->getURI(),
-            'content'   => $this->renderContent($imageTag, $data),
+            'title' => $this->title,
+            'uri' => $this->getURI(),
+            'content' => $this->renderContent($imageTag, $data),
             // This is to ensure that feed readers notice the price change
-            'uid'       => md5($data['price'])
+            'uid' => md5($data['price']),
         ];
 
         $this->items[] = $item;

--- a/bridges/AnidexBridge.php
+++ b/bridges/AnidexBridge.php
@@ -34,8 +34,8 @@ class AnidexBridge extends BridgeAbstract
                     'Applications' => '13',
                     'Pictures' => '14',
                     'Adult Video' => '15',
-                    'Other' => '16'
-                ]
+                    'Other' => '16',
+                ],
             ],
             'lang_id' => [
                 'name' => 'Language',
@@ -72,29 +72,29 @@ class AnidexBridge extends BridgeAbstract
                     'Korean' => '28',
                     'Spanish (LATAM)' => '29',
                     'Persian' => '30',
-                    'Malaysian' => '31'
-                ]
+                    'Malaysian' => '31',
+                ],
             ],
             'group_id' => [
                 'name' => 'Group ID',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'r' => [
                 'name' => 'Hide Remakes',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'b' => [
                 'name' => 'Only Batches',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'a' => [
                 'name' => 'Only Authorized',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'q' => [
                 'name' => 'Keyword',
                 'description' => 'Keyword(s)',
-                'type' => 'text'
+                'type' => 'text',
             ],
             'h' => [
                 'name' => 'Adult content',
@@ -102,10 +102,10 @@ class AnidexBridge extends BridgeAbstract
                 'values' => [
                     'No filter' => '0',
                     'Hide +18' => '1',
-                    'Only +18' => '2'
-                ]
-            ]
-        ]
+                    'Only +18' => '2',
+                ],
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/AnimeUltimeBridge.php
+++ b/bridges/AnimeUltimeBridge.php
@@ -15,9 +15,9 @@ class AnimeUltimeBridge extends BridgeAbstract
             'Everything' => '',
             'Anime' => 'A',
             'Drama' => 'D',
-            'Tokusatsu' => 'T'
-            ]
-        ]
+            'Tokusatsu' => 'T',
+            ],
+        ],
     ]];
 
     private $filter = 'Releases';

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -10,41 +10,41 @@ class AppleAppStoreBridge extends BridgeAbstract
 
     const PARAMETERS = [[
         'id' => [
-            'name'  => 'Application ID',
-            'required'  => true,
-            'exampleValue'  => '310633997'
+            'name' => 'Application ID',
+            'required' => true,
+            'exampleValue' => '310633997',
         ],
         'p' => [
-            'name'  => 'Platform',
-            'type'  => 'list',
-            'values'    => [
-                'iPad'  => 'ipad',
-                'iPhone'    => 'iphone',
-                'Mac'   => 'mac',
+            'name' => 'Platform',
+            'type' => 'list',
+            'values' => [
+                'iPad' => 'ipad',
+                'iPhone' => 'iphone',
+                'Mac' => 'mac',
 
                 // The following 2 are present in responses
                 // but not yet tested
-                'Web'   => 'web',
-                'Apple TV'  => 'appletv',
+                'Web' => 'web',
+                'Apple TV' => 'appletv',
             ],
-            'defaultValue'  => 'iphone',
+            'defaultValue' => 'iphone',
         ],
-        'country'   => [
-            'name'  => 'Store Country',
-            'type'  => 'list',
-            'values'    => [
-                'US'    => 'US',
+        'country' => [
+            'name' => 'Store Country',
+            'type' => 'list',
+            'values' => [
+                'US' => 'US',
                 'India' => 'IN',
                 'Canada' => 'CA',
                 'Germany' => 'DE',
             ],
-            'defaultValue'  => 'US',
+            'defaultValue' => 'US',
         ],
     ]];
 
     const PLATFORM_MAPPING = [
-        'iphone'    => 'ios',
-        'ipad'  => 'ios',
+        'iphone' => 'ios',
+        'ipad' => 'ios',
     ];
 
     private function makeHtmlUrl($id, $country)

--- a/bridges/ArtStationBridge.php
+++ b/bridges/ArtStationBridge.php
@@ -13,9 +13,9 @@ class ArtStationBridge extends BridgeAbstract
             'q' => [
                 'name' => 'Search term',
                 'required' => true,
-                'exampleValue'  => 'bird'
-            ]
-        ]
+                'exampleValue' => 'bird',
+            ],
+        ],
     ];
 
     public function getIcon()
@@ -35,13 +35,13 @@ class ArtStationBridge extends BridgeAbstract
 
         $header = [
             'Content-Type: application/json',
-            'Accept: application/json'
+            'Accept: application/json',
         ];
 
         $opts = [
             CURLOPT_POST => true,
             CURLOPT_POSTFIELDS => $data,
-            CURLOPT_RETURNTRANSFER => true
+            CURLOPT_RETURNTRANSFER => true,
         ];
 
         $jsonSearchURL = self::URI . '/api/v2/search/projects.json';

--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -27,7 +27,7 @@ class Arte7Bridge extends BridgeAbstract
                     'Number of views' => 'views',
                     'Number of views per period' => 'viewsPeriod',
                     'Available screens' => 'availableScreens',
-                    'Episode' => 'episode'
+                    'Episode' => 'episode',
                 ],
             ],
             'sort_direction' => [
@@ -37,14 +37,14 @@ class Arte7Bridge extends BridgeAbstract
                 'defaultValue' => 'DESC',
                 'values' => [
                     'Ascending' => 'ASC',
-                    'Descending' => 'DESC'
+                    'Descending' => 'DESC',
                 ],
             ],
             'exclude_trailers' => [
                 'name' => 'Exclude trailers',
                 'type' => 'checkbox',
                 'required' => false,
-                'defaultValue' => false
+                'defaultValue' => false,
             ],
         ],
         'Category' => [
@@ -57,7 +57,7 @@ class Arte7Bridge extends BridgeAbstract
                     'English' => 'en',
                     'Español' => 'es',
                     'Polski' => 'pl',
-                    'Italiano' => 'it'
+                    'Italiano' => 'it',
                 ],
             ],
             'cat' => [
@@ -73,8 +73,8 @@ class Arte7Bridge extends BridgeAbstract
                     'Discovery' => 'DEC',
                     'History' => 'HIST',
                     'Science' => 'SCI',
-                    'Other' => 'AUT'
-                ]
+                    'Other' => 'AUT',
+                ],
             ],
         ],
         'Collection' => [
@@ -87,16 +87,16 @@ class Arte7Bridge extends BridgeAbstract
                     'English' => 'en',
                     'Español' => 'es',
                     'Polski' => 'pl',
-                    'Italiano' => 'it'
-                ]
+                    'Italiano' => 'it',
+                ],
             ],
             'col' => [
                 'name' => 'Collection id',
                 'required' => true,
                 'title' => 'ex. RC-014095 pour https://www.arte.tv/de/videos/RC-014095/blow-up/',
-                'exampleValue'  => 'RC-014095'
-            ]
-        ]
+                'exampleValue' => 'RC-014095',
+            ],
+        ],
     ];
 
     public function collectData()
@@ -123,7 +123,7 @@ class Arte7Bridge extends BridgeAbstract
             . ($collectionId != null ? '&collections.collectionId=' . $collectionId : '');
 
         $header = [
-            'Authorization: Bearer ' . self::API_TOKEN
+            'Authorization: Bearer ' . self::API_TOKEN,
         ];
 
         $input = getContents($url, $header);

--- a/bridges/AsahiShimbunAJWBridge.php
+++ b/bridges/AsahiShimbunAJWBridge.php
@@ -30,8 +30,8 @@ class AsahiShimbunAJWBridge extends BridgeAbstract
                     'Opinion » Vox Populi' => 'opinion/vox',
                 ],
                 'defaultValue' => 'politics',
-            ]
-        ]
+            ],
+        ],
     ];
 
     private function getSectionURI($section)

--- a/bridges/AskfmBridge.php
+++ b/bridges/AskfmBridge.php
@@ -12,9 +12,9 @@ class AskfmBridge extends BridgeAbstract
             'u' => [
                 'name' => 'Username',
                 'required' => true,
-                'exampleValue'  => 'ApprovedAndReal'
-            ]
-        ]
+                'exampleValue' => 'ApprovedAndReal',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/AssociatedPressNewsBridge.php
+++ b/bridges/AssociatedPressNewsBridge.php
@@ -38,9 +38,9 @@ class AssociatedPressNewsBridge extends BridgeAbstract
                 'name' => 'Topic',
                 'type' => 'text',
                 'required' => true,
-                'exampleValue' => 'europe'
+                'exampleValue' => 'europe',
             ],
-        ]
+        ],
     ];
 
     const CACHE_TIMEOUT = 900; // 15 mins
@@ -119,7 +119,7 @@ class AssociatedPressNewsBridge extends BridgeAbstract
         foreach ($tagContents['cards'] as $card) {
             $item = [];
 
-             // skip hub peeks & Notifications
+            // skip hub peeks & Notifications
             if ($card['cardType'] == 'Hub Peek' || $card['cardType'] == 'Notification') {
                 continue;
             }
@@ -207,15 +207,15 @@ class AssociatedPressNewsBridge extends BridgeAbstract
                     $mediaCaption = $media['caption'];
 
                     $div->outertext = <<<EOD
-	<figure><img loading="lazy" src="{$mediaUrl}"/><figcaption>{$mediaCaption}</figcaption></figure>
-EOD;
+                        	<figure><img loading="lazy" src="{$mediaUrl}"/><figcaption>{$mediaCaption}</figcaption></figure>
+                        EOD;
                 }
 
                 if ($media['type'] === 'YouTube') {
                     $div->outertext = <<<EOD
-	<iframe src="https://www.youtube.com/embed/{$media['externalId']}" width="560" height="315">
-	</iframe>
-EOD;
+                        	<iframe src="https://www.youtube.com/embed/{$media['externalId']}" width="560" height="315">
+                        	</iframe>
+                        EOD;
                 }
             }
         }
@@ -234,8 +234,8 @@ EOD;
 
                     if ($div) {
                         $div->outertext = <<<EOD
-<p><a href="{$url}">{$embed['calloutText']} {$embed['displayName']}</a></p>
-EOD;
+                            <p><a href="{$url}">{$embed['calloutText']} {$embed['displayName']}</a></p>
+                            EOD;
                     }
                 }
             }
@@ -249,14 +249,14 @@ EOD;
         if ($video['type'] === 'YouTube') {
             $url = 'https://www.youtube.com/embed/' . $video['externalId'];
             $html = <<<EOD
-<iframe width="560" height="315" src="{$url}" frameborder="0" allowfullscreen></iframe>
-EOD;
+                <iframe width="560" height="315" src="{$url}" frameborder="0" allowfullscreen></iframe>
+                EOD;
         } else {
             $html = <<<EOD
-<video controls poster="https://storage.googleapis.com/afs-prod/media/{$video['id']}/800.jpeg" preload="none">
-	<source src="{$video['gcsBaseUrl']} {$video['videoRenderedSizes'][0]} {$video['videoFileExtension']}" type="video/mp4">
-</video>
-EOD;
+                <video controls poster="https://storage.googleapis.com/afs-prod/media/{$video['id']}/800.jpeg" preload="none">
+                	<source src="{$video['gcsBaseUrl']} {$video['videoRenderedSizes'][0]} {$video['videoFileExtension']}" type="video/mp4">
+                </video>
+                EOD;
         }
 
         return $html;

--- a/bridges/AstrophysicsDataSystemBridge.php
+++ b/bridges/AstrophysicsDataSystemBridge.php
@@ -11,9 +11,9 @@ class AstrophysicsDataSystemBridge extends BridgeAbstract
                 'name' => 'query',
                 'title' => 'Same format as the search bar on the website',
                 'exampleValue' => 'author:"huchra, john"',
-                'required' => true
-            ]
-        ]];
+                'required' => true,
+            ],
+        ], ];
 
     private $feedTitle;
 
@@ -36,7 +36,7 @@ class AstrophysicsDataSystemBridge extends BridgeAbstract
     public function collectData()
     {
         $headers = [
-            'Cookie: core=always;'
+            'Cookie: core=always;',
         ];
         $html = str_get_html(defaultLinkTo(getContents($this->getURI(), $headers), self::URI));
         $this->feedTitle = html_entity_decode($html->find('title', 0)->plaintext);

--- a/bridges/AtmoNouvelleAquitaineBridge.php
+++ b/bridges/AtmoNouvelleAquitaineBridge.php
@@ -10,8 +10,8 @@ class AtmoNouvelleAquitaineBridge extends BridgeAbstract
         'cities' => [
             'name' => 'Choisir une ville',
             'type' => 'list',
-            'values' => self::CITIES
-        ]
+            'values' => self::CITIES,
+        ],
     ]];
     const CACHE_TIMEOUT = 7200;
 
@@ -4645,6 +4645,6 @@ class AtmoNouvelleAquitaineBridge extends BridgeAbstract
         'Yviers (16210)' => '16424',
         'Yvrac (33370)' => '33554',
         'Yvrac-et-Malleyrand (16110)' => '16425',
-        'Yzosse (40180)' => '40334'
+        'Yzosse (40180)' => '40334',
     ];
 }

--- a/bridges/AtmoOccitanieBridge.php
+++ b/bridges/AtmoOccitanieBridge.php
@@ -10,8 +10,8 @@ class AtmoOccitanieBridge extends BridgeAbstract
         'city' => [
             'name' => 'Ville',
             'required' => true,
-            'exampleValue'  => 'cahors'
-        ]
+            'exampleValue' => 'cahors',
+        ],
     ]];
     const CACHE_TIMEOUT = 7200;
 

--- a/bridges/AutoJMBridge.php
+++ b/bridges/AutoJMBridge.php
@@ -13,9 +13,9 @@ class AutoJMBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'URL d\'une recherche avec filtre de véhicules sans le http://www.autojm.fr/',
-                'exampleValue' => 'recherche?brands[]=peugeot&ranges[]=peugeot-nouvelle-308-2021-5p'
+                'exampleValue' => 'recherche?brands[]=peugeot&ranges[]=peugeot-nouvelle-308-2021-5p',
             ],
-        ]
+        ],
     ];
     const CACHE_TIMEOUT = 3600;
 
@@ -42,7 +42,7 @@ class AutoJMBridge extends BridgeAbstract
 
         // Set the header 'X-Requested-With' like the website does it
         $header = [
-            'X-Requested-With: XMLHttpRequest'
+            'X-Requested-With: XMLHttpRequest',
         ];
 
         // Get the JSON content of the form

--- a/bridges/BAEBridge.php
+++ b/bridges/BAEBridge.php
@@ -10,7 +10,7 @@ class BAEBridge extends BridgeAbstract
         [
             'keyword' => [
                 'name' => 'Filtrer par mots clés',
-                'title' => 'Entrez le mot clé à filtrer ici'
+                'title' => 'Entrez le mot clé à filtrer ici',
             ],
             'type' => [
                 'name' => 'Type de recherche',
@@ -20,10 +20,10 @@ class BAEBridge extends BridgeAbstract
                     'Toutes les annonces' => false,
                     'Les embarquements' => 'boat',
                     'Les skippers' => 'skipper',
-                    'Les équipiers' => 'crew'
-                ]
-            ]
-        ]
+                    'Les équipiers' => 'crew',
+                ],
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/BadDragonBridge.php
+++ b/bridges/BadDragonBridge.php
@@ -13,40 +13,40 @@ class BadDragonBridge extends BridgeAbstract
         'Clearance' => [
             'ready_made' => [
                 'name' => 'Ready Made',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'flop' => [
                 'name' => 'Flops',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'skus' => [
                 'name' => 'Products',
                 'exampleValue' => 'chanceflared, crackers',
-                'title' => 'Comma separated list of product SKUs'
+                'title' => 'Comma separated list of product SKUs',
             ],
             'onesize' => [
                 'name' => 'One-Size',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'mini' => [
                 'name' => 'Mini',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'small' => [
                 'name' => 'Small',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'medium' => [
                 'name' => 'Medium',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'large' => [
                 'name' => 'Large',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'extralarge' => [
                 'name' => 'Extra Large',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'category' => [
                 'name' => 'Category',
@@ -60,50 +60,50 @@ class BadDragonBridge extends BridgeAbstract
                     'Packers' => 'packer',
                     'Lil\' Squirts' => 'shooter',
                     'Lil\' Vibes' => 'vibrator',
-                    'Wearables' => 'wearable'
+                    'Wearables' => 'wearable',
                 ],
                 'defaultValue' => 'all',
             ],
             'soft' => [
                 'name' => 'Soft Firmness',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'med_firm' => [
                 'name' => 'Medium Firmness',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'firm' => [
                 'name' => 'Firm',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'split' => [
                 'name' => 'Split Firmness',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'maxprice' => [
                 'name' => 'Max Price',
                 'type' => 'number',
                 'required' => true,
-                'defaultValue' => 300
+                'defaultValue' => 300,
             ],
             'minprice' => [
                 'name' => 'Min Price',
                 'type' => 'number',
-                'defaultValue' => 0
+                'defaultValue' => 0,
             ],
             'cumtube' => [
                 'name' => 'Cumtube',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'suctionCup' => [
                 'name' => 'Suction Cup',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'noAccessories' => [
                 'name' => 'No Accessories',
-                'type' => 'checkbox'
-            ]
-        ]
+                'type' => 'checkbox',
+            ],
+        ],
     ];
 
     /*
@@ -329,7 +329,7 @@ class BadDragonBridge extends BridgeAbstract
                     '2' => 'Extra soft',
                     '3' => 'Soft',
                     '5' => 'Medium',
-                    '8' => 'Firm'
+                    '8' => 'Firm',
                     ];
                     $firmnesses = explode('/', $toy->firmness);
                     if (count($firmnesses) === 2) {

--- a/bridges/BakaUpdatesMangaReleasesBridge.php
+++ b/bridges/BakaUpdatesMangaReleasesBridge.php
@@ -9,20 +9,20 @@ class BakaUpdatesMangaReleasesBridge extends BridgeAbstract
     const PARAMETERS = [
         'By series' => [
             'series_id' => [
-                'name'      => 'Series ID',
-                'type'      => 'number',
-                'required'  => true,
-                'exampleValue'  => '188066'
-            ]
+                'name' => 'Series ID',
+                'type' => 'number',
+                'required' => true,
+                'exampleValue' => '188066',
+            ],
         ],
         'By list' => [
             'list_id' => [
-                'name'      => 'List ID and Type',
-                'type'      => 'text',
-                'required'  => true,
-                'exampleValue'  => '4395&list=read'
-            ]
-        ]
+                'name' => 'List ID and Type',
+                'type' => 'text',
+                'required' => true,
+                'exampleValue' => '4395&list=read',
+            ],
+        ],
     ];
     const LIMIT_COLS = 5;
     const LIMIT_ITEMS = 10;

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -13,8 +13,8 @@ class BandcampBridge extends BridgeAbstract
                 'name' => 'tag',
                 'type' => 'text',
                 'required' => true,
-                'exampleValue'  => 'hip-hop-rap'
-            ]
+                'exampleValue' => 'hip-hop-rap',
+            ],
         ],
         'By band' => [
             'band' => [
@@ -22,7 +22,7 @@ class BandcampBridge extends BridgeAbstract
                 'type' => 'text',
                 'title' => 'Band name as seen in the band page URL',
                 'required' => true,
-                'exampleValue'  => 'aesoprock'
+                'exampleValue' => 'aesoprock',
             ],
             'type' => [
                 'name' => 'Articles are',
@@ -30,24 +30,24 @@ class BandcampBridge extends BridgeAbstract
                 'values' => [
                     'Releases' => 'releases',
                     'Releases, new one when track list changes' => 'changes',
-                    'Individual tracks' => 'tracks'
+                    'Individual tracks' => 'tracks',
                 ],
-                'defaultValue' => 'changes'
+                'defaultValue' => 'changes',
             ],
             'limit' => [
                 'name' => 'limit',
                 'type' => 'number',
                 'required' => true,
                 'title' => 'Number of releases to return',
-                'defaultValue' => 5
-            ]
+                'defaultValue' => 5,
+            ],
         ],
         'By label' => [
             'label' => [
                 'name' => 'label',
                 'type' => 'text',
                 'title' => 'label name as seen in the label page URL',
-                'required' => true
+                'required' => true,
             ],
             'type' => [
                 'name' => 'Articles are',
@@ -55,16 +55,16 @@ class BandcampBridge extends BridgeAbstract
                 'values' => [
                     'Releases' => 'releases',
                     'Releases, new one when track list changes' => 'changes',
-                    'Individual tracks' => 'tracks'
+                    'Individual tracks' => 'tracks',
                 ],
-                'defaultValue' => 'changes'
+                'defaultValue' => 'changes',
             ],
             'limit' => [
                 'name' => 'limit',
                 'type' => 'number',
                 'title' => 'Number of releases to return',
-                'defaultValue' => 5
-            ]
+                'defaultValue' => 5,
+            ],
         ],
         'By album' => [
             'band' => [
@@ -72,14 +72,14 @@ class BandcampBridge extends BridgeAbstract
                 'type' => 'text',
                 'title' => 'Band name as seen in the album page URL',
                 'required' => true,
-                'exampleValue'  => 'aesoprock'
+                'exampleValue' => 'aesoprock',
             ],
             'album' => [
                 'name' => 'album',
                 'type' => 'text',
                 'title' => 'Album name as seen in the album page URL',
                 'required' => true,
-                'exampleValue'  => 'appleseed'
+                'exampleValue' => 'appleseed',
             ],
             'type' => [
                 'name' => 'Articles are',
@@ -87,11 +87,11 @@ class BandcampBridge extends BridgeAbstract
                 'values' => [
                     'Releases' => 'releases',
                     'Releases, new one when track list changes' => 'changes',
-                    'Individual tracks' => 'tracks'
+                    'Individual tracks' => 'tracks',
                 ],
-                'defaultValue' => 'tracks'
-            ]
-        ]
+                'defaultValue' => 'tracks',
+            ],
+        ],
     ];
     const IMGURI = 'https://f4.bcbits.com/';
     const IMGSIZE_300PX = 23;
@@ -112,11 +112,11 @@ class BandcampBridge extends BridgeAbstract
                 $data = $this->buildRequestJson();
                 $header = [
                 'Content-Type: application/json',
-                'Content-Length: ' . strlen($data)
+                'Content-Length: ' . strlen($data),
                 ];
                 $opts = [
                 CURLOPT_CUSTOMREQUEST => 'POST',
-                CURLOPT_POSTFIELDS => $data
+                CURLOPT_POSTFIELDS => $data,
                 ];
                 $content = getContents($url, $header, $opts);
 
@@ -145,7 +145,7 @@ class BandcampBridge extends BridgeAbstract
                     $item = [
                     'uri' => $url,
                     'author' => $full_artist,
-                    'title' => $full_title
+                    'title' => $full_title,
                     ];
                     $item['content'] = "<img src='$small_img' /><br/>$full_title";
                     $item['enclosures'] = [$img];
@@ -174,7 +174,7 @@ class BandcampBridge extends BridgeAbstract
                     case 'By band':
                     case 'By label':
                         $query_data = [
-                        'band_id' => $band_id
+                        'band_id' => $band_id,
                         ];
                         $band_data = $this->apiGet('mobile/22/band_details', $query_data);
 
@@ -188,7 +188,7 @@ class BandcampBridge extends BridgeAbstract
                             $query_data = [
                             'band_id' => $band_id,
                             'tralbum_type' => $tralbum_type,
-                            'tralbum_id' => $album_basic_data->item_id
+                            'tralbum_id' => $album_basic_data->item_id,
                             ];
                             $tralbums[] = $this->apiGet('mobile/22/tralbum_details', $query_data);
                         }
@@ -203,7 +203,7 @@ class BandcampBridge extends BridgeAbstract
                         $query_data = [
                         'band_id' => $band_id,
                         'tralbum_type' => 'a',
-                        'tralbum_id' => $album_id
+                        'tralbum_id' => $album_id,
                         ];
                         $tralbums[] = $this->apiGet('mobile/22/tralbum_details', $query_data);
 
@@ -216,7 +216,7 @@ class BandcampBridge extends BridgeAbstract
                             $query_data = [
                             'band_id' => $band_id,
                             'tralbum_type' => 't',
-                            'tralbum_id' => $track->track_id
+                            'tralbum_id' => $track->track_id,
                             ];
                             $track_data = $this->apiGet('mobile/22/tralbum_details', $query_data);
 
@@ -261,7 +261,7 @@ class BandcampBridge extends BridgeAbstract
             'author' => $full_artist,
             'title' => $full_title,
             'enclosures' => [$img],
-            'timestamp' => $tralbum_data->release_date
+            'timestamp' => $tralbum_data->release_date,
         ];
 
         $item['categories'] = [];
@@ -300,7 +300,7 @@ class BandcampBridge extends BridgeAbstract
         $requestJson = [
             'tag' => $this->getInput('tag'),
             'page' => 1,
-            'sort' => 'date'
+            'sort' => 'date',
         ];
         return json_encode($requestJson);
     }

--- a/bridges/BandcampDailyBridge.php
+++ b/bridges/BandcampDailyBridge.php
@@ -86,7 +86,7 @@ class BandcampDailyBridge extends BridgeAbstract
                 ],
                 'defaultValue' => 'lists',
             ],
-        ]
+        ],
     ];
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/BlizzardNewsBridge.php
+++ b/bridges/BlizzardNewsBridge.php
@@ -26,12 +26,12 @@ class BlizzardNewsBridge extends XPathAbstract
                     'Русский' => 'ru-ru',
                     'ภาษาไทย' => 'th-th',
                     '简体中文' => 'zh-cn',
-                    '繁體中文' => 'zh-tw'
+                    '繁體中文' => 'zh-tw',
                 ],
                 'defaultValue' => 'en-us',
-                'title' => 'Select your language'
-            ]
-        ]
+                'title' => 'Select your language',
+            ],
+        ],
     ];
     const CACHE_TIMEOUT = 3600;
 

--- a/bridges/BookMyShowBridge.php
+++ b/bridges/BookMyShowBridge.php
@@ -1044,15 +1044,15 @@ class BookMyShowBridge extends BridgeAbstract
                     'Malayalam' => 'Malayalam',
                     'Gujarati' => 'Gujarati',
                     'Assamese' => 'Assamese',
-                ]
+                ],
             ],
             'include_online' => [
                 'name' => 'Include Online Events',
                 'type' => 'checkbox',
                 'defaultValue' => false,
-                'title' => 'Whether to include Online Events (applies only in case of "Events" category)'
+                'title' => 'Whether to include Online Events (applies only in case of "Events" category)',
             ],
-        ]
+        ],
     ];
 
     // Headers used in the generated table for Events/Plays
@@ -1085,7 +1085,7 @@ class BookMyShowBridge extends BridgeAbstract
         'EventLanguage' => 'Language',
         'EventDimension' => 'Formats',
         'EventIsAtmosEnabled' => 'Dolby Atmos',
-        'IsMovieClubEnabled' => 'Movie Club'
+        'IsMovieClubEnabled' => 'Movie Club',
     ];
 
     // Primary URL for fetching information
@@ -1203,11 +1203,11 @@ class BookMyShowBridge extends BridgeAbstract
             }
 
             $table .= <<<EOT
-			<tr>
-				<th>$header</th>
-				<td>$value</td>
-			</tr>
-EOT;
+                			<tr>
+                				<th>$header</th>
+                				<td>$value</td>
+                			</tr>
+                EOT;
         }
 
         return "<table>$table</table>";
@@ -1220,12 +1220,12 @@ EOT;
         $imgsrc = $event['BannerURL'];
 
         return <<<EOT
-		<img title="Event Banner URL" src="$imgsrc"></img>
-		<br>
-		$table
-		<br>
-		More Details are available on the <a href="${event['FShareURL']}">BookMyShow website</a>.
-EOT;
+            		<img title="Event Banner URL" src="$imgsrc"></img>
+            		<br>
+            		$table
+            		<br>
+            		More Details are available on the <a href="${event['FShareURL']}">BookMyShow website</a>.
+            EOT;
     }
 
     /**
@@ -1238,7 +1238,7 @@ EOT;
         $headers = ['EventLanguage', 'EventDimension'];
         // if any of these has a Y for any of the screenings, mark it as YES
         $booleanHeaders = [
-            'EventIsAtmosEnabled', 'IsMovieClubEnabled'
+            'EventIsAtmosEnabled', 'IsMovieClubEnabled',
         ];
 
         $items = [];
@@ -1293,13 +1293,13 @@ EOT;
         $synopsis = preg_replace(self::SYNOPSIS_REGEX, '', $data['EventSynopsis']);
 
         return <<<EOT
-		<img title="Movie Poster" src="$imgsrc"></img>
-		<div>$table</div>
-		<p>$innerHtml</p>
-		<p>${synopsis}</p>
-		More Details are available on the <a href="$url">BookMyShow website</a> and a trailer is available
-		<a href="${data['EventTrailerURL']}" title="Trailer URL">here</a>
-EOT;
+            		<img title="Movie Poster" src="$imgsrc"></img>
+            		<div>$table</div>
+            		<p>$innerHtml</p>
+            		<p>${synopsis}</p>
+            		More Details are available on the <a href="$url">BookMyShow website</a> and a trailer is available
+            		<a href="${data['EventTrailerURL']}" title="Trailer URL">here</a>
+            EOT;
     }
 
     /**
@@ -1330,7 +1330,7 @@ EOT;
             'categories' => array_filter(
                 explode('|', ucwords(strtolower($eventGroup['EventGrpGenre']), '|'))
             ),
-            'uid' => $eventGroup['EventGroup']
+            'uid' => $eventGroup['EventGroup'],
         ];
     }
 
@@ -1443,7 +1443,7 @@ EOT;
         $uniqid = uniqid();
         $rgn = urlencode("|Code=$city|");
         return [
-            "Cookie: bmsId=$uniqid; Rgn=$rgn;"
+            "Cookie: bmsId=$uniqid; Rgn=$rgn;",
         ];
     }
 

--- a/bridges/BooruprojectBridge.php
+++ b/bridges/BooruprojectBridge.php
@@ -11,22 +11,22 @@ class BooruprojectBridge extends DanbooruBridge
             'p' => [
                 'name' => 'page',
                 'defaultValue' => 0,
-                'type' => 'number'
+                'type' => 'number',
             ],
             't' => [
                 'name' => 'tags',
                 'required' => true,
-                'exampleValue'  => 'tagme',
-                'title' => 'Use "all" to get all posts'
-            ]
+                'exampleValue' => 'tagme',
+                'title' => 'Use "all" to get all posts',
+            ],
         ],
         'Booru subdomain (subdomain.booru.org)' => [
             'i' => [
                 'name' => 'Subdomain',
                 'required' => true,
-                'exampleValue'  => 'rm'
-            ]
-        ]
+                'exampleValue' => 'rm',
+            ],
+        ],
     ];
 
     const PATHTODATA = '.thumb';

--- a/bridges/BrutBridge.php
+++ b/bridges/BrutBridge.php
@@ -34,8 +34,8 @@ class BrutBridge extends BridgeAbstract
                         'Mexico' => 'mx',
                 ],
                 'defaultValue' => 'us',
-            ]
-        ]
+            ],
+        ],
     ];
 
     const CACHE_TIMEOUT = 1800; // 30 mins
@@ -70,12 +70,12 @@ class BrutBridge extends BridgeAbstract
             }
 
             $item['content'] = <<<EOD
-			<video controls poster="{$json->media->index->$id->media->thumbnail}" preload="none">
-				<source src="{$json->media->index->$id->media->mp4_url}" type="video/mp4">
-			</video>
-			<p>{$description}</p>
-			{$article}
-EOD;
+                			<video controls poster="{$json->media->index->$id->media->thumbnail}" preload="none">
+                				<source src="{$json->media->index->$id->media->mp4_url}" type="video/mp4">
+                			</video>
+                			<p>{$description}</p>
+                			{$article}
+                EOD;
 
             $this->items[] = $item;
 

--- a/bridges/BugzillaBridge.php
+++ b/bridges/BugzillaBridge.php
@@ -11,8 +11,8 @@ class BugzillaBridge extends BridgeAbstract
             'instance' => [
                 'name' => 'Instance URL',
                 'required' => true,
-                'exampleValue' => 'https://bugzilla.mozilla.org'
-            ]
+                'exampleValue' => 'https://bugzilla.mozilla.org',
+            ],
         ],
         'Bug comments' => [
             'id' => [
@@ -20,26 +20,26 @@ class BugzillaBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'title' => 'Insert bug tracking ID',
-                'exampleValue' => 121241
+                'exampleValue' => 121241,
             ],
             'limit' => [
                 'name' => 'Number of comments to return',
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Specify number of comments to return',
-                'defaultValue' => -1
+                'defaultValue' => -1,
             ],
             'skiptags' => [
                 'name' => 'Skip offtopic comments',
                 'type' => 'checkbox',
-                'title' => 'Excludes comments tagged as advocacy, metoo, or offtopic from the feed'
-            ]
-        ]
+                'title' => 'Excludes comments tagged as advocacy, metoo, or offtopic from the feed',
+            ],
+        ],
     ];
 
     const SKIPPED_ACTIVITY = [
         'cc' => true,
-        'comment_tag' => true
+        'comment_tag' => true,
     ];
 
     const SKIPPED_TAGS = ['advocacy', 'metoo', 'offtopic'];

--- a/bridges/BukowskisBridge.php
+++ b/bridges/BukowskisBridge.php
@@ -139,7 +139,7 @@ class BukowskisBridge extends BridgeAbstract
                     'Bags & Trunks' => 'vintage-fashion.bags-trunks',
                     'Clothes' => 'vintage-fashion.clothes',
                 ],
-            ]
+            ],
         ],
         'sort_order' => [
             'name' => 'Sort order',
@@ -162,7 +162,7 @@ class BukowskisBridge extends BridgeAbstract
             'values' => [
                 'English' => 'en',
                 'Swedish' => 'sv',
-                'Finnish' => 'fi'
+                'Finnish' => 'fi',
             ],
         ],
     ]];

--- a/bridges/BundesbankBridge.php
+++ b/bridges/BundesbankBridge.php
@@ -21,10 +21,10 @@ class BundesbankBridge extends BridgeAbstract
                 'defaultValue' => self::LANG_DE,
                 'values' => [
                     'English' => self::LANG_EN,
-                    'Deutsch' => self::LANG_DE
-                ]
-            ]
-        ]
+                    'Deutsch' => self::LANG_DE,
+                ],
+            ],
+        ],
     ];
 
     public function getIcon()
@@ -78,7 +78,7 @@ class BundesbankBridge extends BridgeAbstract
             // Downloads and older studies don't have images
             if ($study->find('.teasable__image', 0)) {
                 $item['enclosures'] = [
-                    $study->find('.teasable__image img', 0)->src
+                    $study->find('.teasable__image img', 0)->src,
                 ];
             }
 

--- a/bridges/BundestagParteispendenBridge.php
+++ b/bridges/BundestagParteispendenBridge.php
@@ -9,11 +9,11 @@ class BundestagParteispendenBridge extends BridgeAbstract
     const CACHE_TIMEOUT = 86400; // 24h
     const DESCRIPTION = 'Returns the latest "soft money" donations to parties represented in the German Bundestag.';
     const CONTENT_TEMPLATE = <<<TMPL
-<p><b>Partei:</b><br>%s</p>
-<p><b>Spendenbetrag:</b><br>%s</p>
-<p><b>Spender:</b><br>%s</p>
-<p><b>Eingang der Spende:</b><br>%s</p>
-TMPL;
+        <p><b>Partei:</b><br>%s</p>
+        <p><b>Spendenbetrag:</b><br>%s</p>
+        <p><b>Spender:</b><br>%s</p>
+        <p><b>Eingang der Spende:</b><br>%s</p>
+        TMPL;
 
     public function getIcon()
     {
@@ -23,8 +23,8 @@ TMPL;
     public function collectData()
     {
         $ajaxUri = <<<URI
-https://www.bundestag.de/ajax/filterlist/de/parlament/praesidium/parteienfinanzierung/fundstellen50000/462002-462002
-URI;
+            https://www.bundestag.de/ajax/filterlist/de/parlament/praesidium/parteienfinanzierung/fundstellen50000/462002-462002
+            URI;
         // Get the main page
         $html = getSimpleHTMLDOMCached($ajaxUri, self::CACHE_TIMEOUT)
             or returnServerError('Could not request AJAX list.');
@@ -61,11 +61,11 @@ URI;
         $item = [];
 
         //              | column     | paragraph inside column
-        $party  = $row->children[0]->children[0]->innertext;
+        $party = $row->children[0]->children[0]->innertext;
         $amount = $row->children[1]->children[0]->innertext . ' €';
-        $donor  = $row->children[2]->children[0]->innertext;
-        $date   = $row->children[3]->children[0]->innertext;
-        $dip    = $row->children[4]->children[0]->find('a.dipLink', 0);
+        $donor = $row->children[2]->children[0]->innertext;
+        $date = $row->children[3]->children[0]->innertext;
+        $dip = $row->children[4]->children[0]->find('a.dipLink', 0);
 
         // Strip whitespace from date string.
         $date = str_replace(' ', '', $date);

--- a/bridges/CNETBridge.php
+++ b/bridges/CNETBridge.php
@@ -22,10 +22,10 @@ class CNETBridge extends BridgeAbstract
                     'Sci-Tech' => 'topics-sci-tech',
                     'Security' => 'topics-security',
                     'Internet' => 'topics-internet',
-                    'Tech Industry' => 'topics-tech-industry'
-                ]
-            ]
-        ]
+                    'Tech Industry' => 'topics-tech-industry',
+                ],
+            ],
+        ],
     ];
 
     private function cleanArticle($article_html)

--- a/bridges/CNETFranceBridge.php
+++ b/bridges/CNETFranceBridge.php
@@ -13,15 +13,15 @@ class CNETFranceBridge extends FeedExpander
                 'name' => 'Exclude by title',
                 'required' => false,
                 'title' => 'Title term, separated by semicolon (;)',
-                'exampleValue' => 'bon plan;bons plans;au meilleur prix;des meilleures offres;Amazon Prime Day;RED by SFR ou B&You'
+                'exampleValue' => 'bon plan;bons plans;au meilleur prix;des meilleures offres;Amazon Prime Day;RED by SFR ou B&You',
             ],
             'url' => [
                 'name' => 'Exclude by url',
                 'required' => false,
                 'title' => 'URL term, separated by semicolon (;)',
-                'exampleValue' => 'bon-plan;bons-plans'
-            ]
-        ]
+                'exampleValue' => 'bon-plan;bons-plans',
+            ],
+        ],
     ];
 
     private $bannedTitle = [];

--- a/bridges/CachetBridge.php
+++ b/bridges/CachetBridge.php
@@ -5,7 +5,7 @@ class CachetBridge extends BridgeAbstract
     const NAME = 'Cachet Bridge';
     const URI = 'https://cachethq.io/';
     const DESCRIPTION = 'Returns status updates from any Cachet installation';
-    const MAINTAINER  = 'klimplant';
+    const MAINTAINER = 'klimplant';
     const PARAMETERS = [
         [
             'host' => [
@@ -17,9 +17,9 @@ class CachetBridge extends BridgeAbstract
             ], 'additional_info' => [
                 'name' => 'Additional Timestamps',
                 'type' => 'checkbox',
-                'title' => 'Whether to include the given timestamps'
-            ]
-        ]
+                'title' => 'Whether to include the given timestamps',
+            ],
+        ],
     ];
     const CACHE_TIMEOUT = 300;
 

--- a/bridges/CastorusBridge.php
+++ b/bridges/CastorusBridge.php
@@ -16,8 +16,8 @@ class CastorusBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => '7',
-                'title' => 'Insert ZIP code (complete or partial). e.g: 78125 OR 781 OR 7'
-            ]
+                'title' => 'Insert ZIP code (complete or partial). e.g: 78125 OR 781 OR 7',
+            ],
         ],
         'Get latest changes via city name' => [
             'city' => [
@@ -25,9 +25,9 @@ class CastorusBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'Paris',
-                'title' => 'Insert city name (complete or partial). e.g: Paris OR Par OR P'
-            ]
-        ]
+                'title' => 'Insert city name (complete or partial). e.g: Paris OR Par OR P',
+            ],
+        ],
     ];
 
     // Extracts the title from an actitiy

--- a/bridges/CdactionBridge.php
+++ b/bridges/CdactionBridge.php
@@ -30,9 +30,9 @@ class CdactionBridge extends BridgeAbstract
                 'Na luzie' => [
                     'Konkursy' => 'konkursy',
                     'Nadgodziny' => 'nadgodziny',
-                ]
-            ]
-        ]]
+                ],
+            ],
+        ], ],
     ];
 
     public function collectData()

--- a/bridges/CeskaTelevizeBridge.php
+++ b/bridges/CeskaTelevizeBridge.php
@@ -13,9 +13,9 @@ class CeskaTelevizeBridge extends BridgeAbstract
             'url' => [
                 'name' => 'url to the show',
                 'required' => true,
-                'exampleValue' => 'https://www.ceskatelevize.cz/porady/1097181328-udalosti/'
-            ]
-        ]
+                'exampleValue' => 'https://www.ceskatelevize.cz/porady/1097181328-udalosti/',
+            ],
+        ],
     ];
 
     private function fixChars($text)
@@ -33,7 +33,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
             returnServerError('Could not get date from Česká televize string');
         }
 
-        $date = sprintf('%04d-%02d-%02d', isset($match[3]) ? $match[3] : date('Y'), $match[2], $match[1]);
+        $date = sprintf('%04d-%02d-%02d', $match[3] ?? date('Y'), $match[2], $match[1]);
         return strtotime($date);
     }
 
@@ -46,7 +46,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
             returnServerError('Invalid url');
         }
 
-        $category = isset($match[4]) ? $match[4] : 'nove';
+        $category = $match[4] ?? 'nove';
         $fixedUrl = "{$match[1]}dily/{$category}/";
 
         $html = getSimpleHTMLDOM($fixedUrl);
@@ -69,7 +69,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
                 'uri' => $itemUri,
                 'content' => '<img src="' . $itemThumbnail->getAttribute('src') . '" /><br />'
                     . $this->fixChars($itemContent->plaintext),
-                'timestamp' => $this->getUploadTimeFromString($itemDate->plaintext)
+                'timestamp' => $this->getUploadTimeFromString($itemDate->plaintext),
             ];
 
             $this->items[] = $item;
@@ -78,11 +78,11 @@ class CeskaTelevizeBridge extends BridgeAbstract
 
     public function getURI()
     {
-        return isset($this->feedUri) ? $this->feedUri : parent::getURI();
+        return $this->feedUri ?? parent::getURI();
     }
 
     public function getName()
     {
-        return isset($this->feedName) ? $this->feedName : parent::getName();
+        return $this->feedName ?? parent::getName();
     }
 }

--- a/bridges/CodebergBridge.php
+++ b/bridges/CodebergBridge.php
@@ -23,7 +23,7 @@ class CodebergBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => '513',
-            ]
+            ],
         ],
         'Pull Requests' => [],
         'Releases' => [],
@@ -40,31 +40,31 @@ class CodebergBridge extends BridgeAbstract
                 'type' => 'text',
                 'exampleValue' => 'Community',
                 'required' => true,
-            ]
-        ]
+            ],
+        ],
     ];
 
     const CACHE_TIMEOUT = 1800;
 
     const TEST_DETECT_PARAMETERS = [
         'https://codeberg.org/Codeberg/Community/issues/507' => [
-            'context' => 'Issue Comments', 'username' => 'Codeberg', 'repo' => 'Community', 'issueId' => '507'
+            'context' => 'Issue Comments', 'username' => 'Codeberg', 'repo' => 'Community', 'issueId' => '507',
         ],
         'https://codeberg.org/Codeberg/Community/issues' => [
-            'context' => 'Issues', 'username' => 'Codeberg', 'repo' => 'Community'
+            'context' => 'Issues', 'username' => 'Codeberg', 'repo' => 'Community',
         ],
         'https://codeberg.org/Codeberg/Community/pulls' => [
-            'context' => 'Pull Requests', 'username' => 'Codeberg', 'repo' => 'Community'
+            'context' => 'Pull Requests', 'username' => 'Codeberg', 'repo' => 'Community',
         ],
         'https://codeberg.org/Codeberg/Community/releases' => [
-            'context' => 'Releases', 'username' => 'Codeberg', 'repo' => 'Community'
+            'context' => 'Releases', 'username' => 'Codeberg', 'repo' => 'Community',
         ],
         'https://codeberg.org/Codeberg/Community/commits/branch/master' => [
-            'context' => 'Commits', 'username' => 'Codeberg', 'repo' => 'Community', 'branch' => 'master'
+            'context' => 'Commits', 'username' => 'Codeberg', 'repo' => 'Community', 'branch' => 'master',
         ],
         'https://codeberg.org/Codeberg/Community/commits' => [
-            'context' => 'Commits', 'username' => 'Codeberg', 'repo' => 'Community'
-        ]
+            'context' => 'Commits', 'username' => 'Codeberg', 'repo' => 'Community',
+        ],
     ];
 
     private $defaultBranch = 'main';
@@ -354,12 +354,12 @@ class CodebergBridge extends BridgeAbstract
 
             $item['content'] = $li->find('div.markup.desc', 0);
             $item['content'] .= <<<HTML
-<strong>Tag</strong>
-<p>{$tag}</p>
-<strong>Commit</strong>
-<p>{$commit}</p>
-{$downloads}
-HTML;
+                <strong>Tag</strong>
+                <p>{$tag}</p>
+                <strong>Commit</strong>
+                <p>{$commit}</p>
+                {$downloads}
+                HTML;
 
             $item['timestamp'] = $li->find('span.time', 0)->find('span', 0)->title;
             $item['author'] = $li->find('span.author', 0)->find('a', 0)->plaintext;
@@ -381,14 +381,14 @@ HTML;
             }
 
             $downloads .= <<<HTML
-<a href="{$a->herf}">{$a->plaintext}</a><br>
-HTML;
+                <a href="{$a->herf}">{$a->plaintext}</a><br>
+                HTML;
         }
 
         return <<<EOD
-<strong>Downloads</strong>
-<p>{$downloads}</p>
-EOD;
+            <strong>Downloads</strong>
+            <p>{$downloads}</p>
+            EOD;
     }
 
     /**

--- a/bridges/CollegeDeFranceBridge.php
+++ b/bridges/CollegeDeFranceBridge.php
@@ -22,7 +22,7 @@ class CollegeDeFranceBridge extends BridgeAbstract
             '09' => 'sept.',
             '10' => 'oct.',
             '11' => 'nov.',
-            '12' => 'déc.'
+            '12' => 'déc.',
         ];
 
         // The "API" used by the site returns a list of partial HTML in this form

--- a/bridges/ComicsKingdomBridge.php
+++ b/bridges/ComicsKingdomBridge.php
@@ -13,8 +13,8 @@ class ComicsKingdomBridge extends BridgeAbstract
             'type' => 'text',
             'exampleValue' => 'mutts',
             'title' => 'The name of the comic in the URL after https://comicskingdom.com/',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     public function collectData()

--- a/bridges/CraigslistBridge.php
+++ b/bridges/CraigslistBridge.php
@@ -11,28 +11,28 @@ class CraigslistBridge extends BridgeAbstract
             'name' => 'Region',
             'title' => 'The subdomain before craigslist.org in the URL',
             'exampleValue' => 'sfbay',
-            'required' => true
+            'required' => true,
         ],
         'search' => [
             'name' => 'Search Query',
             'title' => 'Everything in the URL after /search/',
             'exampleValue' => 'sya?query=laptop',
-            'required' => true
+            'required' => true,
         ],
         'limit' => [
             'name' => 'Number of Posts',
             'type' => 'number',
             'title' => 'The maximum number of posts is 120. Use 0 for unlimited posts.',
-            'defaultValue' => '25'
-        ]
+            'defaultValue' => '25',
+        ],
     ]];
 
     const TEST_DETECT_PARAMETERS = [
         'https://sfbay.craigslist.org/search/sya?query=laptop' => [
-            'region' => 'sfbay', 'search' => 'sya?query=laptop'
+            'region' => 'sfbay', 'search' => 'sya?query=laptop',
         ],
         'https://newyork.craigslist.org/search/sss?query=32gb+flash+drive&bundleDuplicates=1&max_price=20' => [
-            'region' => 'newyork', 'search' => 'sss?query=32gb+flash+drive&bundleDuplicates=1&max_price=20'
+            'region' => 'newyork', 'search' => 'sss?query=32gb+flash+drive&bundleDuplicates=1&max_price=20',
         ],
     ];
 

--- a/bridges/CrewbayBridge.php
+++ b/bridges/CrewbayBridge.php
@@ -10,7 +10,7 @@ class CrewbayBridge extends BridgeAbstract
         [
             'keyword' => [
                 'name' => 'Filter by keyword',
-                'title' => 'Enter the keyword to filter here'
+                'title' => 'Enter the keyword to filter here',
             ],
             'type' => [
                 'name' => 'Type of search',
@@ -18,8 +18,8 @@ class CrewbayBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     'Find a boat' => 'boats',
-                    'Find a crew' => 'crew'
-                ]
+                    'Find a crew' => 'crew',
+                ],
             ],
             'status' => [
                 'name' => 'Status on the boat',
@@ -27,8 +27,8 @@ class CrewbayBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     'Recreational' => 'recreational',
-                    'Professional' => 'professional'
-                ]
+                    'Professional' => 'professional',
+                ],
             ],
             'recreational_position' => [
                 'name' => 'Recreational position wanted',
@@ -42,8 +42,8 @@ class CrewbayBridge extends BridgeAbstract
                     'Competent Crew' => 'Competent Crew',
                     'Racing' => 'Racing',
                     'Voluntary work' => 'Voluntary work',
-                    'Mile building' => 'Mile building'
-                ]
+                    'Mile building' => 'Mile building',
+                ],
             ],
             'professional_position' => [
                 'name' => 'Professional position wanted',
@@ -100,10 +100,10 @@ class CrewbayBridge extends BridgeAbstract
                     'Stew/Beautician' => 'Stew/Beautician',
                     'Stew/Masseuse' => 'Stew/Masseuse',
                     'Manager' => 'Manager',
-                    'Sailing instructor' => 'Sailing instructor'
-                ]
-            ]
-        ]
+                    'Sailing instructor' => 'Sailing instructor',
+                ],
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/CryptomeBridge.php
+++ b/bridges/CryptomeBridge.php
@@ -12,8 +12,8 @@ class CryptomeBridge extends BridgeAbstract
             'name' => 'number of elements',
             'type' => 'number',
             'required' => true,
-            'exampleValue' => 10
-        ]
+            'exampleValue' => 10,
+        ],
     ]];
 
     public function getIcon()

--- a/bridges/CubariBridge.php
+++ b/bridges/CubariBridge.php
@@ -11,8 +11,8 @@ class CubariBridge extends BridgeAbstract
             'name' => 'Gist/Raw Url',
             'type' => 'text',
             'required' => true,
-            'exampleValue' => 'https://raw.githubusercontent.com/kurisumx/baka/main/ikedan'
-        ]
+            'exampleValue' => 'https://raw.githubusercontent.com/kurisumx/baka/main/ikedan',
+        ],
     ]];
 
     private $mangaTitle = '';

--- a/bridges/CuriousCatBridge.php
+++ b/bridges/CuriousCatBridge.php
@@ -12,7 +12,7 @@ class CuriousCatBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'exampleValue' => 'koethekoethe',
-        ]
+        ],
     ]];
 
     const CACHE_TIMEOUT = 3600;
@@ -70,19 +70,19 @@ class CuriousCatBridge extends BridgeAbstract
             $authorUrl = self::URI . '/' . $post['senderData']['username'];
 
             $author = <<<EOD
-<a href="{$authorUrl}">{$post['senderData']['username']}</a>
-EOD;
+                <a href="{$authorUrl}">{$post['senderData']['username']}</a>
+                EOD;
         }
 
         $question = $this->formatUrls($post['comment']);
         $answer = $this->formatUrls($post['reply']);
 
         $content = <<<EOD
-<p>{$author} asked:</p>
-<blockquote>{$question}</blockquote><br/>
-<p>{$post['addresseeData']['username']} answered:</p>
-<blockquote>{$answer}</blockquote>
-EOD;
+            <p>{$author} asked:</p>
+            <blockquote>{$question}</blockquote><br/>
+            <p>{$post['addresseeData']['username']} answered:</p>
+            <blockquote>{$answer}</blockquote>
+            EOD;
 
         return $content;
     }

--- a/bridges/CyanideAndHappinessBridge.php
+++ b/bridges/CyanideAndHappinessBridge.php
@@ -23,18 +23,18 @@ class CyanideAndHappinessBridge extends BridgeAbstract
         $html = getSimpleHTMLDOM($this->getUri());
 
         foreach ($html->find('[class*=ComicImage]') as $element) {
-            $date        = $element->find('[class^=Author__Right] p', 0)->plaintext;
-            $author      = str_replace('by ', '', $element->find('[class^=Author__Right] p', 1)->plaintext);
-            $image       = $element->find('img', 0)->src;
-            $link        = $html->find('[rel=canonical]', 0)->href;
+            $date = $element->find('[class^=Author__Right] p', 0)->plaintext;
+            $author = str_replace('by ', '', $element->find('[class^=Author__Right] p', 1)->plaintext);
+            $image = $element->find('img', 0)->src;
+            $link = $html->find('[rel=canonical]', 0)->href;
 
             $item = [
-                'uid'       => $link,
-                'author'    => $author,
-                'title'     => $date,
-                'uri'       => $link . '#comic',
+                'uid' => $link,
+                'author' => $author,
+                'title' => $date,
+                'uri' => $link . '#comic',
                 'timestamp' => str_replace('.', '-', $date) . 'T00:00:00Z',
-                'content'   => "<img src=\"$image\" />"
+                'content' => "<img src=\"$image\" />",
             ];
             $this->items[] = $item;
         }

--- a/bridges/DailymotionBridge.php
+++ b/bridges/DailymotionBridge.php
@@ -14,14 +14,14 @@ class DailymotionBridge extends BridgeAbstract
                 'name' => 'username',
                 'required' => true,
                 'exampleValue' => 'moviepilot',
-            ]
+            ],
         ],
         'By playlist id' => [
             'p' => [
                 'name' => 'playlist id',
                 'required' => true,
                 'exampleValue' => 'x6xyc6',
-            ]
+            ],
         ],
         'From search results' => [
             's' => [
@@ -33,8 +33,8 @@ class DailymotionBridge extends BridgeAbstract
                 'name' => 'Page',
                 'type' => 'number',
                 'defaultValue' => 1,
-            ]
-        ]
+            ],
+        ],
     ];
 
     private $feedName = '';

--- a/bridges/DanbooruBridge.php
+++ b/bridges/DanbooruBridge.php
@@ -13,15 +13,15 @@ class DanbooruBridge extends BridgeAbstract
             'p' => [
                 'name' => 'page',
                 'defaultValue' => 1,
-                'type' => 'number'
+                'type' => 'number',
             ],
             't' => [
                 'type' => 'text',
                 'name' => 'tags',
                 'exampleValue' => 'cosplay',
-            ]
+            ],
         ],
-        0 => []
+        0 => [],
     ];
 
     const PATHTODATA = 'article';

--- a/bridges/DarkReadingBridge.php
+++ b/bridges/DarkReadingBridge.php
@@ -34,7 +34,7 @@ class DarkReadingBridge extends FeedExpander
                 'Advanced Threats' => '662_Advanced%20Threats',
                 'Insider Threats' => '663_Insider%20Threats',
                 'Vulnerability Management' => '664_Vulnerability%20Management',
-            ]
+            ],
         ],
         'limit' => self::LIMIT,
     ]];

--- a/bridges/DauphineLibereBridge.php
+++ b/bridges/DauphineLibereBridge.php
@@ -27,9 +27,9 @@ class DauphineLibereBridge extends FeedExpander
                 'Isère Sud' => 'isere-sud',
                 'Savoie' => 'savoie',
                 'Haute-Savoie' => 'haute-savoie',
-                'Vaucluse' => 'vaucluse'
-            ]
-        ]
+                'Vaucluse' => 'vaucluse',
+            ],
+        ],
     ]];
 
     public function collectData()

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -12,7 +12,7 @@ class DealabsBridge extends PepperBridgeAbstract
                 'name' => 'Mot(s) clé(s)',
                 'type' => 'text',
                 'exampleValue' => 'lampe',
-                'required' => true
+                'required' => true,
             ],
             'hide_expired' => [
                 'name' => 'Masquer les éléments expirés',
@@ -27,13 +27,13 @@ class DealabsBridge extends PepperBridgeAbstract
                 'name' => 'Prix minimum',
                 'type' => 'text',
                 'title' => 'Prix mnimum en euros',
-                'required' => false
+                'required' => false,
             ],
             'priceTo' => [
                 'name' => 'Prix maximum',
                 'type' => 'text',
                 'title' => 'Prix maximum en euros',
-                'required' => false
+                'required' => false,
             ],
         ],
 
@@ -1869,7 +1869,7 @@ class DealabsBridge extends PepperBridgeAbstract
                     'Yeelight' => 'xiaomi-yeelight',
                     'Yoshi&#039;s Crafted World' => 'yoshi-crafted-world',
                     'Zoos' => 'zoos',
-                ]
+                ],
             ],
             'order' => [
                 'name' => 'Trier par',
@@ -1878,8 +1878,8 @@ class DealabsBridge extends PepperBridgeAbstract
                 'values' => [
                     'Du deal le plus Hot au moins Hot' => '-hot',
                     'Du deal le plus récent au plus ancien' => '-nouveaux',
-                ]
-            ]
+                ],
+            ],
         ],
         'Surveillance Discussion' => [
             'url' => [
@@ -1895,10 +1895,10 @@ class DealabsBridge extends PepperBridgeAbstract
                 'type' => 'checkbox',
                 'title' => 'Exclure les commentaires ne contenant pas d\'URL dans le flux',
                 'defaultValue' => false,
-                ]
+                ],
 
 
-            ]
+            ],
 
     ];
 
@@ -1934,7 +1934,7 @@ class DealabsBridge extends PepperBridgeAbstract
             'septembre',
             'octobre',
             'novembre',
-            'décembre'
+            'décembre',
         ],
         'local-time-relative' => [
             'il y a ',
@@ -1944,7 +1944,7 @@ class DealabsBridge extends PepperBridgeAbstract
             'jours',
             'mois',
             'ans',
-            'et '
+            'et ',
         ],
         'date-prefixes' => [
             'Actualisé ',
@@ -1957,7 +1957,7 @@ class DealabsBridge extends PepperBridgeAbstract
 
         'localdeal' => [
             'Local',
-            'Pays d\'expédition'
+            'Pays d\'expédition',
         ],
     ];
 }

--- a/bridges/DemoBridge.php
+++ b/bridges/DemoBridge.php
@@ -11,8 +11,8 @@ class DemoBridge extends BridgeAbstract
         'testCheckbox' => [
             'testCheckbox' => [
                 'type' => 'checkbox',
-                'name' => 'test des checkbox'
-            ]
+                'name' => 'test des checkbox',
+            ],
         ],
         'testList' => [
             'testList' => [
@@ -20,17 +20,17 @@ class DemoBridge extends BridgeAbstract
                 'name' => 'test des listes',
                 'values' => [
                     'Test' => 'test',
-                    'Test 2' => 'test2'
-                ]
-            ]
+                    'Test 2' => 'test2',
+                ],
+            ],
         ],
         'testNumber' => [
             'testNumber' => [
                 'type' => 'number',
                 'name' => 'test des numéros',
-                'exampleValue' => '1515632'
-            ]
-        ]
+                'exampleValue' => '1515632',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/DerpibooruBridge.php
+++ b/bridges/DerpibooruBridge.php
@@ -19,17 +19,17 @@ class DerpibooruBridge extends BridgeAbstract
                     'Legacy Default' => 37431,
                     '18+ Dark' => 37429,
                     'Maximum Spoilers' => 37430,
-                    'Default' => 100073
+                    'Default' => 100073,
                 ],
-                'defaultValue' => 56027
+                'defaultValue' => 56027,
 
             ],
             'q' => [
                 'name' => 'Query',
                 'required' => true,
                 'exampleValue' => 'dog',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function detectParameters($url)

--- a/bridges/DesoutterBridge.php
+++ b/bridges/DesoutterBridge.php
@@ -59,7 +59,7 @@ class DesoutterBridge extends BridgeAbstract
                     => 'https://www.desoutter.com.tr/desoutter-hakkinda/haberler-etkinlikler',
                     '中国'
                     => 'https://www.desouttertools.com.cn/guan-yu-ma-tou/xin-wen-he-huo-dong',
-                ]
+                ],
             ],
         ],
         self::CATEGORY_INDUSTRY => [
@@ -109,23 +109,23 @@ class DesoutterBridge extends BridgeAbstract
                     => 'https://www.desoutter.com.tr/endustri-4-0/haberler',
                     '中国'
                     => 'https://www.desouttertools.com.cn/industry-4-0/news',
-                ]
+                ],
             ],
         ],
         'global' => [
             'full' => [
                 'name' => 'Load full articles',
                 'type' => 'checkbox',
-                'title' => 'Enable to load the full article for each item'
+                'title' => 'Enable to load the full article for each item',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 3,
-                'title' => "Maximum number of items to return in the feed.\n0 = unlimited"
-            ]
-        ]
+                'title' => "Maximum number of items to return in the feed.\n0 = unlimited",
+            ],
+        ],
     ];
 
     private $title;

--- a/bridges/DevToBridge.php
+++ b/bridges/DevToBridge.php
@@ -17,15 +17,15 @@ class DevToBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert your tag',
-                'exampleValue' => 'python'
+                'exampleValue' => 'python',
             ],
             'full' => [
                 'name' => 'Full article',
                 'type' => 'checkbox',
                 'required' => false,
-                'title' => 'Enable to receive the full article for each item'
-            ]
-        ]
+                'title' => 'Enable to receive the full article for each item',
+            ],
+        ],
     ];
 
     public function getURI()
@@ -71,13 +71,13 @@ apple-icon-5c6fa9f2bce280428589c6195b7f1924206a53b782b371cfe2d02da932c8c173.png'
             if ($this->getInput('full')) {
                 $fullArticle = $this->getFullArticle($item['uri']);
                 $item['content'] = <<<EOD
-<p>{$fullArticle}</p>
-EOD;
+                    <p>{$fullArticle}</p>
+                    EOD;
             } else {
                 $item['content'] = <<<EOD
-<img src="{$item['enclosures'][0]}" alt="{$item['author']}">
-<p>{$item['title']}</p>
-EOD;
+                    <img src="{$item['enclosures'][0]}" alt="{$item['author']}">
+                    <p>{$item['title']}</p>
+                    EOD;
             }
 
             // categories

--- a/bridges/DeveloppezDotComBridge.php
+++ b/bridges/DeveloppezDotComBridge.php
@@ -157,10 +157,10 @@ class DeveloppezDotComBridge extends FeedExpander
                     'word' => 'word',
                     'xhtml' => 'xhtml',
                     'xml' => 'xml',
-                    'zend-framework' => 'zend-framework'
+                    'zend-framework' => 'zend-framework',
                 ],
-            ]
-        ]
+            ],
+        ],
     ];
 
     /**

--- a/bridges/DiarioDeNoticiasBridge.php
+++ b/bridges/DiarioDeNoticiasBridge.php
@@ -12,8 +12,8 @@ class DiarioDeNoticiasBridge extends BridgeAbstract
                 'name' => 'Tag Name',
                 'required' => true,
                 'exampleValue' => 'rogerio-casanova',
-            ]
-        ]
+            ],
+        ],
     ];
 
     const MONPT = [

--- a/bridges/DiarioDoAlentejoBridge.php
+++ b/bridges/DiarioDoAlentejoBridge.php
@@ -21,7 +21,7 @@ class DiarioDoAlentejoBridge extends BridgeAbstract
         'setembro',
         'outubro',
         'novembro',
-        'dezembro'];
+        'dezembro', ];
 
     public function getIcon()
     {

--- a/bridges/DiscogsBridge.php
+++ b/bridges/DiscogsBridge.php
@@ -13,8 +13,8 @@ class DiscogsBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'exampleValue' => '28104',
-                'title' => 'Only the ID from an artist page. EG /artist/28104-Aesop-Rock is 28104'
-            ]
+                'title' => 'Only the ID from an artist page. EG /artist/28104-Aesop-Rock is 28104',
+            ],
         ],
         'Label Releases' => [
             'labelid' => [
@@ -22,8 +22,8 @@ class DiscogsBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'exampleValue' => '8201',
-                'title' => 'Only the ID from a label page. EG /label/8201-Rhymesayers-Entertainment is 8201'
-            ]
+                'title' => 'Only the ID from a label page. EG /label/8201-Rhymesayers-Entertainment is 8201',
+            ],
         ],
         'User Wantlist' => [
             'username_wantlist' => [
@@ -31,7 +31,7 @@ class DiscogsBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'TheBlindMaster',
-            ]
+            ],
         ],
         'User Folder' => [
             'username_folder' => [
@@ -41,8 +41,8 @@ class DiscogsBridge extends BridgeAbstract
             'folderid' => [
                 'name' => 'Folder ID',
                 'type' => 'number',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/DockerHubBridge.php
+++ b/bridges/DockerHubBridge.php
@@ -19,7 +19,7 @@ class DockerHubBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'rss-bridge',
-            ]
+            ],
         ],
         'Official Image' => [
             'repo' => [
@@ -27,7 +27,7 @@ class DockerHubBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'postgres',
-            ]
+            ],
         ],
     ];
 
@@ -76,13 +76,13 @@ class DockerHubBridge extends BridgeAbstract
             $item['author'] = $result->last_updater_username;
             $item['timestamp'] = $result->tag_last_pushed;
             $item['content'] = <<<EOD
-<Strong>Tag</strong><br>
-<p>{$result->name}</p>
-<Strong>Last pushed</strong><br>
-<p>{$lastPushed}</p>
-<Strong>Images</strong><br>
-{$this->getImages($result)}
-EOD;
+                <Strong>Tag</strong><br>
+                <p>{$result->name}</p>
+                <Strong>Last pushed</strong><br>
+                <p>{$lastPushed}</p>
+                <Strong>Images</strong><br>
+                {$this->getImages($result)}
+                EOD;
 
             $this->items[] = $item;
         }
@@ -150,19 +150,19 @@ EOD;
     private function getImages($result)
     {
         $html = <<<EOD
-<table style="width:300px;"><thead><tr><th>Digest</th><th>OS/architecture</th></tr></thead></tbody>
-EOD;
+            <table style="width:300px;"><thead><tr><th>Digest</th><th>OS/architecture</th></tr></thead></tbody>
+            EOD;
 
         foreach ($result->images as $image) {
             $layersUrl = $this->getLayerUrl($result->name, $image->digest);
             $id = $this->getShortDigestId($image->digest);
 
             $html .= <<<EOD
-			<tr>
-				<td><a href="{$layersUrl}">{$id}</a></td>
-				<td>{$image->os}/{$image->architecture}</td>
-			</tr>
-EOD;
+                			<tr>
+                				<td><a href="{$layersUrl}">{$id}</a></td>
+                				<td>{$image->os}/{$image->architecture}</td>
+                			</tr>
+                EOD;
         }
 
         return $html . '</tbody></table>';

--- a/bridges/DonnonsBridge.php
+++ b/bridges/DonnonsBridge.php
@@ -26,9 +26,9 @@ class DonnonsBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 5,
-                'title' => 'Indique le nombre de pages de donnons.org qui seront scannées'
-            ]
-        ]
+                'title' => 'Indique le nombre de pages de donnons.org qui seront scannées',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/Drive2ruBridge.php
+++ b/bridges/Drive2ruBridge.php
@@ -15,7 +15,7 @@ class Drive2ruBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Например: https://www.drive2.ru/experience/suzuki/g4895/',
-                'exampleValue' => 'https://www.drive2.ru/experience/suzuki/g4895/'
+                'exampleValue' => 'https://www.drive2.ru/experience/suzuki/g4895/',
             ],
         ],
         'Личные блоги' => [
@@ -24,8 +24,8 @@ class Drive2ruBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Например: Mickey',
-                'exampleValue' => 'Mickey'
-            ]
+                'exampleValue' => 'Mickey',
+            ],
         ],
         'Публикации по темам (Стоит почитать)' => [
             'topic' => [
@@ -63,17 +63,17 @@ class Drive2ruBridge extends BridgeAbstract
                     'Фотосессии' => '120',
                     'Шины и диски' => '140',
                     'Электрика' => '130',
-                    'Электромобили' => '131'
+                    'Электромобили' => '131',
                 ],
                 'defaultValue' => '16',
-            ]
+            ],
         ],
         'global' => [
             'full_articles' => [
                 'name' => 'Загружать в ленту полный текст',
-                'type' => 'checkbox'
-            ]
-        ]
+                'type' => 'checkbox',
+            ],
+        ],
     ];
 
     private $title;
@@ -182,7 +182,7 @@ class Drive2ruBridge extends BridgeAbstract
 
     private function addCommentsLink($content, $url)
     {
-                return $content . '<br><a href="' . $url . '#comments">Перейти к комментариям</a>';
+        return $content . '<br><a href="' . $url . '#comments">Перейти к комментариям</a>';
     }
 
     private function addReadMoreLink($content, $url)

--- a/bridges/DuckDuckGoBridge.php
+++ b/bridges/DuckDuckGoBridge.php
@@ -15,7 +15,7 @@ class DuckDuckGoBridge extends BridgeAbstract
         'u' => [
             'name' => 'keyword',
             'exampleValue' => 'duck',
-            'required' => true
+            'required' => true,
         ],
         'sort' => [
             'name' => 'sort by',
@@ -23,10 +23,10 @@ class DuckDuckGoBridge extends BridgeAbstract
             'required' => false,
             'values' => [
                 'date' => self::SORT_DATE,
-                'relevance' => self::SORT_RELEVANCE
+                'relevance' => self::SORT_RELEVANCE,
             ],
-            'defaultValue' => self::SORT_DATE
-        ]
+            'defaultValue' => self::SORT_DATE,
+        ],
     ]];
 
     public function collectData()

--- a/bridges/EZTVBridge.php
+++ b/bridges/EZTVBridge.php
@@ -14,34 +14,34 @@ on EZTV. Get IMDB IDs from IMDB.';
                 'name' => 'Show IMDB IDs',
                 'exampleValue' => '8740790,1733785',
                 'required' => true,
-                'title' => 'One or more IMDB show IDs (can be found in the IMDB show URL)'
+                'title' => 'One or more IMDB show IDs (can be found in the IMDB show URL)',
             ],
             'no480' => [
                 'name' => 'No 480p',
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude 480p torrents'
+                'title' => 'Activate to exclude 480p torrents',
             ],
             'no720' => [
                 'name' => 'No 720p',
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude 720p torrents'
+                'title' => 'Activate to exclude 720p torrents',
             ],
             'no1080' => [
                 'name' => 'No 1080p',
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude 1080p torrents'
+                'title' => 'Activate to exclude 1080p torrents',
             ],
             'no2160' => [
                 'name' => 'No 2160p',
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude 2160p torrents'
+                'title' => 'Activate to exclude 2160p torrents',
             ],
             'noUnknownRes' => [
                 'name' => 'No Unknown resolution',
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude unknown resolution torrents'
+                'title' => 'Activate to exclude unknown resolution torrents',
             ],
-        ]
+        ],
     ];
 
     // Shamelessly lifted from https://stackoverflow.com/a/2510459

--- a/bridges/EconomistBridge.php
+++ b/bridges/EconomistBridge.php
@@ -15,8 +15,8 @@ class EconomistBridge extends FeedExpander
                 'required' => true,
                 'type' => 'number',
                 'defaultValue' => 10,
-                'title' => 'Maximum number of returned feed items. Maximum 30, default 10'
-            ]
+                'title' => 'Maximum number of returned feed items. Maximum 30, default 10',
+            ],
         ],
         'Topics' => [
             'topic' => [
@@ -46,8 +46,8 @@ class EconomistBridge extends FeedExpander
                     'Obituaries' => 'obituary',
                     'Graphic detail' => 'graphic-detail',
                     'Indicators' => 'economic-and-financial-indicators',
-                ]
-            ]
+                ],
+            ],
         ],
         'Blogs' => [
             'blog' => [
@@ -67,9 +67,9 @@ class EconomistBridge extends FeedExpander
                     'Kaffeeklatsch' => 'kaffeeklatsch',
                     'Prospero' => 'prospero',
                     'The Economist Explains' => 'the-economist-explains',
-                ]
-            ]
-        ]
+                ],
+            ],
+        ],
     ];
 
     public function collectData()
@@ -134,7 +134,7 @@ class EconomistBridge extends FeedExpander
         // clean the article content. Remove all div's since the text is in paragraph elements
         foreach (
             [
-            '<div '
+            '<div ',
             ] as $tag_start
         ) {
             $content = stripRecursiveHTMLSection($content, 'div', $tag_start);

--- a/bridges/EconomistWorldInBriefBridge.php
+++ b/bridges/EconomistWorldInBriefBridge.php
@@ -15,28 +15,28 @@ class EconomistWorldInBriefBridge extends BridgeAbstract
                 'name' => 'Split the short stories',
                 'type' => 'checkbox',
                 'defaultValue' => false,
-                'title' => 'Whether to split the short stories into separate entries'
+                'title' => 'Whether to split the short stories into separate entries',
             ],
             'limit' => [
                 'name' => 'Truncate headers for the short stories',
                 'type' => 'number',
-                'defaultValue' => 100
+                'defaultValue' => 100,
             ],
             'agenda' => [
                 'name' => 'Add agenda for the day',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'agendaPictures' => [
                 'name' => 'Include pictures to the agenda',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'quote' => [
                 'name' => 'Include the quote of the day',
-                'type' => 'checkbox'
-            ]
-        ]
+                'type' => 'checkbox',
+            ],
+        ],
     ];
 
     public function collectData()
@@ -78,7 +78,7 @@ class EconomistWorldInBriefBridge extends BridgeAbstract
                 'title' => $title,
                 'content' => $gobbet->innertext,
                 'timestamp' => $today->format('U'),
-                'uid' => md5($gobbet->plaintext)
+                'uid' => md5($gobbet->plaintext),
             ];
             $this->items[] = $item;
         }
@@ -97,7 +97,7 @@ class EconomistWorldInBriefBridge extends BridgeAbstract
             'title' => 'World in brief at ' . $today->format('Y.m.d'),
             'content' => $contents,
             'timestamp' => $today->format('U'),
-            'uid' => 'world-in-brief-' . $today->format('U')
+            'uid' => 'world-in-brief-' . $today->format('U'),
         ];
     }
 
@@ -137,7 +137,7 @@ class EconomistWorldInBriefBridge extends BridgeAbstract
             'title' => 'Quote of the day ' . $today->format('Y.m.d'),
             'content' => $quote->innertext,
             'timestamp' => $today->format('U'),
-            'uid' => 'quote-' . $today->format('U')
+            'uid' => 'quote-' . $today->format('U'),
         ];
     }
 }

--- a/bridges/EliteDangerousGalnetBridge.php
+++ b/bridges/EliteDangerousGalnetBridge.php
@@ -15,11 +15,11 @@ class EliteDangerousGalnetBridge extends BridgeAbstract
                 'values' => [
                     'English' => 'en',
                     'French' => 'fr',
-                    'German' => 'de'
+                    'German' => 'de',
                 ],
-                'defaultValue' => 'en'
-            ]
-        ]
+                'defaultValue' => 'en',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/ElloBridge.php
+++ b/bridges/ElloBridge.php
@@ -14,23 +14,23 @@ class ElloBridge extends BridgeAbstract
                 'name' => 'Username',
                 'required' => true,
                 'exampleValue' => 'zteph',
-                'title' => 'Username'
-            ]
+                'title' => 'Username',
+            ],
         ],
         'Search' => [
             's' => [
                 'name' => 'Search',
                 'required' => true,
                 'exampleValue' => 'bird',
-                'title' => 'Search'
-            ]
-        ]
+                'title' => 'Search',
+            ],
+        ],
     ];
 
     public function collectData()
     {
         $header = [
-            'Authorization: Bearer ' . $this->getAPIKey()
+            'Authorization: Bearer ' . $this->getAPIKey(),
         ];
 
         if (!empty($this->getInput('u'))) {

--- a/bridges/ElsevierBridge.php
+++ b/bridges/ElsevierBridge.php
@@ -13,8 +13,8 @@ class ElsevierBridge extends BridgeAbstract
             'name' => 'Journal name',
             'required' => true,
             'exampleValue' => 'academic-pediatrics',
-            'title' => 'Insert html-part of your journal'
-        ]
+            'title' => 'Insert html-part of your journal',
+        ],
     ]];
 
     public function collectData()

--- a/bridges/EsquerdaNetBridge.php
+++ b/bridges/EsquerdaNetBridge.php
@@ -18,9 +18,9 @@ class EsquerdaNetBridge extends FeedExpander
                     'Vídeo' => 'video',
                     'Opinião' => 'opinioes',
                     'Rádio' => 'radio',
-                ]
-            ]
-        ]
+                ],
+            ],
+        ],
     ];
 
     public function getURI()

--- a/bridges/EtsyBridge.php
+++ b/bridges/EtsyBridge.php
@@ -13,7 +13,7 @@ class EtsyBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert your search term here',
-                'exampleValue' => 'lamp'
+                'exampleValue' => 'lamp',
             ],
             'queryextension' => [
                 'name' => 'Query extension',
@@ -21,14 +21,14 @@ class EtsyBridge extends BridgeAbstract
                 'required' => false,
                 'title' => 'Insert additional query parts here
 (anything after ?search=<your search query>)',
-                'exampleValue' => '&explicit=1&locationQuery=2921044'
+                'exampleValue' => '&explicit=1&locationQuery=2921044',
             ],
             'hideimage' => [
                 'name' => 'Hide image in content',
                 'type' => 'checkbox',
                 'title' => 'Activate to hide the image in the content',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/EuronewsBridge.php
+++ b/bridges/EuronewsBridge.php
@@ -33,16 +33,16 @@ class EuronewsBridge extends BridgeAbstract
                     // 'Georigian' => 'euronewsgeorgia.com',
                     // 'Bulgarian' => 'euronewsbulgaria.com'
                     // 'Serbian' => 'euronews.rs'
-                ]
+                ],
             ],
             'limit' => [
                 'name' => 'Limit of items per feed',
                 'required' => true,
                 'type' => 'number',
                 'defaultValue' => 10,
-                'title' => 'Maximum number of returned feed items. Maximum 50, default 10'
+                'title' => 'Maximum number of returned feed items. Maximum 50, default 10',
             ],
-        ]
+        ],
     ];
 
     public function collectData()
@@ -75,7 +75,7 @@ class EuronewsBridge extends BridgeAbstract
                 'content' => $url_datum['content'],
                 'author' => $url_datum['author'],
                 'enclosures' => $url_datum['enclosures'],
-                'categories' => array_unique($categories)
+                'categories' => array_unique($categories),
             ];
             $this->items[] = $item;
         }
@@ -205,7 +205,7 @@ class EuronewsBridge extends BridgeAbstract
         return [
             'author' => $author,
             'content' => $content,
-            'enclosures' => $enclosures
+            'enclosures' => $enclosures,
         ];
     }
 }

--- a/bridges/ExplosmBridge.php
+++ b/bridges/ExplosmBridge.php
@@ -13,9 +13,9 @@ class ExplosmBridge extends BridgeAbstract
                 'name' => 'Posts limit',
                 'type' => 'number',
                 'title' => 'Maximum number of items to return',
-                'defaultValue' => 5
-                ]
-            ]
+                'defaultValue' => 5,
+                ],
+            ],
         ];
 
     public function collectData()

--- a/bridges/ExtremeDownloadBridge.php
+++ b/bridges/ExtremeDownloadBridge.php
@@ -13,7 +13,7 @@ class ExtremeDownloadBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'URL d\'une série sans le https://www.extreme-down.plus/',
-                'exampleValue' => 'series-hd/hd-series-vostfr/46631-halt-and-catch-fire-saison-04-vostfr-hdtv-720p.html'],
+                'exampleValue' => 'series-hd/hd-series-vostfr/46631-halt-and-catch-fire-saison-04-vostfr-hdtv-720p.html', ],
             'filter' => [
                 'name' => 'Type de contenu',
                 'type' => 'list',
@@ -21,10 +21,10 @@ class ExtremeDownloadBridge extends BridgeAbstract
                 'values' => [
                     'Streaming et Téléchargement' => 'both',
                     'Téléchargement' => 'download',
-                    'Streaming' => 'streaming'
-                    ]
-                ]
-            ]
+                    'Streaming' => 'streaming',
+                    ],
+                ],
+            ],
         ];
 
     public function collectData()
@@ -35,7 +35,7 @@ class ExtremeDownloadBridge extends BridgeAbstract
 
         $typesText = [
             'download' => 'Téléchargement',
-            'streaming' => 'Streaming'
+            'streaming' => 'Streaming',
         ];
 
         // Get the TV show title

--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -12,7 +12,7 @@ class FB2Bridge extends BridgeAbstract
     const PARAMETERS = [ [
         'u' => [
             'name' => 'Username',
-            'required' => true
+            'required' => true,
         ],
         'abbrev_name' => [
             'name' => 'Abbreviate author name in title',
@@ -65,7 +65,7 @@ class FB2Bridge extends BridgeAbstract
                 'confused' => 'o_O',
                 'upset' => 'xD',
                 'colonthree' => ':3',
-                'like' => '&#x1F44D;'];
+                'like' => '&#x1F44D;', ];
             $len = count($matches);
             if ($len > 1) {
                 for ($i = 1; $i < $len; $i++) {
@@ -85,14 +85,16 @@ class FB2Bridge extends BridgeAbstract
             $pageInfo = $this->getPageInfos($page, $cookies);
 
             if ($pageInfo['userId'] === null) {
-                returnClientError(<<<EOD
-Unable to get the page id. You should consider getting the ID by hand, then importing it into FB2Bridge
-EOD
+                returnClientError(
+                    <<<EOD
+                        Unable to get the page id. You should consider getting the ID by hand, then importing it into FB2Bridge
+                        EOD
                 );
             } elseif ($pageInfo['userId'] == -1) {
-                returnClientError(<<<EOD
-This page is not accessible without being logged in.
-EOD
+                returnClientError(
+                    <<<EOD
+                        This page is not accessible without being logged in.
+                        EOD
                 );
             }
         }
@@ -120,7 +122,7 @@ EOD
 
             //Decode images
             $imagecleaned = preg_replace_callback('/<i [^>]* style="[^"]*url\(\'(.*?)\'\).*?><\/i>/m', function ($matches) {
-                    return "<img src='" . str_replace(['\\3a ', '\\3d ', '\\26 '], [':', '=', '&'], $matches[1]) . "' />";
+                return "<img src='" . str_replace(['\\3a ', '\\3d ', '\\26 '], [':', '=', '&'], $matches[1]) . "' />";
             }, $content);
             $content = str_get_html($imagecleaned);
 
@@ -156,9 +158,9 @@ EOD
                 'aria-[^=]*',
                 'role',
                 'rel',
-                'id'] as $property_name
+                'id', ] as $property_name
             ) {
-                    $content = preg_replace('/ ' . $property_name . '=\"[^"]*\"/i', '', $content);
+                $content = preg_replace('/ ' . $property_name . '=\"[^"]*\"/i', '', $content);
             }
             $content = preg_replace('/<\/a [^>]+>/i', '</a>', $content);
 
@@ -247,8 +249,8 @@ EOD
         $ctx = stream_context_create([
             'http' => [
                 'user_agent' => Configuration::getConfig('http', 'useragent'),
-                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
-                ]
+                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                ],
             ]);
         $a = file_get_contents($pageURL, 0, $ctx);
 
@@ -271,8 +273,8 @@ EOD
         $context = stream_context_create([
             'http' => [
                 'user_agent' => Configuration::getConfig('http', 'useragent'),
-                'header' => 'Cookie: ' . $cookies
-                ]
+                'header' => 'Cookie: ' . $cookies,
+                ],
             ]);
 
         $pageContent = file_get_contents($page, 0, $context);

--- a/bridges/FDroidBridge.php
+++ b/bridges/FDroidBridge.php
@@ -14,9 +14,9 @@ class FDroidBridge extends BridgeAbstract
             'type' => 'list',
             'values' => [
                 'Latest added apps' => 'added',
-                'Latest updated apps' => 'updated'
-            ]
-        ]
+                'Latest updated apps' => 'updated',
+            ],
+        ],
     ]];
 
     public function getIcon()
@@ -28,10 +28,10 @@ class FDroidBridge extends BridgeAbstract
     {
         $curlOptions = [
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_HEADER         => true,
-            CURLOPT_NOBODY         => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_NOBODY => true,
             CURLOPT_CONNECTTIMEOUT => 19,
-            CURLOPT_TIMEOUT        => 19,
+            CURLOPT_TIMEOUT => 19,
         ];
         $ch = curl_init($url);
         curl_setopt_array($ch, $curlOptions);
@@ -72,17 +72,17 @@ class FDroidBridge extends BridgeAbstract
         // and now extracting app info from the selected widget (and yeah turns out icons are of heterogeneous sizes)
 
         foreach ($html_widget->find('a') as $element) {
-                $item = [];
-                $item['uri'] = self::URI . $element->href;
-                $item['title'] = $element->find('h4', 0)->plaintext;
-                $item['icon'] = $element->find('img', 0)->src;
-                $item['timestamp'] = $this->getTimestamp($item['icon']);
-                $item['summary'] = $element->find('span.package-summary', 0)->plaintext;
-                $item['content'] = '
+            $item = [];
+            $item['uri'] = self::URI . $element->href;
+            $item['title'] = $element->find('h4', 0)->plaintext;
+            $item['icon'] = $element->find('img', 0)->src;
+            $item['timestamp'] = $this->getTimestamp($item['icon']);
+            $item['summary'] = $element->find('span.package-summary', 0)->plaintext;
+            $item['content'] = '
 					<a href="' . $item['uri'] . '">
 						<img alt="" style="max-height:128px" src="' . $item['icon'] . '">
 					</a><br>' . $item['summary'];
-                $this->items[] = $item;
+            $this->items[] = $item;
         }
     }
 }

--- a/bridges/FDroidRepoBridge.php
+++ b/bridges/FDroidRepoBridge.php
@@ -14,8 +14,8 @@ class FDroidRepoBridge extends BridgeAbstract
                 'name' => 'Repository URL',
                 'title' => 'Usually ends with /repo/',
                 'required' => true,
-                'exampleValue' => 'https://srv.tt-rss.org/fdroid/repo'
-            ]
+                'exampleValue' => 'https://srv.tt-rss.org/fdroid/repo',
+            ],
         ],
         'Latest Updates' => [
             'sorting' => [
@@ -23,21 +23,21 @@ class FDroidRepoBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     'Latest added apps' => 'added',
-                    'Latest updated apps' => 'lastUpdated'
-                ]
+                    'Latest updated apps' => 'lastUpdated',
+                ],
             ],
             'locale' => [
                 'name' => 'Locale',
-                'defaultValue' => 'en-US'
-            ]
+                'defaultValue' => 'en-US',
+            ],
         ],
         'Follow Package' => [
             'package' => [
                 'name' => 'Package Identifier',
                 'required' => true,
-                'exampleValue' => 'org.fox.ttrss'
-            ]
-        ]
+                'exampleValue' => 'org.fox.ttrss',
+            ],
+        ],
     ];
 
     // Stores repo information
@@ -157,18 +157,18 @@ class FDroidRepoBridge extends BridgeAbstract
             $issueTracker = $this->link($app['issueTracker'] ?? null);
             $license = $app['license'] ?? 'None';
             $item['content'] = <<<EOD
-{$icon}
-<p>{$summary}</p>
-<h1>Description</h1>
-{$description}
-<h1>What's New</h1>
-{$whatsNew}
-<h1>Information</h1>
-<p>Website: {$website}</p>
-<p>Source Code: {$source}</p>
-<p>Issue Tracker: {$issueTracker}</p>
-<p>license: {$app['license']}</p>
-EOD;
+                {$icon}
+                <p>{$summary}</p>
+                <h1>Description</h1>
+                {$description}
+                <h1>What's New</h1>
+                {$whatsNew}
+                <h1>Information</h1>
+                <p>Website: {$website}</p>
+                <p>Source Code: {$source}</p>
+                <p>Issue Tracker: {$issueTracker}</p>
+                <p>license: {$app['license']}</p>
+                EOD;
             $this->items[] = $item;
         }
     }
@@ -190,11 +190,11 @@ EOD;
             $size = round($version['size'] / 1048576, 1); // Bytes -> MB
             $sdk_link = 'https://developer.android.com/studio/releases/platforms';
             $item['content'] = <<<EOD
-<p>size: {$size}MB</p>
-<p>Minimum SDK: {$version['minSdkVersion']}
-(<a href="{$sdk_link}">SDK to Android Version List</a>)</p>
-<p>hash ({$version['hashType']}): {$version['hash']}</p>
-EOD;
+                <p>size: {$size}MB</p>
+                <p>Minimum SDK: {$version['minSdkVersion']}
+                (<a href="{$sdk_link}">SDK to Android Version List</a>)</p>
+                <p>hash ({$version['hashType']}): {$version['hash']}</p>
+                EOD;
             $this->items[] = $item;
             if (--$count <= 0) {
                 break;

--- a/bridges/FM4Bridge.php
+++ b/bridges/FM4Bridge.php
@@ -12,20 +12,20 @@ class FM4Bridge extends BridgeAbstract
             'tag' => [
                 'name' => 'Tag (author, category, ...)',
                 'title' => 'Tag to retrieve',
-                'exampleValue' => 'musik'
+                'exampleValue' => 'musik',
             ],
             'loadcontent' => [
                 'name' => 'Load Full Article Content',
                 'title' => 'Retrieve full content of articles (may take longer)',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'pages' => [
                 'name' => 'Pages',
                 'title' => 'Amount of pages to load',
                 'type' => 'number',
-                'defaultValue' => 1
-            ]
-        ]
+                'defaultValue' => 1,
+            ],
+        ],
     ];
 
     private function getPageData($tag, $page)

--- a/bridges/FSecureBlogBridge.php
+++ b/bridges/FSecureBlogBridge.php
@@ -21,7 +21,7 @@ class FSecureBlogBridge extends BridgeAbstract
                 'name' => 'Oldest article date',
                 'exampleValue' => '-6 months',
             ],
-        ]
+        ],
     ];
 
     public function getURI()

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -13,7 +13,7 @@ class FacebookBridge extends BridgeAbstract
         'User' => [
             'u' => [
                 'name' => 'Username',
-                'required' => true
+                'required' => true,
             ],
             'media_type' => [
                 'name' => 'Media type',
@@ -22,17 +22,17 @@ class FacebookBridge extends BridgeAbstract
                 'values' => [
                     'All' => 'all',
                     'Video' => 'video',
-                    'No Video' => 'novideo'
+                    'No Video' => 'novideo',
                 ],
-                'defaultValue' => 'all'
+                'defaultValue' => 'all',
             ],
             'skip_reviews' => [
                 'name' => 'Skip reviews',
                 'type' => 'checkbox',
                 'required' => false,
                 'defaultValue' => false,
-                'title' => 'Feed includes reviews when unchecked'
-            ]
+                'title' => 'Feed includes reviews when unchecked',
+            ],
         ],
         'Group' => [
             'g' => [
@@ -40,8 +40,8 @@ class FacebookBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'https://www.facebook.com/groups/743149642484225',
-                'title' => 'Insert group name or facebook group URL'
-            ]
+                'title' => 'Insert group name or facebook group URL',
+            ],
         ],
         'global' => [
             'limit' => [
@@ -49,9 +49,9 @@ class FacebookBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Specify the number of items to return (default: -1)',
-                'defaultValue' => -1
-            ]
-        ]
+                'defaultValue' => -1,
+            ],
+        ],
     ];
 
     private $authorName = '';
@@ -67,7 +67,7 @@ class FacebookBridge extends BridgeAbstract
         switch ($this->queriedContext) {
             case 'User':
                 if (!empty($this->authorName)) {
-                    return isset($this->extraInfos['name']) ? $this->extraInfos['name'] : $this->authorName;
+                    return $this->extraInfos['name'] ?? $this->authorName;
                 }
                 break;
 
@@ -425,7 +425,7 @@ class FacebookBridge extends BridgeAbstract
     private function unescapeFacebookEmote($content)
     {
         return preg_replace_callback('/<i><u>([^ <>]+) ([^<>]+)<\/u><\/i>/i', function ($matches) {
-                static $facebook_emoticons = [
+            static $facebook_emoticons = [
                     'smile' => ':)',
                     'frown' => ':(',
                     'tongue' => ':P',
@@ -446,21 +446,21 @@ class FacebookBridge extends BridgeAbstract
                     'confused' => 'o_O',
                     'upset' => 'xD',
                     'colonthree' => ':3',
-                    'like' => '&#x1F44D;'];
+                    'like' => '&#x1F44D;', ];
 
-                $len = count($matches);
+            $len = count($matches);
 
-                if ($len > 1) {
-                    for ($i = 1; $i < $len; $i++) {
-                        foreach ($facebook_emoticons as $name => $emote) {
-                            if ($matches[$i] === $name) {
-                                return $emote;
-                            }
+            if ($len > 1) {
+                for ($i = 1; $i < $len; $i++) {
+                    foreach ($facebook_emoticons as $name => $emote) {
+                        if ($matches[$i] === $name) {
+                            return $emote;
                         }
                     }
                 }
+            }
 
-                return $matches[0];
+            return $matches[0];
         }, $content);
     }
 
@@ -489,15 +489,15 @@ class FacebookBridge extends BridgeAbstract
         header('Content-Type: text/html', true, 500);
 
         $message = <<<EOD
-<form method="post" action="?{$_SERVER['QUERY_STRING']}">
-<h2>Facebook captcha challenge</h2>
-<p>Unfortunately, rss-bridge cannot fetch the requested page.<br />
-Facebook wants rss-bridge to resolve the following captcha:</p>
-<p><img src="data:image/png;base64,{$img}" /></p>
-<p><b>Response:</b> <input name="captcha_response" placeholder="please fill in" />
-<input type="submit" value="Submit!" /></p>
-</form>
-EOD;
+            <form method="post" action="?{$_SERVER['QUERY_STRING']}">
+            <h2>Facebook captcha challenge</h2>
+            <p>Unfortunately, rss-bridge cannot fetch the requested page.<br />
+            Facebook wants rss-bridge to resolve the following captcha:</p>
+            <p><img src="data:image/png;base64,{$img}" /></p>
+            <p><b>Response:</b> <input name="captcha_response" placeholder="please fill in" />
+            <input type="submit" value="Submit!" /></p>
+            </form>
+            EOD;
 
         die($message);
     }
@@ -521,12 +521,12 @@ EOD;
                 $header = [
                     'Content-type: application/x-www-form-urlencoded',
                     'Referer: ' . $captcha_action,
-                    'Cookie: noscript=1'
+                    'Cookie: noscript=1',
                 ];
 
                 $opts = [
                     CURLOPT_POST => 1,
-                    CURLOPT_POSTFIELDS => http_build_query($captcha_fields)
+                    CURLOPT_POSTFIELDS => http_build_query($captcha_fields),
                 ];
 
                 $html = getSimpleHTMLDOM($captcha_action, $header, $opts);
@@ -688,7 +688,7 @@ EOD;
                             'aria-[^=]*',
                             'role',
                             'rel',
-                            'id'] as $property_name
+                            'id', ] as $property_name
                         ) {
                             $content = preg_replace('/ ' . $property_name . '=\"[^"]*\"/i', '', $content);
                         }

--- a/bridges/FeedExpanderExampleBridge.php
+++ b/bridges/FeedExpanderExampleBridge.php
@@ -18,10 +18,10 @@ class FeedExpanderExampleBridge extends FeedExpander
                     'RSS 0.91' => 'rss_0_9_1',
                     'RSS 1.0' => 'rss_1_0',
                     'RSS 2.0' => 'rss_2_0',
-                    'ATOM 1.0' => 'atom_1_0'
-                ]
-            ]
-        ]
+                    'ATOM 1.0' => 'atom_1_0',
+                ],
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/FeedMergeBridge.php
+++ b/bridges/FeedMergeBridge.php
@@ -6,8 +6,8 @@ class FeedMergeBridge extends FeedExpander
     const NAME = 'FeedMerge';
     const URI = 'https://github.com/RSS-Bridge/rss-bridge';
     const DESCRIPTION = <<<'TEXT'
-This bridge merges two or more feeds into a single feed. Max 10 items are fetched from each feed.
-TEXT;
+        This bridge merges two or more feeds into a single feed. Max 10 items are fetched from each feed.
+        TEXT;
 
     const PARAMETERS = [
         [
@@ -20,7 +20,7 @@ TEXT;
                 'name' => 'Feed url',
                 'type' => 'text',
                 'required' => true,
-                'exampleValue' => 'https://lorem-rss.herokuapp.com/feed?unit=day'
+                'exampleValue' => 'https://lorem-rss.herokuapp.com/feed?unit=day',
             ],
             'feed_2' => ['name' => 'Feed url', 'type' => 'text'],
             'feed_3' => ['name' => 'Feed url', 'type' => 'text'],
@@ -28,7 +28,7 @@ TEXT;
             'feed_5' => ['name' => 'Feed url', 'type' => 'text'],
 
             'limit' => self::LIMIT,
-        ]
+        ],
     ];
 
     public function collectData()
@@ -48,7 +48,7 @@ TEXT;
             $this->collectExpandableDatas($feed);
         }
         // Sort by timestamp descending
-        usort($this->items, fn($a, $b) => $b['timestamp'] <=> $a['timestamp']);
+        usort($this->items, fn ($a, $b) => $b['timestamp'] <=> $a['timestamp']);
         // Grab the first $limit items
         $this->items = array_slice($this->items, 0, $limit);
     }

--- a/bridges/FeedReducerBridge.php
+++ b/bridges/FeedReducerBridge.php
@@ -10,14 +10,14 @@ class FeedReducerBridge extends FeedExpander
         'url' => [
             'name' => 'Feed URI',
             'exampleValue' => 'https://lorem-rss.herokuapp.com/feed?length=42',
-            'required' => true
+            'required' => true,
         ],
         'percentage' => [
             'name' => 'percentage',
             'type' => 'number',
             'exampleValue' => 50,
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
     const CACHE_TIMEOUT = 3600;
 

--- a/bridges/FilterBridge.php
+++ b/bridges/FilterBridge.php
@@ -11,7 +11,7 @@ class FilterBridge extends FeedExpander
     const PARAMETERS = [[
         'url' => [
             'name' => 'Feed URL',
-            'type'  => 'text',
+            'type' => 'text',
             'defaultValue' => 'https://lorem-rss.herokuapp.com/feed?unit=day',
             'required' => true,
         ],
@@ -43,7 +43,7 @@ class FilterBridge extends FeedExpander
             'name' => 'Apply filter on title',
             'type' => 'checkbox',
             'required' => false,
-            'defaultValue' => 'checked'
+            'defaultValue' => 'checked',
         ],
         'target_content' => [
             'name' => 'Apply filter on content',

--- a/bridges/FindACrewBridge.php
+++ b/bridges/FindACrewBridge.php
@@ -14,23 +14,23 @@ class FindACrewBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     'Find a boat' => 'boat',
-                    'Find a crew' => 'crew'
-                ]
+                    'Find a crew' => 'crew',
+                ],
             ],
             'long' => [
                 'name' => 'Longitude of the searched location',
-                'title' => 'Center the search at that longitude (e.g: -42.02)'
+                'title' => 'Center the search at that longitude (e.g: -42.02)',
             ],
             'lat' => [
                 'name' => 'Latitude of the searched location',
-                'title' => 'Center the search at that latitude (e.g: 12.42)'
+                'title' => 'Center the search at that latitude (e.g: 12.42)',
             ],
             'distance' => [
                 'name' => 'Limit boundary of search in KM',
-                'title' => 'Boundary of the search in kilometers when using longitude and latitude'
+                'title' => 'Boundary of the search in kilometers when using longitude and latitude',
             ],
             'limit' => self::LIMIT,
-        ]
+        ],
     ];
 
     public function collectData()
@@ -52,12 +52,12 @@ class FindACrewBridge extends BridgeAbstract
         }
 
         $header = [
-            'Content-Type: application/x-www-form-urlencoded'
+            'Content-Type: application/x-www-form-urlencoded',
         ];
 
         $opts = [
             CURLOPT_CUSTOMREQUEST => 'POST',
-            CURLOPT_POSTFIELDS => http_build_query($data) . "\n"
+            CURLOPT_POSTFIELDS => http_build_query($data) . "\n",
         ];
 
         $html = getSimpleHTMLDOM($url, $header, $opts) or returnClientError('No results for this query.');

--- a/bridges/FirefoxAddonsBridge.php
+++ b/bridges/FirefoxAddonsBridge.php
@@ -12,8 +12,8 @@ class FirefoxAddonsBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'save-to-the-wayback-machine',
-            ]
-        ]
+            ],
+        ],
     ];
 
     const CACHE_TIMEOUT = 3600;
@@ -73,15 +73,15 @@ class FirefoxAddonsBridge extends BridgeAbstract
             }
 
             $item['content'] = <<<EOD
-<strong>Release Notes</strong>
-<p>{$releaseNotes}</p>
-<strong>Compatibility</strong>
-<p>{$compatibility}</p>
-<strong>License</strong>
-<p>{$license}</p>
-<strong>Download</strong>
-<p><a href="{$downloadlink}">{$xpiFilename}</a> ($size)</p>
-EOD;
+                <strong>Release Notes</strong>
+                <p>{$releaseNotes}</p>
+                <strong>Compatibility</strong>
+                <p>{$compatibility}</p>
+                <strong>License</strong>
+                <p>{$license}</p>
+                <strong>Download</strong>
+                <p><a href="{$downloadlink}">{$xpiFilename}</a> ($size)</p>
+                EOD;
 
             $this->items[] = $item;
         }

--- a/bridges/FirstLookMediaTechBridge.php
+++ b/bridges/FirstLookMediaTechBridge.php
@@ -11,8 +11,8 @@ class FirstLookMediaTechBridge extends BridgeAbstract
             'projects' => [
                 'type' => 'checkbox',
                 'name' => 'Include Projects?',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/FlashbackBridge.php
+++ b/bridges/FlashbackBridge.php
@@ -14,24 +14,24 @@ class FlashbackBridge extends BridgeAbstract
                 'name' => 'Category number',
                 'type' => 'number',
                 'exampleValue' => '249',
-                'required' => true
-                ]
+                'required' => true,
+                ],
     ],
     'Tag' => [
     'a' => [
                 'name' => 'Tag',
                 'type' => 'text',
                 'exampleValue' => 'stockholm',
-                'required' => true
-                ]
+                'required' => true,
+                ],
     ],
     'Thread' => [
     't' => [
                 'name' => 'Thread number',
                 'type' => 'number',
                 'exampleValue' => '1420554',
-                'required' => true
-                ]
+                'required' => true,
+                ],
     ],
     /*'User' => array(
     'u' => array(
@@ -46,7 +46,7 @@ class FlashbackBridge extends BridgeAbstract
                 'name' => 'Words',
                 'type' => 'text',
                 'exampleValue' => 'sök',
-                'required' => true
+                'required' => true,
                 ],
     'type' => [
                 'name' => 'Type of search',
@@ -54,10 +54,10 @@ class FlashbackBridge extends BridgeAbstract
                 'defaultValue' => 'Posts',
                 'values' => [
                     'Posts' => 'posts',
-                    'Subjects' => 'subjects'
-                ]
-    ]
-    ]
+                    'Subjects' => 'subjects',
+                ],
+    ],
+    ],
     ];
 
     public function getName()

--- a/bridges/FlickrBridge.php
+++ b/bridges/FlickrBridge.php
@@ -19,7 +19,7 @@ class FlickrBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert keyword',
-                'exampleValue' => 'bird'
+                'exampleValue' => 'bird',
             ],
             'media' => [
                 'name' => 'Media',
@@ -41,7 +41,7 @@ class FlickrBridge extends BridgeAbstract
                     'Interesting' => 'interestingness-desc',
                 ],
                 'defaultValue' => 'relevance',
-            ]
+            ],
         ],
         'By username' => [
             'u' => [
@@ -49,7 +49,7 @@ class FlickrBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert username (as shown in the address bar)',
-                'exampleValue' => 'flickr'
+                'exampleValue' => 'flickr',
             ],
             'content' => [
                 'name' => 'Content',
@@ -80,8 +80,8 @@ class FlickrBridge extends BridgeAbstract
                     'Interesting' => 'interestingness-desc',
                 ],
                 'defaultValue' => 'date-posted-desc',
-            ]
-        ]
+            ],
+        ],
     ];
 
     private $username = '';

--- a/bridges/FolhaDeSaoPauloBridge.php
+++ b/bridges/FolhaDeSaoPauloBridge.php
@@ -26,7 +26,7 @@ class FolhaDeSaoPauloBridge extends FeedExpander
                 'type' => 'checkbox',
                 'defaultValue' => true,
             ],
-        ]
+        ],
     ];
 
     protected function parseItem($item)

--- a/bridges/Formula1Bridge.php
+++ b/bridges/Formula1Bridge.php
@@ -26,9 +26,9 @@ class Formula1Bridge extends BridgeAbstract
                 'required' => false,
                 'title' => 'Number of articles to return',
                 'exampleValue' => self::LIMIT_DEFAULT,
-                'defaultValue' => self::LIMIT_DEFAULT
-            ]
-        ]
+                'defaultValue' => self::LIMIT_DEFAULT,
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/FourchanBridge.php
+++ b/bridges/FourchanBridge.php
@@ -18,8 +18,8 @@ class FourchanBridge extends BridgeAbstract
             'name' => 'Thread number',
             'type' => 'number',
             'exampleValue' => '597271',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     public function getURI()

--- a/bridges/FunkBridge.php
+++ b/bridges/FunkBridge.php
@@ -13,14 +13,14 @@ class FunkBridge extends BridgeAbstract
                 'name' => 'Slug',
                 'type' => 'text',
                 'required' => true,
-                'exampleValue' => 'game-two-856'
+                'exampleValue' => 'game-two-856',
             ],
             'max' => [
                 'name' => 'Maximum',
                 'type' => 'number',
-                'defaultValue' => '-1'
-            ]
-        ]
+                'defaultValue' => '-1',
+            ],
+        ],
     ];
 
     public function collectData()
@@ -53,7 +53,7 @@ class FunkBridge extends BridgeAbstract
         $item['author'] = str_replace('-' . $element['channelId'], '', $element['channelAlias']);
         $item['content'] = $element['shortDescription'];
         $item['enclosures'] = [
-            'https://www.funk.net/api/v4.0/thumbnails/' . $element['imageLandscape']
+            'https://www.funk.net/api/v4.0/thumbnails/' . $element['imageLandscape'],
         ];
         $item['uid'] = $element['entityId'];
         return $item;
@@ -64,7 +64,7 @@ class FunkBridge extends BridgeAbstract
         $regex = '/^https?:\/\/(?:www\.)?funk\.net\/channel\/([^\/]+).*$/';
         if (preg_match($regex, $url, $urlMatches) > 0) {
             return [
-                'channel' => $urlMatches[1]
+                'channel' => $urlMatches[1],
             ];
         } else {
             return null;

--- a/bridges/FurAffinityBridge.php
+++ b/bridges/FurAffinityBridge.php
@@ -17,7 +17,7 @@ class FurAffinityBridge extends BridgeAbstract
             'rating-general' => [
                 'name' => 'General',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'rating-mature' => [
                 'name' => 'Mature',
@@ -35,39 +35,39 @@ class FurAffinityBridge extends BridgeAbstract
                     '3 Days' => '3days',
                     'A Week' => 'week',
                     'A Month' => 'month',
-                    'All time' => 'all'
+                    'All time' => 'all',
                 ],
-                'defaultValue' => 'all'
+                'defaultValue' => 'all',
             ],
             'type-art' => [
                 'name' => 'Art',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'type-flash' => [
                 'name' => 'Flash',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'type-photo' => [
                 'name' => 'Photography',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'type-music' => [
                 'name' => 'Music',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'type-story' => [
                 'name' => 'Story',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'type-poetry' => [
                 'name' => 'Poetry',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'mode' => [
                 'name' => 'Match mode',
@@ -75,29 +75,29 @@ class FurAffinityBridge extends BridgeAbstract
                 'values' => [
                     'All of the words' => 'all',
                     'Any of the words' => 'any',
-                    'Extended' => 'extended'
+                    'Extended' => 'extended',
                 ],
-                'defaultValue' => 'extended'
+                'defaultValue' => 'extended',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 10,
-                'title' => 'Limit number of submissions to return. -1 for unlimited.'
+                'title' => 'Limit number of submissions to return. -1 for unlimited.',
             ],
             'full' => [
                 'name' => 'Full view',
                 'title' => 'Include description, tags, date and larger image in article. Uses more bandwidth.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'cache' => [
                 'name' => 'Cache submission pages',
                 'title' => 'Reduces requests to FA when Full view is enabled. Changes to submission details may be delayed.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
-            ]
+                'defaultValue' => 'checked',
+            ],
         ],
         'Browse' => [
             'cat' => [
@@ -116,21 +116,21 @@ class FurAffinityBridge extends BridgeAbstract
                         'Icons' => 9,
                         'Mosaics' => 10,
                         'Photography' => 11,
-                        'Sculpting' => 12
+                        'Sculpting' => 12,
                     ],
                     'Readable Art' => [
                         'Story' => 13,
                         'Poetry' => 14,
-                        'Prose' => 15
+                        'Prose' => 15,
                     ],
                     'Audio Art' => [
                         'Music' => 16,
-                        'Podcasts' => 17
+                        'Podcasts' => 17,
                     ],
                     'Downloadable' => [
                         'Skins' => 18,
                         'Handhelds' => 19,
-                        'Resources' => 20
+                        'Resources' => 20,
                     ],
                     'Other Stuff' => [
                         'Adoptables' => 21,
@@ -143,10 +143,10 @@ class FurAffinityBridge extends BridgeAbstract
                         'Scraps' => 28,
                         'Wallpaper' => 29,
                         'YCH / Sale' => 30,
-                        'Other' => 31
-                    ]
+                        'Other' => 31,
+                    ],
                 ],
-                'defaultValue' => 1
+                'defaultValue' => 1,
             ],
             'atype' => [
                 'name' => 'Type',
@@ -166,7 +166,7 @@ class FurAffinityBridge extends BridgeAbstract
                         'Scenery' => 11,
                         'Still Life' => 12,
                         'Tutorials' => 13,
-                        'Miscellaneous' => 14
+                        'Miscellaneous' => 14,
                     ],
                     'Fetish / Furry specialty' => [
                         'Baby fur' => 101,
@@ -188,7 +188,7 @@ class FurAffinityBridge extends BridgeAbstract
                         'Transformation' => 116,
                         'Vore' => 117,
                         'Water Sports' => 118,
-                        'General Furry Art' => 100
+                        'General Furry Art' => 100,
                     ],
                     'Music' => [
                         'Techno' => 201,
@@ -205,10 +205,10 @@ class FurAffinityBridge extends BridgeAbstract
                         'Pop' => 212,
                         'Rap' => 213,
                         'Industrial' => 214,
-                        'Other Music' => 200
-                    ]
+                        'Other Music' => 200,
+                    ],
                 ],
-                'defaultValue' => 1
+                'defaultValue' => 1,
             ],
             'species' => [
                 'name' => 'Species',
@@ -219,7 +219,7 @@ class FurAffinityBridge extends BridgeAbstract
                         'Frog' => 1001,
                         'Newt' => 1002,
                         'Salamander' => 1003,
-                        'Amphibian (Other)' => 1000
+                        'Amphibian (Other)' => 1000,
                     ],
                     'Aquatic' => [
                         'Cephalopod' => 2001,
@@ -229,7 +229,7 @@ class FurAffinityBridge extends BridgeAbstract
                         'Seal' => 6068,
                         'Shark' => 2006,
                         'Whale' => 2003,
-                        'Aquatic (Other)' => 2000
+                        'Aquatic (Other)' => 2000,
                     ],
                     'Avian' => [
                         'Corvid' => 3001,
@@ -243,14 +243,14 @@ class FurAffinityBridge extends BridgeAbstract
                         'Owl' => 3009,
                         'Phoenix' => 3010,
                         'Swan' => 3011,
-                        'Avian (Other)' => 3000
+                        'Avian (Other)' => 3000,
                     ],
                     'Bears &amp; Ursines' => [
-                        'Bear' => 6002
+                        'Bear' => 6002,
                     ],
                     'Camelids' => [
                         'Camel' => 6074,
-                        'Llama' => 6036
+                        'Llama' => 6036,
                     ],
                     'Canines &amp; Lupines' => [
                         'Coyote' => 6008,
@@ -261,17 +261,17 @@ class FurAffinityBridge extends BridgeAbstract
                         'Jackal' => 6013,
                         'Husky' => 6014,
                         'Wolf' => 6016,
-                        'Canine (Other)' => 6017
+                        'Canine (Other)' => 6017,
                     ],
                     'Cervines' => [
-                        'Cervine (Other)' => 6018
+                        'Cervine (Other)' => 6018,
                     ],
                     'Cows &amp; Bovines' => [
                         'Antelope' => 6004,
                         'Cows' => 6003,
                         'Gazelle' => 6005,
                         'Goat' => 6006,
-                        'Bovines (General)' => 6007
+                        'Bovines (General)' => 6007,
                     ],
                     'Dragons' => [
                         'Eastern Dragon' => 4001,
@@ -279,13 +279,13 @@ class FurAffinityBridge extends BridgeAbstract
                         'Serpent' => 4003,
                         'Western Dragon' => 4004,
                         'Wyvern' => 4005,
-                        'Dragon (Other)' => 4000
+                        'Dragon (Other)' => 4000,
                     ],
                     'Equestrians' => [
                         'Donkey' => 6019,
                         'Horse' => 6034,
                         'Pony' => 6073,
-                        'Zebra' => 6071
+                        'Zebra' => 6071,
                     ],
                     'Exotic &amp; Mythicals' => [
                         'Argonian' => 5002,
@@ -312,7 +312,7 @@ class FurAffinityBridge extends BridgeAbstract
                         'Unicorn' => 5023,
                         'Xenomorph' => 5024,
                         'Alien (Other)' => 5001,
-                        'Exotic (Other)' => 5000
+                        'Exotic (Other)' => 5000,
                     ],
                     'Felines' => [
                         'Domestic Cat' => 6020,
@@ -325,13 +325,13 @@ class FurAffinityBridge extends BridgeAbstract
                         'Ocelot' => 6027,
                         'Panther' => 6028,
                         'Tiger' => 6029,
-                        'Feline (Other)' => 6030
+                        'Feline (Other)' => 6030,
                     ],
                     'Insects' => [
                         'Arachnid' => 8000,
                         'Mantid' => 8004,
                         'Scorpion' => 8005,
-                        'Insect (Other)' => 8003
+                        'Insect (Other)' => 8003,
                     ],
                     'Mammals (Other)' => [
                         'Bat' => 6001,
@@ -347,7 +347,7 @@ class FurAffinityBridge extends BridgeAbstract
                         'Meerkat' => 6043,
                         'Mongoose' => 6044,
                         'Rhinoceros' => 6063,
-                        'Mammals (Other)' => 6000
+                        'Mammals (Other)' => 6000,
                     ],
                     'Marsupials' => [
                         'Opossum' => 6037,
@@ -355,7 +355,7 @@ class FurAffinityBridge extends BridgeAbstract
                         'Koala' => 6039,
                         'Quoll' => 6040,
                         'Wallaby' => 6041,
-                        'Marsupial (Other)' => 6042
+                        'Marsupial (Other)' => 6042,
                     ],
                     'Mustelids' => [
                         'Badger' => 6045,
@@ -364,14 +364,14 @@ class FurAffinityBridge extends BridgeAbstract
                         'Otter' => 6047,
                         'Skunk' => 6069,
                         'Weasel' => 6049,
-                        'Mustelid (Other)' => 6051
+                        'Mustelid (Other)' => 6051,
                     ],
                     'Primates' => [
                         'Gorilla' => 6054,
                         'Human' => 6055,
                         'Lemur' => 6056,
                         'Monkey' => 6057,
-                        'Primate (Other)' => 6058
+                        'Primate (Other)' => 6058,
                     ],
                     'Reptillian' => [
                         'Alligator &amp; Crocodile' => 7001,
@@ -380,26 +380,26 @@ class FurAffinityBridge extends BridgeAbstract
                         'Lizard' => 7005,
                         'Snakes &amp; Serpents' => 7006,
                         'Turtle' => 7007,
-                        'Reptilian (Other)' => 7000
+                        'Reptilian (Other)' => 7000,
                     ],
                     'Rodents' => [
                         'Beaver' => 6064,
                         'Mouse' => 6065,
                         'Rat' => 6061,
                         'Squirrel' => 6070,
-                        'Rodent (Other)' => 6067
+                        'Rodent (Other)' => 6067,
                     ],
                     'Vulpines' => [
                         'Fennec' => 6072,
                         'Fox' => 6075,
-                        'Vulpine (Other)' => 6015
+                        'Vulpine (Other)' => 6015,
                     ],
                     'Other' => [
                         'Dinosaur' => 8001,
-                        'Wolverine' => 6050
-                    ]
+                        'Wolverine' => 6050,
+                    ],
                 ],
-                'defaultValue' => 1
+                'defaultValue' => 1,
             ],
             'gender' => [
                 'name' => 'Gender',
@@ -411,14 +411,14 @@ class FurAffinityBridge extends BridgeAbstract
                     'Herm' => 4,
                     'Transgender' => 5,
                     'Multiple characters' => 6,
-                    'Other / Not Specified' => 7
+                    'Other / Not Specified' => 7,
                 ],
-                'defaultValue' => 0
+                'defaultValue' => 0,
             ],
             'rating_general' => [
                 'name' => 'General',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'rating_mature' => [
                 'name' => 'Mature',
@@ -433,20 +433,20 @@ class FurAffinityBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 10,
-                'title' => 'Limit number of submissions to return. -1 for unlimited.'
+                'title' => 'Limit number of submissions to return. -1 for unlimited.',
             ],
             'full' => [
                 'name' => 'Full view',
                 'title' => 'Include description, tags, date and larger image in article. Uses more bandwidth.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'cache' => [
                 'name' => 'Cache submission pages',
                 'title' => 'Reduces requests to FA when Full view is enabled. Changes to submission details may be delayed.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
-            ]
+                'defaultValue' => 'checked',
+            ],
 
         ],
         'Journals' => [
@@ -454,14 +454,14 @@ class FurAffinityBridge extends BridgeAbstract
                 'name' => 'Username',
                 'required' => true,
                 'exampleValue' => 'dhw',
-                'title' => 'Lowercase username as seen in URLs'
+                'title' => 'Lowercase username as seen in URLs',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'defaultValue' => -1,
-                'title' => 'Limit number of journals to return. -1 for unlimited.'
-            ]
+                'title' => 'Limit number of journals to return. -1 for unlimited.',
+            ],
 
         ],
         'Single Journal' => [
@@ -470,124 +470,124 @@ class FurAffinityBridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => '10008853',
                 'type' => 'number',
-                'title' => 'Number seen in journal URL'
-            ]
+                'title' => 'Number seen in journal URL',
+            ],
         ],
         'Gallery' => [
             'username-gallery' => [
                 'name' => 'Username',
                 'required' => true,
                 'exampleValue' => 'dhw',
-                'title' => 'Lowercase username as seen in URLs'
+                'title' => 'Lowercase username as seen in URLs',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 10,
-                'title' => 'Limit number of submissions to return. -1 for unlimited.'
+                'title' => 'Limit number of submissions to return. -1 for unlimited.',
             ],
             'full' => [
                 'name' => 'Full view',
                 'title' => 'Include description, tags, date and larger image in article. Uses more bandwidth.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'cache' => [
                 'name' => 'Cache submission pages',
                 'title' => 'Reduces requests to FA when Full view is enabled. Changes to submission details may be delayed.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
-            ]
+                'defaultValue' => 'checked',
+            ],
         ],
         'Scraps' => [
             'username-scraps' => [
                 'name' => 'Username',
                 'required' => true,
                 'exampleValue' => 'dhw',
-                'title' => 'Lowercase username as seen in URLs'
+                'title' => 'Lowercase username as seen in URLs',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 10,
-                'title' => 'Limit number of submissions to return. -1 for unlimited.'
+                'title' => 'Limit number of submissions to return. -1 for unlimited.',
             ],
             'full' => [
                 'name' => 'Full view',
                 'title' => 'Include description, tags, date and larger image in article. Uses more bandwidth.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'cache' => [
                 'name' => 'Cache submission pages',
                 'title' => 'Reduces requests to FA when Full view is enabled. Changes to submission details may be delayed.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
-            ]
+                'defaultValue' => 'checked',
+            ],
         ],
         'Favorites' => [
             'username-favorites' => [
                 'name' => 'Username',
                 'required' => true,
                 'exampleValue' => 'dhw',
-                'title' => 'Lowercase username as seen in URLs'
+                'title' => 'Lowercase username as seen in URLs',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 10,
-                'title' => 'Limit number of submissions to return. -1 for unlimited.'
+                'title' => 'Limit number of submissions to return. -1 for unlimited.',
             ],
             'full' => [
                 'name' => 'Full view',
                 'title' => 'Include description, tags, date and larger image in article. Uses more bandwidth.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'cache' => [
                 'name' => 'Cache submission pages',
                 'title' => 'Reduces requests to FA when Full view is enabled. Changes to submission details may be delayed.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
-            ]
+                'defaultValue' => 'checked',
+            ],
         ],
         'Gallery Folder' => [
             'username-folder' => [
                 'name' => 'Username',
                 'required' => true,
                 'exampleValue' => 'kopk',
-                'title' => 'Lowercase username as seen in URLs'
+                'title' => 'Lowercase username as seen in URLs',
             ],
             'folder-id' => [
                 'name' => 'Folder ID',
                 'required' => true,
                 'exampleValue' => '1031990',
                 'type' => 'number',
-                'title' => 'Number seen in folder URL'
+                'title' => 'Number seen in folder URL',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => true,
                 'defaultValue' => 10,
-                'title' => 'Limit number of submissions to return. -1 for unlimited.'
+                'title' => 'Limit number of submissions to return. -1 for unlimited.',
             ],
             'full' => [
                 'name' => 'Full view',
                 'title' => 'Include description, tags, date and larger image in article. Uses more bandwidth.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'cache' => [
                 'name' => 'Cache submission pages',
                 'title' => 'Reduces requests to FA when Full view is enabled. Changes to submission details may be delayed.',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
-            ]
-        ]
+                'defaultValue' => 'checked',
+            ],
+        ],
     ];
 
     /*
@@ -752,7 +752,7 @@ class FurAffinityBridge extends BridgeAbstract
                 'type-music' => ($this->getInput('type-music') === true ? 'on' : 0),
                 'type-story' => ($this->getInput('type-story') === true ? 'on' : 0),
                 'type-poetry' => ($this->getInput('type-poetry') === true ? 'on' : 0),
-                'mode' => $this->getInput('mode')
+                'mode' => $this->getInput('mode'),
                 ];
                 $html = $this->postFASimpleHTMLDOM($data);
                 $limit = (is_int($this->getInput('limit')) ? $this->getInput('limit') : 10);
@@ -767,7 +767,7 @@ class FurAffinityBridge extends BridgeAbstract
                 'perpage' => 72,
                 'rating_general' => ($this->getInput('rating_general') === true ? 'on' : 0),
                 'rating_mature' => ($this->getInput('rating_mature') === true ? 'on' : 0),
-                'rating_adult' => ($this->getInput('rating_adult') === true ? 'on' : 0)
+                'rating_adult' => ($this->getInput('rating_adult') === true ? 'on' : 0),
                 ];
                 $html = $this->postFASimpleHTMLDOM($data);
                 $limit = (is_int($this->getInput('limit-browse')) ? $this->getInput('limit-browse') : 10);
@@ -795,37 +795,37 @@ class FurAffinityBridge extends BridgeAbstract
 
     private function postFASimpleHTMLDOM($data)
     {
-            $opts = [
+        $opts = [
                 CURLOPT_CUSTOMREQUEST => 'POST',
-                CURLOPT_POSTFIELDS => http_build_query($data)
+                CURLOPT_POSTFIELDS => http_build_query($data),
             ];
-            $header = [
+        $header = [
                 'Host: ' . parse_url(self::URI, PHP_URL_HOST),
                 'Content-Type: application/x-www-form-urlencoded',
-                'Cookie: ' . self::FA_AUTH_COOKIE
+                'Cookie: ' . self::FA_AUTH_COOKIE,
             ];
 
-            $html = getSimpleHTMLDOM($this->getURI(), $header, $opts);
-            $html = defaultLinkTo($html, $this->getURI());
+        $html = getSimpleHTMLDOM($this->getURI(), $header, $opts);
+        $html = defaultLinkTo($html, $this->getURI());
 
-            return $html;
+        return $html;
     }
 
     private function getFASimpleHTMLDOM($url, $cache = false)
     {
-            $header = [
-                'Cookie: ' . self::FA_AUTH_COOKIE
+        $header = [
+                'Cookie: ' . self::FA_AUTH_COOKIE,
             ];
 
-            if ($cache) {
-                $html = getSimpleHTMLDOMCached($url, 86400, $header); // 24 hours
-            } else {
-                $html = getSimpleHTMLDOM($url, $header);
-            }
+        if ($cache) {
+            $html = getSimpleHTMLDOMCached($url, 86400, $header); // 24 hours
+        } else {
+            $html = getSimpleHTMLDOM($url, $header);
+        }
 
-            $html = defaultLinkTo($html, $url);
+        $html = defaultLinkTo($html, $url);
 
-            return $html;
+        return $html;
     }
 
     private function itemsFromJournalList($html, $limit)
@@ -902,7 +902,7 @@ class FurAffinityBridge extends BridgeAbstract
                 $stats = $submissionHTML->find('.stats-container', 0);
                 $item['timestamp'] = strtotime($stats->find('.popup_date', 0)->title);
                 $item['enclosures'] = [
-                    $submissionHTML->find('.actions a[href^=https://d.facdn]', 0)->href
+                    $submissionHTML->find('.actions a[href^=https://d.facdn]', 0)->href,
                 ];
                 foreach ($stats->find('#keywords a') as $keyword) {
                     $item['categories'][] = $keyword->plaintext;
@@ -920,19 +920,19 @@ class FurAffinityBridge extends BridgeAbstract
                 $description = $description->innertext;
 
                 $item['content'] = <<<EOD
-<a href="$submissionURL">
-	<img src="{$imgURL}" referrerpolicy="no-referrer" />
-</a>
-<p>
-{$description}
-</p>
-EOD;
+                    <a href="$submissionURL">
+                    	<img src="{$imgURL}" referrerpolicy="no-referrer" />
+                    </a>
+                    <p>
+                    {$description}
+                    </p>
+                    EOD;
             } else {
                 $item['content'] = <<<EOD
-<a href="$submissionURL">
-	<img src="$imgURL" referrerpolicy="no-referrer" />
-</a>
-EOD;
+                    <a href="$submissionURL">
+                    	<img src="$imgURL" referrerpolicy="no-referrer" />
+                    </a>
+                    EOD;
             }
 
             $this->items[] = $item;

--- a/bridges/FurAffinityUserBridge.php
+++ b/bridges/FurAffinityUserBridge.php
@@ -18,14 +18,14 @@ class FurAffinityUserBridge extends BridgeAbstract
             'aCookie' => [
                 'name' => 'Login cookie \'a\'',
                 'type' => 'text',
-                'required' => true
+                'required' => true,
             ],
             'bCookie' => [
                 'name' => 'Login cookie \'b\'',
                 'type' => 'text',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/FuturaSciencesBridge.php
+++ b/bridges/FuturaSciencesBridge.php
@@ -17,66 +17,66 @@ class FuturaSciencesBridge extends FeedExpander
                     'Les dernières définitions de Futura-Sciences' => 'definitions',
                     'Les dernières photos de Futura-Sciences' => 'photos',
                     'Les dernières questions - réponses de Futura-Sciences' => 'questions-reponses',
-                    'Les derniers dossiers de Futura-Sciences' => 'dossiers'
+                    'Les derniers dossiers de Futura-Sciences' => 'dossiers',
                 ],
                 'Les flux Services' => [
                     'Les cartes virtuelles de Futura-Sciences' => 'services/cartes-virtuelles',
-                    'Les fonds d\'écran de Futura-Sciences' => 'services/fonds-ecran'
+                    'Les fonds d\'écran de Futura-Sciences' => 'services/fonds-ecran',
                 ],
                 'Les flux Santé' => [
                     'Les dernières actualités de Futura-Santé' => 'sante/actualites',
                     'Les dernières définitions de Futura-Santé' => 'sante/definitions',
                     'Les dernières questions-réponses de Futura-Santé' => 'sante/question-reponses',
-                    'Les derniers dossiers de Futura-Santé' => 'sante/dossiers'
+                    'Les derniers dossiers de Futura-Santé' => 'sante/dossiers',
                 ],
                 'Les flux High-Tech' => [
                     'Les dernières actualités de Futura-High-Tech' => 'high-tech/actualites',
                     'Les dernières astuces de Futura-High-Tech' => 'high-tech/question-reponses',
                     'Les dernières définitions de Futura-High-Tech' => 'high-tech/definitions',
-                    'Les derniers dossiers de Futura-High-Tech' => 'high-tech/dossiers'
+                    'Les derniers dossiers de Futura-High-Tech' => 'high-tech/dossiers',
                 ],
                 'Les flux Espace' => [
                     'Les dernières actualités de Futura-Espace' => 'espace/actualites',
                     'Les dernières définitions de Futura-Espace' => 'espace/definitions',
                     'Les dernières questions-réponses de Futura-Espace' => 'espace/question-reponses',
-                    'Les derniers dossiers de Futura-Espace' => 'espace/dossiers'
+                    'Les derniers dossiers de Futura-Espace' => 'espace/dossiers',
                 ],
                 'Les flux Environnement' => [
                     'Les dernières actualités de Futura-Environnement' => 'environnement/actualites',
                     'Les dernières définitions de Futura-Environnement' => 'environnement/definitions',
                     'Les dernières questions-réponses de Futura-Environnement' => 'environnement/question-reponses',
-                    'Les derniers dossiers de Futura-Environnement' => 'environnement/dossiers'
+                    'Les derniers dossiers de Futura-Environnement' => 'environnement/dossiers',
                 ],
                 'Les flux Maison' => [
                     'Les dernières actualités de Futura-Maison' => 'maison/actualites',
                     'Les dernières astuces de Futura-Maison' => 'maison/question-reponses',
                     'Les dernières définitions de Futura-Maison' => 'maison/definitions',
-                    'Les derniers dossiers de Futura-Maison' => 'maison/dossiers'
+                    'Les derniers dossiers de Futura-Maison' => 'maison/dossiers',
                 ],
                 'Les flux Nature' => [
                     'Les dernières actualités de Futura-Nature' => 'nature/actualites',
                     'Les dernières définitions de Futura-Nature' => 'nature/definitions',
                     'Les dernières questions-réponses de Futura-Nature' => 'nature/question-reponses',
-                    'Les derniers dossiers de Futura-Nature' => 'nature/dossiers'
+                    'Les derniers dossiers de Futura-Nature' => 'nature/dossiers',
                 ],
                 'Les flux Terre' => [
                     'Les dernières actualités de Futura-Terre' => 'terre/actualites',
                     'Les dernières définitions de Futura-Terre' => 'terre/definitions',
                     'Les dernières questions-réponses de Futura-Terre' => 'terre/question-reponses',
-                    'Les derniers dossiers de Futura-Terre' => 'terre/dossiers'
+                    'Les derniers dossiers de Futura-Terre' => 'terre/dossiers',
                 ],
                 'Les flux Matière' => [
                     'Les dernières actualités de Futura-Matière' => 'matiere/actualites',
                     'Les dernières définitions de Futura-Matière' => 'matiere/definitions',
                     'Les dernières questions-réponses de Futura-Matière' => 'matiere/question-reponses',
-                    'Les derniers dossiers de Futura-Matière' => 'matiere/dossiers'
+                    'Les derniers dossiers de Futura-Matière' => 'matiere/dossiers',
                 ],
                 'Les flux Mathématiques' => [
                     'Les dernières actualités de Futura-Mathématiques' => 'mathematiques/actualites',
-                    'Les derniers dossiers de Futura-Mathématiques' => 'mathematiques/dossiers'
-                ]
-            ]
-        ]
+                    'Les derniers dossiers de Futura-Mathématiques' => 'mathematiques/dossiers',
+                ],
+            ],
+        ],
     ]];
 
     public function collectData()
@@ -123,14 +123,14 @@ class FuturaSciencesBridge extends FeedExpander
             'addthis_toolbox',
             'noprint',
             'hubbottom',
-            'hubbottom2'
+            'hubbottom2',
             ] as $div_class_remove
         ) {
             foreach ($contents->find('div.' . $div_class_remove) as $div) {
                 $keep_div = false;
                 foreach (
                     [
-                    'didyouknow'
+                    'didyouknow',
                     ] as $div_class_dont_remove
                 ) {
                     if (strpos($div->getAttribute('class'), $div_class_dont_remove) !== false) {

--- a/bridges/GBAtempBridge.php
+++ b/bridges/GBAtempBridge.php
@@ -15,9 +15,9 @@ class GBAtempBridge extends BridgeAbstract
                 'News' => 'N',
                 'Reviews' => 'R',
                 'Tutorials' => 'T',
-                'Forum' => 'F'
-            ]
-        ]
+                'Forum' => 'F',
+            ],
+        ],
     ]];
 
     private function buildItem($uri, $title, $author, $timestamp, $thumbnail, $content)

--- a/bridges/GQMagazineBridge.php
+++ b/bridges/GQMagazineBridge.php
@@ -25,12 +25,12 @@ class GQMagazineBridge extends BridgeAbstract
         'domain' => [
             'name' => 'Domain to use',
             'required' => true,
-            'defaultValue' => self::DEFAULT_DOMAIN
+            'defaultValue' => self::DEFAULT_DOMAIN,
         ],
         'page' => [
             'name' => 'Initial page to load',
             'required' => true,
-            'exampleValue' => 'sexe/news'
+            'exampleValue' => 'sexe/news',
         ],
         'limit' => self::LIMIT,
     ]];
@@ -38,12 +38,12 @@ class GQMagazineBridge extends BridgeAbstract
     const REPLACED_ATTRIBUTES = [
         'href' => 'href',
         'src' => 'src',
-        'data-original' => 'src'
+        'data-original' => 'src',
     ];
 
     const POSSIBLE_TITLES = [
         'h2',
-        'h3'
+        'h3',
     ];
 
     private function getDomain()

--- a/bridges/GelbooruBridge.php
+++ b/bridges/GelbooruBridge.php
@@ -12,20 +12,20 @@ class GelbooruBridge extends BridgeAbstract
             'p' => [
                 'name' => 'page',
                 'defaultValue' => 0,
-                'type' => 'number'
+                'type' => 'number',
             ],
             't' => [
                 'name' => 'tags',
                 'exampleValue' => 'solo',
-                'title' => 'Tags to search for'
+                'title' => 'Tags to search for',
             ],
             'l' => [
                 'name' => 'limit',
                 'exampleValue' => 100,
-                'title' => 'How many posts to retrieve (hard limit of 1000)'
-            ]
+                'title' => 'How many posts to retrieve (hard limit of 1000)',
+            ],
         ],
-        0 => []
+        0 => [],
     ];
 
     protected function getFullURI()

--- a/bridges/GenshinImpactBridge.php
+++ b/bridges/GenshinImpactBridge.php
@@ -16,11 +16,11 @@ class GenshinImpactBridge extends BridgeAbstract
                     'Latest' => 10,
                     'Info' => 11,
                     'Updates' => 12,
-                    'Events' => 13
+                    'Events' => 13,
                 ],
-                'defaultValue' => 10
-            ]
-        ]
+                'defaultValue' => 10,
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/GettrBridge.php
+++ b/bridges/GettrBridge.php
@@ -22,7 +22,7 @@ class GettrBridge extends BridgeAbstract
                 'defaultValue' => 5,
                 'required' => true,
             ],
-        ]
+        ],
     ];
 
     public function collectData()
@@ -68,27 +68,27 @@ class GettrBridge extends BridgeAbstract
         // Preview image
         if (isset($post->previmg)) {
             $content .= <<<HTML
-<a href="$post->prevsrc" target="_blank">
-    <img
-        src='$post->previmg'
-        alt='Unable to load image'
-        loading='lazy'
-    >
-</a>
-<br><br>
-HTML;
+                <a href="$post->prevsrc" target="_blank">
+                    <img
+                        src='$post->previmg'
+                        alt='Unable to load image'
+                        loading='lazy'
+                    >
+                </a>
+                <br><br>
+                HTML;
         }
 
         // Images
         foreach ($post->imgs ?? [] as $imageUrl) {
             $content .= <<<HTML
-<img
-    src='https://media.gettr.com/$imageUrl'
-    alt='Unable to load image'
-    target='_blank'
->
-<br><br>
-HTML;
+                <img
+                    src='https://media.gettr.com/$imageUrl'
+                    alt='Unable to load image'
+                    target='_blank'
+                >
+                <br><br>
+                HTML;
         }
 
         // Video
@@ -96,16 +96,16 @@ HTML;
             $mainImage = $post->main;
 
             $content .= <<<HTML
-<video
-    style="max-width: 100%"
-    controls
-    preload="none"
-    poster="https://media.gettr.com/$mainImage"
->
-  <source src="https://media.gettr.com/$post->ovid" type="video/mp4">
-  Your browser does not support the video element. Kindly update it to latest version.
-</video >
-HTML;
+                <video
+                    style="max-width: 100%"
+                    controls
+                    preload="none"
+                    poster="https://media.gettr.com/$mainImage"
+                >
+                  <source src="https://media.gettr.com/$post->ovid" type="video/mp4">
+                  Your browser does not support the video element. Kindly update it to latest version.
+                </video >
+                HTML;
             // This is typically a m3u8 which I don't know how to present in a browser
             $streamingUrl = $post->vid;
         }

--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -12,23 +12,23 @@ class GiphyBridge extends BridgeAbstract
         's' => [
             'name' => 'search tag',
             'exampleValue' => 'bird',
-            'required' => true
+            'required' => true,
         ],
         'noGif' => [
             'name' => 'Without gifs',
             'type' => 'checkbox',
-            'title' => 'Exclude gifs from the results'
+            'title' => 'Exclude gifs from the results',
         ],
         'noStick' => [
             'name' => 'Without stickers',
             'type' => 'checkbox',
-            'title' => 'Exclude stickers from the results'
+            'title' => 'Exclude stickers from the results',
         ],
         'n' => [
             'name' => 'max number of returned items (max 50)',
             'type' => 'number',
             'exampleValue' => 3,
-        ]
+        ],
     ]];
 
     public function getName()
@@ -46,20 +46,20 @@ class GiphyBridge extends BridgeAbstract
             $createdAt = new \DateTime($entry->import_datetime);
 
             $this->items[] = [
-                'id'        => $entry->id,
-                'uri'       => $entry->url,
-                'author'    => $entry->username,
+                'id' => $entry->id,
+                'uri' => $entry->url,
+                'author' => $entry->username,
                 'timestamp' => $createdAt->format('U'),
-                'title'     => $entry->title,
-                'content'   => <<<HTML
-<a href="{$entry->url}">
-<img
-	loading="lazy"
-	src="{$entry->images->downsized->url}"
-	width="{$entry->images->downsized->width}"
-	height="{$entry->images->downsized->height}" />
-</a>
-HTML
+                'title' => $entry->title,
+                'content' => <<<HTML
+                    <a href="{$entry->url}">
+                    <img
+                    	loading="lazy"
+                    	src="{$entry->images->downsized->url}"
+                    	width="{$entry->images->downsized->width}"
+                    	height="{$entry->images->downsized->height}" />
+                    </a>
+                    HTML,
             ];
         }
     }

--- a/bridges/GitHubGistBridge.php
+++ b/bridges/GitHubGistBridge.php
@@ -14,8 +14,8 @@ class GitHubGistBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'title' => 'Insert Gist ID or URI',
-            'exampleValue' => '2646763'
-        ]
+            'exampleValue' => '2646763',
+        ],
     ]];
 
     private $filename;
@@ -101,24 +101,24 @@ class GitHubGistBridge extends BridgeAbstract
         // Restore code (inside <pre />) highlighting
         foreach ($content->find('pre') as $pre) {
             $pre->style = <<<EOD
-padding: 16px;
-overflow: auto;
-font-size: 85%;
-line-height: 1.45;
-background-color: #f6f8fa;
-border-radius: 3px;
-word-wrap: normal;
-box-sizing: border-box;
-margin-bottom: 16px;
-EOD;
+                padding: 16px;
+                overflow: auto;
+                font-size: 85%;
+                line-height: 1.45;
+                background-color: #f6f8fa;
+                border-radius: 3px;
+                word-wrap: normal;
+                box-sizing: border-box;
+                margin-bottom: 16px;
+                EOD;
 
             $code = $pre->find('code', 0);
 
             if ($code) {
                 $code->style = <<<EOD
-white-space: pre;
-word-break: normal;
-EOD;
+                    white-space: pre;
+                    word-break: normal;
+                    EOD;
             }
         }
 
@@ -129,10 +129,10 @@ EOD;
             }
 
             $code->style = <<<EOD
-background-color: rgba(27,31,35,0.05);
-padding: 0.2em 0.4em;
-border-radius: 3px;
-EOD;
+                background-color: rgba(27,31,35,0.05);
+                padding: 0.2em 0.4em;
+                border-radius: 3px;
+                EOD;
         }
 
         // restore text spacing

--- a/bridges/GithubIssueBridge.php
+++ b/bridges/GithubIssueBridge.php
@@ -13,33 +13,33 @@ class GithubIssueBridge extends BridgeAbstract
             'u' => [
                 'name' => 'User name',
                 'exampleValue' => 'RSS-Bridge',
-                'required' => true
+                'required' => true,
             ],
             'p' => [
                 'name' => 'Project name',
                 'exampleValue' => 'rss-bridge',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Project Issues' => [
             'c' => [
                 'name' => 'Show Issues Comments',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'q' => [
                 'name' => 'Search Query',
                 'defaultValue' => 'is:issue is:open sort:updated-desc',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Issue comments' => [
             'i' => [
                 'name' => 'Issue number',
                 'type' => 'number',
                 'exampleValue' => '2099',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     // Allows generalization with GithubPullRequestBridge
@@ -274,18 +274,18 @@ class GithubIssueBridge extends BridgeAbstract
 
         switch (count($path_segments)) {
             case 2: // Project issues
-                list($user, $project) = $path_segments;
+                [$user, $project] = $path_segments;
                 $show_comments = 'off';
                 break;
             case 3: // Project issues with issue comments
                 if ($path_segments[2] !== static::URL_PATH) {
                     return null;
                 }
-                list($user, $project) = $path_segments;
+                [$user, $project] = $path_segments;
                 $show_comments = 'on';
                 break;
             case 4: // Issue comments
-                list($user, $project, /* issues */, $issue) = $path_segments;
+                [$user, $project, /* issues */, $issue] = $path_segments;
                 break;
             default:
                 return null;
@@ -294,8 +294,8 @@ class GithubIssueBridge extends BridgeAbstract
         return [
             'u' => $user,
             'p' => $project,
-            'c' => isset($show_comments) ? $show_comments : null,
-            'i' => isset($issue) ? $issue : null,
+            'c' => $show_comments ?? null,
+            'i' => $issue ?? null,
         ];
     }
 }

--- a/bridges/GithubPullRequestBridge.php
+++ b/bridges/GithubPullRequestBridge.php
@@ -10,33 +10,33 @@ class GitHubPullRequestBridge extends GithubIssueBridge
             'u' => [
                 'name' => 'User name',
                 'exampleValue' => 'RSS-Bridge',
-                'required' => true
+                'required' => true,
             ],
             'p' => [
                 'name' => 'Project name',
                 'exampleValue' => 'rss-bridge',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Project Pull Requests' => [
             'c' => [
                 'name' => 'Show Pull Request Comments',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'q' => [
                 'name' => 'Search Query',
                 'defaultValue' => 'is:pr is:open sort:created-desc',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Pull Request comments' => [
             'i' => [
                 'name' => 'Pull Request number',
                 'type' => 'number',
                 'exampleValue' => '2100',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     const BRIDGE_OPTIONS = [0 => 'Project Pull Requests', 1 => 'Pull Request comments'];

--- a/bridges/GithubSearchBridge.php
+++ b/bridges/GithubSearchBridge.php
@@ -12,8 +12,8 @@ class GithubSearchBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'exampleValue' => 'rss-bridge',
-            'name' => 'Search query'
-        ]
+            'name' => 'Search query',
+        ],
     ]];
 
     public function collectData()
@@ -22,7 +22,7 @@ class GithubSearchBridge extends BridgeAbstract
                                         'q' => urlencode($this->getInput('s')),
                                         's' => 'updated',
                                         'o' => 'desc',
-                                        'type' => 'Repositories'];
+                                        'type' => 'Repositories', ];
         $url = self::URI . 'search?' . http_build_query($params);
 
         $html = getSimpleHTMLDOM($url);

--- a/bridges/GithubTrendingBridge.php
+++ b/bridges/GithubTrendingBridge.php
@@ -572,8 +572,8 @@ class GithubTrendingBridge extends BridgeAbstract
                     'ZIL' => 'zil',
                     'Zimpl' => 'zimpl',
                 ],
-                'defaultValue' => 'All languages'
-            ]
+                'defaultValue' => 'All languages',
+            ],
         ],
 
         'global' => [
@@ -585,9 +585,9 @@ class GithubTrendingBridge extends BridgeAbstract
                     'Weekly' => 'weekly',
                     'Monthly' => 'monthly',
                 ],
-                'defaultValue' => 'today'
-            ]
-        ]
+                'defaultValue' => 'today',
+            ],
+        ],
 
     ];
 

--- a/bridges/GitlabIssueBridge.php
+++ b/bridges/GitlabIssueBridge.php
@@ -14,18 +14,18 @@ class GitlabIssueBridge extends BridgeAbstract
                 'name' => 'Gitlab instance host name',
                 'exampleValue' => 'gitlab.com',
                 'defaultValue' => 'gitlab.com',
-                'required' => true
+                'required' => true,
             ],
             'u' => [
                 'name' => 'User/Organization name',
                 'exampleValue' => 'fdroid',
-                'required' => true
+                'required' => true,
             ],
             'p' => [
                 'name' => 'Project name',
                 'exampleValue' => 'fdroidclient',
-                'required' => true
-            ]
+                'required' => true,
+            ],
 
         ],
         'Issue comments' => [
@@ -33,17 +33,17 @@ class GitlabIssueBridge extends BridgeAbstract
                 'name' => 'Issue number',
                 'type' => 'number',
                 'exampleValue' => '2099',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Merge Request comments' => [
             'i' => [
                 'name' => 'Merge Request number',
                 'type' => 'number',
                 'exampleValue' => '2099',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     public function getName()

--- a/bridges/GizmodoBridge.php
+++ b/bridges/GizmodoBridge.php
@@ -69,8 +69,8 @@ class GizmodoBridge extends FeedExpander
             $imageUrl = 'https://i.kinja-img.com/gawker-media/image/upload/' . $id . '.' . $format;
 
             $figure->find('span', 0)->outertext = <<<EOD
-<img src="{$imageUrl}">
-EOD;
+                <img src="{$imageUrl}">
+                EOD;
         }
     }
 

--- a/bridges/GlassdoorBridge.php
+++ b/bridges/GlassdoorBridge.php
@@ -3,7 +3,7 @@
 class GlassdoorBridge extends BridgeAbstract
 {
     // Contexts
-    const CONTEXT_BLOG   = 'Blogs';
+    const CONTEXT_BLOG = 'Blogs';
     const CONTEXT_REVIEW = 'Company Reviews';
     const CONTEXT_GLOBAL = 'global';
 
@@ -14,10 +14,10 @@ class GlassdoorBridge extends BridgeAbstract
     const PARAM_BLOG_TYPE = 'blog_type';
     const PARAM_BLOG_FULL = 'full_article';
 
-    const BLOG_TYPE_HOME             = 'Home';
+    const BLOG_TYPE_HOME = 'Home';
     const BLOG_TYPE_COMPANIES_HIRING = 'Companies Hiring';
-    const BLOG_TYPE_CAREER_ADVICE    = 'Career Advice';
-    const BLOG_TYPE_INTERVIEWS       = 'Interviews';
+    const BLOG_TYPE_CAREER_ADVICE = 'Career Advice';
+    const BLOG_TYPE_INTERVIEWS = 'Interviews';
 
     // Review context parameters
     const PARAM_REVIEW_COMPANY = 'company';
@@ -35,16 +35,16 @@ class GlassdoorBridge extends BridgeAbstract
                 'type' => 'list',
                 'title' => 'Select the blog you want to follow',
                 'values' => [
-                    self::BLOG_TYPE_HOME                => 'blog/',
-                    self::BLOG_TYPE_COMPANIES_HIRING    => 'blog/companies-hiring/',
-                    self::BLOG_TYPE_CAREER_ADVICE       => 'blog/career-advice/',
-                    self::BLOG_TYPE_INTERVIEWS          => 'blog/interviews/',
-                ]
+                    self::BLOG_TYPE_HOME => 'blog/',
+                    self::BLOG_TYPE_COMPANIES_HIRING => 'blog/companies-hiring/',
+                    self::BLOG_TYPE_CAREER_ADVICE => 'blog/career-advice/',
+                    self::BLOG_TYPE_INTERVIEWS => 'blog/interviews/',
+                ],
             ],
             self::PARAM_BLOG_FULL => [
                 'name' => 'Full article',
                 'type' => 'checkbox',
-                'title' => 'Enable to return the full article for each post'
+                'title' => 'Enable to return the full article for each post',
             ],
         ],
         self::CONTEXT_REVIEW => [
@@ -53,17 +53,17 @@ class GlassdoorBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Paste the company review page URL here!',
-                'exampleValue' => 'https://www.glassdoor.com/Reviews/GitHub-Reviews-E671945.htm'
-            ]
+                'exampleValue' => 'https://www.glassdoor.com/Reviews/GitHub-Reviews-E671945.htm',
+            ],
         ],
         self::CONTEXT_GLOBAL => [
             self::PARAM_LIMIT => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'defaultValue' => -1,
-                'title' => 'Specifies the maximum number of items to return (default: All)'
-            ]
-        ]
+                'title' => 'Specifies the maximum number of items to return (default: All)',
+            ],
+        ],
     ];
 
     public function getURI()
@@ -185,7 +185,7 @@ class GlassdoorBridge extends BridgeAbstract
             'de-CH' => 'Bewertungen',
             'fr-CH' => 'Avis',
             'en-GB' => 'Reviews',
-            'en'    => 'Reviews'
+            'en' => 'Reviews',
         ];
 
         if (!in_array($parts[1], $allowed_strings)) {

--- a/bridges/GlowficBridge.php
+++ b/bridges/GlowficBridge.php
@@ -15,14 +15,14 @@ class GlowficBridge extends BridgeAbstract
                 'title' => 'https://www.glowfic.com/posts/POST ID',
                 'required' => true,
                 'exampleValue' => '2756',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'start_page' => [
                 'name' => 'Start Page',
                 'title' => 'To start from an offset page',
-                'type' => 'number'
-            ]
-        ]
+                'type' => 'number',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -12,8 +12,8 @@ class GoComicsBridge extends BridgeAbstract
             'name' => 'comicname',
             'type' => 'text',
             'exampleValue' => 'heartofthecity',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     public function collectData()

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -41,16 +41,16 @@ class GolemBridge extends FeedExpander
                 'Wirtschaft'
                 => 'https://rss.golem.de/rss.php?ms=wirtschaft&feed=ATOM1.0',
                 'Wissenschaft'
-                => 'https://rss.golem.de/rss.php?ms=wissenschaft&feed=ATOM1.0'
-            ]
+                => 'https://rss.golem.de/rss.php?ms=wissenschaft&feed=ATOM1.0',
+            ],
         ],
         'limit' => [
             'name' => 'Limit',
             'type' => 'number',
             'required' => false,
             'title' => 'Specify number of full articles to return',
-            'defaultValue' => 5
-        ]
+            'defaultValue' => 5,
+        ],
     ]];
     const LIMIT = 5;
     const HEADERS = ['Cookie: golem_consent20=simple|220101;'];
@@ -66,7 +66,7 @@ class GolemBridge extends FeedExpander
     protected function parseItem($item)
     {
         $item = parent::parseItem($item);
-        $item['content'] = $item['content'] ?? '';
+        $item['content'] ??= '';
         $uri = $item['uri'];
 
         while ($uri) {

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -19,7 +19,7 @@ class GoodreadsBridge extends BridgeAbstract
                 'required' => true,
                 'title' => 'Should look somewhat like goodreads.com/author/show/',
                 'pattern' => '^(https:\/\/)?(www.)?goodreads\.com\/author\/show\/\d+\..*$',
-                'exampleValue' => 'https://www.goodreads.com/author/show/38550.Brandon_Sanderson'
+                'exampleValue' => 'https://www.goodreads.com/author/show/38550.Brandon_Sanderson',
             ],
             'published_only' => [
                 'name' => 'Show published books only',
@@ -47,7 +47,7 @@ class GoodreadsBridge extends BridgeAbstract
             $dateSpan = $row->find('.uitext', 0)->plaintext;
             $date = null;
 
-        // If book is not yet published, ignore for now
+            // If book is not yet published, ignore for now
             if (preg_match('/published\s+(\d{4})/', $dateSpan, $matches) === 1) {
                 // Goodreads doesn't give us exact publication date here, only a year
                 // We are skipping future dates anyway, so this is def published
@@ -73,7 +73,7 @@ class GoodreadsBridge extends BridgeAbstract
             . '"></a>';
             $item['timestamp'] = $date;
             $item['enclosures'] = [
-            $row->find('.bookCover', 0)->getAttribute('src')
+            $row->find('.bookCover', 0)->getAttribute('src'),
             ];
 
             $this->items[] = $item; // Add item to the list

--- a/bridges/GoogleGroupsBridge.php
+++ b/bridges/GoogleGroupsBridge.php
@@ -10,23 +10,23 @@ class GoogleGroupsBridge extends XPathAbstract
             'name' => 'Group id',
             'title' => 'The string that follows /g/ in the URL',
             'exampleValue' => 'governance',
-            'required' => true
+            'required' => true,
         ],
         'account' => [
             'name' => 'Account id',
             'title' => 'Some Google groups have an additional id following /a/ in the URL',
             'exampleValue' => 'mozilla.org',
-            'required' => false
-        ]
+            'required' => false,
+        ],
     ]];
     const CACHE_TIMEOUT = 3600;
 
     const TEST_DETECT_PARAMETERS = [
         'https://groups.google.com/a/mozilla.org/g/announce' => [
-            'account' => 'mozilla.org', 'group' => 'announce'
+            'account' => 'mozilla.org', 'group' => 'announce',
         ],
         'https://groups.google.com/g/ansible-project' => [
-            'account' => null, 'group' => 'ansible-project'
+            'account' => null, 'group' => 'ansible-project',
         ],
     ];
 

--- a/bridges/GooglePlayStoreBridge.php
+++ b/bridges/GooglePlayStoreBridge.php
@@ -9,22 +9,22 @@ class GooglePlayStoreBridge extends BridgeAbstract
 
     const TEST_DETECT_PARAMETERS = [
         'https://play.google.com/store/apps/details?id=com.ichi2.anki' => [
-            'id' => 'com.ichi2.anki'
-        ]
+            'id' => 'com.ichi2.anki',
+        ],
     ];
 
     const PARAMETERS = [[
         'id' => [
             'name' => 'Application ID',
             'exampleValue' => 'com.ichi2.anki',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     const INFORMATION_MAP = [
         'Updated' => 'timestamp',
         'Current Version' => 'title',
-        'Offered By' => 'author'
+        'Offered By' => 'author',
     ];
 
     public function collectData()

--- a/bridges/GoogleSearchBridge.php
+++ b/bridges/GoogleSearchBridge.php
@@ -81,12 +81,12 @@ class GoogleSearchBridge extends BridgeAbstract
     {
         if ($this->getInput('q')) {
             $queryParameters = [
-                'q'         => $this->getInput('q'),
-                'hl'        => 'en',
-                'num'       => '100', // get 100 results
-                'complete'  => '0',
+                'q' => $this->getInput('q'),
+                'hl' => 'en',
+                'num' => '100', // get 100 results
+                'complete' => '0',
                 // in past year, sort by date, optionally verbatim
-                'tbs'       => 'qdr:y,sbd:1' . ($this->getInput('verbatim') ? ',li:1' : ''),
+                'tbs' => 'qdr:y,sbd:1' . ($this->getInput('verbatim') ? ',li:1' : ''),
             ];
             return sprintf('https://www.google.com/search?%s', http_build_query($queryParameters));
         }

--- a/bridges/HDWallpapersBridge.php
+++ b/bridges/HDWallpapersBridge.php
@@ -12,17 +12,17 @@ class HDWallpapersBridge extends BridgeAbstract
         'c' => [
             'name' => 'category',
             'required' => true,
-            'defaultValue' => 'latest_wallpapers'
+            'defaultValue' => 'latest_wallpapers',
         ],
         'm' => [
-            'name' => 'max number of wallpapers'
+            'name' => 'max number of wallpapers',
         ],
         'r' => [
             'name' => 'resolution',
             'required' => true,
             'defaultValue' => 'HD',
-            'title' => 'e.g=HD OR 1920x1200 OR 1680x1050'
-        ]
+            'title' => 'e.g=HD OR 1920x1200 OR 1680x1050',
+        ],
     ]];
 
     public function collectData()

--- a/bridges/HackerNewsUserThreadsBridge.php
+++ b/bridges/HackerNewsUserThreadsBridge.php
@@ -13,8 +13,8 @@ class HackerNewsUserThreadsBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'exampleValue' => 'nixcraft',
-            'title' => 'User whose threads you want to see'
-        ]
+            'title' => 'User whose threads you want to see',
+        ],
     ]];
 
     public function collectData()

--- a/bridges/HardwareInfoBridge.php
+++ b/bridges/HardwareInfoBridge.php
@@ -43,7 +43,7 @@ class HardwareInfoBridge extends FeedExpander
         'div.incontent',
         'div.article__content__social-bar',
         'div#revealNewsTip',
-        'div.article__previous_next'
+        'div.article__previous_next',
         ];
 
         foreach ($to_remove_selectors as $selector) {

--- a/bridges/HaveIBeenPwnedBridge.php
+++ b/bridges/HaveIBeenPwnedBridge.php
@@ -28,7 +28,7 @@ class HaveIBeenPwnedBridge extends BridgeAbstract
             'type' => 'number',
             'required' => true,
             'defaultValue' => 20,
-        ]
+        ],
     ]];
     const API_URI = 'https://haveibeenpwned.com/api/v3';
 
@@ -58,12 +58,12 @@ class HaveIBeenPwnedBridge extends BridgeAbstract
             $compData = implode(', ', $breach['DataClasses']);
 
             $item['content'] .= <<<EOD
-<p>
-<strong>Breach date:</strong> {$breachDate}<br>
-<strong>Date added to HIBP:</strong> {$addedDate}<br>
-<strong>Compromised accounts:</strong> {$pwnCount}<br>
-<strong>Compromised data:</strong> {$compData}<br>
-EOD;
+                <p>
+                <strong>Breach date:</strong> {$breachDate}<br>
+                <strong>Date added to HIBP:</strong> {$addedDate}<br>
+                <strong>Compromised accounts:</strong> {$pwnCount}<br>
+                <strong>Compromised data:</strong> {$compData}<br>
+                EOD;
             $item['uid'] = $breach['Name'];
             $this->breaches[] = $item;
         }
@@ -74,22 +74,22 @@ EOD;
 
     private const BREACH_TYPES = [
         'IsVerified' => [
-            false => 'Unverified breach, may be sourced from elsewhere'
+            false => 'Unverified breach, may be sourced from elsewhere',
         ],
         'IsFabricated' => [
-            true => 'Fabricated breach, likely not legitimate'
+            true => 'Fabricated breach, likely not legitimate',
         ],
         'IsSensitive' => [
-            true => 'Sensitive breach, not publicly searchable'
+            true => 'Sensitive breach, not publicly searchable',
         ],
         'IsRetired' => [
-            true => 'Retired breach, removed from system'
+            true => 'Retired breach, removed from system',
         ],
         'IsSpamList' => [
-            true => 'Spam list, used for spam marketing'
+            true => 'Spam list, used for spam marketing',
         ],
         'IsMalware' => [
-            true => 'Malware breach'
+            true => 'Malware breach',
         ],
     ];
 

--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -19,16 +19,16 @@ class HeiseBridge extends FeedExpander
                 'Internet-Störungen'
                 => 'https://www.heise.de/netze/netzwerk-tools/imonitor-internet-stoerungen/feed/aktuelle-meldungen/',
                 'Alle News von heise Developer'
-                => 'https://www.heise.de/developer/rss/news-atom.xml'
-            ]
+                => 'https://www.heise.de/developer/rss/news-atom.xml',
+            ],
         ],
         'limit' => [
             'name' => 'Limit',
             'type' => 'number',
             'required' => false,
             'title' => 'Specify number of full articles to return',
-            'defaultValue' => 5
-        ]
+            'defaultValue' => 5,
+        ],
     ]];
     const LIMIT = 5;
 

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -12,7 +12,7 @@ class HotUKDealsBridge extends PepperBridgeAbstract
                 'name' => 'Keyword(s)',
                 'type' => 'text',
                 'exampleValue' => 'lamp',
-                'required' => true
+                'required' => true,
             ],
             'hide_expired' => [
                 'name' => 'Hide expired deals',
@@ -27,13 +27,13 @@ class HotUKDealsBridge extends PepperBridgeAbstract
                 'name' => 'Minimal Price',
                 'type' => 'text',
                 'title' => 'Minmal Price in Pounds',
-                'required' => false
+                'required' => false,
             ],
             'priceTo' => [
                 'name' => 'Maximum Price',
                 'type' => 'text',
                 'title' => 'Maximum Price in Pounds',
-                'required' => false
+                'required' => false,
             ],
         ],
 
@@ -3235,7 +3235,7 @@ class HotUKDealsBridge extends PepperBridgeAbstract
                     'ZTE' => 'zte',
                     'ZTE Smartphone' => 'zte-smartphone',
                     'ZyXEL' => 'zyxel',
-                ]
+                ],
             ],
             'order' => [
                 'name' => 'Order by',
@@ -3244,8 +3244,8 @@ class HotUKDealsBridge extends PepperBridgeAbstract
                 'values' => [
                     'From the most to the least hot deal' => '-hot',
                     'From the most recent deal to the oldest' => '-new',
-                ]
-            ]
+                ],
+            ],
         ],
         'Discussion Monitoring' => [
             'url' => [
@@ -3260,8 +3260,8 @@ class HotUKDealsBridge extends PepperBridgeAbstract
                 'type' => 'checkbox',
                 'title' => 'Exclude comments that does not contains URL in the feed',
                 'defaultValue' => false,
-                ]
-            ]
+                ],
+            ],
 
 
     ];
@@ -3302,7 +3302,7 @@ class HotUKDealsBridge extends PepperBridgeAbstract
             'st',
             'nd',
             'rd',
-            'th'
+            'th',
         ],
         'local-time-relative' => [
             'Posted ',
@@ -3312,24 +3312,24 @@ class HotUKDealsBridge extends PepperBridgeAbstract
             'days',
             'month',
             'year',
-            'and '
+            'and ',
         ],
         'date-prefixes' => [
             'Found ',
             'Refreshed ',
-            'Made hot '
+            'Made hot ',
         ],
         'relative-date-alt-prefixes' => [
             'Made hot ',
             'Refreshed ',
-            'Last updated '
+            'Last updated ',
         ],
         'relative-date-ignore-suffix' => [
-            '/by.*$/'
+            '/by.*$/',
         ],
         'localdeal' => [
             'Local',
-            'Expires'
-        ]
+            'Expires',
+        ],
     ];
 }

--- a/bridges/IGNBridge.php
+++ b/bridges/IGNBridge.php
@@ -33,7 +33,7 @@ class IGNBridge extends FeedExpander
             '.jsx-4213937408',
             '.commerce-container',
             '.widget-container',
-            '.newsletter-signup-button'
+            '.newsletter-signup-button',
         ];
 
         // Remove useless elements

--- a/bridges/IKWYDBridge.php
+++ b/bridges/IKWYDBridge.php
@@ -12,14 +12,14 @@ class IKWYDBridge extends BridgeAbstract
             'ip' => [
                 'name' => 'IP Address',
                 'exampleValue' => '8.8.8.8',
-                'required' => true
+                'required' => true,
             ],
             'update' => [
                 'name' => 'Update last seen',
                 'type' => 'checkbox',
-                'title' => 'Update timestamp every time "last seen" changes'
-            ]
-        ]
+                'title' => 'Update timestamp every time "last seen" changes',
+            ],
+        ],
     ];
     private $name;
     private $uri;

--- a/bridges/IPBBridge.php
+++ b/bridges/IPBBridge.php
@@ -13,16 +13,16 @@ class IPBBridge extends FeedExpander
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert forum, subforum or topic URI',
-                'exampleValue' => 'https://invisioncommunity.com/forums/forum/499-feedback-and-ideas/'
+                'exampleValue' => 'https://invisioncommunity.com/forums/forum/499-feedback-and-ideas/',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Specifies the number of items to return on each request (-1: all)',
-                'defaultValue' => 10
-            ]
-        ]
+                'defaultValue' => 10,
+            ],
+        ],
     ];
     const CACHE_TIMEOUT = 3600;
 
@@ -306,12 +306,12 @@ class IPBBridge extends FeedExpander
         // Restore quote highlighting
         foreach ($html->find('blockquote') as $quote) {
             $quote->style = <<<EOD
-padding: 0px 15px;
-border-width: 1px 1px 1px 2px;
-border-style: solid;
-border-color: #ededed #e8e8e8 #dbdbdb #666666;
-background: #fbfbfb;
-EOD;
+                padding: 0px 15px;
+                border-width: 1px 1px 1px 2px;
+                border-style: solid;
+                border-color: #ededed #e8e8e8 #dbdbdb #666666;
+                background: #fbfbfb;
+                EOD;
         }
 
         // Remove unnecessary tags

--- a/bridges/IdenticaBridge.php
+++ b/bridges/IdenticaBridge.php
@@ -12,8 +12,8 @@ class IdenticaBridge extends BridgeAbstract
         'u' => [
             'name' => 'username',
             'exampleValue' => 'jxself',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     public function collectData()

--- a/bridges/IndeedBridge.php
+++ b/bridges/IndeedBridge.php
@@ -16,7 +16,7 @@ class IndeedBridge extends BridgeAbstract
                 'required' => true,
                 'title' => 'Company name',
                 'exampleValue' => 'GitHub',
-            ]
+            ],
         ],
         'global' => [
             'language' => [
@@ -70,7 +70,7 @@ class IndeedBridge extends BridgeAbstract
                     'ar-EG' => 'ar-EG',
                     'fr-MA' => 'fr-MA',
                     'en-NG' => 'en-NG',
-                ]
+                ],
             ],
             'limit' => [
                 'name' => 'Limit',
@@ -78,8 +78,8 @@ class IndeedBridge extends BridgeAbstract
                 'required' => true,
                 'title' => 'Maximum number of items to return',
                 'exampleValue' => 20,
-            ]
-        ]
+            ],
+        ],
     ];
 
     const SITES = [

--- a/bridges/IndiegogoBridge.php
+++ b/bridges/IndiegogoBridge.php
@@ -17,7 +17,7 @@ class IndiegogoBridge extends BridgeAbstract
                     'Just Launched' => 'just_launched',
                     'Ending Soon' => 'ending_soon',
                 ],
-                'defaultValue' => 'Just Launched'
+                'defaultValue' => 'Just Launched',
             ],
         ],
         'All Categories' => [],
@@ -106,15 +106,15 @@ class IndiegogoBridge extends BridgeAbstract
     protected function getCategories()
     {
         $selection = [
-            'sort'  => 'trending',
-            'project_type'  => 'campaign',
+            'sort' => 'trending',
+            'project_type' => 'campaign',
             'project_timing' => $this->getInput('timing'),
             'category_main' => null,
             'category_top_level' => null,
-            'page_num'  => 1,
-            'per_page'  => 12,
+            'page_num' => 1,
+            'per_page' => 12,
             'q' => '',
-            'tags'  => []
+            'tags' => [],
         ];
 
         switch ($this->queriedContext) {

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -21,22 +21,22 @@ class InstagramBridge extends BridgeAbstract
             'u' => [
                 'name' => 'username',
                 'exampleValue' => 'aesoprockwins',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Hashtag' => [
             'h' => [
                 'name' => 'hashtag',
                 'exampleValue' => 'beautifulday',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Location' => [
             'l' => [
                 'name' => 'location',
                 'exampleValue' => 'london',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'global' => [
             'media_type' => [
@@ -49,13 +49,13 @@ class InstagramBridge extends BridgeAbstract
                     'Picture' => 'picture',
                     'Multiple' => 'multiple',
                 ],
-                'defaultValue' => 'all'
+                'defaultValue' => 'all',
             ],
             'direct_links' => [
                 'name' => 'Use direct media links',
                 'type' => 'checkbox',
-            ]
-        ]
+            ],
+        ],
 
     ];
 
@@ -102,7 +102,7 @@ class InstagramBridge extends BridgeAbstract
         $key = $cache->loadData();
 
         if ($key == null) {
-                $data = $this->getContents(self::URI . 'web/search/topsearch/?query=' . $username);
+            $data = $this->getContents(self::URI . 'web/search/topsearch/?query=' . $username);
             foreach (json_decode($data)->users as $user) {
                 if (strtolower($user->user->username) === strtolower($username)) {
                     $key = $user->user->pk;
@@ -111,7 +111,7 @@ class InstagramBridge extends BridgeAbstract
             if ($key == null) {
                 returnServerError('Unable to find username in search result.');
             }
-                $cache->saveData($key);
+            $cache->saveData($key);
         }
         return $key;
     }
@@ -179,7 +179,7 @@ class InstagramBridge extends BridgeAbstract
             $pattern = ['/\@([\w\.]+)/', '/#([\w\.]+)/'];
             $replace = [
                 '<a href="https://www.instagram.com/$1">@$1</a>',
-                '<a href="https://www.instagram.com/explore/tags/$1">#$1</a>'];
+                '<a href="https://www.instagram.com/explore/tags/$1">#$1</a>', ];
 
             switch ($media->__typename) {
                 case 'GraphSidecar':

--- a/bridges/InstructablesBridge.php
+++ b/bridges/InstructablesBridge.php
@@ -217,7 +217,7 @@ class InstructablesBridge extends BridgeAbstract
                     ],
                 ],
                 'title' => 'Select your category (required)',
-                'defaultValue' => 'Circuits'
+                'defaultValue' => 'Circuits',
             ],
             'filter' => [
                 'name' => 'Filter',
@@ -227,12 +227,12 @@ class InstructablesBridge extends BridgeAbstract
                     'Recent' => 'recent/',
                     'Popular' => 'popular/',
                     'Views' => 'views/',
-                    'Contest Winners' => 'winners/'
+                    'Contest Winners' => 'winners/',
                 ],
                 'title' => 'Select a filter',
-                'defaultValue' => 'Featured'
-            ]
-        ]
+                'defaultValue' => 'Featured',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/InternetArchiveBridge.php
+++ b/bridges/InternetArchiveBridge.php
@@ -27,23 +27,23 @@ class InternetArchiveBridge extends BridgeAbstract
                 'defaultValue' => 'uploads',
             ],
             'limit' => self::LIMIT,
-        ]
+        ],
     ];
 
     const CACHE_TIMEOUT = 900; // 15 mins
 
     const TEST_DETECT_PARAMETERS = [
         'https://archive.org/details/@verifiedjoseph' => [
-            'context' => 'Account', 'username' => 'verifiedjoseph', 'content' => 'uploads'
+            'context' => 'Account', 'username' => 'verifiedjoseph', 'content' => 'uploads',
         ],
         'https://archive.org/details/@verifiedjoseph?tab=collections' => [
-            'context' => 'Account', 'username' => 'verifiedjoseph', 'content' => 'collections'
+            'context' => 'Account', 'username' => 'verifiedjoseph', 'content' => 'collections',
         ],
     ];
 
     private $skipClasses = [
         'item-ia mobile-header hidden-tiles',
-        'item-ia account-ia'
+        'item-ia account-ia',
     ];
 
     private $detectParamsRegex = '/https?:\/\/archive\.org\/details\/@([\w]+)(?:\?tab=([a-z-]+))?/';
@@ -173,9 +173,9 @@ class InternetArchiveBridge extends BridgeAbstract
         }
 
         $item['content'] = <<<EOD
-<p>Media Type: {$result->attr['data-mediatype']}<br>
-Collection: <a href="{$collectionLink}">{$collectionTitle}</a></p>
-EOD;
+            <p>Media Type: {$result->attr['data-mediatype']}<br>
+            Collection: <a href="{$collectionLink}">{$collectionTitle}</a></p>
+            EOD;
 
         $item['enclosures'][] = self::URI . $result->find('img.item-img', 0)->source;
 
@@ -195,9 +195,9 @@ EOD;
         }
 
         $item['content'] = <<<EOD
-<p><strong>Subject: {$result->find('div.review-title', 0)->plaintext}</strong></p>
-<p>{$result->find('div.hidden-lists.review' , 0)->children(1)->plaintext}</p>
-EOD;
+            <p><strong>Subject: {$result->find('div.review-title', 0)->plaintext}</strong></p>
+            <p>{$result->find('div.hidden-lists.review', 0)->children(1)->plaintext}</p>
+            EOD;
 
         $item['enclosures'][] = self::URI . $result->find('img.item-img', 0)->source;
 
@@ -213,8 +213,8 @@ EOD;
         $item['uri'] = $result->find('div.item-ttl.C.C2 > a', 0)->href;
 
         $item['content'] = <<<EOD
-{$this->processUsername()} archived <a href="{$item['uri']}">{$result->find('div.ttl', 0)->plaintext}</a>
-EOD;
+            {$this->processUsername()} archived <a href="{$item['uri']}">{$result->find('div.ttl', 0)->plaintext}</a>
+            EOD;
 
         $item['enclosures'][] = $result->find('img.item-img', 0)->source;
 
@@ -285,8 +285,8 @@ EOD;
             $item['uri'] = $tr->find('td', 0)->children(0)->href;
 
             $formLink = <<<EOD
-<a href="{$tr->find('td', 2)->children(0)->href}">{$tr->find('td', 2)->children(0)->plaintext}</a>
-EOD;
+                <a href="{$tr->find('td', 2)->children(0)->href}">{$tr->find('td', 2)->children(0)->plaintext}</a>
+                EOD;
 
             $postDate = $tr->find('td', 4)->children(0)->plaintext;
 
@@ -298,21 +298,21 @@ EOD;
 
             $parentLink = '';
             $replyLink = <<<EOD
-<a href="{$post->find('a', 0)->href}">Reply</a>
-EOD;
+                <a href="{$post->find('a', 0)->href}">Reply</a>
+                EOD;
 
             if ($post->find('a', 1)->innertext = 'See parent post') {
                 $parentLink = <<<EOD
-<a href="{$post->find('a', 1)->href}">View parent post</a>
-EOD;
+                    <a href="{$post->find('a', 1)->href}">View parent post</a>
+                    EOD;
             }
 
             $post->find('h1', 0)->outertext = '';
             $post->find('h2', 0)->outertext = '';
 
             $item['content'] = <<<EOD
-<p>{$post->innertext}</p>{$replyLink} - {$parentLink} - Posted in {$formLink} on {$postDate}
-EOD;
+                <p>{$post->innertext}</p>{$replyLink} - {$parentLink} - Posted in {$formLink} on {$postDate}
+                EOD;
 
             $items[] = $item;
 

--- a/bridges/ItchioBridge.php
+++ b/bridges/ItchioBridge.php
@@ -11,7 +11,7 @@ class ItchioBridge extends BridgeAbstract
             'name' => 'Product URL',
             'exampleValue' => 'https://remedybg.itch.io/remedybg',
             'required' => true,
-        ]
+        ],
     ]];
     const CACHE_TIMEOUT = 21600; // 6 hours
 

--- a/bridges/IvooxBridge.php
+++ b/bridges/IvooxBridge.php
@@ -17,9 +17,9 @@ class IvooxBridge extends BridgeAbstract
             's' => [
                 'name' => 'keyword',
                 'required' => true,
-                'exampleValue' => 'car'
-            ]
-        ]
+                'exampleValue' => 'car',
+            ],
+        ],
     ];
 
     private function ivBridgeAddItem(
@@ -120,7 +120,7 @@ class IvooxBridge extends BridgeAbstract
 
         foreach ($originalLocales as $localeSetting) {
             if (strpos($localeSetting, '=') !== false) {
-                list($category, $locale) = explode('=', $localeSetting);
+                [$category, $locale] = explode('=', $localeSetting);
             } else {
                 $category = LC_ALL;
                 $locale = $localeSetting;

--- a/bridges/JapanExpoBridge.php
+++ b/bridges/JapanExpoBridge.php
@@ -11,7 +11,7 @@ class JapanExpoBridge extends BridgeAbstract
         'mode' => [
             'name' => 'Show full contents',
             'type' => 'checkbox',
-        ]
+        ],
     ]];
 
     public function getIcon()
@@ -100,7 +100,7 @@ class JapanExpoBridge extends BridgeAbstract
                     'septembre' => 'sep',
                     'octobre' => 'oct',
                     'novembre' => 'nov',
-                    'décembre' => 'dec'
+                    'décembre' => 'dec',
                 ]
             )
         );

--- a/bridges/JornalDeNoticiasBridge.php
+++ b/bridges/JornalDeNoticiasBridge.php
@@ -11,8 +11,8 @@ class JornalDeNoticiasBridge extends BridgeAbstract
             'url' => [
                 'name' => 'URL (relative)',
                 'exampleValue' => 'opiniao/catia-domingues.html',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function getIcon()

--- a/bridges/JustETFBridge.php
+++ b/bridges/JustETFBridge.php
@@ -11,8 +11,8 @@ class JustETFBridge extends BridgeAbstract
             'full' => [
                 'name' => 'Full Article',
                 'type' => 'checkbox',
-                'title' => 'Enable to load full articles'
-            ]
+                'title' => 'Enable to load full articles',
+            ],
         ],
         'Profile' => [
             'isin' => [
@@ -21,18 +21,18 @@ class JustETFBridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => 'IE00B4X9L533',
                 'pattern' => '[a-zA-Z]{2}[a-zA-Z0-9]{10}',
-                'title' => 'ISIN, consisting of 2-letter country code, 9-character identifier, check character'
+                'title' => 'ISIN, consisting of 2-letter country code, 9-character identifier, check character',
             ],
             'strategy' => [
                 'name' => 'Include Strategy',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'description' => [
                 'name' => 'Include Description',
                 'type' => 'checkbox',
-                'defaultValue' => 'checked'
-            ]
+                'defaultValue' => 'checked',
+            ],
         ],
         'global' => [
             'lang' => [
@@ -40,12 +40,12 @@ class JustETFBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     'Englisch' => 'en',
-                    'Deutsch'  => 'de',
-                    'Italiano' => 'it'
+                    'Deutsch' => 'de',
+                    'Italiano' => 'it',
                 ],
-                'defaultValue' => 'Englisch'
-            ]
-        ]
+                'defaultValue' => 'Englisch',
+            ],
+        ],
     ];
 
     public function collectData()
@@ -78,7 +78,7 @@ class JustETFBridge extends BridgeAbstract
                 break;
             case 'Profile':
                 $uri .= '/etf-profile.html?' . http_build_query([
-                    'isin' => strtoupper($this->getInput('isin'))
+                    'isin' => strtoupper($this->getInput('isin')),
                 ]);
                 break;
         }

--- a/bridges/KernelBugTrackerBridge.php
+++ b/bridges/KernelBugTrackerBridge.php
@@ -14,14 +14,14 @@ Returns feeds for bug comments';
                 'type' => 'number',
                 'required' => true,
                 'title' => 'Insert bug tracking ID',
-                'exampleValue' => 121241
+                'exampleValue' => 121241,
             ],
             'limit' => [
                 'name' => 'Number of comments to return',
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Specify number of comments to return',
-                'defaultValue' => -1
+                'defaultValue' => -1,
             ],
             'sorting' => [
                 'name' => 'Sorting',
@@ -31,10 +31,10 @@ Returns feeds for bug comments';
                 'defaultValue' => 'of',
                 'values' => [
                     'Oldest first' => 'of',
-                    'Latest first' => 'lf'
-                ]
-            ]
-        ]
+                    'Latest first' => 'lf',
+                ],
+            ],
+        ],
     ];
 
     private $bugid = '';

--- a/bridges/KilledbyGoogleBridge.php
+++ b/bridges/KilledbyGoogleBridge.php
@@ -47,8 +47,8 @@ class KilledbyGoogleBridge extends BridgeAbstract
             $item['timestamp'] = strtotime($tombstone['dateClose']);
 
             $item['content'] = <<<EOD
-<p>{$tombstone['description']}</p><p><a href="{$tombstone['link']}">{$tombstone['link']}</a></p>
-EOD;
+                <p>{$tombstone['description']}</p><p><a href="{$tombstone['link']}">{$tombstone['link']}</a></p>
+                EOD;
 
             $item['enclosures'][] = 'https://static.killedbygoogle.com/com/tombstone.svg';
 

--- a/bridges/KununuBridge.php
+++ b/bridges/KununuBridge.php
@@ -17,30 +17,30 @@ class KununuBridge extends BridgeAbstract
                 'values' => [
                     'Austria' => 'at',
                     'Germany' => 'de',
-                    'Switzerland' => 'ch'
+                    'Switzerland' => 'ch',
                 ],
                 'exampleValue' => 'de',
             ],
             'include_ratings' => [
                 'name' => 'Include ratings',
                 'type' => 'checkbox',
-                'title' => 'Activate to include ratings in the feed'
+                'title' => 'Activate to include ratings in the feed',
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'defaultValue' => 3,
-                'title' => "Maximum number of items to return in the feed.\n0 = unlimited"
-            ]
+                'title' => "Maximum number of items to return in the feed.\n0 = unlimited",
+            ],
         ],
         [
             'company' => [
                 'name' => 'Company',
                 'required' => true,
                 'exampleValue' => 'kununu',
-                'title' => 'Insert company name (i.e. Kununu) or URI path (i.e. kununu)'
-            ]
-        ]
+                'title' => 'Insert company name (i.e. Kununu) or URI path (i.e. kununu)',
+            ],
+        ],
     ];
 
     private $companyName = '';
@@ -141,12 +141,12 @@ class KununuBridge extends BridgeAbstract
             $retVal .= (empty($retVal) ? '' : '<hr>') . '<table>';
             foreach ($json['ratings'] as $rating) {
                 $retVal .= <<<EOD
-<tr>
-	<td>{$rating['id']}
-	<td>{$rating['roundedScore']}
-	<td>{$rating['text']}
-</tr>
-EOD;
+                    <tr>
+                    	<td>{$rating['id']}
+                    	<td>{$rating['roundedScore']}
+                    	<td>{$rating['text']}
+                    </tr>
+                    EOD;
             }
             $retVal .= '</table>';
         }

--- a/bridges/LWNprevBridge.php
+++ b/bridges/LWNprevBridge.php
@@ -48,9 +48,9 @@ class LWNprevBridge extends BridgeAbstract
         foreach ($contents as $content) {
             if (strpos($content, '<html>') === false) {
                 $content = <<<EOD
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html><head><title>LWN</title></head><body>{$content}</body></html>
-EOD;
+                    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+                    <html><head><title>LWN</title></head><body>{$content}</body></html>
+                    EOD;
             } else {
                 $content = $content . '</body></html>';
             }

--- a/bridges/LaCentraleBridge.php
+++ b/bridges/LaCentraleBridge.php
@@ -17,8 +17,8 @@ class LaCentraleBridge extends BridgeAbstract
                 'Moto' => 'moto',
                 'Scooter' => 'scooter',
                 'Quad' => 'quad',
-                'Caravane/Camping-car' => 'mobileHome'
-            ]
+                'Caravane/Camping-car' => 'mobileHome',
+            ],
         ],
         'brand' => [
             'name' => 'Marque',
@@ -216,18 +216,18 @@ class LaCentraleBridge extends BridgeAbstract
                 'YAMAHA' => 'YAMAHA',
                 'YCF' => 'YCF',
                 'ZERO' => 'ZERO',
-                'ZONGSHEN' => 'ZONGSHEN'
-            ]
+                'ZONGSHEN' => 'ZONGSHEN',
+            ],
         ],
         'model' => [
             'name' => 'Modèle',
             'type' => 'text',
-            'title' => 'Get the exact name on LaCentrale'
+            'title' => 'Get the exact name on LaCentrale',
         ],
         'versions' => [
             'name' => 'Version(s)',
             'type' => 'text',
-            'title' => 'Get the exact name(s) on LaCentrale. Separate by comma'
+            'title' => 'Get the exact name(s) on LaCentrale. Separate by comma',
         ],
         'category' => [
             'name' => 'Catégorie',
@@ -256,7 +256,7 @@ class LaCentraleBridge extends BridgeAbstract
                     'Bus et minibus' => '82',
                     'Fourgonnette' => '85',
                     'Pick-up' => '50',
-                    'Voiture société, commerciale' => '80'
+                    'Voiture société, commerciale' => '80',
                 ],
                 'Moto' => [
                     'Custom' => '60',
@@ -268,29 +268,29 @@ class LaCentraleBridge extends BridgeAbstract
                     'Supermotard' => '66',
                     'Trail' => '67',
                     'Side-car' => '69',
-                    'Sportive' => '68'
+                    'Sportive' => '68',
                 ],
                 'Caravane/Camping-car' => [
                     'Caravane' => '423',
                     'Profilé' => '506',
                     'Fourgon aménagé' => '507',
                     'Intégral' => '508',
-                    'Capucine' => '510'
-                ]
-            ]
+                    'Capucine' => '510',
+                ],
+            ],
         ],
         'pricemin' => [
             'name' => 'Prix min',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'pricemax' => [
             'name' => 'Prix max',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'location' => [
             'name' => 'CP ou département',
             'type' => 'number',
-            'title' => 'Only one'
+            'title' => 'Only one',
         ],
         'distance' => [
             'name' => 'Rayon de recherche',
@@ -301,8 +301,8 @@ class LaCentraleBridge extends BridgeAbstract
                 '20 km' => '2',
                 '50 km' => '3',
                 '100 km' => '4',
-                '200 km' => '5'
-            ]
+                '200 km' => '5',
+            ],
         ],
         'region' => [
             'name' => 'Région',
@@ -321,32 +321,32 @@ class LaCentraleBridge extends BridgeAbstract
                 'Nouvelle-Aquitaine' => 'FR-PAC',
                 'Occitanie' => 'FR-PDL',
                 'Pays de la Loire' => 'FR-OCC',
-                'Provence-Alpes-Côte d\'Azur' => 'FR-NAQ'
-            ]
+                'Provence-Alpes-Côte d\'Azur' => 'FR-NAQ',
+            ],
         ],
         'mileagemin' => [
             'name' => 'Kilométrage min',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'mileagemax' => [
             'name' => 'Kilométrage max',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'yearmin' => [
             'name' => 'Année min',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'yearmax' => [
             'name' => 'Année max',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'cubiccapacitymin' => [
             'name' => 'Cylindrée min',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'cubiccapacitymax' => [
             'name' => 'Cylindrée max',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'fuel' => [
             'name' => 'Énergie',
@@ -359,8 +359,8 @@ class LaCentraleBridge extends BridgeAbstract
                 'Hybride' => 'hyb',
                 'GPL' => 'gpl',
                 'Bioéthanol' => 'eth',
-                'Autre' => 'alt'
-            ]
+                'Autre' => 'alt',
+            ],
         ],
         'gearbox' => [
             'name' => 'Boite de vitesse',
@@ -368,8 +368,8 @@ class LaCentraleBridge extends BridgeAbstract
             'values' => [
                 '' => '',
                 'Boite automatique' => 'AUTO',
-                'Boite mécanique' => 'MANUAL'
-            ]
+                'Boite mécanique' => 'MANUAL',
+            ],
         ],
         'doors' => [
             'name' => 'Nombre de portes',
@@ -380,12 +380,12 @@ class LaCentraleBridge extends BridgeAbstract
                 '3 portes' => '3',
                 '4 portes' => '4',
                 '5 portes' => '5',
-                '6 portes ou plus' => '6'
-            ]
+                '6 portes ou plus' => '6',
+            ],
         ],
         'firsthand' => [
             'name' => 'Première main',
-            'type' => 'checkbox'
+            'type' => 'checkbox',
         ],
         'seller' => [
             'name' => 'Vendeur',
@@ -393,8 +393,8 @@ class LaCentraleBridge extends BridgeAbstract
             'values' => [
                 '' => '',
                 'Particulier' => 'PART',
-                'Professionel' => 'PRO'
-            ]
+                'Professionel' => 'PRO',
+            ],
         ],
         'sort' => [
             'name' => 'Tri',
@@ -409,8 +409,8 @@ class LaCentraleBridge extends BridgeAbstract
                 'Année (croissant)' => 'yearAsc',
                 'Année (décroissant)' => 'yearDesc',
                 'Département (croissant)' => 'visitPlaceAsc',
-                'Département (décroissant)' => 'visitPlaceDesc'
-            ]
+                'Département (décroissant)' => 'visitPlaceDesc',
+            ],
         ],
     ]];
 
@@ -443,7 +443,7 @@ class LaCentraleBridge extends BridgeAbstract
             'firstHand' => $this->getInput('firsthand') ? 'true' : 'false',
             'gearbox' => $this->getInput('gearbox'),
             'doors' => $this->getInput('doors'),
-            'sortBy' => $this->getInput('sort')
+            'sortBy' => $this->getInput('sort'),
         ];
         $url = sprintf('%slisting?%s', self::URI, http_build_query($params));
         $html = getSimpleHTMLDOM($url);

--- a/bridges/LeBonCoinBridge.php
+++ b/bridges/LeBonCoinBridge.php
@@ -40,8 +40,8 @@ class LeBonCoinBridge extends BridgeAbstract
                     'Guadeloupe' => '23',
                     'Martinique' => '24',
                     'Guyane' => '25',
-                    'Réunion' => '26'
-                ]
+                    'Réunion' => '26',
+                ],
             ],
             'department' => [
                 'name' => 'Département',
@@ -143,12 +143,12 @@ class LeBonCoinBridge extends BridgeAbstract
                     'Hauts-de-Seine' => '92',
                     'Seine-Saint-Denis' => '93',
                     'Val-de-Marne' => '94',
-                    'Val-d\'Oise' => '95'
-                ]
+                    'Val-d\'Oise' => '95',
+                ],
             ],
             'cities' => [
                 'name' => 'Villes',
-                'title' => 'Codes postaux séparés par des virgules'
+                'title' => 'Codes postaux séparés par des virgules',
             ],
             'category' => [
                 'name' => 'Catégorie',
@@ -157,7 +157,7 @@ class LeBonCoinBridge extends BridgeAbstract
                     'Toutes catégories' => '',
                     'EMPLOI' => [
                         'Emploi et recrutement' => '71',
-                        'Offres d\'emploi et jobs' => '33'
+                        'Offres d\'emploi et jobs' => '33',
                     ],
                     'VÉHICULES' => [
                         'Tous' => '1',
@@ -169,14 +169,14 @@ class LeBonCoinBridge extends BridgeAbstract
                         'Equipement Moto' => '44',
                         'Equipement Caravaning' => '50',
                         'Nautisme' => '7',
-                        'Equipement Nautisme' => '51'
+                        'Equipement Nautisme' => '51',
                     ],
                     'IMMOBILIER' => [
                         'Tous' => '8',
                         'Ventes immobilières' => '9',
                         'Locations' => '10',
                         'Colocations' => '11',
-                        'Bureaux & Commerces' => '13'
+                        'Bureaux & Commerces' => '13',
                     ],
                     'VACANCES' => [
                         'Tous' => '66',
@@ -184,14 +184,14 @@ class LeBonCoinBridge extends BridgeAbstract
                         'Chambres d\'hôtes' => '67',
                         'Campings' => '68',
                         'Hôtels' => '69',
-                        'Hébergements insolites' => '70'
+                        'Hébergements insolites' => '70',
                     ],
                     'MULTIMÉDIA' => [
                         'Tous' => '14',
                         'Informatique' => '15',
                         'Consoles & Jeux vidéo' => '43',
                         'Image & Son' => '16',
-                        'Téléphonie' => '17'
+                        'Téléphonie' => '17',
                     ],
                     'LOISIRS' => [
                         'Tous' => '24',
@@ -204,7 +204,7 @@ class LeBonCoinBridge extends BridgeAbstract
                         'Instruments de musique' => '30',
                         'Collection' => '40',
                         'Jeux & Jouets' => '41',
-                        'Vins & Gastronomie' => '48'
+                        'Vins & Gastronomie' => '48',
                     ],
                     'MATÉRIEL PROFESSIONNEL' => [
                         'Tous' => '56',
@@ -216,7 +216,7 @@ class LeBonCoinBridge extends BridgeAbstract
                         'Restauration - Hôtellerie' => '61',
                         'Fournitures de Bureau' => '62',
                         'Commerces & Marchés' => '63',
-                        'Matériel Médical' => '64'
+                        'Matériel Médical' => '64',
                     ],
                     'SERVICES' => [
                         'Tous' => '31',
@@ -224,7 +224,7 @@ class LeBonCoinBridge extends BridgeAbstract
                         'Billetterie' => '35',
                         'Événements' => '49',
                         'Cours particuliers' => '36',
-                        'Covoiturage' => '65'
+                        'Covoiturage' => '65',
                     ],
                     'MAISON' => [
                         'Tous' => '18',
@@ -242,16 +242,16 @@ class LeBonCoinBridge extends BridgeAbstract
                         'Équipement bébé' => '23',
                         'Vêtements bébé' => '54',
                     ],
-                    'AUTRES' => '37'
-                ]
+                    'AUTRES' => '37',
+                ],
             ],
             'pricemin' => [
                 'name' => 'Prix min',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'pricemax' => [
                 'name' => 'Prix max',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'estate' => [
                 'name' => 'Type de bien',
@@ -262,48 +262,48 @@ class LeBonCoinBridge extends BridgeAbstract
                     'Appartement' => '2',
                     'Terrain' => '3',
                     'Parking' => '4',
-                    'Autre' => '5'
-                ]
+                    'Autre' => '5',
+                ],
             ],
             'roomsmin' => [
                 'name' => 'Pièces min',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'roomsmax' => [
                 'name' => 'Pièces max',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'squaremin' => [
                 'name' => 'Surface min',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'squaremax' => [
                 'name' => 'Surface max',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'mileagemin' => [
                 'name' => 'Kilométrage min',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'mileagemax' => [
                 'name' => 'Kilométrage max',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'yearmin' => [
                 'name' => 'Année min',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'yearmax' => [
                 'name' => 'Année max',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'cubiccapacitymin' => [
                 'name' => 'Cylindrée min',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'cubiccapacitymax' => [
                 'name' => 'Cylindrée max',
-                'type' => 'number'
+                'type' => 'number',
             ],
             'fuel' => [
                 'name' => 'Énergie',
@@ -315,8 +315,8 @@ class LeBonCoinBridge extends BridgeAbstract
                     'GPL' => '3',
                     'Électrique' => '4',
                     'Hybride' => '6',
-                    'Autre' => '5'
-                ]
+                    'Autre' => '5',
+                ],
             ],
             'owner' => [
                 'name' => 'Vendeur',
@@ -324,10 +324,10 @@ class LeBonCoinBridge extends BridgeAbstract
                 'values' => [
                     'Tous' => '',
                     'Particuliers' => 'private',
-                    'Professionnels' => 'pro'
-                ]
-            ]
-        ]
+                    'Professionnels' => 'pro',
+                ],
+            ],
+        ],
     ];
 
     public static $LBC_API_KEY = 'ba0c2dad52b3ec';
@@ -351,7 +351,7 @@ class LeBonCoinBridge extends BridgeAbstract
 
         return [
             'min' => $range_min,
-            'max' => $range_max
+            'max' => $range_max,
         ];
     }
 
@@ -366,12 +366,12 @@ class LeBonCoinBridge extends BridgeAbstract
             'X-LBC-CC: 7',
             'Accept: application/json,application/hal+json',
             'Content-Length: ' . strlen($data),
-            'api_key: ' . self::$LBC_API_KEY
+            'api_key: ' . self::$LBC_API_KEY,
         ];
 
         $opts = [
             CURLOPT_CUSTOMREQUEST => 'POST',
-            CURLOPT_POSTFIELDS => $data
+            CURLOPT_POSTFIELDS => $data,
 
         ];
 
@@ -426,7 +426,7 @@ class LeBonCoinBridge extends BridgeAbstract
         $requestJson->filters = new StdClass();
 
         $requestJson->filters->keywords = [
-            'text' => $this->getInput('keywords')
+            'text' => $this->getInput('keywords'),
         ];
 
         if ($this->getInput('region') != '') {
@@ -442,13 +442,13 @@ class LeBonCoinBridge extends BridgeAbstract
 
             foreach (explode(',', $this->getInput('cities')) as $zipcode) {
                 $requestJson->filters->location['city_zipcodes'][] = [
-                    'zipcode' => trim($zipcode)
+                    'zipcode' => trim($zipcode),
                 ];
             }
         }
 
         $requestJson->filters->category = [
-            'id' => $this->getInput('category')
+            'id' => $this->getInput('category'),
         ];
 
         if (

--- a/bridges/LeMondeInformatiqueBridge.php
+++ b/bridges/LeMondeInformatiqueBridge.php
@@ -23,7 +23,7 @@ class LeMondeInformatiqueBridge extends FeedExpander
                 '/grande/',
                 '/petite/',
                 $article_html->find('.article-image > img, figure > img', 0)->src
-            )
+            ),
         ];
 
         //No response header sets the encoding, explicit conversion is needed or subsequent xml_encode() will fail

--- a/bridges/LegoIdeasBridge.php
+++ b/bridges/LegoIdeasBridge.php
@@ -13,7 +13,7 @@ class LegoIdeasBridge extends BridgeAbstract
                 'title' => 'The number of people that need to have supported a project at minimum.
 Once a project reaches 10,000 supporters, it gets reviewed by the lego experts.',
                 'type' => 'number',
-                'defaultValue' => 1000
+                'defaultValue' => 1000,
             ],
             'idea_phase' => [
                 'name' => 'Idea Phase',
@@ -27,9 +27,9 @@ Once a project reaches 10,000 supporters, it gets reviewed by the lego experts.'
                     'On Shelves' => 'idea_on_shelves',
                     'Expired Ideas' => 'idea_expired_ideas',
                 ],
-                'defaultValue' => 'idea_gathering_support'
-            ]
-        ]
+                'defaultValue' => 'idea_gathering_support',
+            ],
+        ],
     ];
 
     public function getURI()
@@ -46,11 +46,11 @@ Once a project reaches 10,000 supporters, it gets reviewed by the lego experts.'
     {
         $header = [
             'Content-Type: application/json',
-            'Accept: application/json'
+            'Accept: application/json',
         ];
         $opts = [
             CURLOPT_POST => 1,
-            CURLOPT_POSTFIELDS => $this->getHttpPostData()
+            CURLOPT_POSTFIELDS => $this->getHttpPostData(),
         ];
         $responseData = getContents($this->getHttpPostURI(), $header, $opts) or
                 returnServerError('Unable to query Lego Ideas API.');
@@ -58,22 +58,22 @@ Once a project reaches 10,000 supporters, it gets reviewed by the lego experts.'
         foreach (json_decode($responseData)->results as $project) {
             preg_match('/datetime=\"(\S+)\"/', $project->entity->published_at, $date_matches);
             $datetime = $date_matches[1];
-            $link     = self::URI . $project->entity->view_url;
-            $title    = $project->entity->title;
-            $desc     = $project->entity->content;
+            $link = self::URI . $project->entity->view_url;
+            $title = $project->entity->title;
+            $desc = $project->entity->content;
             $imageUrl = $project->entity->image_url;
-            $creator  = $project->entity->creator->alias;
-            $uuid     = $project->entity->uuid;
+            $creator = $project->entity->creator->alias;
+            $uuid = $project->entity->uuid;
 
             $item = [
-                'uri'       => $link,
-                'title'     => $title,
+                'uri' => $link,
+                'title' => $title,
                 'timestamp' => strtotime($datetime),
-                'author'    => $creator,
-                'content'   => <<<EOD
-<p><img src="{$imageUrl}" alt="{$title}"/></p>
-<p>{$desc}</p>
-EOD
+                'author' => $creator,
+                'content' => <<<EOD
+                    <p><img src="{$imageUrl}" alt="{$title}"/></p>
+                    <p>{$desc}</p>
+                    EOD,
             ];
             $this->items[] = $item;
         }
@@ -96,12 +96,12 @@ EOD
         $minSupporters = $this->getInput('support_value_min');
 
         return <<<EOD
-{ "filters": {
-	 "idea_phase": [ "$phase" ],
-	 "support_value": [ $minSupporters, 10000 ]
-},
-"sort": [ "most_recent:desc" ]
-}
-EOD;
+            { "filters": {
+            	 "idea_phase": [ "$phase" ],
+            	 "support_value": [ $minSupporters, 10000 ]
+            },
+            "sort": [ "most_recent:desc" ]
+            }
+            EOD;
     }
 }

--- a/bridges/MallTvBridge.php
+++ b/bridges/MallTvBridge.php
@@ -13,9 +13,9 @@ class MallTvBridge extends BridgeAbstract
             'url' => [
                 'name' => 'url to the show',
                 'required' => true,
-                'exampleValue' => 'https://www.mall.tv/zivot-je-hra'
-            ]
-        ]
+                'exampleValue' => 'https://www.mall.tv/zivot-je-hra',
+            ],
+        ],
     ];
 
     private function fixChars($text)
@@ -57,7 +57,7 @@ class MallTvBridge extends BridgeAbstract
                 'title' => $this->fixChars($itemTitle->plaintext),
                 'uri' => $itemUri,
                 'content' => '<img src="' . $itemThumbnail->getAttribute('data-src') . '" />',
-                'timestamp' => $this->getUploadTimeFromUrl($itemUri)
+                'timestamp' => $this->getUploadTimeFromUrl($itemUri),
             ];
 
             $this->items[] = $item;
@@ -66,11 +66,11 @@ class MallTvBridge extends BridgeAbstract
 
     public function getURI()
     {
-        return isset($this->feedUri) ? $this->feedUri : parent::getURI();
+        return $this->feedUri ?? parent::getURI();
     }
 
     public function getName()
     {
-        return isset($this->feedName) ? $this->feedName : parent::getName();
+        return $this->feedName ?? parent::getName();
     }
 }

--- a/bridges/MangaDexBridge.php
+++ b/bridges/MangaDexBridge.php
@@ -13,33 +13,33 @@ class MangaDexBridge extends BridgeAbstract
                 'name' => 'Item Limit',
                 'type' => 'number',
                 'defaultValue' => 10,
-                'required' => true
+                'required' => true,
             ],
             'lang' => [
                 'name' => 'Chapter Languages (default=all)',
                 'title' => 'comma-separated, two-letter language codes (example "en,jp")',
                 'exampleValue' => 'en,jp',
-                'required' => false
+                'required' => false,
             ],
         ],
         'Title Chapters' => [
             'url' => [
                 'name' => 'URL to title page',
                 'exampleValue' => 'https://mangadex.org/title/f9c33607-9180-4ba6-b85c-e4b5faee7192/official-test-manga',
-                'required' => true
+                'required' => true,
             ],
             'external' => [
                 'name' => 'Allow external feed items',
                 'type' => 'checkbox',
-                'title' => 'Some chapters are inaccessible or only available on an external site. Include these?'
-            ]
+                'title' => 'Some chapters are inaccessible or only available on an external site. Include these?',
+            ],
         ],
         'Search Chapters' => [
             'chapter' => [
                 'name' => 'Chapter Number (default=all)',
                 'title' => 'The example value finds the newest first chapters',
                 'exampleValue' => 1,
-                'required' => false
+                'required' => false,
             ],
             'groups' => [
                 'name' => 'Group UUID (default=all)',
@@ -56,9 +56,9 @@ class MangaDexBridge extends BridgeAbstract
             'external' => [
                 'name' => 'Allow external feed items',
                 'type' => 'checkbox',
-                'title' => 'Some chapters are inaccessible or only available on an external site. Include these?'
-            ]
-        ]
+                'title' => 'Some chapters are inaccessible or only available on an external site. Include these?',
+            ],
+        ],
         // Future Manga Contexts:
         // Manga List (by author or tags): https://api.mangadex.org/swagger.html#/Manga/get-search-manga
         // Random Manga: https://api.mangadex.org/swagger.html#/Manga/get-manga-random
@@ -85,7 +85,7 @@ class MangaDexBridge extends BridgeAbstract
     protected function getAPI()
     {
         $params = [
-            'limit' => $this->getInput('limit')
+            'limit' => $this->getInput('limit'),
         ];
 
         $array_params = [];
@@ -162,7 +162,7 @@ class MangaDexBridge extends BridgeAbstract
     {
         $api_uri = $this->getAPI();
         $header = [
-            'Content-Type: application/json'
+            'Content-Type: application/json',
         ];
         $content = json_decode(getContents($api_uri, $header), true);
         if ($content['result'] == 'ok') {

--- a/bridges/MarktplaatsBridge.php
+++ b/bridges/MarktplaatsBridge.php
@@ -57,8 +57,8 @@ class MarktplaatsBridge extends BridgeAbstract
                 'type' => 'checkbox',
                 'required' => false,
                 'title' => 'Include the raw data behind the content',
-            ]
-        ]
+            ],
+        ],
     ];
     const CACHE_TIMEOUT = 900;
 
@@ -126,8 +126,8 @@ class MarktplaatsBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('q'))) {
-                return $this->getInput('q') . ' - Marktplaats';
+            return $this->getInput('q') . ' - Marktplaats';
         }
-                return parent::getName();
+        return parent::getName();
     }
 }

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -38,14 +38,14 @@ class MastodonBridge extends BridgeAbstract
         'norep' => [
             'name' => 'Without replies',
             'type' => 'checkbox',
-            'title' => 'Only return statuses that are not replies, as determined by relations (not mentions).'
+            'title' => 'Only return statuses that are not replies, as determined by relations (not mentions).',
         ],
         'noboost' => [
             'name' => 'Without boosts',
             'required' => false,
             'type' => 'checkbox',
-            'title' => 'Hide boosts. Note that RSS-Bridge will fetch the original status from other federated instances.'
-            ]
+            'title' => 'Hide boosts. Note that RSS-Bridge will fetch the original status from other federated instances.',
+            ],
         ]];
 
     public function getName()
@@ -77,7 +77,7 @@ class MastodonBridge extends BridgeAbstract
             $resource = 'acct:' . $this->getUsername() . '@' . $this->getInstance();
             $webfingerUrl = 'https://' . $this->getInstance() . '/.well-known/webfinger?resource=' . $resource;
             $webfingerHeader = [
-                'Content-Type: application/jrd+json'
+                'Content-Type: application/jrd+json',
             ];
             $webfinger = json_decode(getContents($webfingerUrl, $webfingerHeader), true);
             foreach ($webfinger['links'] as $link) {
@@ -185,7 +185,7 @@ class MastodonBridge extends BridgeAbstract
         $headers = [
             'Accept: application/activity+json',
             'Host: ' . $matches[1],
-            'Date: ' . $date
+            'Date: ' . $date,
         ];
         $privateKey = $this->getOption('private_key');
         $keyId = $this->getOption('key_id');

--- a/bridges/MediapartBlogsBridge.php
+++ b/bridges/MediapartBlogsBridge.php
@@ -14,8 +14,8 @@ class MediapartBlogsBridge extends BridgeAbstract
                 'title' => 'Blog user name',
                 'required' => true,
                 'exampleValue' => 'jean-vincot',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function getIcon()

--- a/bridges/MediapartBridge.php
+++ b/bridges/MediapartBridge.php
@@ -11,14 +11,14 @@ class MediapartBridge extends FeedExpander
                 'name' => 'Single page article',
                 'type' => 'checkbox',
                 'title' => 'Display long articles on a single page',
-                'defaultValue' => 'checked'
+                'defaultValue' => 'checked',
             ],
             'mpsessid' => [
                 'name' => 'MPSESSID',
                 'type' => 'text',
-                'title' => 'Value of the session cookie MPSESSID'
-            ]
-        ]
+                'title' => 'Value of the session cookie MPSESSID',
+            ],
+        ],
     ];
     const CACHE_TIMEOUT = 7200; // 2h
     const DESCRIPTION = 'Returns the newest articles.';

--- a/bridges/MixCloudBridge.php
+++ b/bridges/MixCloudBridge.php
@@ -14,7 +14,7 @@ class MixCloudBridge extends BridgeAbstract
             'name' => 'username',
             'required' => true,
             'exampleValue' => 'DJJazzyJeff',
-        ]
+        ],
     ]];
 
     public function getName()

--- a/bridges/ModelKarteiBridge.php
+++ b/bridges/ModelKarteiBridge.php
@@ -8,10 +8,10 @@ class ModelKarteiBridge extends BridgeAbstract
     const MAINTAINER = 'fulmeek';
     const PARAMETERS = [[
         'model_id' => [
-            'name'          => 'Model ID',
+            'name' => 'Model ID',
             'required' => true,
-            'exampleValue'  => '614931'
-        ]
+            'exampleValue' => '614931',
+        ],
     ]];
 
     const LIMIT_ITEMS = 10;
@@ -44,13 +44,13 @@ class ModelKarteiBridge extends BridgeAbstract
 
             $item = [];
 
-            $title      = $element->title;
-            $date       = $element->{'data-date'};
-            $author     = $this->feedName;
-            $text       = '';
+            $title = $element->title;
+            $date = $element->{'data-date'};
+            $author = $this->feedName;
+            $text = '';
 
-            $objImage   = $element->find('a.photoLink img', 0);
-            $objLink    = $element->find('a.photoLink', 0);
+            $objImage = $element->find('a.photoLink img', 0);
+            $objLink = $element->find('a.photoLink', 0);
 
             if ($objLink) {
                 $page = getSimpleHTMLDOMCached($objLink->href);
@@ -85,9 +85,9 @@ class ModelKarteiBridge extends BridgeAbstract
                 }
             }
 
-            $item['title']      = $title;
-            $item['timestamp']  = $date;
-            $item['author']     = $author;
+            $item['title'] = $title;
+            $item['timestamp'] = $date;
+            $item['author'] = $author;
 
             if ($objImage) {
                 $item['content'] = '<img src="' . $objImage->src . '"/>';

--- a/bridges/MoebooruBridge.php
+++ b/bridges/MoebooruBridge.php
@@ -12,11 +12,11 @@ class MoebooruBridge extends BridgeAbstract
         'p' => [
             'name' => 'page',
             'defaultValue' => 1,
-            'type' => 'number'
+            'type' => 'number',
         ],
         't' => [
-            'name' => 'tags'
-        ]
+            'name' => 'tags',
+        ],
     ]];
 
     protected function getFullURI()

--- a/bridges/MoinMoinBridge.php
+++ b/bridges/MoinMoinBridge.php
@@ -13,7 +13,7 @@ class MoinMoinBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert wiki page URI (e.g.: https://moinmo.in/MoinMoin)',
-                'exampleValue' => 'https://moinmo.in/MoinMoin'
+                'exampleValue' => 'https://moinmo.in/MoinMoin',
             ],
             'separator' => [
                 'name' => 'Separator',
@@ -26,15 +26,15 @@ class MoinMoinBridge extends BridgeAbstract
                     'Header (h2)' => 'h2',
                     'Header (h3)' => 'h3',
                     'List element (li)' => 'li',
-                    'Anchor (a)' => 'a'
-                ]
+                    'Anchor (a)' => 'a',
+                ],
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Number of items to return (from top)',
-                'defaultValue' => -1
+                'defaultValue' => -1,
             ],
             'content' => [
                 'name' => 'Content',
@@ -45,10 +45,10 @@ class MoinMoinBridge extends BridgeAbstract
                 'values' => [
                     'By separator' => 'separator',
                     'Follow link (only for anchor)' => 'follow',
-                    'None' => 'none'
-                ]
-            ]
-        ]
+                    'None' => 'none',
+                ],
+            ],
+        ],
     ];
 
     private $title = '';
@@ -176,7 +176,7 @@ class MoinMoinBridge extends BridgeAbstract
                 "\<{$this->getInput('separator')}.+?(?=\>)\>",
                 "(.+?)(?=\<\/{$this->getInput('separator')}\>)",
                 "\<\/{$this->getInput('separator')}\>",
-                "(.+?)((?=\<{$this->getInput('separator')})|(?=\<div\sid=\"pagebottom\")){1}"
+                "(.+?)((?=\<{$this->getInput('separator')})|(?=\<div\sid=\"pagebottom\")){1}",
             ]
         );
 
@@ -193,8 +193,8 @@ class MoinMoinBridge extends BridgeAbstract
                 [
                     $content,
                     $html->find('title', 0)->innertext,
-                    $content
-                ]
+                    $content,
+                ],
             ];
         }
 

--- a/bridges/MozillaBugTrackerBridge.php
+++ b/bridges/MozillaBugTrackerBridge.php
@@ -14,14 +14,14 @@ Returns feeds for bug comments';
                 'type' => 'number',
                 'required' => true,
                 'title' => 'Insert bug tracking ID',
-                'exampleValue' => 121241
+                'exampleValue' => 121241,
             ],
             'limit' => [
                 'name' => 'Number of comments to return',
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Specify number of comments to return',
-                'defaultValue' => -1
+                'defaultValue' => -1,
             ],
             'sorting' => [
                 'name' => 'Sorting',
@@ -31,10 +31,10 @@ Returns feeds for bug comments';
                 'defaultValue' => 'of',
                 'values' => [
                     'Oldest first' => 'of',
-                    'Latest first' => 'lf'
-                ]
-            ]
-        ]
+                    'Latest first' => 'lf',
+                ],
+            ],
+        ],
     ];
 
     private $bugid = '';

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -12,7 +12,7 @@ class MydealsBridge extends PepperBridgeAbstract
                 'name' => 'Stichworten',
                 'type' => 'text',
                 'exampleValue' => 'lamp',
-                'required' => true
+                'required' => true,
             ],
             'hide_expired' => [
                 'name' => 'Abgelaufenes ausblenden',
@@ -27,13 +27,13 @@ class MydealsBridge extends PepperBridgeAbstract
                 'name' => 'Minimaler Preis',
                 'type' => 'text',
                 'title' => 'Minmaler Preis in Euros',
-                'required' => false
+                'required' => false,
             ],
             'priceTo' => [
                 'name' => 'Maximaler Preis',
                 'type' => 'text',
                 'title' => 'maximaler Preis in Euro',
-                'required' => false
+                'required' => false,
             ],
         ],
 
@@ -1984,7 +1984,7 @@ class MydealsBridge extends PepperBridgeAbstract
                     'ZTE Smartphones' => 'zte-smartphones',
                     'ZWILLING' => 'zwilling',
                     'ZWILLING Besteck' => 'zwilling-besteck',
-                ]
+                ],
             ],
             'order' => [
                 'name' => 'sortieren nach',
@@ -1993,7 +1993,7 @@ class MydealsBridge extends PepperBridgeAbstract
                 'values' => [
                     'Vom heißesten zum kältesten Deal' => '-hot',
                     'Vom jüngsten Deal zum ältesten' => '-new',
-                ]
+                ],
             ],
         ],
         'Überwachung Diskussion' => [
@@ -2009,8 +2009,8 @@ class MydealsBridge extends PepperBridgeAbstract
                 'type' => 'checkbox',
                 'title' => 'Kommentare, die keine URL enthalten, im Feed ausschließen',
                 'defaultValue' => false,
-                ]
-            ]
+                ],
+            ],
     ];
 
     public $lang = [
@@ -2025,7 +2025,7 @@ class MydealsBridge extends PepperBridgeAbstract
         'no-results' => 'Ups, wir konnten keine Deals zu',
         'relative-date-indicator' => [
             'vor',
-            'seit'
+            'seit',
         ],
         'price' => 'Preis',
         'shipping' => 'Versand',
@@ -2047,7 +2047,7 @@ class MydealsBridge extends PepperBridgeAbstract
             'Okt',
             'Nov',
             'Dez',
-            '.'
+            '.',
         ],
         'local-time-relative' => [
             'eingestellt vor ',
@@ -2057,7 +2057,7 @@ class MydealsBridge extends PepperBridgeAbstract
             'days',
             'month',
             'year',
-            'and '
+            'and ',
         ],
         'date-prefixes' => [
             'eingestellt am ',
@@ -2067,14 +2067,14 @@ class MydealsBridge extends PepperBridgeAbstract
         'relative-date-alt-prefixes' => [
             'aktualisiert vor ',
             'kommentiert vor ',
-            'heiß seit '
+            'heiß seit ',
         ],
         'relative-date-ignore-suffix' => [
-            '/von.*$/'
+            '/von.*$/',
         ],
         'localdeal' => [
             'Lokal ',
-            'Läuft bis '
-        ]
+            'Läuft bis ',
+        ],
     ];
 }

--- a/bridges/NationalGeographicBridge.php
+++ b/bridges/NationalGeographicBridge.php
@@ -20,19 +20,19 @@ class NationalGeographicBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     self::TOPIC_MAGAZINE => 'magazine',
-                    self::TOPIC_LATEST_STORIES => 'latest-stories'
+                    self::TOPIC_LATEST_STORIES => 'latest-stories',
                 ],
                 'title' => 'Select your topic',
-                'defaultValue' => 'Magazine'
-            ]
+                'defaultValue' => 'Magazine',
+            ],
         ],
         'global' => [
             self::PARAMETER_FULL_ARTICLE => [
                 'name' => 'Full Article',
                 'type' => 'checkbox',
-                'title' => 'Enable to load full articles and other infos (takes longer)'
-            ]
-        ]
+                'title' => 'Enable to load full articles and other infos (takes longer)',
+            ],
+        ],
     ];
 
     private $topicName = '';
@@ -40,7 +40,7 @@ class NationalGeographicBridge extends BridgeAbstract
 			RvcGljL2xhdGVzdC1zdG9yaWVzIiwicG9ydGZvbGlvIjoibmF0Z2VvIiwicXVlcn
 			lUeXBlIjoiTE9DQVRPUiJ9LCJtb2R1bGVJZCI6bnVsbH0';
     const LATEST_STORIES_ID = [
-        '1df278bb-0e3d-4a67-a0ce-8fae48392822-f2-m1'
+        '1df278bb-0e3d-4a67-a0ce-8fae48392822-f2-m1',
     ];
     const MAGAZINE_ID = [
         '94d87d74-f41a-4a32-9acd-b591ba2df288-f2-m1',
@@ -230,17 +230,17 @@ class NationalGeographicBridge extends BridgeAbstract
                 if (isset($image['crdt'])) {
                     $image_credit = $image['crdt'];
                 }
-                $caption = (isset($image_module['caption']) ? $image_module['caption'] : '');
+                $caption = ($image_module['caption'] ?? '');
                 break;
             case 'photogallery':
-                $image_credit = (isset($image_module['caption']['credit']) ? $image_module['caption']['credit'] : '');
+                $image_credit = ($image_module['caption']['credit'] ?? '');
                 $caption = $image_module['caption']['text'];
                 $image_src = $image_module['img']['src'];
                 $image_alt = $image_module['img']['altText'];
                 break;
             case 'video':
-                $image_credit = (isset($image_module['credit']) ? $image_module['credit'] : '');
-                $description = (isset($image_module['description']) ? $image_module['description'] : '');
+                $image_credit = ($image_module['credit'] ?? '');
+                $description = ($image_module['description'] ?? '');
                 $caption = $description . ' Video can be watched on the article\'s page';
                 $image = $image_module['image'];
                 $image_alt = $image['altText'];
@@ -250,11 +250,11 @@ class NationalGeographicBridge extends BridgeAbstract
         $image_caption = $caption . ' ' . $image_credit
                     . '. Notes: Some image may have copyrighted on it.';
         $wrapper = <<<EOD
-<figure>
-<img src="{$image_src}" alt="{$image_alt}">
-<figcaption>$image_caption</figcaption>
-</figure>
-EOD;
+            <figure>
+            <img src="{$image_src}" alt="{$image_alt}">
+            <figcaption>$image_caption</figcaption>
+            </figure>
+            EOD;
         return $wrapper;
     }
 
@@ -325,7 +325,7 @@ EOD;
                             if (isset($module['image'])) {
                                 $content .= $this->handleImages($module['image'], $module['image']['cmsType']);
                             }
-                            $content .= '<p>' . (isset($module['text']) ? $module['text'] : '') . '</p>';
+                            $content .= '<p>' . ($module['text'] ?? '') . '</p>';
                             break;
                         case 'photogallery':
                             $gallery = $body['cntnt']['media'];
@@ -339,19 +339,19 @@ EOD;
                         case 'pullquote':
                             $quote = $module['quote'];
                             $author_name = '';
-                            $authors = (isset($module['byLineProps']['authors']) ? $module['byLineProps']['authors'] : []);
+                            $authors = ($module['byLineProps']['authors'] ?? []);
                             foreach ($authors as $author) {
-                                $author_desc = (isset($author['authorDesc']) ? $author['authorDesc'] : '');
+                                $author_desc = ($author['authorDesc'] ?? '');
                                 $author_name .= $author['displayName'] . ', ' . $author_desc;
                             }
                             $content .= <<<EOD
-<figure>
-<blockquote>
-<p>$quote</p>
-</blockquote>
-<figcaption>$author_name</figcaption>
-</figure>
-EOD;
+                                <figure>
+                                <blockquote>
+                                <p>$quote</p>
+                                </blockquote>
+                                <figcaption>$author_name</figcaption>
+                                </figure>
+                                EOD;
                             break;
                     }
                     break;
@@ -364,7 +364,7 @@ EOD;
         return [
             'content' => $content,
             'published_date' => $published_date,
-            'authors' => $authors_name
+            'authors' => $authors_name,
         ];
     }
 }

--- a/bridges/NewOnNetflixBridge.php
+++ b/bridges/NewOnNetflixBridge.php
@@ -17,7 +17,7 @@ class NewOnNetflixBridge extends BridgeAbstract
                 'United States' => 'usa',
             ],
             'defaultValue' => 'uk',
-        ]
+        ],
     ]];
     const CACHE_TIMEOUT = 3600 * 24;
 
@@ -42,11 +42,11 @@ class NewOnNetflixBridge extends BridgeAbstract
                 $to = 'unknown';
             }
             $summary = <<<EOD
-				<img src="{$img->lazy_src}" loading="lazy">
-				<div>{$title->title}</div>
-				<div><strong>Added on:</strong>$from</div>
-				<div><strong>Removed on:</strong>$to</div>
-EOD;
+                				<img src="{$img->lazy_src}" loading="lazy">
+                				<div>{$title->title}</div>
+                				<div><strong>Added on:</strong>$from</div>
+                				<div><strong>Removed on:</strong>$to</div>
+                EOD;
 
             $item = [];
             $item['uri'] = $baseURI . $title->href;

--- a/bridges/NewgroundsBridge.php
+++ b/bridges/NewgroundsBridge.php
@@ -14,9 +14,9 @@ class NewgroundsBridge extends BridgeAbstract
                 'name' => 'Username',
                 'type' => 'text',
                 'required' => true,
-                'exampleValue' => 'TomFulp'
-            ]
-        ]
+                'exampleValue' => 'TomFulp',
+            ],
+        ],
     ];
 
     public function collectData()
@@ -42,21 +42,21 @@ class NewgroundsBridge extends BridgeAbstract
             if ($titleOrRestricted === 'Restricted Content: Sign in to view!') {
                 $item['title'] = 'NSFW: ' . $item['uri'];
                 $item['content'] = <<<EOD
-<a href="{$item['uri']}">
-{$item['title']}
-</a>
-EOD;
+                    <a href="{$item['uri']}">
+                    {$item['title']}
+                    </a>
+                    EOD;
             } else {
                 $item['title'] = $titleOrRestricted;
                 $item['content'] = <<<EOD
-<a href="{$item['uri']}">
-<img
-    style="align:top; width:270px; border:1px solid black;"
-    alt="{$item['title']}"
-    src="{$post->find('img')[0]->src}"
-    title="{$item['title']}" />
-</a>
-EOD;
+                    <a href="{$item['uri']}">
+                    <img
+                        style="align:top; width:270px; border:1px solid black;"
+                        alt="{$item['title']}"
+                        src="{$post->find('img')[0]->src}"
+                        title="{$item['title']}" />
+                    </a>
+                    EOD;
             }
 
             $this->items[] = $item;

--- a/bridges/NextInpactBridge.php
+++ b/bridges/NextInpactBridge.php
@@ -36,8 +36,8 @@ class NextInpactBridge extends FeedExpander
                     'Économie' => 'category:6',
                     'Culture numérique' => 'category:7',
                     'Next INpact' => 'category:8',
-                ]
-            ]
+                ],
+            ],
         ],
         'filter_premium' => [
             'name' => 'Premium',
@@ -45,8 +45,8 @@ class NextInpactBridge extends FeedExpander
             'values' => [
                 'No filter' => '0',
                 'Hide Premium' => '1',
-                'Only Premium' => '2'
-            ]
+                'Only Premium' => '2',
+            ],
         ],
         'filter_brief' => [
             'name' => 'Brief',
@@ -54,8 +54,8 @@ class NextInpactBridge extends FeedExpander
             'values' => [
                 'No filter' => '0',
                 'Hide Brief' => '1',
-                'Only Brief' => '2'
-            ]
+                'Only Brief' => '2',
+            ],
         ],
         'limit' => self::LIMIT,
     ]];
@@ -110,7 +110,7 @@ class NextInpactBridge extends FeedExpander
         foreach (
             [
             'filter_premium' => 'p.red-msg',
-            'filter_brief' => $brief_selector
+            'filter_brief' => $brief_selector,
             ] as $param_name => $selector
         ) {
             $param_val = intval($this->getInput($param_name));

--- a/bridges/NextgovBridge.php
+++ b/bridges/NextgovBridge.php
@@ -20,8 +20,8 @@ class NextgovBridge extends FeedExpander
                 'IT Modernization' => 'it-modernization',
                 'Policy' => 'policy',
                 'Ideas' => 'ideas',
-            ]
-        ]
+            ],
+        ],
     ]];
 
     public function collectData()

--- a/bridges/NikonDownloadCenterBridge.php
+++ b/bridges/NikonDownloadCenterBridge.php
@@ -24,24 +24,24 @@ class NikonDownloadCenterBridge extends BridgeAbstract
         $html = getSimpleHTMLDOM($this->getURI());
 
         foreach ($html->find('dd>ul>li') as $element) {
-            $date        = $element->find('.date', 0)->plaintext;
+            $date = $element->find('.date', 0)->plaintext;
             $productType = $element->find('.icon>img', 0)->alt;
-            $desc        = $element->find('p>a', 0)->plaintext;
-            $link        = urljoin(self::URI, $element->find('p>a', 0)->href);
+            $desc = $element->find('p>a', 0)->plaintext;
+            $link = urljoin(self::URI, $element->find('p>a', 0)->href);
 
             $item = [
-                'title'     => $desc,
-                'uri'       => $link,
+                'title' => $desc,
+                'uri' => $link,
                 'timestamp' => strtotime($date),
-                'content'   => <<<EOD
-<p>
- New/updated {$productType}:<br>
- <strong><a href="{$link}">{$desc}</a></strong>
-</p>
-<p>
- {$date}
-</p>
-EOD
+                'content' => <<<EOD
+                    <p>
+                     New/updated {$productType}:<br>
+                     <strong><a href="{$link}">{$desc}</a></strong>
+                    </p>
+                    <p>
+                     {$date}
+                    </p>
+                    EOD,
             ];
             $this->items[] = $item;
         }

--- a/bridges/NordbayernBridge.php
+++ b/bridges/NordbayernBridge.php
@@ -36,15 +36,15 @@ class NordbayernBridge extends BridgeAbstract
                 'Roth' => 'roth',
                 'Rothenburg o.d.T.' => 'rothenburg-o-d-t',
                 'Treuchtlingen' => 'treuchtlingen',
-                'Weißenburg' => 'weissenburg'
-            ]
+                'Weißenburg' => 'weissenburg',
+            ],
         ],
         'policeReports' => [
             'name' => 'Police Reports',
             'type' => 'checkbox',
             'exampleValue' => 'checked',
             'title' => 'Include Police Reports',
-        ]
+        ],
     ]];
 
     private function getValidImage($picture)

--- a/bridges/NotAlwaysBridge.php
+++ b/bridges/NotAlwaysBridge.php
@@ -2,13 +2,13 @@
 
 class NotAlwaysBridge extends BridgeAbstract
 {
-        const MAINTAINER = 'mozes';
-        const NAME = 'Not Always family Bridge';
-        const URI = 'https://notalwaysright.com/';
-        const DESCRIPTION = 'Returns the latest stories';
-        const CACHE_TIMEOUT = 1800; // 30 minutes
+    const MAINTAINER = 'mozes';
+    const NAME = 'Not Always family Bridge';
+    const URI = 'https://notalwaysright.com/';
+    const DESCRIPTION = 'Returns the latest stories';
+    const CACHE_TIMEOUT = 1800; // 30 minutes
 
-        const PARAMETERS = [ [
+    const PARAMETERS = [ [
                 'filter' => [
                         'type' => 'list',
                         'name' => 'Filter',
@@ -21,44 +21,44 @@ class NotAlwaysBridge extends BridgeAbstract
                                 'Learning' => 'learning',
                                 'Friendly' => 'friendly',
                                 'Hopeless' => 'hopeless',
-                                'Unfiltered' => 'unfiltered'
-                        ]
-                ]
+                                'Unfiltered' => 'unfiltered',
+                        ],
+                ],
         ]];
 
-        public function getIcon()
-        {
-            return self::URI . 'favicon_nar.png';
+    public function getIcon()
+    {
+        return self::URI . 'favicon_nar.png';
+    }
+
+    public function collectData()
+    {
+        $html = getSimpleHTMLDOM($this->getURI());
+        foreach ($html->find('.post') as $post) {
+            #print_r($post);
+            $item = [];
+            $item['uri'] = $post->find('h1', 0)->find('a', 0)->href;
+            $item['content'] = $post;
+            $item['title'] = $post->find('h1', 0)->find('a', 0)->innertext;
+            $this->items[] = $item;
+        }
+    }
+
+    public function getName()
+    {
+        if (!is_null($this->getInput('filter'))) {
+            return $this->getInput('filter') . ' - NotAlways Bridge';
         }
 
-        public function collectData()
-        {
-                $html = getSimpleHTMLDOM($this->getURI());
-            foreach ($html->find('.post') as $post) {
-                    #print_r($post);
-                    $item = [];
-                    $item['uri'] = $post->find('h1', 0)->find('a', 0)->href;
-                    $item['content'] = $post;
-                    $item['title'] = $post->find('h1', 0)->find('a', 0)->innertext;
-                    $this->items[] = $item;
-            }
+        return parent::getName();
+    }
+
+    public function getURI()
+    {
+        if (!is_null($this->getInput('filter'))) {
+            return self::URI . $this->getInput('filter') . '/';
         }
 
-        public function getName()
-        {
-            if (!is_null($this->getInput('filter'))) {
-                    return $this->getInput('filter') . ' - NotAlways Bridge';
-            }
-
-                return parent::getName();
-        }
-
-        public function getURI()
-        {
-            if (!is_null($this->getInput('filter'))) {
-                    return self::URI . $this->getInput('filter') . '/';
-            }
-
-                return parent::getURI();
-        }
+        return parent::getURI();
+    }
 }

--- a/bridges/NovayaGazetaEuropeBridge.php
+++ b/bridges/NovayaGazetaEuropeBridge.php
@@ -18,16 +18,16 @@ class NovayaGazetaEuropeBridge extends BridgeAbstract
                 'values' => [
                     'Russian' => 'ru',
                     'English' => 'en',
-                ]
+                ],
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Maximum number of items to return',
-                'defaultValue' => 20
-            ]
-        ]
+                'defaultValue' => 20,
+            ],
+        ],
     ];
 
     public function collectData()
@@ -57,7 +57,7 @@ class NovayaGazetaEuropeBridge extends BridgeAbstract
                         return $author->name;
                     }, $block->authors)),
                     'timestamp' => $block->date / 1000,
-                    'categories' => $block->tags
+                    'categories' => $block->tags,
                 ];
                 $this->items[] = $item;
             }

--- a/bridges/NovelUpdatesBridge.php
+++ b/bridges/NovelUpdatesBridge.php
@@ -11,8 +11,8 @@ class NovelUpdatesBridge extends BridgeAbstract
         'n' => [
             'name' => 'Novel name as found in the url',
             'exampleValue' => 'spirit-realm',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     private $seriesTitle = '';
@@ -38,12 +38,12 @@ class NovelUpdatesBridge extends BridgeAbstract
         $html = stristr($html, '<tr>'); //remove tbody
         $html = str_get_html(stristr($html, '</tbody>', true)); //remove last tbody and get back as an array
         foreach ($html->find('tr') as $element) {
-                $item = [];
-                $item['uri'] = $element->find('td', 2)->find('a', 0)->href;
-                $item['title'] = $element->find('td', 2)->find('a', 0)->plaintext;
-                $item['team'] = $element->find('td', 1)->innertext;
-                $item['timestamp'] = strtotime($element->find('td', 0)->plaintext);
-                $item['content'] = '<a href="'
+            $item = [];
+            $item['uri'] = $element->find('td', 2)->find('a', 0)->href;
+            $item['title'] = $element->find('td', 2)->find('a', 0)->plaintext;
+            $item['team'] = $element->find('td', 1)->innertext;
+            $item['timestamp'] = strtotime($element->find('td', 0)->plaintext);
+            $item['content'] = '<a href="'
                 . $item['uri']
                 . '">'
                 . $this->seriesTitle
@@ -57,7 +57,7 @@ class NovelUpdatesBridge extends BridgeAbstract
                 . $fullhtml->find('div.seriesimg', 0)->innertext
                 . '</a>';
 
-                $this->items[] = $item;
+            $this->items[] = $item;
         }
     }
 

--- a/bridges/NpciBridge.php
+++ b/bridges/NpciBridge.php
@@ -40,9 +40,9 @@ class NpciBridge extends BridgeAbstract
                 'AePS' => 'aeps',
                 'BHIM Aadhaar' => 'bhim-aadhaar',
                 'e-RUPI' => 'e-rupi',
-                'Bharat BillPay' => 'bharat-billpay'
-            ]
-        ]
+                'Bharat BillPay' => 'bharat-billpay',
+            ],
+        ],
     ]];
 
     public function getName()
@@ -84,11 +84,11 @@ class NpciBridge extends BridgeAbstract
             $item = [
                 'uri' => $uri,
                 'title' => $title,
-                'content' => $title ,
+                'content' => $title,
                 'uid' => sha1($pdfLink),
                 'enclosures' => [
-                    $uri
-                ]
+                    $uri,
+                ],
             ];
 
             $this->items[] = $item;

--- a/bridges/NyaaTorrentsBridge.php
+++ b/bridges/NyaaTorrentsBridge.php
@@ -14,8 +14,8 @@ class NyaaTorrentsBridge extends FeedExpander
                 'values' => [
                     'No filter' => '0',
                     'No remakes' => '1',
-                    'Trusted only' => '2'
-                ]
+                    'Trusted only' => '2',
+                ],
             ],
             'c' => [
                 'name' => 'Category',
@@ -45,19 +45,19 @@ class NyaaTorrentsBridge extends FeedExpander
                     'Software' => '6_0',
                     'Software - Apps' => '6_1',
                     'Software - Games' => '6_2',
-                ]
+                ],
             ],
             'q' => [
                 'name' => 'Keyword',
                 'description' => 'Keyword(s)',
-                'type' => 'text'
+                'type' => 'text',
             ],
             'u' => [
                 'name' => 'User',
                 'description' => 'User',
-                'type' => 'text'
-            ]
-        ]
+                'type' => 'text',
+            ],
+        ],
     ];
 
     public function getIcon()
@@ -73,7 +73,7 @@ class NyaaTorrentsBridge extends FeedExpander
                 'f' => $this->getInput('f'),
                 'c' => $this->getInput('c'),
                 'q' => $this->getInput('q'),
-                'u' => $this->getInput('u')
+                'u' => $this->getInput('u'),
             ]),
             20
         );

--- a/bridges/OnVaSortirBridge.php
+++ b/bridges/OnVaSortirBridge.php
@@ -112,9 +112,9 @@ class OnVaSortirBridge extends FeedExpander
                     'Valence' => 'valence',
                     'Vannes' => 'vannes',
                     'Zurich' => 'zurich',
-                ]
-            ]
-            ]
+                ],
+            ],
+            ],
     ];
 
     protected function parseItem($item)

--- a/bridges/OneFortuneADayBridge.php
+++ b/bridges/OneFortuneADayBridge.php
@@ -8,19 +8,19 @@ class OneFortuneADayBridge extends BridgeAbstract
     const MAINTAINER = 'fulmeek';
     const PARAMETERS = [[
         'time' => [
-            'name'      => 'Time in UTC',
-            'type'      => 'list',
-            'values'    => [
-                '0:00'  => 0,
-                '1:00'  => 1,
-                '2:00'  => 2,
-                '3:00'  => 3,
-                '4:00'  => 4,
-                '5:00'  => 5,
-                '6:00'  => 6,
-                '7:00'  => 7,
-                '8:00'  => 8,
-                '9:00'  => 9,
+            'name' => 'Time in UTC',
+            'type' => 'list',
+            'values' => [
+                '0:00' => 0,
+                '1:00' => 1,
+                '2:00' => 2,
+                '3:00' => 3,
+                '4:00' => 4,
+                '5:00' => 5,
+                '6:00' => 6,
+                '7:00' => 7,
+                '8:00' => 8,
+                '9:00' => 9,
                 '10:00' => 10,
                 '11:00' => 11,
                 '12:00' => 12,
@@ -36,12 +36,12 @@ class OneFortuneADayBridge extends BridgeAbstract
                 '22:00' => 22,
                 '23:00' => 23,
             ],
-            'defaultValue' => 5
+            'defaultValue' => 5,
         ],
         'lucky' => [
             'name' => 'Lucky number (optional)',
-            'type' => 'text'
-        ]
+            'type' => 'text',
+        ],
     ]];
 
     const LIMIT_ITEMS = 7;
@@ -63,10 +63,10 @@ class OneFortuneADayBridge extends BridgeAbstract
             $seed = gmdate('Ymd', $time) . $this->getInput('lucky');
             $quote = $this->getQuote($seed);
 
-            $item['title']      = strftime('%A, %x', $time);
-            $item['content']    = htmlentities($quote, ENT_QUOTES, 'UTF-8');
-            $item['timestamp']  = $time;
-            $item['uid']        = hash('sha1', $seed);
+            $item['title'] = strftime('%A, %x', $time);
+            $item['content'] = htmlentities($quote, ENT_QUOTES, 'UTF-8');
+            $item['timestamp'] = $time;
+            $item['uid'] = hash('sha1', $seed);
 
             $this->items[] = $item;
 
@@ -76,890 +76,892 @@ class OneFortuneADayBridge extends BridgeAbstract
 
     private function getQuote($seed)
     {
-        $quotes = explode('//', <<<QUOTES
-People are naturally attracted to you.
-//You learn from your mistakes... You will learn a lot today.
-//If you have something good in your life, don't let it go!
-//What ever you're goal is in life, embrace it visualize it, and for it will be
-yours.
-//Your shoes will make you happy today.
-//You cannot love life until you live the life you love.
-//Be on the lookout for coming events; They cast their shadows beforehand.
-//Land is always on the mind of a flying bird.
-//The man or woman you desire feels the same about you.
-//Meeting adversity well is the source of your strength.
-//A dream you have will come true.
-//Our deeds determine us, as much as we determine our deeds.
-//Never give up. You're not a failure if you don't give up.
-//You will become great if you believe in yourself.
-//There is no greater pleasure than seeing your loved ones prosper.
-//You will marry your lover.
-//A very attractive person has a message for you.
-//You already know the answer to the questions lingering inside your head.
-//It is now, and in this world, that we must live.
-//You must try, or hate yourself for not trying.
-//You can make your own happiness.
-//The greatest risk is not taking one.
-//The love of your life is stepping into your planet this summer.
-//Love can last a lifetime, if you want it to.
-//Adversity is the parent of virtue.
-//Serious trouble will bypass you.
-//A short stranger will soon enter your life with blessings to share.
-//Now is the time to try something new.
-//Wealth awaits you very soon.
-//If you feel you are right, stand firmly by your convictions.
-//If winter comes, can spring be far behind?
-//Keep your eye out for someone special.
-//You are very talented in many ways.
-//A stranger, is a friend you have not spoken to yet.
-//A new voyage will fill your life with untold memories.
-//You will travel to many exotic places in your lifetime.
-//Your ability for accomplishment will follow with success.
-//Nothing astonishes men so much as common sense and plain dealing.
-//Its amazing how much good you can do if you dont care who gets the credit.
-//Everyone agrees. You are the best.
-//LIFE CONSIST NOT IN HOLDING GOOD CARDS, BUT IN PLAYING THOSE YOU HOLD WELL.
-//Jealousy doesn't open doors, it closes them!
-//It's better to be alone sometimes.
-//When fear hurts you, conquer it and defeat it!
-//Let the deeds speak.
-//You will be called in to fulfill a position of high honor and responsibility.
-//The man on the top of the mountain did not fall there.
-//You will conquer obstacles to achieve success.
-//Joys are often the shadows, cast by sorrows.
-//Fortune favors the brave.
-//An upward movement initiated in time can counteract fate.
-//A journey of a thousand miles begins with a single step.
-//Sometimes you just need to lay on the floor.
-//Never give up. Always find a reason to keep trying.
-//If you have something worth fighting for, then fight for it.
-//Stop wishing. Start doing.
-//Accept your past without regrets. Handle your present with confidence. Face
-your future without fear.
-//Stay true to those who would do the same for you.
-//Ask yourself if what you are doing today is getting you closer to where you
-want to be tomorrow.
-//Happiness is an activity.
-//Help is always needed but not always appreciated. Stay true to your heart and
-help those in need weather they appreciate it or not.
-//Hone your competitive instincts.
-//Finish your work on hand don't be greedy.
-//For success today, look first to yourself.
-//Your fortune is as sweet as a cookie.
-//Integrity is the essence of everything successful.
-//If you're happy, you're successful.
-//You will always be surrounded by true friends
-//Believing that you are beautiful will make you appear beautiful to others
-around you.
-//Happinees comes from a good life.
-//Before trying to please others think of what makes you happy.
-//When hungry, order more Chinese food.
-//Your golden opportunity is coming shortly.
-//For hate is never conquered by hate. Hate is conquered by love .
-//You will make many changes before settling down happily.
-//A man is born to live and not prepare to live.
-//You cannot become rich except by enriching others.
-//Don't pursue happiness - create it.
-//You will be successful in love.
-//All your fingers can't be of the same length.
-//Wise sayings often fall on barren ground, but a kind word is never thrown away.
-//A lifetime of happiness is in store for you.
-//It is very possible that you will achieve greatness in your lifetime.
-//Be tactful; overlook your own opportunity.
-//You are the controller of your destiny.
-//Everything happens for a reson.
-//How can you have a beutiful ending without making beautiful mistakes.
-//You can open doors with your charm and patience.
-//Welcome the change coming into your life.
-//There will be a happy romance for you shortly.
-//Your fondest dream will come true within this year.
-//You have a deep interest in all that is artistic.
-//Your emotional nature is strong and sensitive.
-//A letter of great importance may reach you any day now.
-//Good health will be yours for a long time.
-//You will become better acquainted with a coworker.
-//To be old and wise, you must first be young and stupid.
-//Failure is only the opportunity to begin again more intelligently.
-//Integrity is doing the right thing, even if nobody is watching.
-//Conquer your fears or they will conquer you.
-//You are a lover of words; One day you will write a book.
-//In this life it is not what we take up, but what we give up, that makes us
-rich.
-//Fear can keep us up all night long, but faith makes one fine pillow.
-//Seek out the significance of your problem at this time. Try to understand.
-//Never upset the driver of the car you're in; they're the master of your
-destiny until you get home.
-//He who slithers among the ground is not always a foe.
-//You learn from your mistakes, you will learn a lot today.
-//You only need look to your own reflection for inspiration. Because you are
-Beautiful!
-//You are not judged by your efforts you put in; you are judged on your
-performance.
-//Rivers need springs.
-//Good news from afar may bring you a welcome visitor.
-//When all else seems to fail, smile for today and just love someone.
-//Patience is a virtue, unless its against a brick wall.
-//When you look down, all you see is dirt, so keep looking up.
-//If you are afraid to shake the dice, you will never throw a six.
-//Even if the person who appears most wrong, is also quite often right.
-//A single conversation with a wise man is better than ten years of study.
-//Happiness is often a rebound from hard work.
-//The world may be your oyster, but that doesn't mean you'll get it's pearl.
-//Your life will be filled with magical moments.
-//You're true love will show himself to you under the moonlight.
-//Do not follow where the path may lead. Go where there is no path...and leave a
-trail
-//Do not fear what you don't know
-//The object of your desire comes closer.
-//You have a flair for adding a fanciful dimension to any story.
-//If you wish to know the mind of a man, listen to his words
-//The most useless energy is trying to change what and who God so carefully
-created.
-//Do not be covered in sadness or be fooled in happiness they both must exist
-//You will have unexpected great good luck.
-//You will have a pleasant surprise
-//All progress occurs because people dare to be different.
-//Your ability for accomplishment will be followed by success.
-//The world is always ready to receive talent with open arms.
-//Things may come to those who wait, but only the things left by those who
-hustle.
-//We can't help everyone. But everyone can help someone.
-//Every day is a new day. But tomorrow is never promised.
-//Express yourself: Don't hold back!
-//It is not necessary to show others you have change; the change will be obvious.
-//You have a deep appreciation of the arts and music.
-//If your desires are not extravagant, they will be rewarded.
-//You try hard, never to fail. You don't, never to win.
-//Never give up on someone that you don't go a day without thinking about.
-//It never pays to kick a skunk.
-//In case of fire, keep calm, pay bill and run.
-//Next full moon brings an enchanting evening.
-//Not all closed eye is sleeping nor open eye is seeing.
-//Impossible is a word only to be found in the dictionary of fools.
-//You will soon witness a miracle.
-//The time is alway right to do what is right.
-//Love is as necessary to human beings as food and shelter.
-//You will make heads turn.
-//You are extremely loved. Don't worry :)
-//If you are never patient, you will never get anything done. If you believe you
-can do it, you will be rewarded with success.
-//You will soon embark on a business venture.
-//You believe in the goodness of man kind.
-//You will have a long and wealthy life.
-//You will take a pleasant journey to a place far away.
-//You are a person of culture.
-//Keep it simple. The more you say, the less people remember.
-//Life is like a dogsled team. If you ain't the lead dog, the scenery never
-changes.
-//Prosperity makes friends and adversity tries them.
-//Nothing seems impossible to you.
-//Patience is bitter, but its fruit is sweet.
-//The only certainty is that nothing is certain.
-//Success is the sum of my unique visions realized by the sweat of perseverance.
-//When you expect your opponent to yield, you also should avoid hurting him.
-//Human evolution: “wider freeway but narrower viewpoints.
-//Intelligence is the door to freedom and alert attention is the mother of
-intelligence.
-//Back away from individuals who are impulsive.
-//Enjoyed the meal? Buy one to go too.
-//You believe in the goodness of mankind.
-//A big fortune will descend upon you this year.
-//Now these three remain, faith, hope, and love. The greatest of these is love.
-//For success today look first to yourself.
-//Determination is the wake-up call to the human will.
-//There are no limitations to the mind except those we aknowledge.
-//A merry heart does good like a medicine.
-//Whenever possible, keep it simple.
-//Your dearest wish will come true.
-//Poverty is no disgrace.
-//If you don’t do it excellently, don’t do it at all.
-//You have an unusual equipment for success, use it properly.
-//Emotion is energy in motion.
-//You will soon be honored by someone you respect.
-//Punctuality is the politeness of kings and the duty of gentle people
-everywhere.
-//Your happiness is intertwined with your outlook on life.
-//Elegant surroundings will soon be yours.
-//If you feel you are right, stand firmly by your convictions.
-//Your smile brings happiness to everyone you meet.
-//Instead of worrying and agonizing, move ahead constructively.
-//Do you believe? Endurance and persistence will be rewarded.
-//A new business venture is on the horizon.
-//Never underestimate the power of the human touch.
-//Hold on to the past but eventually, let the times go and keep the memories
-into the present.
-//Truth is an unpopular subject. Because it is unquestionably correct.
-//The most important thing in communication is to hear what isn’t being said.
-//You are broad minded and socially active.
-//Your dearest dream is coming true. God looks after you especially.
-//You will recieve some high prize or award.
-//Your present question marks are going to succeed.
-//You have a fine capacity for the enjoyment of life.
-//You will live long and enjoy life.
-//An admirer is concealing his/her affection for you.
-//A wish is what makes life happen when you dream of rose petals.
-//Love can turn cottage into a golden palace.
-//Lend your money and lose your freind.
-//You will kiss your crush ohhh lalahh
-//You will be rewarded for being a good listener in the next week.
-//If you never give up on love, It will never give up on you.
-//Unleash your life force.
-//Your wish will come true.
-//There is a prospect of a thrilling time ahead for you.
-//No distance is too far, if two hearts are tied together.
-//Land is always in the mind of the flying birds.
-//Try? No! Do or do not, there is no try.
-//Do not worry, you will have great peace.
-//It's about time you asked that special someone on a date.
-//You create your own stage ... the audience is waiting.
-//It is never too late. Just as it is never too early.
-//Discover the power within yourself.
-//Good things take time.
-//Stop thinking about the road not taken and pave over the one you did.
-//Put your unhappiness aside. Life is beautiful, be happy.
-//You can still love what you can not have in life.
-//Make a wise choice everyday.
-//Circumstance does not make the man; it reveals him to himself.
-//The man who waits till tomorrow, misses the opportunities of today.
-//Life does not get better by chance. It gets better by change.
-//If you never expect anything you can never be disappointed.
-//People in your surroundings will be more cooperative than usual.
-//True wisdom is found in happiness.
-//Ones always regrets what could have done. Remember for next time.
-//Follow your bliss and the Universe will open doors where there were once only
-walls.
-//Find a peaceful place where you can make plans for the future.
-//All the water in the world can't sink a ship unless it gets inside.
-//The earth is a school learn in it.
-//In music, one must think with his heart and feel with his brain.
-//If you speak honestly, everyone will listen.
-//Ganerosity will repay itself sooner than you imagine.
-//good things take time
-//Do what is right, not what you should.
-//To effect the quality of the day is no small achievement.
-//Simplicity and clearity should be the theme in your dress.
-//Virtuous find joy while Wrongdoers find grieve in their actions.
-//Not all closed eye is sleeping, nor open eye is seeing.
-//Bread today is better than cake tomorrow.
-//In evrything there is a piece of truth.But a piece.
-//A feeling is an idea with roots.
-//Man is born to live and not prepare to live
-//It's all right to have butterflies in your stomach. Just get them to fly in
-formation.
-//If you don t give something, you will not get anything
-//The harder you try to not be like your parents, the more likely you will
-become them
-//Someday everything will all make perfect sense
-//you will think for yourself when you stop letting others think for you
-//Everything will be ok. Don't obsess. Time will prove you right, you must stay
-where you are.
-//Let's finish this up now, someone is waiting for you on that
-//The finest men like the finest steels have been tempered in the hottest
-furnace.
-//A dream you have will come true
-//The worst of friends may become the best of enemies, but you will always find
-yourself hanging on.
-//I think, you ate your fortune while you were eating your cookie
-//If u love someone keep fighting for them
-//Do what you want, when you want, and you will be rewarded
-//Let your fantasies unwind...
-//The cooler you think you are the dumber you look
-//Expect great things and great things will come
-//The Wheel of Good Fortune is finally turning in your direction!
-//Don't lead if you won't lead.
-//You will always be successful in your professional career
-//Share your hapiness with others today.
-//It's up to you to clearify.
-//Your future will be happy and productive.
-//Seize every second of your life and savor it.
-//Those who walk in other's tracks leave no footprints.
-//Failure is the mother of all success.
-//Difficulty at the beginning useually means ease at the end.
-//Do not seek so much to find the answer as much as to understand the question
-better.
-//Your way of doing what other people do their way is what makes you special.
-//A beautiful, smart, and loving person will be coming into your life.
-//Friendship is an ocean that you cannot see bottom.
-//Your life does not get better by chance, it gets better by change.
-//Our duty,as men and women,is to proceed as if limits to our ability did not
-exist.
-//A pleasant expeience is ahead:don't pass it by.
-//Our perception and attitude toward any situation will determine the outcome
-//They say you are stubborn; you call it persistence.
-//Two small jumps are sometimes better than one big leap.
-//A new wardrobe brings great joy and change to your life.
-//The cure for grief is motion.
-//It's a good thing that life is not as serious as it seems to the waiter
-//I hear and I forget. I see and I remember. I do and I understand.
-//I have a dream....Time to go to bed.
-//Ideas you believe are absurd ultimately lead to success!
-//A human being is a deciding being.
-//Today is an ideal time to water your parsonal garden.
-//Some men dream of fortunes, others dream of cookies.
-//Things are never quite the way they seem.
-//the project on your mind will soon gain momentum
-//YOUR FAILURES WILL LEAD YOU TO YOUR SUCCESS.
-//IN ORDER TO GET THE RAINBOW, YOU MUST ENDURE THE RAIN.
-//Beauty is simply beauty. originality is magical.
-//Your dream will come true when you least expect it.
-//Let not your hand be stretched out to receive and shut when you should repay.
-//Don't worry, half the people you know are below average.
-//Vision is the art of seeing what is invisible to others.
-//You don't need talent to gain experience.
-//A focused mind is one of the most powerful forces in the universe.
-//Today you shed your last tear. Tomorrow fortune knocks at your door.
-//Be patient! The Great Wall didn't got build in one day.
-//Think you can. Think you can't. Either way, you'll be right.
-//Wisdom is on her way to you.
-//Digital circuits are made from analog parts.
-//If you eat a box of fortune cookies, anything is possible.
-//The best is yet to come.
-//I'm with you.
-//Be direct,usually one can accomplish more that way.
-//A single kind work will keep one warm for years.
-//Ask a friend to join you on your next voyage.
-//In God we trust.
-//Love is free. Lust will cost you everything you have.
-//Stop searching forever, happiness is just next to you.
-//You don't need the answers to all of life's questions. Just ask your father
-what to do.
-//Jealousy is a useless emotion.
-//You are not a ghost.
-//There is someone rather annoying in your life that you need to listen to.
-//You will plant the smallest seed and it will become the greatest and most
-mighty tree in the world.
-//The dream you've been dreaming all your life isn't worth it. Find a new dream,
-and once you're sure you've found it, fight for it.
-//See if you can learn anything from the children.
-//It's Never Too Late For Good Things To Happen!
-//A clear conscience is usually the sign of a bad memory.
-//Aim high, time flies.
-//One is not sleeping, does not mean they are awake.
-//A great pleasure in life is doing what others say you can't.
-//Isn't there something else you should be working on right now?
-//Your father still loves and is in always with you. Remember that.
-//Before you can be reborn you must die.
-//It better to be the hammer than the nail.
-//You are admired by everyone for your talent and ability.
-//Save the whales. Collect the whole set.
-//You will soon discover a major truth about the one you love most.
-//Your life will prosper only if you acknowledge your faults and work to reduce
-them.
-//Pray to God, but row towards shore.
-//You will soon witness a miracle.
-//The early bird gets the worm, but the second mouse gets the cheese
-//Help, I'm being held prisoner in a Chinese cookie factory.
-//Alas! The onion you are eating is someone else’s water lily.
-//You are a persoon with a good sense of justice, now it's time to act like it.
-//You create enthusiasm around you.
-//There are big changes ahead for you. They will be good ones!
-//You will have many happy days soon.
-//Out of confusion comes new patterns.
-//If you love someone enough and they break your heart, you can't stop yourself
-from still loving them again even after all that pain.
-//Look right...Now look left...Now look forward (do this really fast) do you
-feel any different? good you should feel dizzy.
-//Live like you are on the bottom, even if you are on the top.
-//You will soon emerge victorious from the maze you've been traveling in.
-//Do not judge a book by it's color.
-//Everything will come your way.
-//There is a time to be practical now.
-//Bend the rod while it is still hot.
-//Darkness is only succesful when there is no light. Don't forget about light!
-//Acting is not lying. It is findind someone hiding inside you and letting that
-person run free.
-//You will be forced to face fear, but if you do not run, fear will be afraid of
-you.
-//You are thinking about doing something. Don't do it, it won't help anything.
-//Your worst enemy has a crush on you!
-//Love Conquers all.
-//The phrase is follow your dreams. Not dream period.
-//stop nagging to your partner and take it day by day.
-//Do not think that me or my brothers have supreme control over what will happen
-to you.
-//Bad luck and misfortune will follow you all your days.
-//Remember the fate of the early Worm.
-//Begin your life anew with strength, grace and wonder.
-//Be a good friend and a fair enemy.
-//What goes around comes around.
-//Bad luck and misfortune will infest your pathetic soul for all eternity.
-//The best prophet of the future is the past
-//Movies have pause buttons, friends do not
-//Use the force.
-//Trust your intuition.
-//Encourage your peers.
-//Let your imagination wander.
-//Your pain is the breaking of the shell that encloses your understanding.
-//Patience is key, a wait short or long will have its reward.
-//Tell them before it's too late...
-//A bird in the hand is worth three in the bush!!
-//Be assertive when decisive action is needed.
-//To determine whether someone is beautiful is not by looking at his/her
-appearance, but his/her heart.
-//Hope brings about a better future
-//While you have this day, fill it with life. While you're in this moment, give
-it your own special meaning and purpose and joy.
-//Even though it will often be difficult and complicated, you know you have what
-it takes to get it done.
-//You can choose, right now and in every moment, to put your powerful and
-effective abilities to purposeful use. There is always something you can do, no
-matter what the situation may be, that will move your life forward.
-//IT IS NOT GOOD TO BE A USER BLESSINGS COME FROM BEING A GIVER NOT A TAKER.
-//Cookie says, You crack me up
-//You will prosper in the field of wacky inventions.
-//Your tongue is your ambassador.
-//The cure for grief is movement.
-//Love Is At Your Hands Be Glad And Hold On To It.
-//You are often asked if it is in yet.
-//Life to you is a bold and dashing responsibility.
-//Patience is a key to joy.
-//A bargain is something you don't need at a price you can't resist.
-//Today is going to be a disasterous day, be prepared!
-//Stay to your inner-self, you will benefit in many ways.
-//Rarely do great beauty and great virtue dwell together as they do in you.
-//You are talented in many ways.
-//You are the master of every situation.
-//Your problem just got bigger. Think, what have you done.
-//If your cookie still in one piece, buy lotto.
-//Go with the flow will make your transition ever so much easier.
-//Tomorrow Morning,Take a Left Turn As Soon As You Leave Home
-//A metaphor could save your life.
-//Don't wait for your ship to come in, swim out to it
-//There are lessons to be learned by listening to others.
-//If you want the rainbow, you have to tolerate the rain.
-//Volition, Strength, Languages, Freedom and Power rests in you.
-//TOO MANY PEOPLE VOLUNTEER TO CARRY THE STOOL WHEN ITS TIME TO MOVE THE PIANO
-//It takes more than a good memory to have good memories.
-//You are what you are; understand yourself before you react
-//Word to the wise: Don't play leapfrog with a unicorn.........
-//Forgive your enemies, but never forget them.
-//Everything will now come your way
-//Don't worry about the stock market. Invest in family.
-//Your fortune is as sweet as a cookie.
-//It is much easier to look for the bad, than it is to find the good
-//If a person who has caused you pain and suffering has brought you, reconsider
-that person's value in your life
-//You are worth loving, you are also worth the effort it takes to love you
-//Never trouble trouble till trouble troubles you.
-//Get off to a new start - come out of your shell.
-//Life is a dancefloor,you are the DJ!
-//Cooperate with those who have both know how and integrith.
-//Minor aches today are likely to pay off handsomely tomorrow.
-//You are about to become $8.95 poorer. ($6.95 if you had the buffet)
-//Your mouth may be moving, but nobody is listening.
-//Focus in on the color yellow tomorrow for good luck!
-//The problem with resisting temptation is that it may never come again.
-//All your sorrows will vanish.
-//About time I got out of that cookie.
-//Love will lead the way.
-//The ads revenge is massive success
-//It is best to act with confidence, no matter how little right you have to it.
-//Soon, a visitor shall delight you.
-//What breaks in a moment may take years to mend.
-//Someone stole your fortune and replaced it with this one. Your luck sucks.
-Have a good day!
-//Take control of your life rather than letting things happen just like that!
-//You will be rewarded for your patience and understanding.
-//You will achieve all your desires and pleasures.
-//Never miss a chance to keep your mouth shut.
-//Nothing Shows A Man's Character More Than What He Laughs At.
-//Never regret anything that made you smile.
-//Love Takes Pratice.
-//Don't take yourself so seriously, no one else does.
-//You've got what it takes, but it will take everything you've got!
-//At this very moment you can change the rest of your life.
-//Become who you are.
-//All comes at the proper time to him who knows how to wait.
-//The energy is within you. Money is Coming!
-//The quotes that you do not understand, are not meant for you.
-//You have an important new business development shaping up.
-//if love someone a lot tell it before it's too late
-//Birds are entangled by their feet and men by their tongues.
-//Benefit by doing things that others give up on.
-//Rest has a peaceful effect on your physical and emotional health.
-//One of the best ways to persuade others is with your ears--by listening to
-them.
-//Plan your work and work your plan.
-//Over self-confidence is equal to being blind.
-//Those who bring sunshine to the lives of others cannot keep it from themselves.
-//Love or money, or neither?
-//Before the beginning of great brilliance, there must be chaos.
-//Old friends make best friends.
-//Stop searching forever. Happiness is just next to you.
-//Accept something that you cannot change, and you will feel better.
-//Kiss is not a kiss without the heart.
-//Enhance your karma by engaging in various charitable activities.
-//You will have good luck and overcome many hardships.
-//You never hesitate to tackle the most difficult problems.
-//Hope is like food. You will starve without it.
-//WHEN FIRE AND WATER GO TO WAR WATER ALWAYS WINS.
-//An angry man opens his mouth and shuts up his eyes.
-//Make the system work for you, not the other way around.
-//You will be hungry soon, order takeout now.
-//Be prepared for extra energy.
-//An unexpected relationship will become permanent.
-//The love of your life is sitting across from you.
-//Better be the head of a chicken than the tail of an ox.
-//To forgive others one more time is to create one more blessing for yourself.
-//Enjoy yourself while you can.
-//The ultimate test of a relationship is to disagree but to hold hands.
-//Excellence is the difference between what I do and what I am capable of.
-//Do not let what you do not have prevent you from using what you do have.
-//What ends on hope does not end at all.
-//People enjoy having you around. Appreciate this.
-//You are admired for your adventuous ways.
-//It's never crowded along the extra mile
-//You are blessed, today is the day to bless others.
-//The Greatest War Sometimes Isn't On The Battlefield But Against Oneself.
-//People in your background will be more co-operative than usual.
-//A good way to stay healthy is to eat more Chinese food.
-//Anyone who dares to be, can never be weak.
-//Affirm it, visualize it, believe it, and it`will actualize itself.
-//The measure of time to your next goal is the measure of your discipline.
-//Help, I'm prisoner in a Chinese bakery!!!
-//Take a minute and let it ride, then take a minute to let it breeze.
-//We are here to love each other, serve each other and uplift each other.
-//If everybody is a worm you should be a glow worm
-//To affirm is to make firm.
-//Remember this: duct tape can fix anything, so don't worry about messing things
-up.
-//You broke my cookie!
-//Failure is not defeat until you stop trying.
-//The days that make us happy make us wise.
-//Men do not fail... they give up trying.
-//Time may fly by. But Memories don't.
-//You will win success in whatever you adopt.
-//You will outdistance all your competitors.
-//You have a great capability to break cookies - use it wisely!
-//AT TIMES IT IS BETTER TO KNOW WHEN EXIT THAN ENTER
-//Money will come to you when you are doing the right thing.
-//When you get something for nothing, you just haven't been billed for it yet.
-//You will discover your hidden talents.
-//You'll advance for with your abilities.
-//When you can't naturally feel upbeat it can sometimes help you to act as if
-you did.
-//You will overcome difficult times.
-//Your problem just became your stepping stone. Catch the moment.
-//I am a fortune. You just broke my little house. Where will i live now?
-//The majority of the word can't is can.
-//The secret of getting ahead is getting started.
-//Be most affectionate today.
-//Change your thoughts and you change the world.
-//Sing and rejoice, fortune is smiling on you.
-//All the preparation you've done will finally be paying off!
-//A truly great person never puts away the simplicity of a child.
-//Customer service is like taking a bath you have to keep doing it.
-//The expanse of your intelligence is a void no universe could ever fill.
-//Those grapes you cannot taste are always sour.
-//An unexpected aquaintance will resurface.
-//If you want the rainbow, then you have to tolerate the rain.
-//You don't get harmony when everyone sings the same note.
-//The race is not always to the swift, but to those who keep on running.
-//The early bird gets the worm, but the second mouse gets the cheese.
-//The best things in life aren't things.
-//Don't bother looking for fault. The reward for finding it is low.
-//Everything has beauty but not everyone sees it.
-//Nothing is as good or bad as it appears.
-//Never cut what you can untie.
-//Meet your opponent half way. You need the exercise.
-//Laughter is the shortest distance between two people.
-//We cannot change the direction of the wind, but we can adjust our sails.
-//We could learn a lot from crayons: Some of are sharp, some are pretty, some
-have weird names, and all are different colors. But they all have to learn to
-live in the same box.
-//Use your instincts now.
-//If you take a single step to your journey, you'll succeed; it's not best to
-fail.
-//In the eyes of lovers, everything is beautiful.
-//Warning, do not eat your fortune.
-//Demonstrate refinement in everything you do.
-//Impossible standards just make life difficult.
-//A different world cannot be build by indifferent people.
-//Q. What is H2O? A. Caring, 2 parts Hug and 1 part Open-mind.
-//All troubles you have can pass away very quickly.
-//Integrity is the essense of everything successful.
-//For true love? Send real roses preserved in 24kt gold!
-//Sometimes the object of the journey is not the end, but the journey itself.
-//Fear is just excitement in need of an attitude adjustment.
-//The food here taste so good, even a cave man likes it.
-//Perhaps you've been focusing too much on spending.
-//Happiness isn't something you remember, it's something you experience.
-//Oops... Wrong cookie.
-//The dream is within you.
-//Love is on its way.
-//Be direct, usually one can accomplish more that way.
-//Use your talents. That's what they are intended for.
-//The troubles you have now will pass away quickly.
-//See the light at the end of the tunnel.
-//Your dream will come true when you least expect it.
-//Don't 'face' reality, let it be the place from which you leap.
-//Fortune smiles upon you today.
-//Believing is doing.
-//Your dynamic eyes have attracted a secret admirer.
-//You know where you are going and how to get there.
-//Go confidently in the direction of your dreams.
-//Your ability to pick a winner will bring you success.
-//Humor usually works at the moment of awkwardness.
-//A good time to finish up old tasks.
-//Stop procrastinating - starting tomorrow
-//Enthusiastic leadership gets you a promotion when you least expect it.
-//You love Chinese food.
-//You are far more influential than you think.
-//Adjust finances, make budgets, to improve your standing.
-//Happiness is not the absence of conflict, but the ability to cope with it.
-//An understanding heart warms all that are graced with it's presense.
-//Your co-workers take pleasure in your great sense of creativity.
-//You are one of the people who goes places in life.
-//Others enjoy your company.
-//When in doubt, let your instincts guide you.
-//A cheerful message is on its way to you.
-//A pleasant surprise is in store for you tonight.
-//you cant go down the right path with out first discovering the path to go down
-//To courageously shoulder the responsibility of one's mistake is character.
-//The joyful energy of the day will have a positive affect on you.
-//You have a strong desire for a home and your family interests come first.
-//Dogs have owners, cats have staff.
-//Be patient: in time, even an egg will walk.
-//You are not a person who can be ignored.
-//You always know the right times to be assertive or to simply wait.
-//Reading to the mind is what exercise is to the body.
-//Eat something you never tried before.
-//Your life becomes more and more of an adventure!
-//You need to live authentically, and you can't ignore that.
-//Make all you can, save all you can, give all you can.
-//A well-aimed spear is worth three.
-//To build a better world, start in your community.
-//When you can't naturally feel upbeat, it can sometimes help to act a if you
-did.
-//May you have great luck.
-//A kind word will keep someone warm for years.
-//Nothing in the world is accomplished without passion.
-//Human invented language to satisfy the need to complain.
-//Accept what comes to you each day.
-//A small lucky package is on its way to you soon.
-//In human endeavor, chance favors the prepared mind.
-//Do not upset the penguin today.
-//Don't cry.
-//The best way to give credit is to give it away.
-//Anything you do, do it well. The last thing you want is to be sorry for what
-you didn't do.
-//It takes more then good memory to have good memories.
-//Grant yourself a wish this year only you can do it.
-//love thy neighbour, just don't get caught
-//You will be selected for a promotion because of your accomplishments.
-//There are many new opportunities that are being presented to you.
-//You will inherit a large sum of money.
-//You will recieve a gift from someone that cares about you.
-//You are not illiterate.
-//Love because it is the only true adventure.
-//You are contemplating some action which will bring credit upon you
-//Keep true to the dreams of your youth.
-//Treasure what you have.
-//The greatest precept is continual awareness.
-//A new friend helps you break out of an old routine.
-//I have a dream.... Time to go to bed.
-//Your skill will accomplish what the force of many cannot.
-//You will soon be surrounded by good friends and laughter.
-//The best is yet to come.
-//It is better to be the hammer then the anvil.
-//He who climbs a ladder must begin at the first step.
-//Action speaks nothing, without the Motive.
-//Give yourself some peace and quiet for at least a few hours.
-//Live each day well and wisely
-//Old dreams never die they just get filed away.
-//You can fix it with a little extra energy and a positive attitude.
-//Life is a verb
-//A man without aim is like a clock without hands, as useless if it turns as if
-it stands.
-//Many folks are about as happy as they make up their minds to be.
-//It's kind of fun to do the impossible
-//Wow! A secret message from you teeth!
-//You should be able to make money and hold on to it.
-//The human spirit is stronger than anything that can happen to it.
-//Your succeess will astonish everyone.
-//It is better to have a hen tomorrow than an egg today.
-//Judge each day not by the harvest you reap but by the seeds you plant.
-//You like Chinese food.
-//Your hard work will get payoff today.
-//Today is the tomorrow we worried about yesterday
-//There are no shortcuts to any place worth going
-//No matter what your past has been, you have a spotless future.
-//Your secret desire to completely change your life will manifest.
-//Soon you will be sitting on top of the world.
-//You are never selfish with your advice or your help.
-//A thrilling time is in store for you.
-//It's tough to be fascinating.
-//Soon life will become more interesting
-//Luck sometimes visits a fool, but it never sits down with him.
-//Keep your plans secret for now.
-//Aren't you glad you just had a great meal?
-//Traveling this year will bring your life into greater perspective.
-//Only talent people get help from others.
-//Constant grinding can turn an iron nod into a needle.
-//You will be successful in your work
-//you will spend old age in confort and material wealth
-//When you're about to turn your heart into a stone remember: you do not walk
-alone.
-//I am a bad luck person since I was born
-//You are vigorous in words and action.
-//The one who snores will always fall asleep first.
-//An alien of some sort will be appearing to you shortly!
-//Rest is a good thing, but boredom is its brother.
-//Do not be overly judgemental of your loved one's intentions or actions.
-//Think of how you can assist on a problem, not who to blame.
-//The life of every woman or man - the heart of it - is pure and holy joy.
-//Take it easy
-//Trust your intuition. The universe is guiding your life.
-//Use your head, but live in your heart.
-//Don't find fault, find a remedy
-//It may be those who do most, dream most
-//Your passions sweep you away.
-//Listen to yourself more often
-//Think of mother's exhortations more.
-//The gambler is like the fisherman both have beginners luck.
-//You are given the chance to take part in an exciting adventure.
-//The simplest answer is to act.
-//You will always be surrounded by true friends.
-//Keep your feet on the ground even though friends flatter you.
-//You are the man of righteousness and integrity.
-//He who seeks will find.
-//The smart thing to do is to begin trusting your intuitions.
-//Your many hidden talents will become obvious to those around you.
-//Pick a path with heart.
-//The human spirit is stronger then anything that can happen to it.
-//It takes more than good memory to have good memories.
-//Face facts with dignity.
-//Be calm when confronting an emergency crisis.
-//Do you believe? Endurance and persistence will be rewarded.
-//A new wardrobe brings great joy and change in your life.
-//Everyone agrees you are the best.
-//A new outlook brightens your image and brings new friends.
-//Everything will now come your way.
-//You will be called to fill a position of high honor and responsibility.
-//The eyes believe themselves; the ears believe other people.
-//Good beginning is half done.
-//Some pursue happiness; you create it.
-//It's the worst of times, you need to summon your optimism.
-//You are cautious in showing your true self to others.
-//Your ability to accomplish tasks will follow with success.
-//We all have extraordinary coded within us, waiting to be released.
-//You will have a bright future.
-//Compassion is a way of being.
-//You will always have good luck in your personal affairs.
-//The pleasure of what we enjoy is lost by wanting more
-//Did you remember to order your take out also?
-//Perhaps you've been focusing too much on that one thing..
-//Right now there's an energy pushing you in a new direction.
-//Everybody feels lucky for having you as a friend.
-//When the moment comes, take the top one.
-//Sometimes travel to new places leads to great transformation.
-//There is always a way - if you are committed.
-//Life is too short to waste time hating anyone.
-//All the world may not love a lover but they will be watching him.
-//Don't just spend time, invest it.
-//Life always gets harder near the summit.
-//Take the chance while you still have the choice.
-//It is much easier to be cirtical than to be correct.
-//Enjoy life! It is better to be happy than wise.
-//To make the cart go, you must grease the wheels.
-//You are contemplating some action which will bring credit upon you.
-//Before you wonder Am I doing things right, ask Am I doing the right things?
-//You may be disappointed if you fail, but you are doomed if you don't try.
-//You will always get what you want through your charm and personality.
-//The big issues are work, career, or status right now.
-//Your emotional currents are flowing powerfully now.
-//Any decision you have to make tomorrow is a good decsion.
-//Consume less. Share more. Enjoy life.
-//The secret of staying young is good health and lying about your age.
-//Spring has sprung. Life is blooming.
-//Go ask your mom.
-//The possibility of a career change is near.
-//The important thing is to never stop questioning.
-//Compassion will cure more then condemnation.
-//Excuses are easy to manufacture, and hard to sell.
-//Put your mind into planning today. Look into the future.
-//Listen to life, and you will hear the voice of life crying, Be!
-//Broke is only temporaryl poor is a state of mind.
-//Here we go. Moo Shu Cereal for breakfast with duck sauce.
-//Teamwork: the fuel that allows common people attain uncommon results.
-//Hard words break no bones, fine words butter no parsnips.
-//We cannot direct the wind but we can adjust the sails.
-//You are offered the dream of a lifetime. Say yes!
-//Working out the kinks today will make for a better tomorrow.
-//You have a curious smile and a mysterious nature.
-//Questions provide the key to unlocking our unlimited potential.
-//You will enjoy razon-sharp spiritual vision today.
-//The wise are aware of their treasure, while fools follow their vanity
-//Well-arranged time is the surest sign of a well-arranged mind.
-//Never bring unhappy feelings into your home.
-//This is really a lovely day. Congratulations!
-//Bad luck and ill misfortune will infest your pathetic soul for all eternity.
-//A golden egg of opportunity falls into your lap this month.
-//You are very grateful for the small pleasures of life.
-//today you should be a passenger. Stay close to a driver for a day.
-//For hate is never conquered by hate. Hate is conquered by love.
-//Service is the rent we pay for the privilege of living on this planet.
-//Good clothes open many doors. Go shopping.
-//The leader seeks to communicate his vision to his followers.
-//Great works are performed not by strength, but by perseverance.
-//People who are late are often happier than those who have to wait for them
-//Present your best ideas today to an eager and welcoming audience.
-//Friends long absent are coming back to you.
-//The time is right to make new friends.
-//Life to you is a dashing and bold adventure
-//You may be hungry soon: order a takeout now.
-//Do not hesitate to look for help, an extra hand should always be welcomed.
-//How can you have a beautiful ending without making beautiful mistakes?
-//Humor is an affirmation of dignity
-//He who climbs a ladder must begin at the first step
-//What's vice today may be virtue tomorow.
-//You have an unusually magnetic personality.
-//You will travel to many places.
-//Accept yourself
-//Be a generous friend and a fair enemy
-//Never quit!
-//Old friends, old wines and old gold are best
-//If your desires are not extravagant, they will be granted
-//Every Friend Joys in your Success
-//You should be able to undertake and complete anything
-//You will enjoy good health, you will be surrounded by luxury
-//You are a person of strong sense of duty
-//Dream lofty dreams, and as you dream, so shall you become.
-//You have a quiet and unobtrusive nature.
-//Great thoughts come from the heart.
-//You love peace
-//Judge not according to the appearance.
-//One who admires you greatly is hidden before your eyes.
-//Traveling more often is important for your health and happiness.
-//You will be sharing great news with all people you love
-//You have a reputation for being straightforward and honest.
-//You are always welcome in any gathering.
-//You will be traveling and coming into a fortune.
-//Open up your heart - it can always be closed again.
-//Being happy is not always being perfect.
-//Next time you have the opportunity, go on a rollercoaster.
-//Try everything once, even the things you don't think you will like.
-//Life is too short to hold grudges.
-//Dream your dream and your dream will dream of you.
-//Being alone and being lonely are two different things.
-//Don't worry about things in the past, there is nothing you can do about them
-now. Don't worry about things that are happening now, make the best of a bad
-situation. Don't worry about things in the future, they may never happen.
-//Tomorrow, take a moment to do something just for yourself.
-//Someone close to you is waiting for you to call.
-//A virtual fortune cookie will not satisfy your hunger like that of a home made
-one.
-//Smile. Tomorrow is another day.
-//You can never been certain of success, but you can be certain of failure if
-you never try.
-//It takes ten times as many muscles to frown as it does to smile.
-//Shoot for the moon! If you miss you will still be amongst the stars.
-//Keep your eyes open. You never know what you might see.
-//Tell them what you really think. Otherwise, nothing will change.
-//Let your heart make your decisions - it does not get as confused as your head.
-//Working hard will make you live a happy life.
-//A pleasant surprise is waiting for you.
-QUOTES
+        $quotes = explode(
+            '//',
+            <<<QUOTES
+                People are naturally attracted to you.
+                //You learn from your mistakes... You will learn a lot today.
+                //If you have something good in your life, don't let it go!
+                //What ever you're goal is in life, embrace it visualize it, and for it will be
+                yours.
+                //Your shoes will make you happy today.
+                //You cannot love life until you live the life you love.
+                //Be on the lookout for coming events; They cast their shadows beforehand.
+                //Land is always on the mind of a flying bird.
+                //The man or woman you desire feels the same about you.
+                //Meeting adversity well is the source of your strength.
+                //A dream you have will come true.
+                //Our deeds determine us, as much as we determine our deeds.
+                //Never give up. You're not a failure if you don't give up.
+                //You will become great if you believe in yourself.
+                //There is no greater pleasure than seeing your loved ones prosper.
+                //You will marry your lover.
+                //A very attractive person has a message for you.
+                //You already know the answer to the questions lingering inside your head.
+                //It is now, and in this world, that we must live.
+                //You must try, or hate yourself for not trying.
+                //You can make your own happiness.
+                //The greatest risk is not taking one.
+                //The love of your life is stepping into your planet this summer.
+                //Love can last a lifetime, if you want it to.
+                //Adversity is the parent of virtue.
+                //Serious trouble will bypass you.
+                //A short stranger will soon enter your life with blessings to share.
+                //Now is the time to try something new.
+                //Wealth awaits you very soon.
+                //If you feel you are right, stand firmly by your convictions.
+                //If winter comes, can spring be far behind?
+                //Keep your eye out for someone special.
+                //You are very talented in many ways.
+                //A stranger, is a friend you have not spoken to yet.
+                //A new voyage will fill your life with untold memories.
+                //You will travel to many exotic places in your lifetime.
+                //Your ability for accomplishment will follow with success.
+                //Nothing astonishes men so much as common sense and plain dealing.
+                //Its amazing how much good you can do if you dont care who gets the credit.
+                //Everyone agrees. You are the best.
+                //LIFE CONSIST NOT IN HOLDING GOOD CARDS, BUT IN PLAYING THOSE YOU HOLD WELL.
+                //Jealousy doesn't open doors, it closes them!
+                //It's better to be alone sometimes.
+                //When fear hurts you, conquer it and defeat it!
+                //Let the deeds speak.
+                //You will be called in to fulfill a position of high honor and responsibility.
+                //The man on the top of the mountain did not fall there.
+                //You will conquer obstacles to achieve success.
+                //Joys are often the shadows, cast by sorrows.
+                //Fortune favors the brave.
+                //An upward movement initiated in time can counteract fate.
+                //A journey of a thousand miles begins with a single step.
+                //Sometimes you just need to lay on the floor.
+                //Never give up. Always find a reason to keep trying.
+                //If you have something worth fighting for, then fight for it.
+                //Stop wishing. Start doing.
+                //Accept your past without regrets. Handle your present with confidence. Face
+                your future without fear.
+                //Stay true to those who would do the same for you.
+                //Ask yourself if what you are doing today is getting you closer to where you
+                want to be tomorrow.
+                //Happiness is an activity.
+                //Help is always needed but not always appreciated. Stay true to your heart and
+                help those in need weather they appreciate it or not.
+                //Hone your competitive instincts.
+                //Finish your work on hand don't be greedy.
+                //For success today, look first to yourself.
+                //Your fortune is as sweet as a cookie.
+                //Integrity is the essence of everything successful.
+                //If you're happy, you're successful.
+                //You will always be surrounded by true friends
+                //Believing that you are beautiful will make you appear beautiful to others
+                around you.
+                //Happinees comes from a good life.
+                //Before trying to please others think of what makes you happy.
+                //When hungry, order more Chinese food.
+                //Your golden opportunity is coming shortly.
+                //For hate is never conquered by hate. Hate is conquered by love .
+                //You will make many changes before settling down happily.
+                //A man is born to live and not prepare to live.
+                //You cannot become rich except by enriching others.
+                //Don't pursue happiness - create it.
+                //You will be successful in love.
+                //All your fingers can't be of the same length.
+                //Wise sayings often fall on barren ground, but a kind word is never thrown away.
+                //A lifetime of happiness is in store for you.
+                //It is very possible that you will achieve greatness in your lifetime.
+                //Be tactful; overlook your own opportunity.
+                //You are the controller of your destiny.
+                //Everything happens for a reson.
+                //How can you have a beutiful ending without making beautiful mistakes.
+                //You can open doors with your charm and patience.
+                //Welcome the change coming into your life.
+                //There will be a happy romance for you shortly.
+                //Your fondest dream will come true within this year.
+                //You have a deep interest in all that is artistic.
+                //Your emotional nature is strong and sensitive.
+                //A letter of great importance may reach you any day now.
+                //Good health will be yours for a long time.
+                //You will become better acquainted with a coworker.
+                //To be old and wise, you must first be young and stupid.
+                //Failure is only the opportunity to begin again more intelligently.
+                //Integrity is doing the right thing, even if nobody is watching.
+                //Conquer your fears or they will conquer you.
+                //You are a lover of words; One day you will write a book.
+                //In this life it is not what we take up, but what we give up, that makes us
+                rich.
+                //Fear can keep us up all night long, but faith makes one fine pillow.
+                //Seek out the significance of your problem at this time. Try to understand.
+                //Never upset the driver of the car you're in; they're the master of your
+                destiny until you get home.
+                //He who slithers among the ground is not always a foe.
+                //You learn from your mistakes, you will learn a lot today.
+                //You only need look to your own reflection for inspiration. Because you are
+                Beautiful!
+                //You are not judged by your efforts you put in; you are judged on your
+                performance.
+                //Rivers need springs.
+                //Good news from afar may bring you a welcome visitor.
+                //When all else seems to fail, smile for today and just love someone.
+                //Patience is a virtue, unless its against a brick wall.
+                //When you look down, all you see is dirt, so keep looking up.
+                //If you are afraid to shake the dice, you will never throw a six.
+                //Even if the person who appears most wrong, is also quite often right.
+                //A single conversation with a wise man is better than ten years of study.
+                //Happiness is often a rebound from hard work.
+                //The world may be your oyster, but that doesn't mean you'll get it's pearl.
+                //Your life will be filled with magical moments.
+                //You're true love will show himself to you under the moonlight.
+                //Do not follow where the path may lead. Go where there is no path...and leave a
+                trail
+                //Do not fear what you don't know
+                //The object of your desire comes closer.
+                //You have a flair for adding a fanciful dimension to any story.
+                //If you wish to know the mind of a man, listen to his words
+                //The most useless energy is trying to change what and who God so carefully
+                created.
+                //Do not be covered in sadness or be fooled in happiness they both must exist
+                //You will have unexpected great good luck.
+                //You will have a pleasant surprise
+                //All progress occurs because people dare to be different.
+                //Your ability for accomplishment will be followed by success.
+                //The world is always ready to receive talent with open arms.
+                //Things may come to those who wait, but only the things left by those who
+                hustle.
+                //We can't help everyone. But everyone can help someone.
+                //Every day is a new day. But tomorrow is never promised.
+                //Express yourself: Don't hold back!
+                //It is not necessary to show others you have change; the change will be obvious.
+                //You have a deep appreciation of the arts and music.
+                //If your desires are not extravagant, they will be rewarded.
+                //You try hard, never to fail. You don't, never to win.
+                //Never give up on someone that you don't go a day without thinking about.
+                //It never pays to kick a skunk.
+                //In case of fire, keep calm, pay bill and run.
+                //Next full moon brings an enchanting evening.
+                //Not all closed eye is sleeping nor open eye is seeing.
+                //Impossible is a word only to be found in the dictionary of fools.
+                //You will soon witness a miracle.
+                //The time is alway right to do what is right.
+                //Love is as necessary to human beings as food and shelter.
+                //You will make heads turn.
+                //You are extremely loved. Don't worry :)
+                //If you are never patient, you will never get anything done. If you believe you
+                can do it, you will be rewarded with success.
+                //You will soon embark on a business venture.
+                //You believe in the goodness of man kind.
+                //You will have a long and wealthy life.
+                //You will take a pleasant journey to a place far away.
+                //You are a person of culture.
+                //Keep it simple. The more you say, the less people remember.
+                //Life is like a dogsled team. If you ain't the lead dog, the scenery never
+                changes.
+                //Prosperity makes friends and adversity tries them.
+                //Nothing seems impossible to you.
+                //Patience is bitter, but its fruit is sweet.
+                //The only certainty is that nothing is certain.
+                //Success is the sum of my unique visions realized by the sweat of perseverance.
+                //When you expect your opponent to yield, you also should avoid hurting him.
+                //Human evolution: “wider freeway but narrower viewpoints.
+                //Intelligence is the door to freedom and alert attention is the mother of
+                intelligence.
+                //Back away from individuals who are impulsive.
+                //Enjoyed the meal? Buy one to go too.
+                //You believe in the goodness of mankind.
+                //A big fortune will descend upon you this year.
+                //Now these three remain, faith, hope, and love. The greatest of these is love.
+                //For success today look first to yourself.
+                //Determination is the wake-up call to the human will.
+                //There are no limitations to the mind except those we aknowledge.
+                //A merry heart does good like a medicine.
+                //Whenever possible, keep it simple.
+                //Your dearest wish will come true.
+                //Poverty is no disgrace.
+                //If you don’t do it excellently, don’t do it at all.
+                //You have an unusual equipment for success, use it properly.
+                //Emotion is energy in motion.
+                //You will soon be honored by someone you respect.
+                //Punctuality is the politeness of kings and the duty of gentle people
+                everywhere.
+                //Your happiness is intertwined with your outlook on life.
+                //Elegant surroundings will soon be yours.
+                //If you feel you are right, stand firmly by your convictions.
+                //Your smile brings happiness to everyone you meet.
+                //Instead of worrying and agonizing, move ahead constructively.
+                //Do you believe? Endurance and persistence will be rewarded.
+                //A new business venture is on the horizon.
+                //Never underestimate the power of the human touch.
+                //Hold on to the past but eventually, let the times go and keep the memories
+                into the present.
+                //Truth is an unpopular subject. Because it is unquestionably correct.
+                //The most important thing in communication is to hear what isn’t being said.
+                //You are broad minded and socially active.
+                //Your dearest dream is coming true. God looks after you especially.
+                //You will recieve some high prize or award.
+                //Your present question marks are going to succeed.
+                //You have a fine capacity for the enjoyment of life.
+                //You will live long and enjoy life.
+                //An admirer is concealing his/her affection for you.
+                //A wish is what makes life happen when you dream of rose petals.
+                //Love can turn cottage into a golden palace.
+                //Lend your money and lose your freind.
+                //You will kiss your crush ohhh lalahh
+                //You will be rewarded for being a good listener in the next week.
+                //If you never give up on love, It will never give up on you.
+                //Unleash your life force.
+                //Your wish will come true.
+                //There is a prospect of a thrilling time ahead for you.
+                //No distance is too far, if two hearts are tied together.
+                //Land is always in the mind of the flying birds.
+                //Try? No! Do or do not, there is no try.
+                //Do not worry, you will have great peace.
+                //It's about time you asked that special someone on a date.
+                //You create your own stage ... the audience is waiting.
+                //It is never too late. Just as it is never too early.
+                //Discover the power within yourself.
+                //Good things take time.
+                //Stop thinking about the road not taken and pave over the one you did.
+                //Put your unhappiness aside. Life is beautiful, be happy.
+                //You can still love what you can not have in life.
+                //Make a wise choice everyday.
+                //Circumstance does not make the man; it reveals him to himself.
+                //The man who waits till tomorrow, misses the opportunities of today.
+                //Life does not get better by chance. It gets better by change.
+                //If you never expect anything you can never be disappointed.
+                //People in your surroundings will be more cooperative than usual.
+                //True wisdom is found in happiness.
+                //Ones always regrets what could have done. Remember for next time.
+                //Follow your bliss and the Universe will open doors where there were once only
+                walls.
+                //Find a peaceful place where you can make plans for the future.
+                //All the water in the world can't sink a ship unless it gets inside.
+                //The earth is a school learn in it.
+                //In music, one must think with his heart and feel with his brain.
+                //If you speak honestly, everyone will listen.
+                //Ganerosity will repay itself sooner than you imagine.
+                //good things take time
+                //Do what is right, not what you should.
+                //To effect the quality of the day is no small achievement.
+                //Simplicity and clearity should be the theme in your dress.
+                //Virtuous find joy while Wrongdoers find grieve in their actions.
+                //Not all closed eye is sleeping, nor open eye is seeing.
+                //Bread today is better than cake tomorrow.
+                //In evrything there is a piece of truth.But a piece.
+                //A feeling is an idea with roots.
+                //Man is born to live and not prepare to live
+                //It's all right to have butterflies in your stomach. Just get them to fly in
+                formation.
+                //If you don t give something, you will not get anything
+                //The harder you try to not be like your parents, the more likely you will
+                become them
+                //Someday everything will all make perfect sense
+                //you will think for yourself when you stop letting others think for you
+                //Everything will be ok. Don't obsess. Time will prove you right, you must stay
+                where you are.
+                //Let's finish this up now, someone is waiting for you on that
+                //The finest men like the finest steels have been tempered in the hottest
+                furnace.
+                //A dream you have will come true
+                //The worst of friends may become the best of enemies, but you will always find
+                yourself hanging on.
+                //I think, you ate your fortune while you were eating your cookie
+                //If u love someone keep fighting for them
+                //Do what you want, when you want, and you will be rewarded
+                //Let your fantasies unwind...
+                //The cooler you think you are the dumber you look
+                //Expect great things and great things will come
+                //The Wheel of Good Fortune is finally turning in your direction!
+                //Don't lead if you won't lead.
+                //You will always be successful in your professional career
+                //Share your hapiness with others today.
+                //It's up to you to clearify.
+                //Your future will be happy and productive.
+                //Seize every second of your life and savor it.
+                //Those who walk in other's tracks leave no footprints.
+                //Failure is the mother of all success.
+                //Difficulty at the beginning useually means ease at the end.
+                //Do not seek so much to find the answer as much as to understand the question
+                better.
+                //Your way of doing what other people do their way is what makes you special.
+                //A beautiful, smart, and loving person will be coming into your life.
+                //Friendship is an ocean that you cannot see bottom.
+                //Your life does not get better by chance, it gets better by change.
+                //Our duty,as men and women,is to proceed as if limits to our ability did not
+                exist.
+                //A pleasant expeience is ahead:don't pass it by.
+                //Our perception and attitude toward any situation will determine the outcome
+                //They say you are stubborn; you call it persistence.
+                //Two small jumps are sometimes better than one big leap.
+                //A new wardrobe brings great joy and change to your life.
+                //The cure for grief is motion.
+                //It's a good thing that life is not as serious as it seems to the waiter
+                //I hear and I forget. I see and I remember. I do and I understand.
+                //I have a dream....Time to go to bed.
+                //Ideas you believe are absurd ultimately lead to success!
+                //A human being is a deciding being.
+                //Today is an ideal time to water your parsonal garden.
+                //Some men dream of fortunes, others dream of cookies.
+                //Things are never quite the way they seem.
+                //the project on your mind will soon gain momentum
+                //YOUR FAILURES WILL LEAD YOU TO YOUR SUCCESS.
+                //IN ORDER TO GET THE RAINBOW, YOU MUST ENDURE THE RAIN.
+                //Beauty is simply beauty. originality is magical.
+                //Your dream will come true when you least expect it.
+                //Let not your hand be stretched out to receive and shut when you should repay.
+                //Don't worry, half the people you know are below average.
+                //Vision is the art of seeing what is invisible to others.
+                //You don't need talent to gain experience.
+                //A focused mind is one of the most powerful forces in the universe.
+                //Today you shed your last tear. Tomorrow fortune knocks at your door.
+                //Be patient! The Great Wall didn't got build in one day.
+                //Think you can. Think you can't. Either way, you'll be right.
+                //Wisdom is on her way to you.
+                //Digital circuits are made from analog parts.
+                //If you eat a box of fortune cookies, anything is possible.
+                //The best is yet to come.
+                //I'm with you.
+                //Be direct,usually one can accomplish more that way.
+                //A single kind work will keep one warm for years.
+                //Ask a friend to join you on your next voyage.
+                //In God we trust.
+                //Love is free. Lust will cost you everything you have.
+                //Stop searching forever, happiness is just next to you.
+                //You don't need the answers to all of life's questions. Just ask your father
+                what to do.
+                //Jealousy is a useless emotion.
+                //You are not a ghost.
+                //There is someone rather annoying in your life that you need to listen to.
+                //You will plant the smallest seed and it will become the greatest and most
+                mighty tree in the world.
+                //The dream you've been dreaming all your life isn't worth it. Find a new dream,
+                and once you're sure you've found it, fight for it.
+                //See if you can learn anything from the children.
+                //It's Never Too Late For Good Things To Happen!
+                //A clear conscience is usually the sign of a bad memory.
+                //Aim high, time flies.
+                //One is not sleeping, does not mean they are awake.
+                //A great pleasure in life is doing what others say you can't.
+                //Isn't there something else you should be working on right now?
+                //Your father still loves and is in always with you. Remember that.
+                //Before you can be reborn you must die.
+                //It better to be the hammer than the nail.
+                //You are admired by everyone for your talent and ability.
+                //Save the whales. Collect the whole set.
+                //You will soon discover a major truth about the one you love most.
+                //Your life will prosper only if you acknowledge your faults and work to reduce
+                them.
+                //Pray to God, but row towards shore.
+                //You will soon witness a miracle.
+                //The early bird gets the worm, but the second mouse gets the cheese
+                //Help, I'm being held prisoner in a Chinese cookie factory.
+                //Alas! The onion you are eating is someone else’s water lily.
+                //You are a persoon with a good sense of justice, now it's time to act like it.
+                //You create enthusiasm around you.
+                //There are big changes ahead for you. They will be good ones!
+                //You will have many happy days soon.
+                //Out of confusion comes new patterns.
+                //If you love someone enough and they break your heart, you can't stop yourself
+                from still loving them again even after all that pain.
+                //Look right...Now look left...Now look forward (do this really fast) do you
+                feel any different? good you should feel dizzy.
+                //Live like you are on the bottom, even if you are on the top.
+                //You will soon emerge victorious from the maze you've been traveling in.
+                //Do not judge a book by it's color.
+                //Everything will come your way.
+                //There is a time to be practical now.
+                //Bend the rod while it is still hot.
+                //Darkness is only succesful when there is no light. Don't forget about light!
+                //Acting is not lying. It is findind someone hiding inside you and letting that
+                person run free.
+                //You will be forced to face fear, but if you do not run, fear will be afraid of
+                you.
+                //You are thinking about doing something. Don't do it, it won't help anything.
+                //Your worst enemy has a crush on you!
+                //Love Conquers all.
+                //The phrase is follow your dreams. Not dream period.
+                //stop nagging to your partner and take it day by day.
+                //Do not think that me or my brothers have supreme control over what will happen
+                to you.
+                //Bad luck and misfortune will follow you all your days.
+                //Remember the fate of the early Worm.
+                //Begin your life anew with strength, grace and wonder.
+                //Be a good friend and a fair enemy.
+                //What goes around comes around.
+                //Bad luck and misfortune will infest your pathetic soul for all eternity.
+                //The best prophet of the future is the past
+                //Movies have pause buttons, friends do not
+                //Use the force.
+                //Trust your intuition.
+                //Encourage your peers.
+                //Let your imagination wander.
+                //Your pain is the breaking of the shell that encloses your understanding.
+                //Patience is key, a wait short or long will have its reward.
+                //Tell them before it's too late...
+                //A bird in the hand is worth three in the bush!!
+                //Be assertive when decisive action is needed.
+                //To determine whether someone is beautiful is not by looking at his/her
+                appearance, but his/her heart.
+                //Hope brings about a better future
+                //While you have this day, fill it with life. While you're in this moment, give
+                it your own special meaning and purpose and joy.
+                //Even though it will often be difficult and complicated, you know you have what
+                it takes to get it done.
+                //You can choose, right now and in every moment, to put your powerful and
+                effective abilities to purposeful use. There is always something you can do, no
+                matter what the situation may be, that will move your life forward.
+                //IT IS NOT GOOD TO BE A USER BLESSINGS COME FROM BEING A GIVER NOT A TAKER.
+                //Cookie says, You crack me up
+                //You will prosper in the field of wacky inventions.
+                //Your tongue is your ambassador.
+                //The cure for grief is movement.
+                //Love Is At Your Hands Be Glad And Hold On To It.
+                //You are often asked if it is in yet.
+                //Life to you is a bold and dashing responsibility.
+                //Patience is a key to joy.
+                //A bargain is something you don't need at a price you can't resist.
+                //Today is going to be a disasterous day, be prepared!
+                //Stay to your inner-self, you will benefit in many ways.
+                //Rarely do great beauty and great virtue dwell together as they do in you.
+                //You are talented in many ways.
+                //You are the master of every situation.
+                //Your problem just got bigger. Think, what have you done.
+                //If your cookie still in one piece, buy lotto.
+                //Go with the flow will make your transition ever so much easier.
+                //Tomorrow Morning,Take a Left Turn As Soon As You Leave Home
+                //A metaphor could save your life.
+                //Don't wait for your ship to come in, swim out to it
+                //There are lessons to be learned by listening to others.
+                //If you want the rainbow, you have to tolerate the rain.
+                //Volition, Strength, Languages, Freedom and Power rests in you.
+                //TOO MANY PEOPLE VOLUNTEER TO CARRY THE STOOL WHEN ITS TIME TO MOVE THE PIANO
+                //It takes more than a good memory to have good memories.
+                //You are what you are; understand yourself before you react
+                //Word to the wise: Don't play leapfrog with a unicorn.........
+                //Forgive your enemies, but never forget them.
+                //Everything will now come your way
+                //Don't worry about the stock market. Invest in family.
+                //Your fortune is as sweet as a cookie.
+                //It is much easier to look for the bad, than it is to find the good
+                //If a person who has caused you pain and suffering has brought you, reconsider
+                that person's value in your life
+                //You are worth loving, you are also worth the effort it takes to love you
+                //Never trouble trouble till trouble troubles you.
+                //Get off to a new start - come out of your shell.
+                //Life is a dancefloor,you are the DJ!
+                //Cooperate with those who have both know how and integrith.
+                //Minor aches today are likely to pay off handsomely tomorrow.
+                //You are about to become $8.95 poorer. ($6.95 if you had the buffet)
+                //Your mouth may be moving, but nobody is listening.
+                //Focus in on the color yellow tomorrow for good luck!
+                //The problem with resisting temptation is that it may never come again.
+                //All your sorrows will vanish.
+                //About time I got out of that cookie.
+                //Love will lead the way.
+                //The ads revenge is massive success
+                //It is best to act with confidence, no matter how little right you have to it.
+                //Soon, a visitor shall delight you.
+                //What breaks in a moment may take years to mend.
+                //Someone stole your fortune and replaced it with this one. Your luck sucks.
+                Have a good day!
+                //Take control of your life rather than letting things happen just like that!
+                //You will be rewarded for your patience and understanding.
+                //You will achieve all your desires and pleasures.
+                //Never miss a chance to keep your mouth shut.
+                //Nothing Shows A Man's Character More Than What He Laughs At.
+                //Never regret anything that made you smile.
+                //Love Takes Pratice.
+                //Don't take yourself so seriously, no one else does.
+                //You've got what it takes, but it will take everything you've got!
+                //At this very moment you can change the rest of your life.
+                //Become who you are.
+                //All comes at the proper time to him who knows how to wait.
+                //The energy is within you. Money is Coming!
+                //The quotes that you do not understand, are not meant for you.
+                //You have an important new business development shaping up.
+                //if love someone a lot tell it before it's too late
+                //Birds are entangled by their feet and men by their tongues.
+                //Benefit by doing things that others give up on.
+                //Rest has a peaceful effect on your physical and emotional health.
+                //One of the best ways to persuade others is with your ears--by listening to
+                them.
+                //Plan your work and work your plan.
+                //Over self-confidence is equal to being blind.
+                //Those who bring sunshine to the lives of others cannot keep it from themselves.
+                //Love or money, or neither?
+                //Before the beginning of great brilliance, there must be chaos.
+                //Old friends make best friends.
+                //Stop searching forever. Happiness is just next to you.
+                //Accept something that you cannot change, and you will feel better.
+                //Kiss is not a kiss without the heart.
+                //Enhance your karma by engaging in various charitable activities.
+                //You will have good luck and overcome many hardships.
+                //You never hesitate to tackle the most difficult problems.
+                //Hope is like food. You will starve without it.
+                //WHEN FIRE AND WATER GO TO WAR WATER ALWAYS WINS.
+                //An angry man opens his mouth and shuts up his eyes.
+                //Make the system work for you, not the other way around.
+                //You will be hungry soon, order takeout now.
+                //Be prepared for extra energy.
+                //An unexpected relationship will become permanent.
+                //The love of your life is sitting across from you.
+                //Better be the head of a chicken than the tail of an ox.
+                //To forgive others one more time is to create one more blessing for yourself.
+                //Enjoy yourself while you can.
+                //The ultimate test of a relationship is to disagree but to hold hands.
+                //Excellence is the difference between what I do and what I am capable of.
+                //Do not let what you do not have prevent you from using what you do have.
+                //What ends on hope does not end at all.
+                //People enjoy having you around. Appreciate this.
+                //You are admired for your adventuous ways.
+                //It's never crowded along the extra mile
+                //You are blessed, today is the day to bless others.
+                //The Greatest War Sometimes Isn't On The Battlefield But Against Oneself.
+                //People in your background will be more co-operative than usual.
+                //A good way to stay healthy is to eat more Chinese food.
+                //Anyone who dares to be, can never be weak.
+                //Affirm it, visualize it, believe it, and it`will actualize itself.
+                //The measure of time to your next goal is the measure of your discipline.
+                //Help, I'm prisoner in a Chinese bakery!!!
+                //Take a minute and let it ride, then take a minute to let it breeze.
+                //We are here to love each other, serve each other and uplift each other.
+                //If everybody is a worm you should be a glow worm
+                //To affirm is to make firm.
+                //Remember this: duct tape can fix anything, so don't worry about messing things
+                up.
+                //You broke my cookie!
+                //Failure is not defeat until you stop trying.
+                //The days that make us happy make us wise.
+                //Men do not fail... they give up trying.
+                //Time may fly by. But Memories don't.
+                //You will win success in whatever you adopt.
+                //You will outdistance all your competitors.
+                //You have a great capability to break cookies - use it wisely!
+                //AT TIMES IT IS BETTER TO KNOW WHEN EXIT THAN ENTER
+                //Money will come to you when you are doing the right thing.
+                //When you get something for nothing, you just haven't been billed for it yet.
+                //You will discover your hidden talents.
+                //You'll advance for with your abilities.
+                //When you can't naturally feel upbeat it can sometimes help you to act as if
+                you did.
+                //You will overcome difficult times.
+                //Your problem just became your stepping stone. Catch the moment.
+                //I am a fortune. You just broke my little house. Where will i live now?
+                //The majority of the word can't is can.
+                //The secret of getting ahead is getting started.
+                //Be most affectionate today.
+                //Change your thoughts and you change the world.
+                //Sing and rejoice, fortune is smiling on you.
+                //All the preparation you've done will finally be paying off!
+                //A truly great person never puts away the simplicity of a child.
+                //Customer service is like taking a bath you have to keep doing it.
+                //The expanse of your intelligence is a void no universe could ever fill.
+                //Those grapes you cannot taste are always sour.
+                //An unexpected aquaintance will resurface.
+                //If you want the rainbow, then you have to tolerate the rain.
+                //You don't get harmony when everyone sings the same note.
+                //The race is not always to the swift, but to those who keep on running.
+                //The early bird gets the worm, but the second mouse gets the cheese.
+                //The best things in life aren't things.
+                //Don't bother looking for fault. The reward for finding it is low.
+                //Everything has beauty but not everyone sees it.
+                //Nothing is as good or bad as it appears.
+                //Never cut what you can untie.
+                //Meet your opponent half way. You need the exercise.
+                //Laughter is the shortest distance between two people.
+                //We cannot change the direction of the wind, but we can adjust our sails.
+                //We could learn a lot from crayons: Some of are sharp, some are pretty, some
+                have weird names, and all are different colors. But they all have to learn to
+                live in the same box.
+                //Use your instincts now.
+                //If you take a single step to your journey, you'll succeed; it's not best to
+                fail.
+                //In the eyes of lovers, everything is beautiful.
+                //Warning, do not eat your fortune.
+                //Demonstrate refinement in everything you do.
+                //Impossible standards just make life difficult.
+                //A different world cannot be build by indifferent people.
+                //Q. What is H2O? A. Caring, 2 parts Hug and 1 part Open-mind.
+                //All troubles you have can pass away very quickly.
+                //Integrity is the essense of everything successful.
+                //For true love? Send real roses preserved in 24kt gold!
+                //Sometimes the object of the journey is not the end, but the journey itself.
+                //Fear is just excitement in need of an attitude adjustment.
+                //The food here taste so good, even a cave man likes it.
+                //Perhaps you've been focusing too much on spending.
+                //Happiness isn't something you remember, it's something you experience.
+                //Oops... Wrong cookie.
+                //The dream is within you.
+                //Love is on its way.
+                //Be direct, usually one can accomplish more that way.
+                //Use your talents. That's what they are intended for.
+                //The troubles you have now will pass away quickly.
+                //See the light at the end of the tunnel.
+                //Your dream will come true when you least expect it.
+                //Don't 'face' reality, let it be the place from which you leap.
+                //Fortune smiles upon you today.
+                //Believing is doing.
+                //Your dynamic eyes have attracted a secret admirer.
+                //You know where you are going and how to get there.
+                //Go confidently in the direction of your dreams.
+                //Your ability to pick a winner will bring you success.
+                //Humor usually works at the moment of awkwardness.
+                //A good time to finish up old tasks.
+                //Stop procrastinating - starting tomorrow
+                //Enthusiastic leadership gets you a promotion when you least expect it.
+                //You love Chinese food.
+                //You are far more influential than you think.
+                //Adjust finances, make budgets, to improve your standing.
+                //Happiness is not the absence of conflict, but the ability to cope with it.
+                //An understanding heart warms all that are graced with it's presense.
+                //Your co-workers take pleasure in your great sense of creativity.
+                //You are one of the people who goes places in life.
+                //Others enjoy your company.
+                //When in doubt, let your instincts guide you.
+                //A cheerful message is on its way to you.
+                //A pleasant surprise is in store for you tonight.
+                //you cant go down the right path with out first discovering the path to go down
+                //To courageously shoulder the responsibility of one's mistake is character.
+                //The joyful energy of the day will have a positive affect on you.
+                //You have a strong desire for a home and your family interests come first.
+                //Dogs have owners, cats have staff.
+                //Be patient: in time, even an egg will walk.
+                //You are not a person who can be ignored.
+                //You always know the right times to be assertive or to simply wait.
+                //Reading to the mind is what exercise is to the body.
+                //Eat something you never tried before.
+                //Your life becomes more and more of an adventure!
+                //You need to live authentically, and you can't ignore that.
+                //Make all you can, save all you can, give all you can.
+                //A well-aimed spear is worth three.
+                //To build a better world, start in your community.
+                //When you can't naturally feel upbeat, it can sometimes help to act a if you
+                did.
+                //May you have great luck.
+                //A kind word will keep someone warm for years.
+                //Nothing in the world is accomplished without passion.
+                //Human invented language to satisfy the need to complain.
+                //Accept what comes to you each day.
+                //A small lucky package is on its way to you soon.
+                //In human endeavor, chance favors the prepared mind.
+                //Do not upset the penguin today.
+                //Don't cry.
+                //The best way to give credit is to give it away.
+                //Anything you do, do it well. The last thing you want is to be sorry for what
+                you didn't do.
+                //It takes more then good memory to have good memories.
+                //Grant yourself a wish this year only you can do it.
+                //love thy neighbour, just don't get caught
+                //You will be selected for a promotion because of your accomplishments.
+                //There are many new opportunities that are being presented to you.
+                //You will inherit a large sum of money.
+                //You will recieve a gift from someone that cares about you.
+                //You are not illiterate.
+                //Love because it is the only true adventure.
+                //You are contemplating some action which will bring credit upon you
+                //Keep true to the dreams of your youth.
+                //Treasure what you have.
+                //The greatest precept is continual awareness.
+                //A new friend helps you break out of an old routine.
+                //I have a dream.... Time to go to bed.
+                //Your skill will accomplish what the force of many cannot.
+                //You will soon be surrounded by good friends and laughter.
+                //The best is yet to come.
+                //It is better to be the hammer then the anvil.
+                //He who climbs a ladder must begin at the first step.
+                //Action speaks nothing, without the Motive.
+                //Give yourself some peace and quiet for at least a few hours.
+                //Live each day well and wisely
+                //Old dreams never die they just get filed away.
+                //You can fix it with a little extra energy and a positive attitude.
+                //Life is a verb
+                //A man without aim is like a clock without hands, as useless if it turns as if
+                it stands.
+                //Many folks are about as happy as they make up their minds to be.
+                //It's kind of fun to do the impossible
+                //Wow! A secret message from you teeth!
+                //You should be able to make money and hold on to it.
+                //The human spirit is stronger than anything that can happen to it.
+                //Your succeess will astonish everyone.
+                //It is better to have a hen tomorrow than an egg today.
+                //Judge each day not by the harvest you reap but by the seeds you plant.
+                //You like Chinese food.
+                //Your hard work will get payoff today.
+                //Today is the tomorrow we worried about yesterday
+                //There are no shortcuts to any place worth going
+                //No matter what your past has been, you have a spotless future.
+                //Your secret desire to completely change your life will manifest.
+                //Soon you will be sitting on top of the world.
+                //You are never selfish with your advice or your help.
+                //A thrilling time is in store for you.
+                //It's tough to be fascinating.
+                //Soon life will become more interesting
+                //Luck sometimes visits a fool, but it never sits down with him.
+                //Keep your plans secret for now.
+                //Aren't you glad you just had a great meal?
+                //Traveling this year will bring your life into greater perspective.
+                //Only talent people get help from others.
+                //Constant grinding can turn an iron nod into a needle.
+                //You will be successful in your work
+                //you will spend old age in confort and material wealth
+                //When you're about to turn your heart into a stone remember: you do not walk
+                alone.
+                //I am a bad luck person since I was born
+                //You are vigorous in words and action.
+                //The one who snores will always fall asleep first.
+                //An alien of some sort will be appearing to you shortly!
+                //Rest is a good thing, but boredom is its brother.
+                //Do not be overly judgemental of your loved one's intentions or actions.
+                //Think of how you can assist on a problem, not who to blame.
+                //The life of every woman or man - the heart of it - is pure and holy joy.
+                //Take it easy
+                //Trust your intuition. The universe is guiding your life.
+                //Use your head, but live in your heart.
+                //Don't find fault, find a remedy
+                //It may be those who do most, dream most
+                //Your passions sweep you away.
+                //Listen to yourself more often
+                //Think of mother's exhortations more.
+                //The gambler is like the fisherman both have beginners luck.
+                //You are given the chance to take part in an exciting adventure.
+                //The simplest answer is to act.
+                //You will always be surrounded by true friends.
+                //Keep your feet on the ground even though friends flatter you.
+                //You are the man of righteousness and integrity.
+                //He who seeks will find.
+                //The smart thing to do is to begin trusting your intuitions.
+                //Your many hidden talents will become obvious to those around you.
+                //Pick a path with heart.
+                //The human spirit is stronger then anything that can happen to it.
+                //It takes more than good memory to have good memories.
+                //Face facts with dignity.
+                //Be calm when confronting an emergency crisis.
+                //Do you believe? Endurance and persistence will be rewarded.
+                //A new wardrobe brings great joy and change in your life.
+                //Everyone agrees you are the best.
+                //A new outlook brightens your image and brings new friends.
+                //Everything will now come your way.
+                //You will be called to fill a position of high honor and responsibility.
+                //The eyes believe themselves; the ears believe other people.
+                //Good beginning is half done.
+                //Some pursue happiness; you create it.
+                //It's the worst of times, you need to summon your optimism.
+                //You are cautious in showing your true self to others.
+                //Your ability to accomplish tasks will follow with success.
+                //We all have extraordinary coded within us, waiting to be released.
+                //You will have a bright future.
+                //Compassion is a way of being.
+                //You will always have good luck in your personal affairs.
+                //The pleasure of what we enjoy is lost by wanting more
+                //Did you remember to order your take out also?
+                //Perhaps you've been focusing too much on that one thing..
+                //Right now there's an energy pushing you in a new direction.
+                //Everybody feels lucky for having you as a friend.
+                //When the moment comes, take the top one.
+                //Sometimes travel to new places leads to great transformation.
+                //There is always a way - if you are committed.
+                //Life is too short to waste time hating anyone.
+                //All the world may not love a lover but they will be watching him.
+                //Don't just spend time, invest it.
+                //Life always gets harder near the summit.
+                //Take the chance while you still have the choice.
+                //It is much easier to be cirtical than to be correct.
+                //Enjoy life! It is better to be happy than wise.
+                //To make the cart go, you must grease the wheels.
+                //You are contemplating some action which will bring credit upon you.
+                //Before you wonder Am I doing things right, ask Am I doing the right things?
+                //You may be disappointed if you fail, but you are doomed if you don't try.
+                //You will always get what you want through your charm and personality.
+                //The big issues are work, career, or status right now.
+                //Your emotional currents are flowing powerfully now.
+                //Any decision you have to make tomorrow is a good decsion.
+                //Consume less. Share more. Enjoy life.
+                //The secret of staying young is good health and lying about your age.
+                //Spring has sprung. Life is blooming.
+                //Go ask your mom.
+                //The possibility of a career change is near.
+                //The important thing is to never stop questioning.
+                //Compassion will cure more then condemnation.
+                //Excuses are easy to manufacture, and hard to sell.
+                //Put your mind into planning today. Look into the future.
+                //Listen to life, and you will hear the voice of life crying, Be!
+                //Broke is only temporaryl poor is a state of mind.
+                //Here we go. Moo Shu Cereal for breakfast with duck sauce.
+                //Teamwork: the fuel that allows common people attain uncommon results.
+                //Hard words break no bones, fine words butter no parsnips.
+                //We cannot direct the wind but we can adjust the sails.
+                //You are offered the dream of a lifetime. Say yes!
+                //Working out the kinks today will make for a better tomorrow.
+                //You have a curious smile and a mysterious nature.
+                //Questions provide the key to unlocking our unlimited potential.
+                //You will enjoy razon-sharp spiritual vision today.
+                //The wise are aware of their treasure, while fools follow their vanity
+                //Well-arranged time is the surest sign of a well-arranged mind.
+                //Never bring unhappy feelings into your home.
+                //This is really a lovely day. Congratulations!
+                //Bad luck and ill misfortune will infest your pathetic soul for all eternity.
+                //A golden egg of opportunity falls into your lap this month.
+                //You are very grateful for the small pleasures of life.
+                //today you should be a passenger. Stay close to a driver for a day.
+                //For hate is never conquered by hate. Hate is conquered by love.
+                //Service is the rent we pay for the privilege of living on this planet.
+                //Good clothes open many doors. Go shopping.
+                //The leader seeks to communicate his vision to his followers.
+                //Great works are performed not by strength, but by perseverance.
+                //People who are late are often happier than those who have to wait for them
+                //Present your best ideas today to an eager and welcoming audience.
+                //Friends long absent are coming back to you.
+                //The time is right to make new friends.
+                //Life to you is a dashing and bold adventure
+                //You may be hungry soon: order a takeout now.
+                //Do not hesitate to look for help, an extra hand should always be welcomed.
+                //How can you have a beautiful ending without making beautiful mistakes?
+                //Humor is an affirmation of dignity
+                //He who climbs a ladder must begin at the first step
+                //What's vice today may be virtue tomorow.
+                //You have an unusually magnetic personality.
+                //You will travel to many places.
+                //Accept yourself
+                //Be a generous friend and a fair enemy
+                //Never quit!
+                //Old friends, old wines and old gold are best
+                //If your desires are not extravagant, they will be granted
+                //Every Friend Joys in your Success
+                //You should be able to undertake and complete anything
+                //You will enjoy good health, you will be surrounded by luxury
+                //You are a person of strong sense of duty
+                //Dream lofty dreams, and as you dream, so shall you become.
+                //You have a quiet and unobtrusive nature.
+                //Great thoughts come from the heart.
+                //You love peace
+                //Judge not according to the appearance.
+                //One who admires you greatly is hidden before your eyes.
+                //Traveling more often is important for your health and happiness.
+                //You will be sharing great news with all people you love
+                //You have a reputation for being straightforward and honest.
+                //You are always welcome in any gathering.
+                //You will be traveling and coming into a fortune.
+                //Open up your heart - it can always be closed again.
+                //Being happy is not always being perfect.
+                //Next time you have the opportunity, go on a rollercoaster.
+                //Try everything once, even the things you don't think you will like.
+                //Life is too short to hold grudges.
+                //Dream your dream and your dream will dream of you.
+                //Being alone and being lonely are two different things.
+                //Don't worry about things in the past, there is nothing you can do about them
+                now. Don't worry about things that are happening now, make the best of a bad
+                situation. Don't worry about things in the future, they may never happen.
+                //Tomorrow, take a moment to do something just for yourself.
+                //Someone close to you is waiting for you to call.
+                //A virtual fortune cookie will not satisfy your hunger like that of a home made
+                one.
+                //Smile. Tomorrow is another day.
+                //You can never been certain of success, but you can be certain of failure if
+                you never try.
+                //It takes ten times as many muscles to frown as it does to smile.
+                //Shoot for the moon! If you miss you will still be amongst the stars.
+                //Keep your eyes open. You never know what you might see.
+                //Tell them what you really think. Otherwise, nothing will change.
+                //Let your heart make your decisions - it does not get as confused as your head.
+                //Working hard will make you live a happy life.
+                //A pleasant surprise is waiting for you.
+                QUOTES
         );
 
         $i = round(fmod(hexdec(hash('crc32', $seed)), count($quotes)), 0);

--- a/bridges/OpenlyBridge.php
+++ b/bridges/OpenlyBridge.php
@@ -19,18 +19,18 @@ class OpenlyBridge extends BridgeAbstract
                     'Europe' => 'europe',
                     'Latin America' => 'latin-america',
                     'Middle Easta' => 'middle-east',
-                    'North America' => 'north-america'
-                ]
+                    'North America' => 'north-america',
+                ],
             ],
             'content' => [
                 'name' => 'Content',
                 'type' => 'list',
                 'values' => [
                     'News' => 'news',
-                    'Opinion' => 'people'
+                    'Opinion' => 'people',
                 ],
-                'defaultValue' => 'news'
-            ]
+                'defaultValue' => 'news',
+            ],
         ],
         'By Tag' => [
             'tag' => [
@@ -44,10 +44,10 @@ class OpenlyBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     'News' => 'news',
-                    'Opinion' => 'people'
+                    'Opinion' => 'people',
                 ],
-                'defaultValue' => 'news'
-            ]
+                'defaultValue' => 'news',
+            ],
         ],
         'By Author' => [
             'profileId' => [
@@ -55,26 +55,26 @@ class OpenlyBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => '003D000002WZGYRIA5',
-            ]
-        ]
+            ],
+        ],
     ];
 
     const TEST_DETECT_PARAMETERS = [
         'https://www.openlynews.com/profile/?id=0033z00002XUTepAAH' => [
-            'context' => 'By Author', 'profileId' => '0033z00002XUTepAAH'
+            'context' => 'By Author', 'profileId' => '0033z00002XUTepAAH',
         ],
         'https://www.openlynews.com/news/?page=1&theme=lgbt-law' => [
-            'context' => 'By Tag', 'content' => 'news', 'tag' => 'lgbt-law'
+            'context' => 'By Tag', 'content' => 'news', 'tag' => 'lgbt-law',
         ],
         'https://www.openlynews.com/news/?page=1&region=north-america' => [
-            'context' => 'By Region', 'content' => 'news', 'region' => 'north-america'
+            'context' => 'By Region', 'content' => 'news', 'region' => 'north-america',
         ],
         'https://www.openlynews.com/news/?theme=lgbt-law' => [
-            'context' => 'By Tag', 'content' => 'news', 'tag' => 'lgbt-law'
+            'context' => 'By Tag', 'content' => 'news', 'tag' => 'lgbt-law',
         ],
         'https://www.openlynews.com/news/?region=north-america' => [
-            'context' => 'By Region', 'content' => 'news', 'region' => 'north-america'
-        ]
+            'context' => 'By Region', 'content' => 'news', 'region' => 'north-america',
+        ],
     ];
 
     const CACHE_TIMEOUT = 900; // 15 mins

--- a/bridges/OpenwhydBridge.php
+++ b/bridges/OpenwhydBridge.php
@@ -12,8 +12,8 @@ class OpenwhydBridge extends BridgeAbstract
         'u' => [
             'name' => 'username/id',
             'exampleValue' => '5247f0267e91c862b2b052d0',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     private $userName = '';

--- a/bridges/OtrkeyFinderBridge.php
+++ b/bridges/OtrkeyFinderBridge.php
@@ -55,7 +55,7 @@ class OtrkeyFinderBridge extends BridgeAbstract
                 'exampleValue' => '5',
                 'defaultValue' => '5',
             ],
-        ]
+        ],
     ];
     // Example: Terminator_20.04.13_02-25_sf2_100_TVOON_DE.mpg.avi.otrkey
     // The first group is the running time in minutes

--- a/bridges/ParksOnTheAirBridge.php
+++ b/bridges/ParksOnTheAirBridge.php
@@ -23,19 +23,19 @@ class ParksOnTheAirBridge extends BridgeAbstract
             $park_link = self::URI . '/park/' . $spot['reference'];
 
             $content = <<<EOL
-<a href="{$park_link}">
-{$spot['reference']}, {$spot['name']}</a><br />
-Location: {$spot['locationDesc']}<br />
-Frequency: {$spot['frequency']} kHz<br />
-Spotter: {$spot['spotter']}<br />
-Comments: {$spot['comments']}
-EOL;
+                <a href="{$park_link}">
+                {$spot['reference']}, {$spot['name']}</a><br />
+                Location: {$spot['locationDesc']}<br />
+                Frequency: {$spot['frequency']} kHz<br />
+                Spotter: {$spot['spotter']}<br />
+                Comments: {$spot['comments']}
+                EOL;
 
             $this->items[] = [
                 'uri' => $park_link,
                 'title' => $title,
                 'content' => $content,
-                'timestamp' => $spot['spotTime']
+                'timestamp' => $spot['spotTime'],
             ];
         }
     }

--- a/bridges/ParlerBridge.php
+++ b/bridges/ParlerBridge.php
@@ -16,7 +16,7 @@ final class ParlerBridge extends BridgeAbstract
                 'exampleValue' => 'NigelFarage',
             ],
             'limit' => self::LIMIT,
-        ]
+        ],
     ];
 
     public function collectData()
@@ -34,11 +34,11 @@ final class ParlerBridge extends BridgeAbstract
             $primary = $post->primary;
 
             $item = [
-                'title'     => mb_substr($primary->body, 0, 100),
-                'uri'       => sprintf('https://parler.com/feed/%s', $primary->uuid),
-                'author'    => $primary->username,
-                'uid'       => $primary->uuid,
-                'content'   => nl2br($primary->full_body),
+                'title' => mb_substr($primary->body, 0, 100),
+                'uri' => sprintf('https://parler.com/feed/%s', $primary->uuid),
+                'author' => $primary->username,
+                'uid' => $primary->uuid,
+                'content' => nl2br($primary->full_body),
             ];
 
             $date = DateTimeImmutable::createFromFormat('m/d/YH:i A', $primary->date_str . $primary->time_str);

--- a/bridges/ParuVenduImmoBridge.php
+++ b/bridges/ParuVenduImmoBridge.php
@@ -11,19 +11,19 @@ class ParuVenduImmoBridge extends BridgeAbstract
     const PARAMETERS = [ [
         'minarea' => [
             'name' => 'Minimal surface m²',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'maxprice' => [
             'name' => 'Max price',
-            'type' => 'number'
+            'type' => 'number',
         ],
         'pa' => [
             'name' => 'Country code',
-            'exampleValue' => 'FR'
+            'exampleValue' => 'FR',
         ],
         'lo' => [
-            'name' => 'department numbers or postal codes, comma-separated'
-        ]
+            'name' => 'department numbers or postal codes, comma-separated',
+        ],
     ]];
 
     public function collectData()
@@ -58,7 +58,7 @@ class ParuVenduImmoBridge extends BridgeAbstract
                 $price = '';
             }
 
-            list($href) = explode('#', $element->href);
+            [$href] = explode('#', $element->href);
 
             $item = [];
             $item['uri'] = self::URI . $href;

--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -13,8 +13,8 @@ class PatreonBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'exampleValue' => 'sanityinc',
-            'title' => 'Creator name as seen in their page URL'
-        ]
+            'title' => 'Creator name as seen in their page URL',
+        ],
     ]];
 
     public function collectData()
@@ -72,14 +72,14 @@ class PatreonBridge extends BridgeAbstract
                     //'image_url',
                     'full_name',
                     //'url'
-                ])
+                ]),
             ],
             'filter' => [
                 'contains_exclusive_posts' => true,
                 'is_draft' => false,
-                'campaign_id' => $campaign_id
+                'campaign_id' => $campaign_id,
             ],
-            'sort' => '-published_at'
+            'sort' => '-published_at',
         ];
         $posts = $this->apiGet('posts', $query);
 
@@ -89,7 +89,7 @@ class PatreonBridge extends BridgeAbstract
                 'title' => $post->attributes->title,
                 'timestamp' => $post->attributes->published_at,
                 'content' => '',
-                'uid' => 'patreon.com/' . $post->id
+                'uid' => 'patreon.com/' . $post->id,
             ];
 
             $user = $this->findInclude(
@@ -169,13 +169,13 @@ class PatreonBridge extends BridgeAbstract
          */
         $header = [
             'Accept-Language: en-US',
-            'Content-Type: application/json'
+            'Content-Type: application/json',
         ];
         $opts = [
             CURLOPT_SSL_CIPHER_LIST => implode(':', [
                 'DEFAULT',
-                '!DHE-RSA-CHACHA20-POLY1305'
-            ])
+                '!DHE-RSA-CHACHA20-POLY1305',
+            ]),
         ];
 
         $data = json_decode(getContents($url, $header, $opts));

--- a/bridges/PcGamerBridge.php
+++ b/bridges/PcGamerBridge.php
@@ -11,7 +11,7 @@ class PcGamerBridge extends BridgeAbstract
     const PARAMETERS = [
         [
             'limit' => self::LIMIT,
-        ]
+        ],
     ];
 
     public function collectData()

--- a/bridges/PepperBridgeAbstract.php
+++ b/bridges/PepperBridgeAbstract.php
@@ -72,7 +72,7 @@ class PepperBridgeAbstract extends BridgeAbstract
             ' ', /* Notice this is a space! */
             [
                 'cept-vote-box',
-                'vote-box'
+                'vote-box',
             ]
         );
 
@@ -80,7 +80,7 @@ class PepperBridgeAbstract extends BridgeAbstract
         $selectorDescription = implode(
             ' ', /* Notice this is a space! */
             [
-                'overflow--wrap-break'
+                'overflow--wrap-break',
             ]
         );
 
@@ -90,7 +90,7 @@ class PepperBridgeAbstract extends BridgeAbstract
             [
                 'size--all-s',
                 'flex',
-                'boxAlign-jc--all-fe'
+                'boxAlign-jc--all-fe',
             ]
         );
 
@@ -173,17 +173,17 @@ class PepperBridgeAbstract extends BridgeAbstract
         // This string was extracted during a Website visit, and minified using this neat tool :
         // https://codepen.io/dangodev/pen/Baoqmoy
         $graphqlString = <<<'HEREDOC'
-query comments($filter:CommentFilter!,$limit:Int,$page:Int){comments(filter:$filter,limit:$limit,page:$page){
-items{...commentFields}pagination{...paginationFields}}}fragment commentFields on Comment{commentId threadId url 
-preparedHtmlContent user{...userMediumAvatarFields...userNameFields...userPersonaFields bestBadge{...badgeFields}}
-reactionCounts{type count}deletable currentUserReaction{type}reported reportable source status createdAt updatedAt 
-ignored popular deletedBy{username}notes{content createdAt user{username}}lastEdit{reason timeAgo userId}}fragment 
-userMediumAvatarFields on User{userId isDeletedOrPendingDeletion imageUrls(slot:"default",variations:
-["user_small_avatar"])}fragment userNameFields on User{userId username isUserProfileHidden isDeletedOrPendingDeletion}
-fragment userPersonaFields on User{persona{type text}}fragment badgeFields on Badge{badgeId level{...badgeLevelFields}}
-fragment badgeLevelFields on BadgeLevel{key name description}fragment paginationFields on Pagination{count current last
- next previous size order}
-HEREDOC;
+            query comments($filter:CommentFilter!,$limit:Int,$page:Int){comments(filter:$filter,limit:$limit,page:$page){
+            items{...commentFields}pagination{...paginationFields}}}fragment commentFields on Comment{commentId threadId url 
+            preparedHtmlContent user{...userMediumAvatarFields...userNameFields...userPersonaFields bestBadge{...badgeFields}}
+            reactionCounts{type count}deletable currentUserReaction{type}reported reportable source status createdAt updatedAt 
+            ignored popular deletedBy{username}notes{content createdAt user{username}}lastEdit{reason timeAgo userId}}fragment 
+            userMediumAvatarFields on User{userId isDeletedOrPendingDeletion imageUrls(slot:"default",variations:
+            ["user_small_avatar"])}fragment userNameFields on User{userId username isUserProfileHidden isDeletedOrPendingDeletion}
+            fragment userPersonaFields on User{persona{type text}}fragment badgeFields on Badge{badgeId level{...badgeLevelFields}}
+            fragment badgeLevelFields on BadgeLevel{key name description}fragment paginationFields on Pagination{count current last
+             next previous size order}
+            HEREDOC;
 
         // Construct the JSON object to send to the Website
         $queryArray = [
@@ -215,7 +215,7 @@ HEREDOC;
         // CURL Options
         $opts = [
             CURLOPT_POST => 1,
-            CURLOPT_POSTFIELDS => $queryJSON
+            CURLOPT_POSTFIELDS => $queryJSON,
         ];
         $json = getContents($url, $header, $opts);
         $objects = json_decode($json);
@@ -443,7 +443,7 @@ HEREDOC;
                 'height--all-auto',
                 'imgFrame-img',
                 'img--dummy',
-                'js-lazy-img'
+                'js-lazy-img',
             ]
         );
 
@@ -509,7 +509,7 @@ HEREDOC;
             'September',
             'October',
             'November',
-            'December'
+            'December',
         ];
 
         // A date can be prfixed with some words, we remove theme
@@ -576,7 +576,7 @@ HEREDOC;
             'day',
             'month',
             'year',
-            ''
+            '',
         ];
         $date->modify(str_replace($search, $replace, $str));
         return $date->getTimestamp();

--- a/bridges/PhoronixBridge.php
+++ b/bridges/PhoronixBridge.php
@@ -13,14 +13,14 @@ class PhoronixBridge extends FeedExpander
             'type' => 'number',
             'required' => false,
             'title' => 'Maximum number of items to return',
-            'defaultValue' => 10
+            'defaultValue' => 10,
         ],
         'svgAsImg' => [
             'name' => 'SVG in "image" tag',
             'type' => 'checkbox',
             'title' => 'Some benchmarks are exported as SVG with "object" tag,
 but some RSS readers don\'t support this. "img" tag are supported by most browsers',
-            'defaultValue' => false
+            'defaultValue' => false,
         ],
     ]];
 

--- a/bridges/PicalaBridge.php
+++ b/bridges/PicalaBridge.php
@@ -2,17 +2,17 @@
 
 class PicalaBridge extends BridgeAbstract
 {
-    const TYPES      = [
+    const TYPES = [
         'Actualités' => 'actualites',
-        'Économie'   => 'economie',
-        'Tests'      => 'tests',
-        'Pratique'   => 'pratique',
+        'Économie' => 'economie',
+        'Tests' => 'tests',
+        'Pratique' => 'pratique',
     ];
-    const NAME          = 'Picala Bridge';
-    const URI           = 'https://www.picala.fr';
-    const DESCRIPTION   = 'Dernière nouvelles du média indépendant sur le vélo électrique';
-    const MAINTAINER    = 'Chouchen';
-    const PARAMETERS    = [
+    const NAME = 'Picala Bridge';
+    const URI = 'https://www.picala.fr';
+    const DESCRIPTION = 'Dernière nouvelles du média indépendant sur le vélo électrique';
+    const MAINTAINER = 'Chouchen';
+    const PARAMETERS = [
         [
             'type' => [
                 'name' => 'Type',

--- a/bridges/PickyWallpapersBridge.php
+++ b/bridges/PickyWallpapersBridge.php
@@ -12,22 +12,22 @@ class PickyWallpapersBridge extends BridgeAbstract
         'c' => [
             'name' => 'category',
             'exampleValue' => 'funny',
-            'required' => true
+            'required' => true,
         ],
         's' => [
-            'name' => 'subcategory'
+            'name' => 'subcategory',
         ],
         'm' => [
             'name' => 'Max number of wallpapers',
             'defaultValue' => 12,
-            'type' => 'number'
+            'type' => 'number',
         ],
         'r' => [
             'name' => 'resolution',
             'exampleValue' => '1920x1200, 1680x1050,…',
             'defaultValue' => '1920x1200',
-            'pattern' => '[0-9]{3,4}x[0-9]{3,4}'
-        ]
+            'pattern' => '[0-9]{3,4}x[0-9]{3,4}',
+        ],
     ]];
 
     public function collectData()

--- a/bridges/PicukiBridge.php
+++ b/bridges/PicukiBridge.php
@@ -22,7 +22,7 @@ class PicukiBridge extends BridgeAbstract
                 'exampleValue' => 'beautifulday',
                 'required' => true,
             ],
-        ]
+        ],
     ];
 
     public function getURI()
@@ -72,19 +72,19 @@ class PicukiBridge extends BridgeAbstract
             $imageUrl = $imageUrl . '#.jpg';
 
             $this->items[] = [
-                'uri'        => $url,
-                'author'     => $author,
-                'timestamp'  => date_format($date, 'r'),
-                'title'      => strlen($description) > 60 ? mb_substr($description, 0, 57) . '...' : $description,
-                'thumbnail'  => $imageUrl,
+                'uri' => $url,
+                'author' => $author,
+                'timestamp' => date_format($date, 'r'),
+                'title' => strlen($description) > 60 ? mb_substr($description, 0, 57) . '...' : $description,
+                'thumbnail' => $imageUrl,
                 'enclosures' => [$imageUrl],
-                'content'    => <<<HTML
-<a href="{$url}">
-	<img loading="lazy" src="{$imageUrl}" />
-</a>
-{$videoNote}
-<p>{$description}<p>
-HTML
+                'content' => <<<HTML
+                    <a href="{$url}">
+                    	<img loading="lazy" src="{$imageUrl}" />
+                    </a>
+                    {$videoNote}
+                    <p>{$description}<p>
+                    HTML,
             ];
         }
     }

--- a/bridges/PikabuBridge.php
+++ b/bridges/PikabuBridge.php
@@ -14,7 +14,7 @@ class PikabuBridge extends BridgeAbstract
             'Горячее' => 'hot',
             'Свежее' => 'new',
         ],
-        'defaultValue' => 'hot'
+        'defaultValue' => 'hot',
     ];
 
     const PARAMETERS = [
@@ -22,25 +22,25 @@ class PikabuBridge extends BridgeAbstract
             'tag' => [
                 'name' => 'Тег',
                 'exampleValue' => 'it',
-                'required' => true
+                'required' => true,
             ],
-            'filter' => self::PARAMETERS_FILTER
+            'filter' => self::PARAMETERS_FILTER,
         ],
         'По сообществу' => [
             'community' => [
                 'name' => 'Сообщество',
                 'exampleValue' => 'linux',
-                'required' => true
+                'required' => true,
             ],
-            'filter' => self::PARAMETERS_FILTER
+            'filter' => self::PARAMETERS_FILTER,
         ],
         'По пользователю' => [
             'user' => [
                 'name' => 'Пользователь',
                 'exampleValue' => 'admin',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     protected $title = null;

--- a/bridges/PillowfortBridge.php
+++ b/bridges/PillowfortBridge.php
@@ -11,22 +11,22 @@ class PillowfortBridge extends BridgeAbstract
             'name' => 'Username',
             'type' => 'text',
             'required' => true,
-            'exampleValue'  => 'Staff'
+            'exampleValue' => 'Staff',
         ],
         'noava' => [
             'name' => 'Hide avatar',
             'type' => 'checkbox',
-            'title' => 'Check to hide user avatars.'
+            'title' => 'Check to hide user avatars.',
         ],
         'noreblog' => [
             'name' => 'Hide reblogs',
             'type' => 'checkbox',
-            'title' => 'Check to only show original posts.'
+            'title' => 'Check to only show original posts.',
         ],
         'noretags' => [
             'name' => 'Prefer original tags',
             'type' => 'checkbox',
-            'title' => 'Check to use tags from original post(if available) instead of reblog\'s tags'
+            'title' => 'Check to use tags from original post(if available) instead of reblog\'s tags',
         ],
         'image' => [
             'name' => 'Select image type',
@@ -35,10 +35,10 @@ class PillowfortBridge extends BridgeAbstract
             'values' => [
                 'None' => 'None',
                 'Small' => 'Small',
-                'Full' => 'Full'
+                'Full' => 'Full',
             ],
-            'defaultValue' => 'Full'
-        ]
+            'defaultValue' => 'Full',
+        ],
     ]];
 
     /**
@@ -104,14 +104,14 @@ class PillowfortBridge extends BridgeAbstract
             return '';
         } else {
             return <<<EOD
-<a href="{self::URI}/posts/{$author}">
-<img
-	style="align:top; width:75px; border:1px solid black;"
-	alt="{$author}"
-	src="{$avatar_url}"
-	title="{$title}" />
-</a>
-EOD;
+                <a href="{self::URI}/posts/{$author}">
+                <img
+                	style="align:top; width:75px; border:1px solid black;"
+                	alt="{$author}"
+                	src="{$avatar_url}"
+                	title="{$title}" />
+                </a>
+                EOD;
         }
     }
 
@@ -127,10 +127,10 @@ EOD;
                 foreach ($media as $image) {
                     $imageURL = preg_replace('[ ]', '%20', $image['url']);
                     $text .= <<<EOD
-<a href="{$imageURL}">
-	{$imageURL}
-</a>
-EOD;
+                        <a href="{$imageURL}">
+                        	{$imageURL}
+                        </a>
+                        EOD;
                 }
                 break;
 
@@ -138,13 +138,13 @@ EOD;
                 foreach ($media as $image) {
                     $imageURL = preg_replace('[ ]', '%20', $image['small_image_url']);
                     $text .= <<<EOD
-<a href="{$imageURL}">
-	<img
-		style="align:top; max-width:558px; border:1px solid black;"
-		src="{$imageURL}" 
-	/>
-</a>
-EOD;
+                        <a href="{$imageURL}">
+                        	<img
+                        		style="align:top; max-width:558px; border:1px solid black;"
+                        		src="{$imageURL}" 
+                        	/>
+                        </a>
+                        EOD;
                 }
                 break;
 
@@ -152,13 +152,13 @@ EOD;
                 foreach ($media as $image) {
                     $imageURL = preg_replace('[ ]', '%20', $image['url']);
                     $text .= <<<EOD
-<a href="{$imageURL}">
-	<img
-		style="align:top; max-width:558px; border:1px solid black;"
-		src="{$imageURL}" 
-	/>
-</a>
-EOD;
+                        <a href="{$imageURL}">
+                        	<img
+                        		style="align:top; max-width:558px; border:1px solid black;"
+                        		src="{$imageURL}" 
+                        	/>
+                        </a>
+                        EOD;
                 }
                 break;
 
@@ -214,7 +214,7 @@ EOD;
          */
         $item['categories'] = $post['tags'];
         if ($embPost) {
-            if ($this -> getInput('noretags') || ($post['tags'] == null )) {
+            if ($this -> getInput('noretags') || ($post['tags'] == null)) {
                 $item['categories'] = $post['original_post']['tag_list'];
             }
         }
@@ -227,16 +227,16 @@ EOD;
         $imagesText = $this -> genImagesText($post['media']);
 
         $item['content'] = <<<EOD
-<div style="display: inline-block; vertical-align: top;">
-	{$avatarText}
-</div>
-<div style="display: inline-block; vertical-align: top;">
-	{$post['content']}
-</div>
-<div style="display: block; vertical-align: top;">
-	{$imagesText}
-</div>
-EOD;
+            <div style="display: inline-block; vertical-align: top;">
+            	{$avatarText}
+            </div>
+            <div style="display: inline-block; vertical-align: top;">
+            	{$post['content']}
+            </div>
+            <div style="display: block; vertical-align: top;">
+            	{$imagesText}
+            </div>
+            EOD;
 
         return $item;
     }

--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -12,14 +12,14 @@ class PinterestBridge extends FeedExpander
             'u' => [
                 'name' => 'username',
                 'exampleValue' => 'VIGOIndustries',
-                'required' => true
+                'required' => true,
             ],
             'b' => [
                 'name' => 'board',
                 'exampleValue' => 'bathroom-remodels',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     public function getIcon()

--- a/bridges/PirateCommunityBridge.php
+++ b/bridges/PirateCommunityBridge.php
@@ -13,8 +13,8 @@ class PirateCommunityBridge extends BridgeAbstract
             'type' => 'number',
             'exampleValue' => '12651',
             'title' => 'Topic ID from topic URL. If the URL contains t=12 the ID is 12.',
-            'required' => true
-        ]]];
+            'required' => true,
+        ], ]];
 
     private $feedName = '';
 

--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -14,11 +14,11 @@ class PixivBridge extends BridgeAbstract
             'posts' => [
                 'name' => 'Post Limit',
                 'type' => 'number',
-                'defaultValue' => '10'
+                'defaultValue' => '10',
             ],
             'fullsize' => [
                 'name' => 'Full-size Image',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ],
             'mode' => [
                 'name' => 'Post Type',
@@ -26,23 +26,23 @@ class PixivBridge extends BridgeAbstract
                 'values' => ['All Works' => 'all',
                                   'Illustrations' => 'illustrations/',
                                   'Manga' => 'manga/',
-                                  'Novels' => 'novels/']
+                                  'Novels' => 'novels/', ],
             ],
         ],
         'Tag' => [
             'tag' => [
                 'name' => 'Query to search',
                 'exampleValue' => 'オリジナル',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'User' => [
             'userid' => [
                 'name' => 'User ID from profile URL',
                 'exampleValue' => '11',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     // maps from URLs to json keys by context
@@ -50,13 +50,13 @@ class PixivBridge extends BridgeAbstract
         'Tag' => [
             'illustrations/' => 'illust',
             'manga/' => 'manga',
-            'novels/' => 'novel'
+            'novels/' => 'novel',
         ],
         'User' => [
             'illustrations/' => 'illusts',
             'manga/' => 'manga',
-            'novels/' => 'novels'
-        ]
+            'novels/' => 'novels',
+        ],
     ];
 
     // Hold the username for getName()

--- a/bridges/PokemonTVBridge.php
+++ b/bridges/PokemonTVBridge.php
@@ -26,20 +26,20 @@ class PokemonTVBridge extends BridgeAbstract
                 'Portoguese' => 'br',
                 'Russian' => 'ru',
                 'Spanish' => 'es',
-                'Swedish' => 'se'
+                'Swedish' => 'se',
             ],
-            'defaultValue' => 'English (US)'
+            'defaultValue' => 'English (US)',
         ],
         'filtername' => [
             'name' => 'Series Name Filter',
             'exampleValue' => 'Ultra',
-            'required' => false
+            'required' => false,
         ],
         'filterseason' => [
             'name' => 'Series Season Filter',
             'exampleValue' => '22',
-            'required' => false
-        ]
+            'required' => false,
+        ],
     ]];
 
     public function collectData()

--- a/bridges/PresidenciaPTBridge.php
+++ b/bridges/PresidenciaPTBridge.php
@@ -27,8 +27,8 @@ class PresidenciaPTBridge extends BridgeAbstract
                 'name' => 'Notas Informativas',
                 'type' => 'checkbox',
                 'defaultValue' => 'checked',
-            ]
-        ]
+            ],
+        ],
     ];
 
     const PT_MONTH_NAMES = [
@@ -43,7 +43,7 @@ class PresidenciaPTBridge extends BridgeAbstract
         'setembro',
         'outubro',
         'novembro',
-        'dezembro'];
+        'dezembro', ];
 
     public function getIcon()
     {
@@ -73,7 +73,7 @@ class PresidenciaPTBridge extends BridgeAbstract
                             return ' de ' . $name . ' de ';
                         }, self::PT_MONTH_NAMES),
                         array_map(function ($num) {
-                                return sprintf('-%02d-', $num);
+                            return sprintf('-%02d-', $num);
                         }, range(1, sizeof(self::PT_MONTH_NAMES))),
                         $edt
                     );

--- a/bridges/RadioMelodieBridge.php
+++ b/bridges/RadioMelodieBridge.php
@@ -148,7 +148,7 @@ class RadioMelodieBridge extends BridgeAbstract
             'jeudi',
             'vendredi',
             'samedi',
-            'dimanche'
+            'dimanche',
         ];
 
         // English replacement date text
@@ -171,7 +171,7 @@ class RadioMelodieBridge extends BridgeAbstract
             'thursday',
             'friday',
             'saturday',
-            'sunday'
+            'sunday',
         ];
 
         $dateFormat = 'l j F Y \à H:i';

--- a/bridges/RainbowSixSiegeBridge.php
+++ b/bridges/RainbowSixSiegeBridge.php
@@ -22,7 +22,7 @@ class RainbowSixSiegeBridge extends BridgeAbstract
         $dlUrl = $dlUrl . '&limit=6&mediaFilter=all&skip=0&startIndex=0&tags=BR-rainbow-six%20GA-siege';
         $dlUrl = $dlUrl . '&locale=en-us&fallbackLocale=en-us&environment=master';
         $jsonString = getContents($dlUrl, [
-            'Authorization: ' . self::NIMBUS_API_KEY
+            'Authorization: ' . self::NIMBUS_API_KEY,
         ]);
 
         $json = json_decode($jsonString, true);

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -14,7 +14,7 @@ class RedditBridge extends BridgeAbstract
                 'required' => false,
                 'type' => 'number',
                 'exampleValue' => 100,
-                'title' => 'Filter out posts with lower score'
+                'title' => 'Filter out posts with lower score',
             ],
             'd' => [
                 'name' => 'Sort By',
@@ -24,47 +24,47 @@ class RedditBridge extends BridgeAbstract
                     'Hot' => 'hot',
                     'Relevance' => 'relevance',
                     'New' => 'new',
-                    'Top' => 'top'
+                    'Top' => 'top',
                 ],
-                'defaultValue' => 'Hot'
+                'defaultValue' => 'Hot',
             ],
             'search' => [
                 'name' => 'Keyword search',
                 'required' => false,
                 'exampleValue' => 'cats, dogs',
-                'title' => 'Keyword search, separated by commas'
-            ]
+                'title' => 'Keyword search, separated by commas',
+            ],
         ],
         'single' => [
             'r' => [
                 'name' => 'SubReddit',
                 'required' => true,
                 'exampleValue' => 'selfhosted',
-                'title' => 'SubReddit name'
-            ]
+                'title' => 'SubReddit name',
+            ],
         ],
         'multi' => [
             'rs' => [
                 'name' => 'SubReddits',
                 'required' => true,
                 'exampleValue' => 'selfhosted, php',
-                'title' => 'SubReddit names, separated by commas'
-            ]
+                'title' => 'SubReddit names, separated by commas',
+            ],
         ],
         'user' => [
             'u' => [
                 'name' => 'User',
                 'required' => true,
                 'exampleValue' => 'shwikibot',
-                'title' => 'User name'
+                'title' => 'User name',
             ],
             'comments' => [
                 'type' => 'checkbox',
                 'name' => 'Comments',
                 'title' => 'Whether to return comments',
-                'defaultValue' => false
-            ]
-        ]
+                'defaultValue' => false,
+            ],
+        ],
     ];
 
     public function detectParameters($url)
@@ -79,11 +79,11 @@ class RedditBridge extends BridgeAbstract
 
         if ($path[1] == 'r') {
             return [
-                'r' => $path[2]
+                'r' => $path[2],
             ];
         } elseif ($path[1] == 'user') {
             return [
-                'u' => $path[2]
+                'u' => $path[2],
             ];
         } else {
             return null;
@@ -212,7 +212,7 @@ class RedditBridge extends BridgeAbstract
                         $this->encodePermalink($data->permalink),
                         '<img src="' . $data->url . '" />'
                     );
-                } elseif (isset($data->is_gallery) ? $data->is_gallery : false) {
+                } elseif ($data->is_gallery ?? false) {
                     // Multiple images
 
                     $images = [];

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -2,10 +2,10 @@
 
 class ReporterreBridge extends BridgeAbstract
 {
-        const MAINTAINER = 'nyutag';
-        const NAME = 'Reporterre Bridge';
-        const URI = 'https://www.reporterre.net/';
-        const DESCRIPTION = 'Returns the newest articles.';
+    const MAINTAINER = 'nyutag';
+    const NAME = 'Reporterre Bridge';
+    const URI = 'https://www.reporterre.net/';
+    const DESCRIPTION = 'Returns the newest articles.';
 
     private function extractContent($url)
     {

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -16,7 +16,7 @@ class ReutersBridge extends BridgeAbstract
      */
     const ALLOWED_WIREITEM_TYPES = [
         'story',
-        'headlines'
+        'headlines',
     ];
 
     /**
@@ -24,7 +24,7 @@ class ReutersBridge extends BridgeAbstract
      */
     const ALLOWED_TEMPLATE_TYPES = [
         'story',
-        'headlines'
+        'headlines',
     ];
 
     const PARAMETERS = [
@@ -52,7 +52,7 @@ class ReutersBridge extends BridgeAbstract
                         'UK' => 'chan:61leiu7j',
                         'USA News' => 'us',
                         'The Great Reboot' => '/world/the-great-reboot',
-                        'Reuters Next' => '/world/reuters-next'
+                        'Reuters Next' => '/world/reuters-next',
                     ],
                     'Business' => [
                         'Business' => 'business',
@@ -111,10 +111,10 @@ class ReutersBridge extends BridgeAbstract
                         'Lifestyle' => 'life',
                         'Oddly Enough' => '/lifestyle/oddly-enough',
                         'Science' => 'science',
-                    ]
-                ]
-            ]
-        ]
+                    ],
+                ],
+            ],
+        ],
     ];
 
     const BACKWARD_COMPATIBILITY = [
@@ -140,7 +140,7 @@ class ReutersBridge extends BridgeAbstract
         'chan:abtpk0vm',
         'chan:8ym8q8dl',
         'politics',
-        'wire'
+        'wire',
     ];
 
     /**
@@ -238,7 +238,7 @@ class ReutersBridge extends BridgeAbstract
 
                 if ($is_article_uid) {
                     $query = [
-                        'id' => $endpoint
+                        'id' => $endpoint,
                     ];
                 } else {
                     $query = [
@@ -253,7 +253,7 @@ class ReutersBridge extends BridgeAbstract
             case 'section':
                 if ($this->useWireAPI) {
                     if (strpos($endpoint, 'chan:') !== false) {
-                    // Now checking whether that feed has unique ID or not.
+                        // Now checking whether that feed has unique ID or not.
                         $feed_uri = "/feed/rapp/us/wirefeed/$endpoint";
                     } else {
                         $feed_uri = "/feed/rapp/us/tabbar/feeds/$endpoint";
@@ -263,7 +263,7 @@ class ReutersBridge extends BridgeAbstract
                 $query = [
                     'section_id' => $endpoint,
                     'size' => 30,
-                    'website' => 'reuters'
+                    'website' => 'reuters',
                 ];
 
                 if ($endpoint != '/home') {
@@ -337,7 +337,7 @@ class ReutersBridge extends BridgeAbstract
             'author' => $this->handleAuthorName($authorlist),
             'category' => $category,
             'images' => $this->handleImage($image_list),
-            'published_at' => $published_at
+            'published_at' => $published_at,
         ];
         return $content_detail;
     }
@@ -373,7 +373,7 @@ class ReutersBridge extends BridgeAbstract
             'category' => '',
             'images' => $images,
             'published_at' => '',
-            'status' => 'redirected'
+            'status' => 'redirected',
         ];
     }
 
@@ -469,24 +469,24 @@ class ReutersBridge extends BridgeAbstract
                         case 'instagram':
                             $url = "https://instagram.com/p/$cid/media/?size=l";
                             $embed .= <<<EOD
-<img 
-	src="{$url}"
-	alt="instagram-image-$cid"
->
-EOD;
+                                <img 
+                                	src="{$url}"
+                                	alt="instagram-image-$cid"
+                                >
+                                EOD;
                             break;
                         case 'youtube':
                             $url = "https://www.youtube.com/embed/$cid";
                             $embed .= <<<EOD
-<‌iframe
-	width="560" 
-	height="315" 
-	src="{$url}"
-	frameborder="0" 
-	allowfullscreen
->
-</iframe>
-EOD;
+                                <‌iframe
+                                	width="560" 
+                                	height="315" 
+                                	src="{$url}"
+                                	frameborder="0" 
+                                	allowfullscreen
+                                >
+                                </iframe>
+                                EOD;
                             break;
                     }
                     $description .= $embed;

--- a/bridges/RobinhoodSnacksBridge.php
+++ b/bridges/RobinhoodSnacksBridge.php
@@ -22,7 +22,7 @@ class RobinhoodSnacksBridge extends BridgeAbstract
         'Sec-Fetch-User: ?1',
         'Pragma: no-cache',
         'Cache-Control: no-cache',
-        'TE: trailers'
+        'TE: trailers',
     ];
 
     public function collectData()
@@ -53,7 +53,7 @@ class RobinhoodSnacksBridge extends BridgeAbstract
                 'uri' => $uri,
                 'title' => $title,
                 'timestamp' => $timestamp,
-                'content' => self::getArticleContent($uri)
+                'content' => self::getArticleContent($uri),
             ];
         }
     }

--- a/bridges/RoosterTeethBridge.php
+++ b/bridges/RoosterTeethBridge.php
@@ -24,8 +24,8 @@ class RoosterTeethBridge extends BridgeAbstract
                     'JT Music' => 'jt-music',
                     'Kinda Funny' => 'kinda-funny',
                     'Rooster Teeth' => 'rooster-teeth',
-                    'Sugar Pine 7' => 'sugar-pine-7'
-                ]
+                    'Sugar Pine 7' => 'sugar-pine-7',
+                ],
             ],
             'sort' => [
                 'type' => 'list',
@@ -33,9 +33,9 @@ class RoosterTeethBridge extends BridgeAbstract
                 'title' => 'Select a sort order',
                 'values' => [
                     'Newest -> Oldest' => 'desc',
-                    'Oldest -> Newest' => 'asc'
+                    'Oldest -> Newest' => 'asc',
                 ],
-                'defaultValue' => 'desc'
+                'defaultValue' => 'desc',
             ],
             'first' => [
                 'type' => 'list',
@@ -43,17 +43,17 @@ class RoosterTeethBridge extends BridgeAbstract
                 'title' => 'Select whether to include "First" videos before they are public',
                 'values' => [
                     'True' => true,
-                    'False' => false
-                ]
+                    'False' => false,
+                ],
             ],
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Maximum number of items to return',
-                'defaultValue' => 10
-            ]
-        ]
+                'defaultValue' => 10,
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/RtsBridge.php
+++ b/bridges/RtsBridge.php
@@ -14,8 +14,8 @@ class RtsBridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => 385418,
                 'title' => 'ex. 385418 pour
-				https://www.rts.ch/play/tv/emission/a-bon-entendeur?id=385418'
-            ]
+				https://www.rts.ch/play/tv/emission/a-bon-entendeur?id=385418',
+            ],
         ],
         'ID de la section' => [
             'idSection' => [
@@ -23,9 +23,9 @@ class RtsBridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => 'ce802a54-8877-49cc-acd6-8d244762829b',
                 'title' => 'ex. ce802a54-8877-49cc-acd6-8d244762829b pour
-				https://www.rts.ch/play/tv/detail/humour?id=ce802a54-8877-49cc-acd6-8d244762829b'
-            ]
-        ]
+				https://www.rts.ch/play/tv/detail/humour?id=ce802a54-8877-49cc-acd6-8d244762829b',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/RutubeBridge.php
+++ b/bridges/RutubeBridge.php
@@ -13,7 +13,7 @@ class RutubeBridge extends BridgeAbstract
                 'name' => 'ИД канала',
                 'exampleValue' => 1342940,  // Мятежник Джек
                 'type' => 'number',
-                'required' => true
+                'required' => true,
             ],
         ],
         'По плейлисту' => [
@@ -21,7 +21,7 @@ class RutubeBridge extends BridgeAbstract
                 'name' => 'ИД плейлиста',
                 'exampleValue' => 83641,  // QRUSH
                 'type' => 'number',
-                'required' => true
+                'required' => true,
             ],
         ],
     ];

--- a/bridges/SIMARBridge.php
+++ b/bridges/SIMARBridge.php
@@ -12,8 +12,8 @@ class SIMARBridge extends BridgeAbstract
                 'type' => 'checkbox',
                 'name' => 'Incluir Intervenções?',
                 'defaultValue' => 'checked',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/SchweinfurtBuergerinformationenBridge.php
+++ b/bridges/SchweinfurtBuergerinformationenBridge.php
@@ -17,8 +17,8 @@ class SchweinfurtBuergerinformationenBridge extends BridgeAbstract
                 'title' => 'Specifies the number of pages to fetch. Usually one or two are enough.',
                 'exampleValue' => '1',
                 'defaultValue' => '1',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function getIcon()

--- a/bridges/ScmbBridge.php
+++ b/bridges/ScmbBridge.php
@@ -30,9 +30,9 @@ class ScmbBridge extends BridgeAbstract
 
             // get publication date
             $str_date = $article->find('time', 0)->datetime;
-            list($date, $time) = explode(' ', $str_date);
-            list($y, $m, $d) = explode('-', $date);
-            list($h, $i) = explode(':', $time);
+            [$date, $time] = explode(' ', $str_date);
+            [$y, $m, $d] = explode('-', $date);
+            [$h, $i] = explode(':', $time);
             $timestamp = mktime($h, $i, 0, $m, $d, $y);
             $item['timestamp'] = $timestamp;
 

--- a/bridges/ScoopItBridge.php
+++ b/bridges/ScoopItBridge.php
@@ -12,8 +12,8 @@ class ScoopItBridge extends BridgeAbstract
         'u' => [
             'name' => 'keyword',
             'exampleValue' => 'docker',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     public function collectData()

--- a/bridges/ScribdBridge.php
+++ b/bridges/ScribdBridge.php
@@ -12,7 +12,7 @@ class ScribdBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'title' => 'Profile URL. Example: https://www.scribd.com/user/164147088/Ars-Technica',
-            'exampleValue' => 'https://www.scribd.com/user/164147088/Ars-Technica'
+            'exampleValue' => 'https://www.scribd.com/user/164147088/Ars-Technica',
         ],
     ]];
 
@@ -45,8 +45,8 @@ class ScribdBridge extends BridgeAbstract
             }
 
             $item['content'] = <<<EOD
-<p>{$description}<p><p><img src="{$image}"></p>
-EOD;
+                <p>{$description}<p><p><img src="{$image}"></p>
+                EOD;
 
             $item['enclosures'][] = $image;
 

--- a/bridges/SensCritiqueBridge.php
+++ b/bridges/SensCritiqueBridge.php
@@ -12,24 +12,24 @@ class SensCritiqueBridge extends BridgeAbstract
         's' => [
             'name' => 'Series',
             'type' => 'checkbox',
-            'defaultValue' => 'checked'
+            'defaultValue' => 'checked',
         ],
         'g' => [
             'name' => 'Video Games',
-            'type' => 'checkbox'
+            'type' => 'checkbox',
         ],
         'b' => [
             'name' => 'Books',
-            'type' => 'checkbox'
+            'type' => 'checkbox',
         ],
         'bd' => [
             'name' => 'BD',
-            'type' => 'checkbox'
+            'type' => 'checkbox',
         ],
         'mu' => [
             'name' => 'Music',
-            'type' => 'checkbox'
-        ]
+            'type' => 'checkbox',
+        ],
     ]];
 
     public function collectData()

--- a/bridges/SeznamZpravyBridge.php
+++ b/bridges/SeznamZpravyBridge.php
@@ -14,9 +14,9 @@ class SeznamZpravyBridge extends BridgeAbstract
                 'required' => true,
                 'title' => 'The dash-separated author string, as shown in the URL bar.',
                 'pattern' => '[a-z]+-[a-z]+-[0-9]+',
-                'exampleValue' => 'radek-nohl-1'
+                'exampleValue' => 'radek-nohl-1',
             ],
-        ]
+        ],
     ];
 
     private $feedName;
@@ -43,7 +43,7 @@ class SeznamZpravyBridge extends BridgeAbstract
                 'articleTime' => 'span.mol-formatted-date__time',
                 'articleContent' => 'div[data-dot=ogm-article-content]',
                 'articleImage' => 'div[data-dot=ogm-main-media] img',
-                'articleParagraphs' => 'div[data-dot=mol-paragraph]'
+                'articleParagraphs' => 'div[data-dot=mol-paragraph]',
                 ];
 
                 $html = getSimpleHTMLDOMCached($url . $this->getInput('author'), $ONE_DAY);
@@ -115,7 +115,7 @@ class SeznamZpravyBridge extends BridgeAbstract
                     'timestamp' => strtotime($articleDMY . ' ' . $articleTime),
                     'author' => $author,
                     'content' => $contentText,
-                    'categories' => $categories
+                    'categories' => $categories,
                     ];
                     if (isset($articleImageElem)) {
                         $item['enclosures'] = ['https:' . $articleImageElem->src];

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -33,7 +33,7 @@ class ShanaprojectBridge extends BridgeAbstract
 
     public function getURI()
     {
-        return isset($this->uri) ? $this->uri : parent::getURI();
+        return $this->uri ?? parent::getURI();
     }
 
     public function collectData()
@@ -47,11 +47,11 @@ class ShanaprojectBridge extends BridgeAbstract
         $min_total_episodes = $this->getInput('min_total_episodes') ?: 0;
 
         foreach ($animes as $anime) {
-            list(
+            [
                 $episodes_released,
                 /* of */,
                 $episodes_total
-            ) = explode(' ', $this->extractAnimeEpisodeInformation($anime));
+            ] = explode(' ', $this->extractAnimeEpisodeInformation($anime));
 
             // Skip if not enough episodes yet
             if ($episodes_released < $min_episodes) {

--- a/bridges/SkimfeedBridge.php
+++ b/bridges/SkimfeedBridge.php
@@ -59,8 +59,8 @@ class SkimfeedBridge extends BridgeAbstract
                     'Venture Beat' => '/news/venture-beat.html',
                     'ReadWriteWeb' => '/news/readwriteweb.html',
                     'High Scalability' => '/news/high-scalability.html',
-                ]
-            ]
+                ],
+            ],
         ],
         self::CONTEXT_HOT_TOPICS => [],
         self::CONTEXT_TECH_NEWS => [ // auto-generated (see below)
@@ -394,7 +394,7 @@ class SkimfeedBridge extends BridgeAbstract
                         'Austin Evans' => '/news/austin-evans.html',
                         'NCIX' => '/news/ncix.html',
                     ],
-                ]
+                ],
             ],
         ],
         self::CONTEXT_CUSTOM => [
@@ -403,17 +403,17 @@ class SkimfeedBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Enter feed numbers from Skimfeed! e.g: 5,8,2,l,p,9,23',
-                'exampleValue' => '5'
-            ]
+                'exampleValue' => '5',
+            ],
         ],
         'global' => [
             'limit' => [
                 'name' => 'Limit',
                 'type' => 'number',
                 'title' => 'Limits the number of returned items in the feed',
-                'exampleValue' => 10
-            ]
-        ]
+                'exampleValue' => 10,
+            ],
+        ],
     ];
 
     public function getURI()
@@ -630,7 +630,7 @@ class SkimfeedBridge extends BridgeAbstract
                 or returnServerError('Could not find box anchor!');
 
             $author = '<a href="' . $anchor->href . '">' . trim($anchor->plaintext) . '</a>';
-            $uri    = $anchor->href;
+            $uri = $anchor->href;
 
             $box_html = getSimpleHTMLDOM($uri)
                 or returnServerError('Could not load custom feed!');
@@ -646,7 +646,7 @@ class SkimfeedBridge extends BridgeAbstract
         $query = parse_url($anchor->href, PHP_URL_QUERY);
 
         foreach (explode('&', $query) as $parameter) {
-            list($key, $value) = explode('=', $parameter);
+            [$key, $value] = explode('=', $parameter);
 
             if ($key !== 'u') {
                 continue;
@@ -676,21 +676,21 @@ class SkimfeedBridge extends BridgeAbstract
 
         // begin of 'channel' list
         $message = <<<EOD
-'box_channel' => array(
-	'name' => 'Channel',
-	'type' => 'list',
-	'required' => true,
-	'title' => 'Select your channel',
-	'values' => array(
+            'box_channel' => array(
+            	'name' => 'Channel',
+            	'type' => 'list',
+            	'required' => true,
+            	'title' => 'Select your channel',
+            	'values' => array(
 
-EOD;
+            EOD;
 
         foreach ($boxes as $box) {
             $anchor = $box->find('span.boxtitles a', 0)
                 or returnServerError('Could not find box anchor!');
 
-            $title  = trim($anchor->plaintext);
-            $uri    = $anchor->href;
+            $title = trim($anchor->plaintext);
+            $uri = $anchor->href;
 
             // add value
             $message .= "\t\t'{$title}' => '{$uri}', \n";
@@ -698,19 +698,19 @@ EOD;
 
         // end of 'box' list
         $message .= <<<EOD
-	)
-),
-EOD;
+            	)
+            ),
+            EOD;
 
         echo <<<EOD
-<!DOCTYPE html>
+            <!DOCTYPE html>
 
-<html>
-	<body>
-		<code style="white-space: pre-wrap;">{$message}</code>
-	</body>
-</html>
-EOD;
+            <html>
+            	<body>
+            		<code style="white-space: pre-wrap;">{$message}</code>
+            	</body>
+            </html>
+            EOD;
     }
 
     /**
@@ -733,14 +733,14 @@ EOD;
 
         // begin of 'tech_channel' list
         $message = <<<EOD
-'tech_channel' => array(
-	'name' => 'Tech channel',
-	'type' => 'list',
-	'required' => true,
-	'title' => 'Select your tech channel',
-	'values' => array(
+            'tech_channel' => array(
+            	'name' => 'Tech channel',
+            	'type' => 'list',
+            	'required' => true,
+            	'title' => 'Select your tech channel',
+            	'values' => array(
 
-EOD;
+            EOD;
 
         foreach ($channels as $channel) {
             if (
@@ -753,8 +753,8 @@ EOD;
                 continue;
             }
 
-            $title  = trim($channel->plaintext);
-            $uri    = '/' . $channel->href;
+            $title = trim($channel->plaintext);
+            $uri = '/' . $channel->href;
 
             $message .= "\t\t'{$title}' => array(\n";
 
@@ -768,8 +768,8 @@ EOD;
                 $anchor = $box->find('span.boxtitles a', 0)
                     or returnServerError('Could not find box anchor!');
 
-                $boxtitle   = trim($anchor->plaintext);
-                $boxuri     = $anchor->href;
+                $boxtitle = trim($anchor->plaintext);
+                $boxuri = $anchor->href;
 
                 $message .= "\t\t\t'{$boxtitle}' => '{$boxuri}', \n";
             }
@@ -779,19 +779,19 @@ EOD;
 
         // end of 'box' list
         $message .= <<<EOD
-	)
-),
-EOD;
+            	)
+            ),
+            EOD;
 
         echo <<<EOD
-<!DOCTYPE html>
+            <!DOCTYPE html>
 
-<html>
-	<body>
-		<code style="white-space: pre-wrap;">{$message}</code>
-	</body>
-</html>
-EOD;
+            <html>
+            	<body>
+            		<code style="white-space: pre-wrap;">{$message}</code>
+            	</body>
+            </html>
+            EOD;
     }
 
     /**

--- a/bridges/SlusheBridge.php
+++ b/bridges/SlusheBridge.php
@@ -13,8 +13,8 @@ class SlusheBridge extends BridgeAbstract
                 'name' => 'Artist name',
                 'required' => true,
                 'exampleValue' => 'lexx228',
-                'title' => 'Enter an artist name'
-            ]
+                'title' => 'Enter an artist name',
+            ],
         ],
         'Category' => [
             'category' => [
@@ -50,18 +50,18 @@ class SlusheBridge extends BridgeAbstract
                     'Solo' => '66',
                     'Threesome' => '38',
                     'TV & Film Fan Art' => '34',
-                    'Western Fan Art' => '33'
-                ]
-            ]
+                    'Western Fan Art' => '33',
+                ],
+            ],
         ],
         'Search' => [
             'search_term' => [
                 'name' => 'Search term(s)',
                 'required' => true,
                 'exampleValue' => 'pole dance',
-                'title' => 'Enter one or more search terms, separated by spaces'
-            ]
-        ]
+                'title' => 'Enter one or more search terms, separated by spaces',
+            ],
+        ],
     ];
 
     public function getName()
@@ -107,12 +107,12 @@ class SlusheBridge extends BridgeAbstract
             'sec-fetch-mode: navigate',
             'sec-fetch-site: same-origin',
             'sec-fetch-user: ?1',
-            'upgrade-insecure-requests: 1'
+            'upgrade-insecure-requests: 1',
         ];
         // Add user-agent string to headers with implode, due to line length limit
         $user_agent_string = [
             'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/',
-            '537.36(KHTML, like Gecko) Chrome/100.0.4896.147 Safari/537.36'
+            '537.36(KHTML, like Gecko) Chrome/100.0.4896.147 Safari/537.36',
         ];
         $headers[] = implode('', $user_agent_string);
 

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -12,7 +12,7 @@ class SoundCloudBridge extends BridgeAbstract
         'u' => [
             'name' => 'username',
             'exampleValue' => 'thekidlaroi',
-            'required' => true
+            'required' => true,
         ],
         't' => [
             'name' => 'Content',
@@ -24,9 +24,9 @@ class SoundCloudBridge extends BridgeAbstract
                 'Albums' => 'albums',
                 'Playlists' => 'playlists',
                 'Reposts' => 'reposts',
-                'Likes' => 'likes'
-            ]
-        ]
+                'Likes' => 'likes',
+            ],
+        ],
     ]];
 
     private $apiUrl = 'https://api-v2.soundcloud.com/';
@@ -66,16 +66,16 @@ class SoundCloudBridge extends BridgeAbstract
             $description = nl2br($apiItem->description);
 
             $item['content'] = <<<HTML
-				<p>{$description}</p>
-HTML;
+                				<p>{$description}</p>
+                HTML;
 
             if (isset($apiItem->tracks) && $apiItem->track_count > 0) {
                 $list = $this->getTrackList($apiItem->tracks);
 
                 $item['content'] .= <<<HTML
-					<p><strong>Tracks ({$apiItem->track_count})</strong></p>
-					{$list}
-HTML;
+                    					<p><strong>Tracks ({$apiItem->track_count})</strong></p>
+                    					{$list}
+                    HTML;
             }
 
             $item['enclosures'][] = $apiItem->artwork_url;
@@ -241,13 +241,13 @@ HTML;
         $list = '';
         foreach ($apiItems as $track) {
             $list .= <<<HTML
-				<li>{$track->user->username} — <a href="{$track->permalink_url}">{$track->title}</a></li>
-HTML;
+                				<li>{$track->user->username} — <a href="{$track->permalink_url}">{$track->title}</a></li>
+                HTML;
         }
 
         $html = <<<HTML
-			<ul>{$list}</ul>
-HTML;
+            			<ul>{$list}</ul>
+            HTML;
 
         return $html;
     }

--- a/bridges/SplCenterBridge.php
+++ b/bridges/SplCenterBridge.php
@@ -15,8 +15,8 @@ class SplCenterBridge extends FeedExpander
                     'Hatewatch' => 'hatewatch',
                 ],
                 'defaultValue' => 'news',
-            ]
-        ]
+            ],
+        ],
     ];
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/SpotifyBridge.php
+++ b/bridges/SpotifyBridge.php
@@ -11,12 +11,12 @@ class SpotifyBridge extends BridgeAbstract
         'clientid' => [
             'name' => 'Client ID',
             'type' => 'text',
-            'required' => true
+            'required' => true,
         ],
         'clientsecret' => [
             'name' => 'Client secret',
             'type' => 'text',
-            'required' => true
+            'required' => true,
         ],
         'spotifyuri' => [
             'name' => 'Spotify URIs',
@@ -29,15 +29,15 @@ class SpotifyBridge extends BridgeAbstract
             'type' => 'text',
             'required' => false,
             'exampleValue' => 'album,single,appears_on,compilation',
-            'defaultValue' => 'album,single'
+            'defaultValue' => 'album,single',
         ],
         'country' => [
             'name' => 'Country',
             'type' => 'text',
             'required' => false,
             'exampleValue' => 'US',
-            'defaultValue' => 'US'
-        ]
+            'defaultValue' => 'US',
+        ],
     ]];
 
     const TOKENURI = 'https://accounts.spotify.com/api/token';
@@ -188,7 +188,7 @@ class SpotifyBridge extends BridgeAbstract
         curl_setopt($curl, CURLOPT_HTTPHEADER, ['Authorization: Basic '
             . base64_encode($this->getInput('clientid')
             . ':'
-            . $this->getInput('clientsecret'))]);
+            . $this->getInput('clientsecret')), ]);
 
         $json = curl_exec($curl);
         $json = json_decode($json)->access_token;
@@ -205,7 +205,7 @@ class SpotifyBridge extends BridgeAbstract
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_HTTPHEADER, ['Authorization: Bearer '
-            . $this->token]);
+            . $this->token, ]);
 
         Debug::log('Fetching content from ' . $url);
         $json = curl_exec($curl);

--- a/bridges/SpottschauBridge.php
+++ b/bridges/SpottschauBridge.php
@@ -34,9 +34,9 @@ class SpottschauBridge extends BridgeAbstract
         $imageAlt = $image->attr['alt'];
 
         $item['content'] = <<<EOD
-<img src="{$imageUrl}" alt="{$imageAlt}"/>
-<br/>
-EOD;
+            <img src="{$imageUrl}" alt="{$imageAlt}"/>
+            <br/>
+            EOD;
         $this->items[] = $item;
     }
 }

--- a/bridges/StanfordSIRbookreviewBridge.php
+++ b/bridges/StanfordSIRbookreviewBridge.php
@@ -14,9 +14,9 @@ class StanfordSIRbookreviewBridge extends BridgeAbstract
                 'values' => [
                     'reviews' => 'reviews',
                     'excerpts' => 'excerpts',
-                ]
-             ]
-        ]
+                ],
+             ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/SteamBridge.php
+++ b/bridges/SteamBridge.php
@@ -19,8 +19,8 @@ class SteamBridge extends BridgeAbstract
             'only_discount' => [
                 'name' => 'Only discount',
                 'type' => 'checkbox',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/SteamCommunityBridge.php
+++ b/bridges/SteamCommunityBridge.php
@@ -13,7 +13,7 @@ class SteamCommunityBridge extends BridgeAbstract
             'i' => [
                 'name' => 'App ID',
                 'exampleValue' => '730',
-                'required' => true
+                'required' => true,
             ],
             'category' => [
                 'name' => 'category',
@@ -24,10 +24,10 @@ class SteamCommunityBridge extends BridgeAbstract
                     'Artwork' => 'images',
                     'Screenshots' => 'screenshots',
                     'Videos' => 'videos',
-                    'Workshop' => 'workshop'
-                ]
-            ]
-        ]
+                    'Workshop' => 'workshop',
+                ],
+            ],
+        ],
     ];
 
     public function getIcon()

--- a/bridges/StockFilingsBridge.php
+++ b/bridges/StockFilingsBridge.php
@@ -13,13 +13,13 @@ class StockFilingsBridge extends FeedExpander
     const PARAMETERS = [
         [
         'ticker' => [
-            'name'          => 'cik',
-            'required'      => true,
-            'exampleValue'  => 'AMD',
+            'name' => 'cik',
+            'required' => true,
+            'exampleValue' => 'AMD',
             // https://stackoverflow.com/a/12827734
-            'pattern'       => '[A-Za-z0-9]+',
+            'pattern' => '[A-Za-z0-9]+',
         ],
-        ]];
+        ], ];
 
     public function getIcon()
     {

--- a/bridges/SummitsOnTheAirBridge.php
+++ b/bridges/SummitsOnTheAirBridge.php
@@ -13,9 +13,9 @@ class SummitsOnTheAirBridge extends BridgeAbstract
             'c' => [
                 'name' => 'count',
                 'required' => true,
-                'defaultValue' => 10
-            ]
-        ]
+                'defaultValue' => 10,
+            ],
+        ],
     ];
 
     public function collectData()
@@ -33,18 +33,18 @@ class SummitsOnTheAirBridge extends BridgeAbstract
                 $spot['frequency'] . ' MHz';
 
             $content = <<<EOL
-			<a href="http://summits.sota.org.uk/summit/{$summit}">
-			{$summit}, {$spot['summitDetails']}</a><br />
-			Frequency: {$spot['frequency']} MHz<br />
-			Mode: {$spot['mode']}<br />
-			Comments: {$spot['comments']}
-EOL;
+                			<a href="http://summits.sota.org.uk/summit/{$summit}">
+                			{$summit}, {$spot['summitDetails']}</a><br />
+                			Frequency: {$spot['frequency']} MHz<br />
+                			Mode: {$spot['mode']}<br />
+                			Comments: {$spot['comments']}
+                EOL;
 
             $this->items[] = [
                 'uri' => 'https://sotawatch.sota.org.uk/en/',
                 'title' => $title,
                 'content' => $content,
-                'timestamp' => $spot['timeStamp']
+                'timestamp' => $spot['timeStamp'],
             ];
         }
     }

--- a/bridges/TebeoBridge.php
+++ b/bridges/TebeoBridge.php
@@ -18,9 +18,9 @@ class TebeoBridge extends FeedExpander
                 'Sport' => '/3-sport',
                 'Culture-Loisirs' => '/5-culture-loisirs',
                 'Société' => '/15-societe',
-                'Langue Bretonne' => '/9-langue-bretonne'
-            ]
-        ]
+                'Langue Bretonne' => '/9-langue-bretonne',
+            ],
+        ],
     ]];
 
     public function getIcon()

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -12,8 +12,8 @@ class TelegramBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => '@rssbridge',
-            ]
-        ]
+            ],
+        ],
     ];
     const TEST_DETECT_PARAMETERS = [
         'https://t.me/s/durov' => ['username' => 'durov'],
@@ -179,10 +179,10 @@ class TelegramBridge extends BridgeAbstract
         }
 
         return <<<EOD
-<blockquote>{$author}<br>
-{$text}
-<a href="{$reply->href}">{$reply->href}</a></blockquote><hr>
-EOD;
+            <blockquote>{$author}<br>
+            {$text}
+            <a href="{$reply->href}">{$reply->href}</a></blockquote><hr>
+            EOD;
     }
 
     private function processSticker($messageDiv)
@@ -200,8 +200,8 @@ EOD;
             return $stickerDiv;
         } elseif (preg_match($this->backgroundImageRegex, $stickerDiv->find('i', 0)->style, $sticker)) {
             return <<<EOD
-				<a href="{$stickerDiv->children(0)->herf}"><img src="{$sticker[1]}"></a>
-EOD;
+                				<a href="{$stickerDiv->children(0)->herf}"><img src="{$sticker[1]}"></a>
+                EOD;
         }
     }
 
@@ -225,8 +225,8 @@ EOD;
         $pollOptions .= '</ul>';
 
         return <<<EOD
-			{$title}<br><small>$type</small><br>{$pollOptions}
-EOD;
+            			{$title}<br><small>$type</small><br>{$pollOptions}
+            EOD;
     }
 
     private function processLinkPreview($messageDiv)
@@ -262,9 +262,9 @@ EOD;
         }
 
         return <<<EOD
-<blockquote><a href="{$preview->href}">{$image}</a><br><a href="{$preview->href}">
-{$title} - {$site}</a><br>{$description}</blockquote>
-EOD;
+            <blockquote><a href="{$preview->href}">{$image}</a><br><a href="{$preview->href}">
+            {$title} - {$site}</a><br>{$description}</blockquote>
+            EOD;
     }
 
     private function processVideo($messageDiv)
@@ -282,10 +282,10 @@ EOD;
         $this->enclosures[] = $photo[1];
 
         return <<<EOD
-<video controls="" poster="{$photo[1]}" style="max-width:100%;" preload="none">
-	<source src="{$messageDiv->find('video', 0)->src}" type="video/mp4">
-</video>
-EOD;
+            <video controls="" poster="{$photo[1]}" style="max-width:100%;" preload="none">
+            	<source src="{$messageDiv->find('video', 0)->src}" type="video/mp4">
+            </video>
+            EOD;
     }
 
     private function processPhoto($messageDiv)
@@ -300,8 +300,8 @@ EOD;
             preg_match($this->backgroundImageRegex, $photoWrap->style, $photo);
 
             $photos .= <<<EOD
-<a href="{$photoWrap->href}"><img src="{$photo[1]}"/></a><br>
-EOD;
+                <a href="{$photoWrap->href}"><img src="{$photo[1]}"/></a><br>
+                EOD;
         }
         return $photos;
     }
@@ -319,11 +319,11 @@ EOD;
         }
 
         return <<<EOD
-<a href="{$messageDiv->find('a.not_supported', 0)->href}">
-{$messageDiv->find('div.message_media_not_supported_label', 0)->innertext}<br><br>
-{$messageDiv->find('span.message_media_view_in_telegram', 0)->innertext}<br><br>
-<img src="{$photo[1]}"/></a>
-EOD;
+            <a href="{$messageDiv->find('a.not_supported', 0)->href}">
+            {$messageDiv->find('div.message_media_not_supported_label', 0)->innertext}<br><br>
+            {$messageDiv->find('span.message_media_view_in_telegram', 0)->innertext}<br><br>
+            <img src="{$photo[1]}"/></a>
+            EOD;
     }
 
     private function processAttachment($messageDiv)
@@ -336,9 +336,9 @@ EOD;
 
         foreach ($messageDiv->find('div.tgme_widget_message_document') as $document) {
             $attachments .= <<<EOD
-{$document->find('div.tgme_widget_message_document_title', 0)->plaintext} -
-{$document->find('div.tgme_widget_message_document_extra', 0)->plaintext}<br>
-EOD;
+                {$document->find('div.tgme_widget_message_document_title', 0)->plaintext} -
+                {$document->find('div.tgme_widget_message_document_extra', 0)->plaintext}<br>
+                EOD;
         }
 
         return $attachments;
@@ -355,8 +355,8 @@ EOD;
         $link = $messageDiv->find('a.tgme_widget_message_location_wrap', 0)->href;
 
         return <<<EOD
-			<a href="{$link}"><img src="{$image[1]}"></a>
-EOD;
+            			<a href="{$link}"><img src="{$image[1]}"></a>
+            EOD;
     }
 
     private function ellipsisTitle($text)

--- a/bridges/TheFarSideBridge.php
+++ b/bridges/TheFarSideBridge.php
@@ -39,12 +39,12 @@ class TheFarSideBridge extends BridgeAbstract
             }
 
             $item['content'] .= <<<EOD
-<figure>
-	<img title="{$caption}" src="data:image/jpeg;base64,{$imageBase64}"/>
-	<figcaption>{$caption}</figcaption>
-</figure>
-<br/>
-EOD;
+                <figure>
+                	<img title="{$caption}" src="data:image/jpeg;base64,{$imageBase64}"/>
+                	<figcaption>{$caption}</figcaption>
+                </figure>
+                <br/>
+                EOD;
         }
 
         $this->items[] = $item;

--- a/bridges/TheGuardianBridge.php
+++ b/bridges/TheGuardianBridge.php
@@ -22,9 +22,9 @@ class TheGuardianBridge extends FeedExpander
                 'Opinion' => '/uk/commentisfree/rss',
                 'Lifestyle' => '/uk/lifeandstyle/rss',
                 'Culture' => '/uk/culture/rss',
-                'Sports' => '/uk/sport/rss'
-            ]
-        ]
+                'Sports' => '/uk/sport/rss',
+            ],
+        ],
 
         /*
 
@@ -84,7 +84,7 @@ class TheGuardianBridge extends FeedExpander
             '.element-atom',
             '.submeta',
             'youtube-media-atom',
-            'svg'
+            'svg',
         ];
 
         // Remove the listed crap

--- a/bridges/TheHackerNewsBridge.php
+++ b/bridges/TheHackerNewsBridge.php
@@ -35,7 +35,7 @@ class TheHackerNewsBridge extends BridgeAbstract
                             $element->find('img[data-echo]', 0)->outertext,
                             "data-echo='",
                             "'"
-                        )
+                        ),
                     ];
                 } else {
                     $article_thumbnail = [];

--- a/bridges/ThePirateBayBridge.php
+++ b/bridges/ThePirateBayBridge.php
@@ -17,7 +17,7 @@ class ThePirateBayBridge extends BridgeAbstract
         'q' => [
             'name' => 'keywords/username/category, separated by semicolons',
             'exampleValue' => 'simpsons',
-            'required' => true
+            'required' => true,
         ],
         'crit' => [
             'type' => 'list',
@@ -26,7 +26,7 @@ class ThePirateBayBridge extends BridgeAbstract
                 'search' => 'search',
                 'category' => 'cat',
                 'user' => 'usr',
-            ]
+            ],
         ],
         'catCheck' => [
             'type' => 'checkbox',
@@ -34,7 +34,7 @@ class ThePirateBayBridge extends BridgeAbstract
         ],
         'cat' => [
             'name' => 'Category number',
-            'exampleValue' => '100, 200… See TPB for category number'
+            'exampleValue' => '100, 200… See TPB for category number',
         ],
         'trusted' => [
             'type' => 'checkbox',
@@ -187,7 +187,7 @@ class ThePirateBayBridge extends BridgeAbstract
         $item['timestamp'] = $torrent->added;
         $item['author'] = $torrent->username;
 
-        $content  = '<b>Type:</b> '
+        $content = '<b>Type:</b> '
             . $this->renderCategory($torrent->category) . '<br>';
         $content .= "<b>Files:</b> $torrent->num_files<br>";
         $content .= '<b>Size:</b> ' . $this->renderSize($torrent->size) . '<br><br>';
@@ -206,11 +206,11 @@ class ThePirateBayBridge extends BridgeAbstract
         }
 
         $html = <<<HTML
-<a href="%s">
-	<img src="%s/images/icon-magnet.gif"> GET THIS TORRENT
-</a>
-<br>
-HTML;
+            <a href="%s">
+            	<img src="%s/images/icon-magnet.gif"> GET THIS TORRENT
+            </a>
+            <br>
+            HTML;
         $content .= sprintf($html, $magnetLink, self::STATIC_SERVER);
 
         $item['content'] = $content;

--- a/bridges/TheYeteeBridge.php
+++ b/bridges/TheYeteeBridge.php
@@ -14,26 +14,26 @@ class TheYeteeBridge extends BridgeAbstract
 
         $div = $html->find('.module_timed-item.is--full');
         foreach ($div as $element) {
-                $item = [];
-                $item['enclosures'] = [];
+            $item = [];
+            $item['enclosures'] = [];
 
-                $title = $element->find('h2', 0)->plaintext;
-                $item['title'] = $title;
+            $title = $element->find('h2', 0)->plaintext;
+            $item['title'] = $title;
 
-                $author = trim($element->find('.module_timed-item--artist a', 0)->plaintext);
-                $item['author'] = $author;
+            $author = trim($element->find('.module_timed-item--artist a', 0)->plaintext);
+            $item['author'] = $author;
 
-                $item['uri'] = static::URI;
+            $item['uri'] = static::URI;
 
-                $content = '<p>' . $title . ' by ' . $author . '</p>';
-                $photos = $element->find('a.img');
+            $content = '<p>' . $title . ' by ' . $author . '</p>';
+            $photos = $element->find('a.img');
             foreach ($photos as $photo) {
                 $content = $content . "<br /><img src='$photo->href' />";
                 $item['enclosures'][] = $photo->src;
             }
-                $item['content'] = $content;
+            $item['content'] = $content;
 
-                $this->items[] = $item;
+            $this->items[] = $item;
         }
     }
 }

--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -13,13 +13,13 @@ class TikTokBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'exampleValue' => '@tiktok',
-        ]
-        ]];
+        ],
+        ], ];
 
     const TEST_DETECT_PARAMETERS = [
         'https://www.tiktok.com/@tiktok' => [
-            'context' => 'By user', 'username' => '@tiktok'
-        ]
+            'context' => 'By user', 'username' => '@tiktok',
+        ],
     ];
 
     const CACHE_TIMEOUT = 900; // 15 minutes
@@ -31,7 +31,7 @@ class TikTokBridge extends BridgeAbstract
         if (preg_match('/tiktok\.com\/(@[\w]+)/', $url, $matches) > 0) {
             return [
                 'context' => 'By user',
-                'username' => $matches[1]
+                'username' => $matches[1],
             ];
         }
 
@@ -56,9 +56,9 @@ class TikTokBridge extends BridgeAbstract
             $item['enclosures'][] = $image;
 
             $item['content'] = <<<EOD
-<a href="{$link}"><img src="{$image}"/></a>
-<p>{$views} views<p>
-EOD;
+                <a href="{$link}"><img src="{$image}"/></a>
+                <p>{$views} views<p>
+                EOD;
 
             $this->items[] = $item;
         }

--- a/bridges/TinyLetterBridge.php
+++ b/bridges/TinyLetterBridge.php
@@ -12,8 +12,8 @@ class TinyLetterBridge extends BridgeAbstract
                 'name' => 'User Name',
                 'required' => true,
                 'exampleValue' => 'forwards',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function getName()

--- a/bridges/TorrentGalaxyBridge.php
+++ b/bridges/TorrentGalaxyBridge.php
@@ -14,7 +14,7 @@ class TorrentGalaxyBridge extends BridgeAbstract
                 'name' => 'search',
                 'required' => true,
                 'exampleValue' => 'simpsons',
-                'title' => 'Type your query'
+                'title' => 'Type your query',
             ],
             'lang' => [
                 'name' => 'language',
@@ -45,10 +45,10 @@ class TorrentGalaxyBridge extends BridgeAbstract
                     'Urdu' => '20',
                     'Arabic' => '21',
                     'Swedish' => '22',
-                    'Romanian' => '23'
-                ]
-            ]
-        ]
+                    'Romanian' => '23',
+                ],
+            ],
+        ],
     ];
 
     public function collectData()
@@ -77,15 +77,15 @@ class TorrentGalaxyBridge extends BridgeAbstract
 
             $item['author'] = $authorid->plaintext;
             $item['content'] = <<<HTML
-<h1>{$identity->plaintext}</h1>
-<h2>Links</h2>
-<p><a href="{$glxlinks->find('a', 1)->href}" title="magnet link">magnet</a></p>
-<p><a href="{$glxlinks->find('a', 0)->href}" title="torrent link">torrent</a></p>
-<h2>Infos</h2>
-<p>Size: {$result->find('div.tgxtablecell', 7)->plaintext}</p>
-<p>Added by: <a href="{$authorid->href}" title="author profile">{$authorid->plaintext}</a></p>
-<p>Upload time: {$creadate}</p>
-HTML;
+                <h1>{$identity->plaintext}</h1>
+                <h2>Links</h2>
+                <p><a href="{$glxlinks->find('a', 1)->href}" title="magnet link">magnet</a></p>
+                <p><a href="{$glxlinks->find('a', 0)->href}" title="torrent link">torrent</a></p>
+                <h2>Infos</h2>
+                <p>Size: {$result->find('div.tgxtablecell', 7)->plaintext}</p>
+                <p>Added by: <a href="{$authorid->href}" title="author profile">{$authorid->plaintext}</a></p>
+                <p>Upload time: {$creadate}</p>
+                HTML;
             $item['enclosures'] = [$glxlinks->find('a', 0)->href];
             $item['categories'] = [$result->find('div.tgxtablecell', 0)->plaintext];
             if (preg_match('#/torrent/([^/]+)/#', self::URI . $identity->href, $torrentid)) {

--- a/bridges/TrelloBridge.php
+++ b/bridges/TrelloBridge.php
@@ -13,17 +13,17 @@ class TrelloBridge extends BridgeAbstract
                 'name' => 'Board ID',
                 'required' => true,
                 'exampleValue' => 'g9mdhdzg',
-                'title' => 'Taken from Trello URL, e.g. trello.com/b/[Board ID]'
-            ]
+                'title' => 'Taken from Trello URL, e.g. trello.com/b/[Board ID]',
+            ],
         ],
         'Card' => [
             'c' => [
                 'name' => 'Card ID',
                 'required' => true,
                 'exampleValue' => '8vddc9pE',
-                'title' => 'Taken from Trello URL, e.g. trello.com/c/[Card ID]'
-            ]
-        ]
+                'title' => 'Taken from Trello URL, e.g. trello.com/c/[Card ID]',
+            ],
+        ],
     ];
 
     /*
@@ -476,7 +476,7 @@ class TrelloBridge extends BridgeAbstract
         'action_voting'
             => 'voting',
         'action_withdraw_enterprise_join_request'
-            => '{memberCreator} withdrew a request to add team {organization} to the enterprise {enterprise}'
+            => '{memberCreator} withdrew a request to add team {organization} to the enterprise {enterprise}',
         ];
 
     const REQUEST_ACTIONS_BOARDS = [
@@ -522,7 +522,7 @@ class TrelloBridge extends BridgeAbstract
         'unconfirmedOrganizationInvitation',
         'updateBoard',
         'updateCustomField',
-        'updateList:closed'
+        'updateList:closed',
     ];
 
     const REQUEST_ACTIONS_CARDS = [
@@ -545,7 +545,7 @@ class TrelloBridge extends BridgeAbstract
         'updateCard:due',
         'updateCard:dueComplete',
         'updateCheckItemStateOnCard',
-        'updateCustomFieldItem'
+        'updateCustomFieldItem',
     ];
 
     private $feedName = '';
@@ -618,7 +618,7 @@ class TrelloBridge extends BridgeAbstract
     {
         $apiParams = [
             'actions_display' => 'true',
-            'fields' => 'name,url'
+            'fields' => 'name,url',
         ];
         switch ($this->queriedContext) {
             case 'Board':
@@ -645,7 +645,7 @@ class TrelloBridge extends BridgeAbstract
             $item['categories'] = [
                 'trello',
                 $action->data->board->name,
-                $action->type
+                $action->type,
             ];
             if (isset($action->data->card)) {
                 $item['categories'][] = $action->data->card->name;

--- a/bridges/TwitScoopBridge.php
+++ b/bridges/TwitScoopBridge.php
@@ -75,15 +75,15 @@ class TwitScoopBridge extends BridgeAbstract
                     'United States' => 'united-states',
                     'Venezuela' => 'venezuela',
                     'Vietnam' => 'vietnam',
-                ]
+                ],
             ],
             'limit' => [
                 'name' => 'Topics',
                 'type' => 'number',
                 'title' => 'Number of trending topics to return. Max 50',
                 'defaultValue' => 20,
-            ]
-        ]
+            ],
+        ],
     ];
 
     const CACHE_TIMEOUT = 900; // 15 mins
@@ -118,13 +118,13 @@ class TwitScoopBridge extends BridgeAbstract
             }
 
             $item['content'] = <<<EOD
-<strong>Rank</strong><br>
-<p>{$number}</p>
-<Strong>Topic</strong><br>
-<p>{$name}</p>
-<Strong>Tweets</strong><br>
-<p>{$tweets}</p>
-EOD;
+                <strong>Rank</strong><br>
+                <p>{$number}</p>
+                <Strong>Topic</strong><br>
+                <p>{$name}</p>
+                <Strong>Tweets</strong><br>
+                <p>{$tweets}</p>
+                EOD;
             $item['timestamp'] = $updated;
 
             $this->items[] = $item;

--- a/bridges/TwitchBridge.php
+++ b/bridges/TwitchBridge.php
@@ -13,7 +13,7 @@ class TwitchBridge extends BridgeAbstract
             'type' => 'text',
             'required' => true,
             'exampleValue' => 'criticalrole',
-            'title' => 'Lowercase channel name as seen in channel URL'
+            'title' => 'Lowercase channel name as seen in channel URL',
         ],
         'type' => [
             'name' => 'Type',
@@ -24,10 +24,10 @@ class TwitchBridge extends BridgeAbstract
                 'Highlights' => 'highlight',
                 'Uploads' => 'upload',
                 'Past Premieres' => 'past_premiere',
-                'Premiere Uploads' => 'premiere_upload'
+                'Premiere Uploads' => 'premiere_upload',
             ],
-            'defaultValue' => 'archive'
-        ]
+            'defaultValue' => 'archive',
+        ],
     ]];
 
     /*
@@ -43,57 +43,57 @@ class TwitchBridge extends BridgeAbstract
             'HIGHLIGHT',
             'UPLOAD',
             'PAST_PREMIERE',
-            'PREMIERE_UPLOAD'
+            'PREMIERE_UPLOAD',
         ],
         'archive' => 'ARCHIVE',
         'highlight' => 'HIGHLIGHT',
         'upload' => 'UPLOAD',
         'past_premiere' => 'PAST_PREMIERE',
-        'premiere_upload' => 'PREMIERE_UPLOAD'
+        'premiere_upload' => 'PREMIERE_UPLOAD',
     ];
 
     public function collectData()
     {
         $query = <<<'EOD'
-query VODList($channel: String!, $types: [BroadcastType!]) {
-  user(login: $channel) {
-    displayName
-    videos(types: $types, sort: TIME) {
-      edges {
-        node {
-          id
-          title
-          publishedAt
-          lengthSeconds
-          viewCount
-          thumbnailURLs(width: 640, height: 360)
-          previewThumbnailURL(width: 640, height: 360)
-          description
-          tags
-          contentTags {
-            isLanguageTag
-            localizedName
-          }
-          game {
-            displayName
-          }
-          moments(momentRequestType: VIDEO_CHAPTER_MARKERS) {
-            edges {
-              node {
-                description
-                positionMilliseconds
+            query VODList($channel: String!, $types: [BroadcastType!]) {
+              user(login: $channel) {
+                displayName
+                videos(types: $types, sort: TIME) {
+                  edges {
+                    node {
+                      id
+                      title
+                      publishedAt
+                      lengthSeconds
+                      viewCount
+                      thumbnailURLs(width: 640, height: 360)
+                      previewThumbnailURL(width: 640, height: 360)
+                      description
+                      tags
+                      contentTags {
+                        isLanguageTag
+                        localizedName
+                      }
+                      game {
+                        displayName
+                      }
+                      moments(momentRequestType: VIDEO_CHAPTER_MARKERS) {
+                        edges {
+                          node {
+                            description
+                            positionMilliseconds
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
-          }
-        }
-      }
-    }
-  }
-}
-EOD;
+            EOD;
         $variables = [
             'channel' => $this->getInput('channel'),
-            'types' => self::BROADCAST_TYPES[$this->getInput('type')]
+            'types' => self::BROADCAST_TYPES[$this->getInput('type')],
         ];
         $data = $this->apiRequest($query, $variables);
 
@@ -212,14 +212,14 @@ EOD;
     {
         $request = [
             'query' => $query,
-            'variables' => $variables
+            'variables' => $variables,
         ];
         $header = [
-            'Client-ID: ' . self::CLIENT_ID
+            'Client-ID: ' . self::CLIENT_ID,
         ];
         $opts = [
             CURLOPT_CUSTOMREQUEST => 'POST',
-            CURLOPT_POSTFIELDS => json_encode($request)
+            CURLOPT_POSTFIELDS => json_encode($request),
         ];
 
         Debug::log("Sending GraphQL query:\n" . $query);

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -15,18 +15,18 @@ class TwitterBridge extends BridgeAbstract
             'nopic' => [
                 'name' => 'Hide profile pictures',
                 'type' => 'checkbox',
-                'title' => 'Activate to hide profile pictures in content'
+                'title' => 'Activate to hide profile pictures in content',
             ],
             'noimg' => [
                 'name' => 'Hide images in tweets',
                 'type' => 'checkbox',
-                'title' => 'Activate to hide images in tweets'
+                'title' => 'Activate to hide images in tweets',
             ],
             'noimgscaling' => [
                 'name' => 'Disable image scaling',
                 'type' => 'checkbox',
-                'title' => 'Activate to disable image scaling in tweets (keeps original image)'
-            ]
+                'title' => 'Activate to disable image scaling in tweets (keeps original image)',
+            ],
         ],
         'By keyword or hashtag' => [
             'q' => [
@@ -34,94 +34,94 @@ class TwitterBridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => 'rss-bridge OR rssbridge',
                 'title' => <<<EOD
-* To search for multiple words (must contain all of these words), put a space between them.
+                    * To search for multiple words (must contain all of these words), put a space between them.
 
-Example: `rss-bridge release`.
+                    Example: `rss-bridge release`.
 
-* To search for multiple words (contains any of these words), put "OR" between them.
+                    * To search for multiple words (contains any of these words), put "OR" between them.
 
-Example: `rss-bridge OR rssbridge`.
+                    Example: `rss-bridge OR rssbridge`.
 
-* To search for an exact phrase (including whitespace), put double-quotes around them.
+                    * To search for an exact phrase (including whitespace), put double-quotes around them.
 
-Example: `"rss-bridge release"`
+                    Example: `"rss-bridge release"`
 
-* If you want to search for anything **but** a specific word, put a hyphen before it.
+                    * If you want to search for anything **but** a specific word, put a hyphen before it.
 
-Example: `rss-bridge -release` (ignores "release")
+                    Example: `rss-bridge -release` (ignores "release")
 
-* Of course, this also works for hashtags.
+                    * Of course, this also works for hashtags.
 
-Example: `#rss-bridge OR #rssbridge`
+                    Example: `#rss-bridge OR #rssbridge`
 
-* And you can combine them in any shape or form you like.
+                    * And you can combine them in any shape or form you like.
 
-Example: `#rss-bridge OR #rssbridge -release`
-EOD
-            ]
+                    Example: `#rss-bridge OR #rssbridge -release`
+                    EOD,
+            ],
         ],
         'By username' => [
             'u' => [
                 'name' => 'username',
                 'required' => true,
                 'exampleValue' => 'sebsauvage',
-                'title' => 'Insert a user name'
+                'title' => 'Insert a user name',
             ],
             'norep' => [
                 'name' => 'Without replies',
                 'type' => 'checkbox',
-                'title' => 'Only return initial tweets'
+                'title' => 'Only return initial tweets',
             ],
             'noretweet' => [
                 'name' => 'Without retweets',
                 'required' => false,
                 'type' => 'checkbox',
-                'title' => 'Hide retweets'
+                'title' => 'Hide retweets',
             ],
             'nopinned' => [
                 'name' => 'Without pinned tweet',
                 'required' => false,
                 'type' => 'checkbox',
-                'title' => 'Hide pinned tweet'
-            ]
+                'title' => 'Hide pinned tweet',
+            ],
         ],
         'By list' => [
             'user' => [
                 'name' => 'User',
                 'required' => true,
                 'exampleValue' => 'Scobleizer',
-                'title' => 'Insert a user name'
+                'title' => 'Insert a user name',
             ],
             'list' => [
                 'name' => 'List',
                 'required' => true,
                 'exampleValue' => 'Tech-News',
-                'title' => 'Insert the list name'
+                'title' => 'Insert the list name',
             ],
             'filter' => [
                 'name' => 'Filter',
                 'exampleValue' => '#rss-bridge',
                 'required' => false,
-                'title' => 'Specify term to search for'
-            ]
+                'title' => 'Specify term to search for',
+            ],
         ],
         'By list ID' => [
             'listid' => [
                 'name' => 'List ID',
                 'exampleValue' => '31748',
                 'required' => true,
-                'title' => 'Insert the list id'
+                'title' => 'Insert the list id',
             ],
             'filter' => [
                 'name' => 'Filter',
                 'exampleValue' => '#rss-bridge',
                 'required' => false,
-                'title' => 'Specify term to search for'
-            ]
-        ]
+                'title' => 'Specify term to search for',
+            ],
+        ],
     ];
 
-    private $apiKey     = null;
+    private $apiKey = null;
     private $guestToken = null;
     private $authHeader = [];
 
@@ -230,8 +230,8 @@ EOD
                 }
 
                 $params = [
-                'user_id'       => $user->id_str,
-                'tweet_mode'    => 'extended'
+                'user_id' => $user->id_str,
+                'tweet_mode' => 'extended',
                 ];
 
                 $data = $this->makeApiCall('/1.1/statuses/user_timeline.json', $params);
@@ -239,8 +239,8 @@ EOD
 
             case 'By keyword or hashtag':
                 $params = [
-                'q'                 => urlencode($this->getInput('q')),
-                'tweet_mode'        => 'extended',
+                'q' => urlencode($this->getInput('q')),
+                'tweet_mode' => 'extended',
                 'tweet_search_mode' => 'live',
                 ];
 
@@ -249,9 +249,9 @@ EOD
 
             case 'By list':
                 $params = [
-                'slug'              => strtolower($this->getInput('list')),
+                'slug' => strtolower($this->getInput('list')),
                 'owner_screen_name' => strtolower($this->getInput('user')),
-                'tweet_mode'        => 'extended',
+                'tweet_mode' => 'extended',
                 ];
 
                 $data = $this->makeApiCall('/1.1/lists/statuses.json', $params);
@@ -259,8 +259,8 @@ EOD
 
             case 'By list ID':
                 $params = [
-                'list_id'           => $this->getInput('listid'),
-                'tweet_mode'        => 'extended',
+                'list_id' => $this->getInput('listid'),
+                'tweet_mode' => 'extended',
                 ];
 
                 $data = $this->makeApiCall('/1.1/lists/statuses.json', $params);
@@ -333,13 +333,13 @@ EOD
                 $realtweet = $tweet->retweeted_status;
             }
 
-            $item['username']  = $realtweet->user->screen_name;
-            $item['fullname']  = $realtweet->user->name;
-            $item['avatar']    = $realtweet->user->profile_image_url_https;
+            $item['username'] = $realtweet->user->screen_name;
+            $item['fullname'] = $realtweet->user->name;
+            $item['avatar'] = $realtweet->user->profile_image_url_https;
             $item['timestamp'] = $realtweet->created_at;
-            $item['id']        = $realtweet->id_str;
-            $item['uri']       = self::URI . $item['username'] . '/status/' . $item['id'];
-            $item['author']    = (isset($tweet->retweeted_status) ? 'RT: ' : '' )
+            $item['id'] = $realtweet->id_str;
+            $item['uri'] = self::URI . $item['username'] . '/status/' . $item['id'];
+            $item['author'] = (isset($tweet->retweeted_status) ? 'RT: ' : '')
                          . $item['fullname']
                          . ' (@'
                          . $item['username'] . ')';
@@ -392,14 +392,14 @@ EOD
             $picture_html = '';
             if (!$hidePictures) {
                 $picture_html = <<<EOD
-<a href="https://twitter.com/{$item['username']}">
-<img
-	style="align:top; width:75px; border:1px solid black;"
-	alt="{$item['username']}"
-	src="{$item['avatar']}"
-	title="{$item['fullname']}" />
-</a>
-EOD;
+                    <a href="https://twitter.com/{$item['username']}">
+                    <img
+                    	style="align:top; width:75px; border:1px solid black;"
+                    	alt="{$item['username']}"
+                    	src="{$item['avatar']}"
+                    	title="{$item['fullname']}" />
+                    </a>
+                    EOD;
             }
 
             // Get images
@@ -414,13 +414,13 @@ EOD;
                             $item['enclosures'][] = $image;
 
                             $media_html .= <<<EOD
-<a href="{$image}">
-<img
-	style="align:top; max-width:558px; border:1px solid black;"
-	referrerpolicy="no-referrer"
-	src="{$display_image}" />
-</a>
-EOD;
+                                <a href="{$image}">
+                                <img
+                                	style="align:top; max-width:558px; border:1px solid black;"
+                                	referrerpolicy="no-referrer"
+                                	src="{$display_image}" />
+                                </a>
+                                EOD;
                             break;
                         case 'video':
                         case 'animated_gif':
@@ -430,7 +430,7 @@ EOD;
                                 $video = null;
                                 $maxBitrate = -1;
                                 foreach ($media->video_info->variants as $variant) {
-                                    $bitRate = isset($variant->bitrate) ? $variant->bitrate : -100;
+                                    $bitRate = $variant->bitrate ?? -100;
                                     if ($bitRate > $maxBitrate) {
                                         $maxBitrate = $bitRate;
                                         $video = $variant->url;
@@ -442,12 +442,12 @@ EOD;
                                     $item['enclosures'][] = $poster;
 
                                     $media_html .= <<<EOD
-<a href="{$link}">Video</a>
-<video
-	style="align:top; max-width:558px; border:1px solid black;"
-	referrerpolicy="no-referrer"
-	src="{$video}" poster="{$poster}" />
-EOD;
+                                        <a href="{$link}">Video</a>
+                                        <video
+                                        	style="align:top; max-width:558px; border:1px solid black;"
+                                        	referrerpolicy="no-referrer"
+                                        	src="{$video}" poster="{$poster}" />
+                                        EOD;
                                 }
                             }
                             break;
@@ -476,16 +476,16 @@ EOD;
             }
 
             $item['content'] = <<<EOD
-<div style="display: inline-block; vertical-align: top;">
-	{$picture_html}
-</div>
-<div style="display: inline-block; vertical-align: top;">
-	<blockquote>{$cleanedTweet}</blockquote>
-</div>
-<div style="display: block; vertical-align: top;">
-	<blockquote>{$media_html}</blockquote>
-</div>
-EOD;
+                <div style="display: inline-block; vertical-align: top;">
+                	{$picture_html}
+                </div>
+                <div style="display: inline-block; vertical-align: top;">
+                	<blockquote>{$cleanedTweet}</blockquote>
+                </div>
+                <div style="display: block; vertical-align: top;">
+                	<blockquote>{$media_html}</blockquote>
+                </div>
+                EOD;
 
             // put out
             $this->items[] = $item;
@@ -543,7 +543,7 @@ EOD;
                 }
             }
             if (!$jsLink) {
-                 returnServerError('Could not locate main.js link');
+                returnServerError('Could not locate main.js link');
             }
 
             $jsContent = getContents($jsLink);
@@ -584,8 +584,8 @@ EOD;
             $guestToken = $guestTokenUses[1];
         }
 
-        $this->apiKey      = $apiKey;
-        $this->guestToken  = $guestToken;
+        $this->apiKey = $apiKey;
+        $this->guestToken = $guestToken;
         $this->authHeaders = [
             'authorization: Bearer ' . $apiKey,
             'x-guest-token: ' . $guestToken,
@@ -646,11 +646,12 @@ EOD;
                     default:
                         $code = $e->getCode();
                         $data = $e->getMessage();
-                        returnServerError(<<<EOD
-Failed to make api call: $api
-HTTP Status: $code
-Errormessage: $data
-EOD
+                        returnServerError(
+                            <<<EOD
+                                Failed to make api call: $api
+                                HTTP Status: $code
+                                Errormessage: $data
+                                EOD
                         );
                         break;
                 }

--- a/bridges/TwitterV2Bridge.php
+++ b/bridges/TwitterV2Bridge.php
@@ -17,7 +17,7 @@ class TwitterV2Bridge extends BridgeAbstract
     const CONFIGURATION = [
         'twitterv2apitoken' => [
             'required' => true,
-        ]
+        ],
     ];
     const PARAMETERS = [
         'global' => [
@@ -25,64 +25,64 @@ class TwitterV2Bridge extends BridgeAbstract
                 'name' => 'Filter',
                 'exampleValue' => 'rss-bridge',
                 'required' => false,
-                'title' => 'Specify a single term to search for'
+                'title' => 'Specify a single term to search for',
             ],
             'norep' => [
                 'name' => 'Without replies',
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude reply tweets'
+                'title' => 'Activate to exclude reply tweets',
             ],
             'noretweet' => [
                 'name' => 'Without retweets',
                 'required' => false,
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude retweets'
+                'title' => 'Activate to exclude retweets',
             ],
             'nopinned' => [
                 'name' => 'Without pinned tweet',
                 'required' => false,
                 'type' => 'checkbox',
-                'title' => 'Activate to exclude pinned tweets'
+                'title' => 'Activate to exclude pinned tweets',
             ],
             'maxresults' => [
                 'name' => 'Maximum results',
                 'required' => false,
                 'exampleValue' => '20',
-                'title' => 'Maximum number of tweets to retrieve (limit is 100)'
+                'title' => 'Maximum number of tweets to retrieve (limit is 100)',
             ],
             'imgonly' => [
                 'name' => 'Only media tweets',
                 'type' => 'checkbox',
-                'title' => 'Activate to show only tweets with media (photo/video)'
+                'title' => 'Activate to show only tweets with media (photo/video)',
             ],
             'nopic' => [
                 'name' => 'Hide profile pictures',
                 'type' => 'checkbox',
-                'title' => 'Activate to hide profile pictures in content'
+                'title' => 'Activate to hide profile pictures in content',
             ],
             'noimg' => [
                 'name' => 'Hide images in tweets',
                 'type' => 'checkbox',
-                'title' => 'Activate to hide images in tweets'
+                'title' => 'Activate to hide images in tweets',
             ],
             'noimgscaling' => [
                 'name' => 'Disable image scaling',
                 'type' => 'checkbox',
-                'title' => 'Activate to display original sized images (no thumbnails)'
+                'title' => 'Activate to display original sized images (no thumbnails)',
             ],
             'idastitle' => [
                 'name' => 'Use tweet id as title',
                 'type' => 'checkbox',
-                'title' => 'Activate to use tweet id as title (instead of tweet text)'
-            ]
+                'title' => 'Activate to use tweet id as title (instead of tweet text)',
+            ],
         ],
         'By username' => [
             'u' => [
                 'name' => 'username',
                 'required' => true,
                 'exampleValue' => 'sebsauvage',
-                'title' => 'Insert a user name'
-            ]
+                'title' => 'Insert a user name',
+            ],
         ],
         'By keyword or hashtag' => [
             'query' => [
@@ -90,40 +90,40 @@ class TwitterV2Bridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => 'rss-bridge OR #rss-bridge',
                 'title' => <<<EOD
-* To search for multiple words (must contain all of these words), put a space between them.
+                    * To search for multiple words (must contain all of these words), put a space between them.
 
-Example: `rss-bridge release`.
+                    Example: `rss-bridge release`.
 
-* To search for multiple words (contains any of these words), put "OR" between them.
+                    * To search for multiple words (contains any of these words), put "OR" between them.
 
-Example: `rss-bridge OR rssbridge`.
+                    Example: `rss-bridge OR rssbridge`.
 
-* To search for an exact phrase (including whitespace), put double-quotes around them.
+                    * To search for an exact phrase (including whitespace), put double-quotes around them.
 
-Example: `"rss-bridge release"`
+                    Example: `"rss-bridge release"`
 
-* If you want to search for anything **but** a specific word, put a hyphen before it.
+                    * If you want to search for anything **but** a specific word, put a hyphen before it.
 
-Example: `rss-bridge -release` (ignores "release")
+                    Example: `rss-bridge -release` (ignores "release")
 
-* Of course, this also works for hashtags.
+                    * Of course, this also works for hashtags.
 
-Example: `#rss-bridge OR #rssbridge`
+                    Example: `#rss-bridge OR #rssbridge`
 
-* And you can combine them in any shape or form you like.
+                    * And you can combine them in any shape or form you like.
 
-Example: `#rss-bridge OR #rssbridge -release`
-EOD
-            ]
+                    Example: `#rss-bridge OR #rssbridge -release`
+                    EOD,
+            ],
         ],
         'By list ID' => [
             'listid' => [
                 'name' => 'List ID',
                 'exampleValue' => '31748',
                 'required' => true,
-                'title' => 'Enter a list id'
-            ]
-        ]
+                'title' => 'Enter a list id',
+            ],
+        ],
     ];
 
     // $Item variable needs to be accessible from multiple functions without passing
@@ -181,7 +181,7 @@ EOD
             case 'By username':
                 //Get id from username
                 $params = [
-                'user.fields'   => 'pinned_tweet_id,profile_image_url'
+                'user.fields' => 'pinned_tweet_id,profile_image_url',
                 ];
                 $user = $this->makeApiCall('/users/by/username/'
                 . $this->getInput('u'), $authHeaders, $params);
@@ -193,13 +193,13 @@ EOD
 
                 // Set default params
                 $params = [
-                'max_results'   => (empty($maxResults) ? '10' : $maxResults ),
+                'max_results' => (empty($maxResults) ? '10' : $maxResults),
                 'tweet.fields'
                 => 'created_at,referenced_tweets,entities,attachments',
-                'user.fields'   => 'pinned_tweet_id',
+                'user.fields' => 'pinned_tweet_id',
                 'expansions'
                 => 'referenced_tweets.id.author_id,entities.mentions.username,attachments.media_keys',
-                'media.fields'  => 'type,url,preview_image_url'
+                'media.fields' => 'type,url,preview_image_url',
                 ];
 
                 // Set params to filter out replies and/or retweets
@@ -218,13 +218,13 @@ EOD
 
             case 'By keyword or hashtag':
                 $params = [
-                'query'         => $this->getInput('query'),
-                'max_results'   => (empty($maxResults) ? '10' : $maxResults ),
+                'query' => $this->getInput('query'),
+                'max_results' => (empty($maxResults) ? '10' : $maxResults),
                 'tweet.fields'
                 => 'created_at,referenced_tweets,entities,attachments',
                 'expansions'
                 => 'referenced_tweets.id.author_id,entities.mentions.username,attachments.media_keys',
-                'media.fields'  => 'type,url,preview_image_url'
+                'media.fields' => 'type,url,preview_image_url',
                 ];
 
                 // Set params to filter out replies and/or retweets
@@ -241,12 +241,12 @@ EOD
             case 'By list ID':
                 // Set default params
                 $params = [
-                'max_results' => (empty($maxResults) ? '10' : $maxResults ),
+                'max_results' => (empty($maxResults) ? '10' : $maxResults),
                 'tweet.fields'
                 => 'created_at,referenced_tweets,entities,attachments',
                 'expansions'
                 => 'referenced_tweets.id.author_id,entities.mentions.username,attachments.media_keys',
-                'media.fields'  => 'type,url,preview_image_url'
+                'media.fields' => 'type,url,preview_image_url',
                 ];
 
                 $data = $this->makeApiCall('/lists/' . $this->getInput('listid') .
@@ -310,11 +310,11 @@ EOD
 
             // Set default params for API query
             $params = [
-                'ids'           => join(',', $includesTweetsIds),
-                'tweet.fields'  => 'entities,attachments',
-                'expansions'    => 'author_id,attachments.media_keys',
-                'media.fields'  => 'type,url,preview_image_url',
-                'user.fields'   => 'id,profile_image_url'
+                'ids' => join(',', $includesTweetsIds),
+                'tweet.fields' => 'entities,attachments',
+                'expansions' => 'author_id,attachments.media_keys',
+                'media.fields' => 'type,url,preview_image_url',
+                'user.fields' => 'id,profile_image_url',
             ];
 
             // Get the retweeted tweets
@@ -413,23 +413,23 @@ EOD
                 // Get user object for retweeted tweet
                 $originalUser = $this->getTweetUser($tweet, $retweetedUsers, $includesUsers);
 
-                $this->item['username']  = $originalUser->username;
-                $this->item['fullname']  = $originalUser->name;
+                $this->item['username'] = $originalUser->username;
+                $this->item['fullname'] = $originalUser->name;
                 if (isset($originalUser->profile_image_url)) {
-                    $this->item['avatar']    = $originalUser->profile_image_url;
+                    $this->item['avatar'] = $originalUser->profile_image_url;
                 } else {
                     $this->item['avatar'] = null;
                 }
             } else {
-                $this->item['username']  = $user->data->username;
-                $this->item['fullname']  = $user->data->name;
-                $this->item['avatar']    = $user->data->profile_image_url;
+                $this->item['username'] = $user->data->username;
+                $this->item['fullname'] = $user->data->name;
+                $this->item['avatar'] = $user->data->profile_image_url;
             }
-            $this->item['id']        = $tweet->id;
+            $this->item['id'] = $tweet->id;
             $this->item['timestamp'] = $tweet->created_at;
             $this->item['uri']
             = self::URI . $this->item['username'] . '/status/' . $this->item['id'];
-            $this->item['author']    = ($isRetweet ? 'RT: ' : '' )
+            $this->item['author'] = ($isRetweet ? 'RT: ' : '')
                          . $this->item['fullname']
                          . ' (@'
                          . $this->item['username'] . ')';
@@ -440,8 +440,8 @@ EOD
                 $onlyMediaTweets && !isset($tweet->attachments->media_keys) &&
                 (($isQuote && !isset($quotedTweet->attachments->media_keys)) || !$isQuote)
             ) {
-                    // There is no media in current tweet or quoted tweet, skip to next
-                    continue;
+                // There is no media in current tweet or quoted tweet, skip to next
+                continue;
             }
 
             // Search for and replace URLs in Tweet text
@@ -460,7 +460,7 @@ EOD
 
             if ($isRetweet && substr($titleText, 0, 4) === 'RT @') {
                 $titleText = substr_replace($titleText, ':', 2, 0);
-            } elseif ($isReply  && !$idAsTitle) {
+            } elseif ($isReply && !$idAsTitle) {
                 $titleText = 'R: ' . $titleText;
             }
 
@@ -470,14 +470,14 @@ EOD
             $picture_html = '';
             if (!$hideProfilePic && isset($this->item['avatar'])) {
                 $picture_html = <<<EOD
-<a href="https://twitter.com/{$this->item['username']}">
-<img
-	style="margin-right: 10px; margin-bottom: 10px;"
-	alt="{$this->item['username']}"
-	src="{$this->item['avatar']}"
-	title="{$this->item['fullname']}" />
-</a>
-EOD;
+                    <a href="https://twitter.com/{$this->item['username']}">
+                    <img
+                    	style="margin-right: 10px; margin-bottom: 10px;"
+                    	alt="{$this->item['username']}"
+                    	src="{$this->item['avatar']}"
+                    	title="{$this->item['fullname']}" />
+                    </a>
+                    EOD;
             }
 
             // Generate media HTML block
@@ -496,28 +496,28 @@ EOD;
 
             // Generate the HTML for Item content
             $this->item['content'] = <<<EOD
-<div style="float: left;">
-	{$picture_html}
-</div>
-<div style="display: table;">
-	{$cleanedTweet}
-</div>
-<div style="display: block; margin-top: 16px;">
-	{$media_html}
-EOD;
+                <div style="float: left;">
+                	{$picture_html}
+                </div>
+                <div style="display: table;">
+                	{$cleanedTweet}
+                </div>
+                <div style="display: block; margin-top: 16px;">
+                	{$media_html}
+                EOD;
 
             // Add Quoted Tweet HTML, if relevant
             if (isset($quotedTweet)) {
                 $quotedTweetURI = self::URI . $quotedUser->username . '/status/' . $quotedTweet->id;
                 $quote_html = <<<QUOTE
-<div style="display: table; border-style: solid; border-width: 1px; 
-	border-radius: 5px; padding: 5px;">
-	<p><b>$quotedUser->name</b> @$quotedUser->username · 
-	<a href="$quotedTweetURI">$quotedTweet->created_at</a></p>
-	$cleanedQuotedTweet
-	$quoted_media_html
-</div>
-QUOTE;
+                    <div style="display: table; border-style: solid; border-width: 1px; 
+                    	border-radius: 5px; padding: 5px;">
+                    	<p><b>$quotedUser->name</b> @$quotedUser->username · 
+                    	<a href="$quotedTweetURI">$quotedTweet->created_at</a></p>
+                    	$cleanedQuotedTweet
+                    	$quoted_media_html
+                    </div>
+                    QUOTE;
                 $this->item['content'] .= $quote_html;
             }
 
@@ -679,12 +679,12 @@ QUOTE;
                     $this->item['enclosures'][] = $image;
 
                     $media_html .= <<<EOD
-<a href="{$image}">
-<img
-referrerpolicy="no-referrer"
-src="{$display_image}" />
-</a>
-EOD;
+                        <a href="{$image}">
+                        <img
+                        referrerpolicy="no-referrer"
+                        src="{$display_image}" />
+                        </a>
+                        EOD;
                     break;
                 case 'video':
                     // To Do: Is there a way to easily match this
@@ -692,9 +692,9 @@ EOD;
                     $display_image = $media->preview_image_url;
 
                     $media_html .= <<<EOD
-<p>Video:</p><a href="{$this->item['uri']}">
-<img referrerpolicy="no-referrer" src="{$display_image}" /></a>
-EOD;
+                        <p>Video:</p><a href="{$this->item['uri']}">
+                        <img referrerpolicy="no-referrer" src="{$display_image}" /></a>
+                        EOD;
                     break;
                 case 'animated_gif':
                     // To Do: Is there a way to easily match this to a
@@ -702,9 +702,9 @@ EOD;
                     $display_image = $media->preview_image_url;
 
                     $media_html .= <<<EOD
-<p>Animated Gif:</p><a href="{$this->item['uri']}">
-<img referrerpolicy="no-referrer" src="{$display_image}" /></a>
-EOD;
+                        <p>Animated Gif:</p><a href="{$this->item['uri']}">
+                        <img referrerpolicy="no-referrer" src="{$display_image}" /></a>
+                        EOD;
                     break;
                 default:
                     Debug::log('Missing support for media type: '

--- a/bridges/UberNewsroomBridge.php
+++ b/bridges/UberNewsroomBridge.php
@@ -120,7 +120,7 @@ class UberNewsroomBridge extends BridgeAbstract
                 ],
             ],
             'defaultValue' => 'en-US',
-        ]
+        ],
     ]];
 
     const CACHE_TIMEOUT = 3600;

--- a/bridges/UnogsBridge.php
+++ b/bridges/UnogsBridge.php
@@ -15,8 +15,8 @@ class UnogsBridge extends BridgeAbstract
                 'title' => 'Choose whether you want latest movies or removal on Netflix',
                 'values' => [
                     'What\'s New' => 'new last 7 days',
-                    'Expiring' => 'expiring'
-                ]
+                    'Expiring' => 'expiring',
+                ],
             ],
             'limit' => self::LIMIT,
         ],
@@ -64,10 +64,10 @@ class UnogsBridge extends BridgeAbstract
                     'Turkey' => 432,
                     'Ukraine' => 436,
                     'United Kingdom' => 46,
-                    'United States' => 78
-                ]
-            ]
-        ]
+                    'United States' => 78,
+                ],
+            ],
+        ],
     ];
 
     public function getName()
@@ -106,7 +106,7 @@ class UnogsBridge extends BridgeAbstract
     {
         $header = [
             'Referer: https://unogs.com/',
-            'referrer: http://unogs.com'
+            'referrer: http://unogs.com',
         ];
 
         $raw = getContents($url, $header);
@@ -146,11 +146,11 @@ class UnogsBridge extends BridgeAbstract
         $unogs_url = self::URI . '/title/' . $netflix_id;
 
         $item['content'] = <<<EOD
-<img src={$image_url}>
-$expired_warning
-<p>$netflix_synopsis</p>
-<p>Details: <a href={$unogs_url}>$unogs_url</a></p>
-EOD;
+            <img src={$image_url}>
+            $expired_warning
+            <p>$netflix_synopsis</p>
+            <p>Details: <a href={$unogs_url}>$unogs_url</a></p>
+            EOD;
         $this->items[] = $item;
     }
 

--- a/bridges/UnsplashBridge.php
+++ b/bridges/UnsplashBridge.php
@@ -12,13 +12,13 @@ class UnsplashBridge extends BridgeAbstract
         'u' => [
             'name' => 'Filter by username (optional)',
             'type' => 'text',
-            'defaultValue' => 'unsplash'
+            'defaultValue' => 'unsplash',
         ],
         'm' => [
             'name' => 'Max number of photos',
             'type' => 'number',
             'defaultValue' => 20,
-            'required' => true
+            'required' => true,
         ],
         'prev_q' => [
             'name' => 'Preview quality',
@@ -29,7 +29,7 @@ class UnsplashBridge extends BridgeAbstract
                 'small' => 'small',
                 'thumb' => 'thumb',
             ],
-            'defaultValue' => 'regular'
+            'defaultValue' => 'regular',
         ],
         'w' => [
             'name' => 'Max download width (optional)',
@@ -42,7 +42,7 @@ class UnsplashBridge extends BridgeAbstract
             'exampleValue' => 75,
             'type' => 'number',
             'defaultValue' => 75,
-        ]
+        ],
     ]];
 
     public function collectData()

--- a/bridges/UrlebirdBridge.php
+++ b/bridges/UrlebirdBridge.php
@@ -14,9 +14,9 @@ class UrlebirdBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => '@willsmith',
-                'title' => '@username or #hashtag'
-            ]
-        ]
+                'title' => '@username or #hashtag',
+            ],
+        ],
     ];
 
     private $title;

--- a/bridges/UsbekEtRicaBridge.php
+++ b/bridges/UsbekEtRicaBridge.php
@@ -14,15 +14,15 @@ class UsbekEtRicaBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Specifies the maximum number of articles to return',
-                'defaultValue' => -1
+                'defaultValue' => -1,
             ],
             'fullarticle' => [
                 'name' => 'Load full article',
                 'type' => 'checkbox',
                 'required' => false,
                 'title' => 'Activate to load full articles',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()
@@ -74,7 +74,7 @@ class UsbekEtRicaBridge extends BridgeAbstract
             $image = $article->find('div.card-img img', 0);
             if ($image) {
                 $item['enclosures'] = [
-                    $image->src
+                    $image->src,
                 ];
             }
 

--- a/bridges/UsenixBridge.php
+++ b/bridges/UsenixBridge.php
@@ -63,7 +63,7 @@ final class UsenixBridge extends BridgeAbstract
 
         return [
             'content' => $content,
-            'categories' => $tags
+            'categories' => $tags,
         ];
     }
 }

--- a/bridges/ViadeoCompanyBridge.php
+++ b/bridges/ViadeoCompanyBridge.php
@@ -13,8 +13,8 @@ class ViadeoCompanyBridge extends BridgeAbstract
         'c' => [
             'name' => 'Company name',
             'exampleValue' => 'apple',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     public function collectData()

--- a/bridges/ViceBridge.php
+++ b/bridges/ViceBridge.php
@@ -16,9 +16,9 @@ class ViceBridge extends FeedExpander
                 'Motherboard - Tech' => 'en_us/rss/topic/tech',
                 'Entertainment' => 'en_us/rss/topic/entertainment',
                 'Noisey - Music' => 'en_us/rss/topic/music',
-                'Munchies - Food' => 'en_us/rss/topic/food'
-            ]
-        ]
+                'Munchies - Food' => 'en_us/rss/topic/food',
+            ],
+        ],
     ]];
 
     public function collectData()

--- a/bridges/VieDeMerdeBridge.php
+++ b/bridges/VieDeMerdeBridge.php
@@ -12,8 +12,8 @@ class VieDeMerdeBridge extends BridgeAbstract
             'item_limit' => [
             'name' => 'Limit number of returned items',
             'type' => 'number',
-            'defaultValue' => 20
-            ]
+            'defaultValue' => 20,
+            ],
     ]];
 
     public function collectData()

--- a/bridges/VimeoBridge.php
+++ b/bridges/VimeoBridge.php
@@ -13,7 +13,7 @@ class VimeoBridge extends BridgeAbstract
                 'name' => 'Search Query',
                 'type' => 'text',
                 'exampleValue' => 'birds',
-                'required' => true
+                'required' => true,
             ],
             'type' => [
                 'name' => 'Show results for',
@@ -24,10 +24,10 @@ class VimeoBridge extends BridgeAbstract
                     'On Demand' => 'search/ondemand',
                     'People' => 'search/people',
                     'Channels' => 'search/channels',
-                    'Groups' => 'search/groups'
-                ]
-            ]
-        ]
+                    'Groups' => 'search/groups',
+                ],
+            ],
+        ],
     ];
 
     public function getURI()
@@ -118,7 +118,7 @@ class VimeoBridge extends BridgeAbstract
         $item['timestamp'] = strtotime($element->clip->created_time);
 
         $item['enclosures'] = [
-            end($element->clip->pictures->sizes)->link
+            end($element->clip->pictures->sizes)->link,
         ];
 
         $item['content'] = "<img src={$item['enclosures'][0]} />";
@@ -139,7 +139,7 @@ class VimeoBridge extends BridgeAbstract
         }
 
         $item['enclosures'] = [
-            end($element->ondemand->pictures->sizes)->link
+            end($element->ondemand->pictures->sizes)->link,
         ];
 
         $item['content'] = "<img src={$item['enclosures'][0]} />";
@@ -155,7 +155,7 @@ class VimeoBridge extends BridgeAbstract
         $item['title'] = $element->people->name;
 
         $item['enclosures'] = [
-            end($element->people->pictures->sizes)->link
+            end($element->people->pictures->sizes)->link,
         ];
 
         $item['content'] = "<img src={$item['enclosures'][0]} />";
@@ -171,7 +171,7 @@ class VimeoBridge extends BridgeAbstract
         $item['title'] = $element->channel->name;
 
         $item['enclosures'] = [
-            end($element->channel->pictures->sizes)->link
+            end($element->channel->pictures->sizes)->link,
         ];
 
         $item['content'] = "<img src={$item['enclosures'][0]} />";
@@ -187,7 +187,7 @@ class VimeoBridge extends BridgeAbstract
         $item['title'] = $element->group->name;
 
         $item['enclosures'] = [
-            end($element->group->pictures->sizes)->link
+            end($element->group->pictures->sizes)->link,
         ];
 
         $item['content'] = "<img src={$item['enclosures'][0]} />";

--- a/bridges/VixenBridge.php
+++ b/bridges/VixenBridge.php
@@ -27,10 +27,10 @@ class VixenBridge extends BridgeAbstract
                     'TushyRaw' => 'TushyRaw',
                     'Vixen' => 'Vixen',
                     'Slayed' => 'Slayed',
-                    'Deeper' => 'Deeper'
+                    'Deeper' => 'Deeper',
                 ],
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -14,13 +14,13 @@ class VkBridge extends BridgeAbstract
             'u' => [
                 'name' => 'Group or user name',
                 'exampleValue' => 'elonmusk_tech',
-                'required' => true
+                'required' => true,
             ],
             'hide_reposts' => [
                 'name' => 'Hide reposts',
                 'type' => 'checkbox',
-            ]
-        ]
+            ],
+        ],
     ];
 
     protected $videos = [];
@@ -448,7 +448,7 @@ class VkBridge extends BridgeAbstract
     {
         $result = $this->api('video.get', [
             'videos' => implode(',', array_keys($this->videos)),
-            'count' => 200
+            'count' => 200,
         ]);
 
         if (!isset($result['error'])) {

--- a/bridges/WallpaperflareBridge.php
+++ b/bridges/WallpaperflareBridge.php
@@ -11,9 +11,9 @@ class WallpaperflareBridge extends XPathAbstract
             'search' => [
                 'name' => 'Search',
                 'exampleValue' => 'birds',
-                'required' => true
-            ]
-        ]];
+                'required' => true,
+            ],
+        ], ];
     const CACHE_TIMEOUT = 3600; //1 hour
     const XPATH_EXPRESSION_ITEM = './/figure';
     const XPATH_EXPRESSION_ITEM_TITLE = './/img/@title';

--- a/bridges/WebfailBridge.php
+++ b/bridges/WebfailBridge.php
@@ -14,9 +14,9 @@ class WebfailBridge extends BridgeAbstract
                 'title' => 'Select your language',
                 'values' => [
                     'English' => 'en',
-                    'German' => 'de'
+                    'German' => 'de',
                 ],
-                'defaultValue' => 'English'
+                'defaultValue' => 'English',
             ],
             'type' => [
                 'name' => 'Type',
@@ -27,11 +27,11 @@ class WebfailBridge extends BridgeAbstract
                     'Facebook' => '/ffdts',
                     'Images' => '/images',
                     'Videos' => '/videos',
-                    'Gifs' => '/gifs'
+                    'Gifs' => '/gifs',
                 ],
-                'defaultValue' => 'None'
-            ]
-        ]
+                'defaultValue' => 'None',
+            ],
+        ],
     ];
 
     public function getURI()

--- a/bridges/WikiLeaksBridge.php
+++ b/bridges/WikiLeaksBridge.php
@@ -21,18 +21,18 @@ class WikiLeaksBridge extends BridgeAbstract
                         'International Politics' => '+-International-Politics-+',
                         'Corporations' => '+-Corporations-+',
                         'Government' => '+-Government-+',
-                        'War & Military' => '+-War-Military-+'
-                    ]
+                        'War & Military' => '+-War-Military-+',
+                    ],
                 ],
-                'defaultValue' => 'news'
+                'defaultValue' => 'news',
             ],
             'teaser' => [
                 'name' => 'Show teaser',
                 'type' => 'checkbox',
                 'title' => 'If checked feeds will display the teaser',
-                'defaultValue' => 'checked'
-            ]
-        ]
+                'defaultValue' => 'checked',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/WikipediaBridge.php
+++ b/bridges/WikipediaBridge.php
@@ -23,7 +23,7 @@ class WikipediaBridge extends BridgeAbstract
                 'Esperanto' => 'eo',
                 'French' => 'fr',
                 'German' => 'de',
-            ]
+            ],
         ],
         'subject' => [
             'name' => 'Subject',
@@ -32,14 +32,14 @@ class WikipediaBridge extends BridgeAbstract
             'exampleValue' => 'Today\'s featured article',
             'values' => [
                 'Today\'s featured article' => 'tfa',
-                'Did you know…' => 'dyk'
-            ]
+                'Did you know…' => 'dyk',
+            ],
         ],
         'fullarticle' => [
             'name' => 'Load full article',
             'type' => 'checkbox',
-            'title' => 'Activate to always load the full article'
-        ]
+            'title' => 'Activate to always load the full article',
+        ],
     ]];
 
     public function getURI()

--- a/bridges/WiredBridge.php
+++ b/bridges/WiredBridge.php
@@ -22,8 +22,8 @@ class WiredBridge extends FeedExpander
                 'Transportation' => 'transportation',   // /feed/category/transportation/latest/rss
                 'Backchannel' => 'backchannel',         // /feed/category/backchannel/latest/rss
                 'WIRED Guides' => 'wired-guide',        // /feed/tag/wired-guide/latest/rss
-                'Photo' => 'photo'                      // /feed/category/photo/latest/rss
-            ]
+                'Photo' => 'photo',                      // /feed/category/photo/latest/rss
+            ],
         ],
         'limit' => self::LIMIT,
     ]];

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -10,8 +10,8 @@ class WordPressBridge extends FeedExpander
         'url' => [
             'name' => 'Blog URL',
             'exampleValue' => 'https://www.wpbeginner.com/',
-            'required' => true
-        ]
+            'required' => true,
+        ],
     ]];
 
     private function cleanContent($content)

--- a/bridges/WordPressMadaraBridge.php
+++ b/bridges/WordPressMadaraBridge.php
@@ -16,9 +16,9 @@ The default URI shows the Madara demo page.';
             'url' => [
                 'name' => 'Manga URL',
                 'exampleValue' => 'https://live.mangabooth.com/manga/manga-text-chapter/',
-                'required' => true
-            ]
-        ]
+                'required' => true,
+            ],
+        ],
     ];
 
     public function getName()
@@ -65,7 +65,7 @@ The default URI shows the Madara demo page.';
         $headers = [];
         $opts = [CURLOPT_POSTFIELDS => [
             'action' => 'manga_get_chapters',
-            'manga' => $mangaInfo['id']
+            'manga' => $mangaInfo['id'],
         ]];
         return str_get_html(getContents($uri, $headers, $opts));
     }

--- a/bridges/WordPressPluginUpdateBridge.php
+++ b/bridges/WordPressPluginUpdateBridge.php
@@ -15,8 +15,8 @@ final class WordPressPluginUpdateBridge extends BridgeAbstract
                 'exampleValue' => 'akismet',
                 'required' => true,
                 'title' => 'Slug or url',
-            ]
-        ]
+            ],
+        ],
     ];
 
     public function collectData()
@@ -39,9 +39,9 @@ final class WordPressPluginUpdateBridge extends BridgeAbstract
 
         foreach ($pluginData->versions as $version => $downloadUrl) {
             $this->items[] = [
-                'title'     => $version,
-                'uri'       => sprintf('https://wordpress.org/plugins/%s/#developers', $slug),
-                'uid'       => $downloadUrl,
+                'title' => $version,
+                'uri' => sprintf('https://wordpress.org/plugins/%s/#developers', $slug),
+                'uid' => $downloadUrl,
             ];
         }
 

--- a/bridges/WorldCosplayBridge.php
+++ b/bridges/WorldCosplayBridge.php
@@ -28,8 +28,8 @@ class WorldCosplayBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'title' => 'WorldCosplay character ID',
-                'exampleValue' => 18204
-            ]
+                'exampleValue' => 18204,
+            ],
         ],
         'Cosplayer' => [
             'uid' => [
@@ -37,8 +37,8 @@ class WorldCosplayBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'title' => 'Cosplayer\'s WorldCosplay profile ID',
-                'exampleValue' => 406782
-            ]
+                'exampleValue' => 406782,
+            ],
         ],
         'Series' => [
             'sid' => [
@@ -46,8 +46,8 @@ class WorldCosplayBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'title' => 'WorldCosplay series ID',
-                'exampleValue' => 3139
-            ]
+                'exampleValue' => 3139,
+            ],
         ],
         'Tag' => [
             'tid' => [
@@ -55,8 +55,8 @@ class WorldCosplayBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => true,
                 'title' => 'WorldCosplay tag ID',
-                'exampleValue' => 33643
-            ]
+                'exampleValue' => 33643,
+            ],
         ],
         'global' => [
             'limit' => [
@@ -65,9 +65,9 @@ class WorldCosplayBridge extends BridgeAbstract
                 'required' => false,
                 'title' => 'Maximum number of photos to return',
                 'exampleValue' => 5,
-                'defaultValue' => 5
-            ]
-        ]
+                'defaultValue' => 5,
+            ],
+        ],
     ];
 
     public function collectData()
@@ -103,7 +103,7 @@ class WorldCosplayBridge extends BridgeAbstract
         $list = $json->list;
 
         foreach ($list as $img) {
-            $image = isset($img->photo) ? $img->photo : $img;
+            $image = $img->photo ?? $img;
             $item = [
                 'uri' => self::URI . substr($image->url, 1),
                 'title' => $image->subject,

--- a/bridges/WorldOfTanksBridge.php
+++ b/bridges/WorldOfTanksBridge.php
@@ -18,9 +18,9 @@ class WorldOfTanksBridge extends FeedExpander
                 'Deutsch' => 'de',
                 'Čeština' => 'cs',
                 'Polski' => 'pl',
-                'Türkçe' => 'tr'
-            ]
-        ]
+                'Türkçe' => 'tr',
+            ],
+        ],
     ]];
 
     const POSSIBLE_ARTICLES = ['article', 'rich-article'];

--- a/bridges/XPathBridge.php
+++ b/bridges/XPathBridge.php
@@ -13,143 +13,133 @@ class XPathBridge extends XPathAbstract
             'url' => [
                 'name' => 'Enter web page URL',
                 'title' => <<<"EOL"
-You can specify any website URL which serves data suited for display in RSS feeds
-(for example a news blog).
-EOL
-                , 'type' => 'text',
+                    You can specify any website URL which serves data suited for display in RSS feeds
+                    (for example a news blog).
+                    EOL, 'type' => 'text',
                 'exampleValue' => 'https://news.blizzard.com/en-en',
                 'defaultValue' => 'https://news.blizzard.com/en-en',
-                'required' => true
+                'required' => true,
             ],
 
             'item' => [
                 'name' => 'Item selector',
                 'title' => <<<"EOL"
-Enter an XPath expression matching a list of dom nodes, each node containing one
-feed article item in total (usually a surrounding &lt;div&gt; or &lt;span&gt; tag). This will
-be the context nodes for all of the following expressions. This expression usually
-starts with a single forward slash.
-EOL
-                , 'type' => 'text',
+                    Enter an XPath expression matching a list of dom nodes, each node containing one
+                    feed article item in total (usually a surrounding &lt;div&gt; or &lt;span&gt; tag). This will
+                    be the context nodes for all of the following expressions. This expression usually
+                    starts with a single forward slash.
+                    EOL, 'type' => 'text',
                 'exampleValue' => '/html/body/div/div[4]/div[2]/div[2]/div/div/section/ol/li/article',
                 'defaultValue' => '/html/body/div/div[4]/div[2]/div[2]/div/div/section/ol/li/article',
-                'required' => true
+                'required' => true,
             ],
 
             'title' => [
                 'name' => 'Item title selector',
                 'title' => <<<"EOL"
-This expression should match a node contained within each article item node
-containing the article headline. It should start with a dot followed by two
-forward slashes, referring to any descendant nodes of the article item node.
-EOL
-                , 'type' => 'text',
+                    This expression should match a node contained within each article item node
+                    containing the article headline. It should start with a dot followed by two
+                    forward slashes, referring to any descendant nodes of the article item node.
+                    EOL, 'type' => 'text',
                 'exampleValue' => './/div/div[2]/h2',
                 'defaultValue' => './/div/div[2]/h2',
-                'required' => true
+                'required' => true,
             ],
 
             'content' => [
                 'name' => 'Item description selector',
                 'title' => <<<"EOL"
-This expression should match a node contained within each article item node
-containing the article content or description. It should start with a dot
-followed by two forward slashes, referring to any descendant nodes of the
-article item node.
-EOL
-                , 'type' => 'text',
+                    This expression should match a node contained within each article item node
+                    containing the article content or description. It should start with a dot
+                    followed by two forward slashes, referring to any descendant nodes of the
+                    article item node.
+                    EOL, 'type' => 'text',
                 'exampleValue' => './/div[@class="ArticleListItem-description"]/div[@class="h6"]',
                 'defaultValue' => './/div[@class="ArticleListItem-description"]/div[@class="h6"]',
-                'required' => false
+                'required' => false,
             ],
 
             'uri' => [
                 'name' => 'Item URL selector',
                 'title' => <<<"EOL"
-This expression should match a node's attribute containing the article URL
-(usually the href attribute of an &lt;a&gt; tag). It should start with a dot
-followed by two forward slashes, referring to any descendant nodes of
-the article item node. Attributes can be selected by prepending an @ char
-before the attributes name.
-EOL
-                , 'type' => 'text',
+                    This expression should match a node's attribute containing the article URL
+                    (usually the href attribute of an &lt;a&gt; tag). It should start with a dot
+                    followed by two forward slashes, referring to any descendant nodes of
+                    the article item node. Attributes can be selected by prepending an @ char
+                    before the attributes name.
+                    EOL, 'type' => 'text',
                 'exampleValue' => './/a[@class="ArticleLink ArticleLink"]/@href',
                 'defaultValue' => './/a[@class="ArticleLink ArticleLink"]/@href',
-                'required' => false
+                'required' => false,
             ],
 
             'author' => [
                 'name' => 'Item author selector',
                 'title' => <<<"EOL"
-This expression should match a node contained within each article item
-node containing the article author's name. It should start with a dot
-followed by two forward slashes, referring to any descendant nodes of
-the article item node.
-EOL
-                , 'type' => 'text',
-                'required' => false
+                    This expression should match a node contained within each article item
+                    node containing the article author's name. It should start with a dot
+                    followed by two forward slashes, referring to any descendant nodes of
+                    the article item node.
+                    EOL, 'type' => 'text',
+                'required' => false,
             ],
 
             'timestamp' => [
                 'name' => 'Item date selector',
                 'title' => <<<"EOL"
-This expression should match a node or node's attribute containing the
-article timestamp or date (parsable by PHP's strtotime function). It
-should start with a dot followed by two forward slashes, referring to
-any descendant nodes of the article item node. Attributes can be
-selected by prepending an @ char before the attributes name.
-EOL
-                , 'type' => 'text',
+                    This expression should match a node or node's attribute containing the
+                    article timestamp or date (parsable by PHP's strtotime function). It
+                    should start with a dot followed by two forward slashes, referring to
+                    any descendant nodes of the article item node. Attributes can be
+                    selected by prepending an @ char before the attributes name.
+                    EOL, 'type' => 'text',
                 'exampleValue' => './/time[@class="ArticleListItem-footerTimestamp"]/@timestamp',
                 'defaultValue' => './/time[@class="ArticleListItem-footerTimestamp"]/@timestamp',
-                'required' => false
+                'required' => false,
             ],
 
             'enclosures' => [
                 'name' => 'Item image selector',
                 'title' => <<<"EOL"
-This expression should match a node's attribute containing an article
-image URL (usually the src attribute of an &lt;img&gt; tag or a style
-attribute). It should start with a dot followed by two forward slashes,
-referring to any descendant nodes of the article item node. Attributes
-can be selected by prepending an @ char before the attributes name.
-EOL
-                , 'type' => 'text',
+                    This expression should match a node's attribute containing an article
+                    image URL (usually the src attribute of an &lt;img&gt; tag or a style
+                    attribute). It should start with a dot followed by two forward slashes,
+                    referring to any descendant nodes of the article item node. Attributes
+                    can be selected by prepending an @ char before the attributes name.
+                    EOL, 'type' => 'text',
                 'exampleValue' => './/div[@class="ArticleListItem-image"]/@style',
                 'defaultValue' => './/div[@class="ArticleListItem-image"]/@style',
-                'required' => false
+                'required' => false,
             ],
 
             'categories' => [
                 'name' => 'Item category selector',
                 'title' => <<<"EOL"
-This expression should match a node or node's attribute contained
-within each article item node containing the article category. This
-could be inside &lt;div&gt; or &lt;span&gt; tags or sometimes be hidden
-in a data attribute. It should start with a dot followed by two
-forward slashes, referring to any descendant nodes of the article
-item node. Attributes can be selected by prepending an @ char
-before the attributes name.
-EOL
-                , 'type' => 'text',
+                    This expression should match a node or node's attribute contained
+                    within each article item node containing the article category. This
+                    could be inside &lt;div&gt; or &lt;span&gt; tags or sometimes be hidden
+                    in a data attribute. It should start with a dot followed by two
+                    forward slashes, referring to any descendant nodes of the article
+                    item node. Attributes can be selected by prepending an @ char
+                    before the attributes name.
+                    EOL, 'type' => 'text',
                 'exampleValue' => './/div[@class="ArticleListItem-label"]',
                 'defaultValue' => './/div[@class="ArticleListItem-label"]',
-                'required' => false
+                'required' => false,
             ],
 
             'fix_encoding' => [
                 'name' => 'Fix encoding',
                 'title' => <<<"EOL"
-Check this to fix feed encoding by invoking PHP's utf8_decode
-function on all extracted texts. Try this in case you see "broken" or
-"weird" characters in your feed where you'd normally expect umlauts
-or any other non-ascii characters.
-EOL
-                , 'type' => 'checkbox',
-                'required' => false
+                    Check this to fix feed encoding by invoking PHP's utf8_decode
+                    function on all extracted texts. Try this in case you see "broken" or
+                    "weird" characters in your feed where you'd normally expect umlauts
+                    or any other non-ascii characters.
+                    EOL, 'type' => 'checkbox',
+                'required' => false,
             ],
 
-        ]
+        ],
     ];
 
     /**

--- a/bridges/XenForoBridge.php
+++ b/bridges/XenForoBridge.php
@@ -33,8 +33,8 @@ class XenForoBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert URL to the thread for which the feed should be generated',
-                'exampleValue' => 'https://xenforo.com/community/threads/guide-to-suggestions.2285/'
-            ]
+                'exampleValue' => 'https://xenforo.com/community/threads/guide-to-suggestions.2285/',
+            ],
         ],
         'global' => [
             'limit' => [
@@ -42,9 +42,9 @@ class XenForoBridge extends BridgeAbstract
                 'type' => 'number',
                 'required' => false,
                 'title' => 'Specify maximum number of elements to return in the feed',
-                'defaultValue' => 10
-            ]
-        ]
+                'defaultValue' => 10,
+            ],
+        ],
     ];
     const CACHE_TIMEOUT = 7200; // 10 minutes
 
@@ -288,10 +288,10 @@ class XenForoBridge extends BridgeAbstract
         // high. When this happens we need to load further pages (from last backwards)
         if (($pageNav = $html->find('div.PageNav', 0))) {
             $lastpage = $pageNav->{'data-last'};
-            $baseurl  = $pageNav->{'data-baseurl'};
+            $baseurl = $pageNav->{'data-baseurl'};
             $sentinel = $pageNav->{'data-sentinel'};
 
-            $hosturl  = parse_url($this->threadurl, PHP_URL_SCHEME)
+            $hosturl = parse_url($this->threadurl, PHP_URL_SCHEME)
             . '://'
             . parse_url($this->threadurl, PHP_URL_HOST)
             . '/';
@@ -335,7 +335,7 @@ class XenForoBridge extends BridgeAbstract
 
             $sentinel = '{{sentinel}}';
 
-            $hosturl  = parse_url($this->threadurl, PHP_URL_SCHEME)
+            $hosturl = parse_url($this->threadurl, PHP_URL_SCHEME)
             . '://'
             . parse_url($this->threadurl, PHP_URL_HOST);
 
@@ -390,7 +390,7 @@ class XenForoBridge extends BridgeAbstract
             'September',
             'October',
             'November',
-            'December'
+            'December',
         ];
 
         switch ($lang) {
@@ -411,7 +411,7 @@ class XenForoBridge extends BridgeAbstract
                     'September',
                     'Oktober',
                     'November',
-                    'Dezember'
+                    'Dezember',
                 ];
 
                 $mnamesdeshort = [
@@ -426,7 +426,7 @@ class XenForoBridge extends BridgeAbstract
                     'Sep.',
                     'Okt.',
                     'Nov.',
-                    'Dez.'
+                    'Dez.',
                 ];
 
                 $date = str_ireplace($mnamesde, $mnamesen, $date);

--- a/bridges/YGGTorrentBridge.php
+++ b/bridges/YGGTorrentBridge.php
@@ -56,32 +56,32 @@ class YGGTorrentBridge extends BridgeAbstract
                     'GPS - Toutes les sous-catégories' => '2141.all',
                     'GPS - Applications' => '2141.2168',
                     'GPS - Cartes' => '2141.2169',
-                    'GPS - Divers' => '2141.2170'
-                ]
+                    'GPS - Divers' => '2141.2170',
+                ],
             ],
             'nom' => [
                 'name' => 'Nom',
                 'description' => 'Nom du torrent',
                 'type' => 'text',
-                'exampleValue' => 'matrix'
+                'exampleValue' => 'matrix',
             ],
             'description' => [
                 'name' => 'Description',
                 'description' => 'Description du torrent',
-                'type' => 'text'
+                'type' => 'text',
             ],
             'fichier' => [
                 'name' => 'Fichier',
                 'description' => 'Fichier du torrent',
-                'type' => 'text'
+                'type' => 'text',
             ],
             'uploader' => [
                 'name' => 'Uploader',
                 'description' => 'Uploader du torrent',
-                'type' => 'text'
+                'type' => 'text',
             ],
 
-        ]
+        ],
     ];
 
     public function collectData()

--- a/bridges/YeggiBridge.php
+++ b/bridges/YeggiBridge.php
@@ -13,7 +13,7 @@ class YeggiBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'title' => 'Insert your search term here',
-                'exampleValue' => 'vase'
+                'exampleValue' => 'vase',
             ],
             'sortby' => [
                 'name' => 'Sort by',
@@ -24,7 +24,7 @@ class YeggiBridge extends BridgeAbstract
                     'Popular' => '1',
                     'Latest' => '2',
                 ],
-                'defaultValue' => 'newest'
+                'defaultValue' => 'newest',
             ],
             'show' => [
                 'name' => 'Show',
@@ -35,16 +35,16 @@ class YeggiBridge extends BridgeAbstract
                     'Free' => '1',
                     'For sale' => '2',
                 ],
-                'defaultValue' => 'all'
+                'defaultValue' => 'all',
             ],
             'showimage' => [
                 'name' => 'Show image in content',
                 'type' => 'checkbox',
                 'required' => false,
                 'title' => 'Activate to show the image in the content',
-                'defaultValue' => 'checked'
-            ]
-        ]
+                'defaultValue' => 'checked',
+            ],
+        ],
     ];
 
     public function collectData()

--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -12,17 +12,17 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
                 'name' => 'Channel ID',
                 'type' => 'text',
                 'required' => true,
-                'exampleValue' => 'UCULkRHBdLC5ZcEQBaL0oYHQ'
-            ]
+                'exampleValue' => 'UCULkRHBdLC5ZcEQBaL0oYHQ',
+            ],
         ],
         'By username' => [
             'username' => [
                 'name' => 'Username',
                 'type' => 'text',
                 'required' => true,
-                'exampleValue' => 'YouTubeUK'
+                'exampleValue' => 'YouTubeUK',
             ],
-        ]
+        ],
     ];
 
     const CACHE_TIMEOUT = 3600; // 1 hour
@@ -213,9 +213,9 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
                 }
 
                 $content = <<<EOD
-<iframe width="100%" height="410" src="https://www.youtube.com/embed/{$attachments->videoRenderer->videoId}" 
-frameborder="0" allow="encrypted-media;" allowfullscreen></iframe>
-EOD;
+                    <iframe width="100%" height="410" src="https://www.youtube.com/embed/{$attachments->videoRenderer->videoId}" 
+                    frameborder="0" allow="encrypted-media;" allowfullscreen></iframe>
+                    EOD;
             }
 
             // Image
@@ -227,8 +227,8 @@ EOD;
                 $lastThumb = end($attachments->backstageImageRenderer->image->thumbnails);
 
                 $content = <<<EOD
-<p><img src="{$lastThumb->url}"></p>
-EOD;
+                    <p><img src="{$lastThumb->url}"></p>
+                    EOD;
             }
 
             // Poll
@@ -241,13 +241,13 @@ EOD;
 
                 foreach ($attachments->pollRenderer->choices as $choice) {
                     $pollChoices .= <<<EOD
-<li>{$choice->text->runs[0]->text}</li>
-EOD;
+                        <li>{$choice->text->runs[0]->text}</li>
+                        EOD;
                 }
 
                 $content = <<<EOD
-<hr><p>Poll ({$attachments->pollRenderer->totalVotes->simpleText})<br><ul>{$pollChoices}</ul><p>
-EOD;
+                    <hr><p>Poll ({$attachments->pollRenderer->totalVotes->simpleText})<br><ul>{$pollChoices}</ul><p>
+                    EOD;
             }
         }
 

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -20,64 +20,64 @@ class YoutubeBridge extends BridgeAbstract
             'u' => [
                 'name' => 'username',
                 'exampleValue' => 'LinusTechTips',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'By channel id' => [
             'c' => [
                 'name' => 'channel id',
                 'exampleValue' => 'UCw38-8_Ibv_L6hlKChHO9dQ',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'By custom name' => [
             'custom' => [
                 'name' => 'custom name',
                 'exampleValue' => 'LinusTechTips',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'By playlist Id' => [
             'p' => [
                 'name' => 'playlist id',
                 'exampleValue' => 'PL8mG-RkN2uTzJc8N0EoyhdC54prvBBLpj',
-                'required' => true
-            ]
+                'required' => true,
+            ],
         ],
         'Search result' => [
             's' => [
                 'name' => 'search keyword',
                 'exampleValue' => 'LinusTechTips',
-                'required' => true
+                'required' => true,
             ],
             'pa' => [
                 'name' => 'page',
                 'type' => 'number',
                 'title' => 'This option is not work anymore, as YouTube will always return the same page',
-                'exampleValue' => 1
-            ]
+                'exampleValue' => 1,
+            ],
         ],
         'global' => [
             'duration_min' => [
                 'name' => 'min. duration (minutes)',
                 'type' => 'number',
                 'title' => 'Minimum duration for the video in minutes',
-                'exampleValue' => 5
+                'exampleValue' => 5,
             ],
             'duration_max' => [
                 'name' => 'max. duration (minutes)',
                 'type' => 'number',
                 'title' => 'Maximum duration for the video in minutes',
-                'exampleValue' => 10
-            ]
-        ]
+                'exampleValue' => 10,
+            ],
+        ],
     ];
 
     private $feedName = '';
     private $feeduri = '';
     private $channel_name = '';
     // This took from repo BetterVideoRss of VerifiedJoseph.
-	const URI_REGEX = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2    ,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"\'!?&\/\/=\-*]+|\/)?)/ims'; //phpcs:ignore
+    const URI_REGEX = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2    ,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"\'!?&\/\/=\-*]+|\/)?)/ims'; //phpcs:ignore
 
     private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time)
     {
@@ -192,7 +192,7 @@ class YoutubeBridge extends BridgeAbstract
     private function ytGetSimpleHTMLDOM($url, $cached = false)
     {
         $header = [
-            'Accept-Language: en-US'
+            'Accept-Language: en-US',
         ];
         $opts = [];
         $lowercase = true;
@@ -433,7 +433,7 @@ class YoutubeBridge extends BridgeAbstract
 
     public function getName()
     {
-      // Name depends on queriedContext:
+        // Name depends on queriedContext:
         switch ($this->queriedContext) {
             case 'By username':
             case 'By channel id':

--- a/bridges/ZDNetBridge.php
+++ b/bridges/ZDNetBridge.php
@@ -22,7 +22,7 @@ class ZDNetBridge extends FeedExpander
                     'Latest Australia Articles' => 'au',
                     'Latest UK Articles' => 'uk',
                     'Latest US Articles' => 'us',
-                    'Latest Asia Articles' => 'as'
+                    'Latest Asia Articles' => 'as',
                 ],
                 'Keep up with ZDNet Blogs RSS:' => [
                     'Transforming the Datacenter' => 'blog/transforming-datacenter',
@@ -116,7 +116,7 @@ class ZDNetBridge extends FeedExpander
                     'ZDNet Government' => 'blog/government',
                     'ZDNet UK Book Reviews' => 'blog/zdnet-uk-book-reviews',
                     'ZDNet UK First Take' => 'blog/zdnet-uk-first-take',
-                    'Zero Day' => 'blog/security'
+                    'Zero Day' => 'blog/security',
                 ],
                 'ZDNet Hot Topics RSS:' => [
                     'Apple' => 'topic/apple',
@@ -141,7 +141,7 @@ class ZDNetBridge extends FeedExpander
                     'Processors' => 'topic/processors',
                     'Samsung' => 'topic/samsung',
                     'Security' => 'topic/security',
-                    'Small business: going big on mobility' => 'topic/small-business-going-big-on-mobility'
+                    'Small business: going big on mobility' => 'topic/small-business-going-big-on-mobility',
                 ],
                 'Product Blogs:' => [
                     'Digital Cameras & Camcorders' => 'blog/digitalcameras',
@@ -149,14 +149,14 @@ class ZDNetBridge extends FeedExpander
                     'Laptops and Desktops' => 'blog/computers',
                     'The Mobile Gadgeteer' => 'blog/mobile-gadgeteer',
                     'Smartphones and Cell Phones' => 'blog/cell-phones',
-                    'The ToyBox' => 'blog/gadgetreviews'
+                    'The ToyBox' => 'blog/gadgetreviews',
                 ],
                 'Vertical Blogs:' => [
                     'ZDNet Education' => 'blog/education',
                     'ZDNet Healthcare' => 'blog/healthcare',
-                    'ZDNet Government' => 'blog/government'
-                ]
-            ]
+                    'ZDNet Government' => 'blog/government',
+                ],
+            ],
         ],
         'limit' => self::LIMIT,
     ]];

--- a/contrib/prepare_release/fetch_contributors.php
+++ b/contrib/prepare_release/fetch_contributors.php
@@ -12,7 +12,7 @@ while ($next) { /* Collect all contributors */
     $headers = [
         'Accept: application/json',
         'Content-Type: application/json',
-        'User-Agent: RSS-Bridge'
+        'User-Agent: RSS-Bridge',
     ];
     $result = _http_request($url, ['headers' => $headers]);
 
@@ -26,7 +26,7 @@ while ($next) { /* Collect all contributors */
 
     // Check if there is a link with 'rel="next"'
     foreach ($links as $link) {
-        list($url, $type) = explode(';', $link, 2);
+        [$url, $type] = explode(';', $link, 2);
 
         if (trim($type) === 'rel="next"') {
             $url = trim(preg_replace('/([<>])/', '', $url));

--- a/formats/HtmlFormat.php
+++ b/formats/HtmlFormat.php
@@ -93,43 +93,43 @@ class HtmlFormat extends FormatAbstract
 
             $entries .= <<<EOD
 
-<section class="feeditem">
-	<h2><a class="itemtitle" href="{$entryUri}">{$entryTitle}</a></h2>
-	{$entryDate}
-	{$entryAuthor}
-	{$entryContent}
-	{$entryEnclosures}
-	{$entryCategories}
-</section>
+                <section class="feeditem">
+                	<h2><a class="itemtitle" href="{$entryUri}">{$entryTitle}</a></h2>
+                	{$entryDate}
+                	{$entryAuthor}
+                	{$entryContent}
+                	{$entryEnclosures}
+                	{$entryCategories}
+                </section>
 
-EOD;
+                EOD;
         }
 
         $charset = $this->getCharset();
 
         /* Data are prepared, now let's begin the "MAGIE !!!" */
         $toReturn = <<<EOD
-<!DOCTYPE html>
-<html>
-<head>
-	<meta charset="{$charset}">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>{$title}</title>
-	<link href="static/HtmlFormat.css" rel="stylesheet">
-	<link rel="icon" type="image/png" href="static/favicon.png">
-	{$links}
-	<meta name="robots" content="noindex, follow">
-</head>
-<body>
-	<h1 class="pagetitle"><a href="{$uri}" target="_blank">{$title}</a></h1>
-	<div class="buttons">
-		<a href="./#bridge-{$_GET['bridge']}"><button class="backbutton">← back to rss-bridge</button></a>
-		{$buttons}
-	</div>
-{$entries}
-</body>
-</html>
-EOD;
+            <!DOCTYPE html>
+            <html>
+            <head>
+            	<meta charset="{$charset}">
+            	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            	<title>{$title}</title>
+            	<link href="static/HtmlFormat.css" rel="stylesheet">
+            	<link rel="icon" type="image/png" href="static/favicon.png">
+            	{$links}
+            	<meta name="robots" content="noindex, follow">
+            </head>
+            <body>
+            	<h1 class="pagetitle"><a href="{$uri}" target="_blank">{$title}</a></h1>
+            	<div class="buttons">
+            		<a href="./#bridge-{$_GET['bridge']}"><button class="backbutton">← back to rss-bridge</button></a>
+            		{$buttons}
+            	</div>
+            {$entries}
+            </body>
+            </html>
+            EOD;
 
         // Remove invalid characters
         ini_set('mbstring.substitute_character', 'none');
@@ -140,15 +140,15 @@ EOD;
     private function buildButton($format, $query)
     {
         return <<<EOD
-<a href="./?{$query}"><button class="rss-feed">{$format}</button></a>
-EOD;
+            <a href="./?{$query}"><button class="rss-feed">{$format}</button></a>
+            EOD;
     }
 
     private function buildLink($format, $query, $mime)
     {
         return <<<EOD
-<link href="./?{$query}" title="{$format}" rel="alternate" type="{$mime}">
+            <link href="./?{$query}" title="{$format}" rel="alternate" type="{$mime}">
 
-EOD;
+            EOD;
     }
 }

--- a/formats/JsonFormat.php
+++ b/formats/JsonFormat.php
@@ -36,7 +36,7 @@ class JsonFormat extends FormatAbstract
             'version' => 'https://jsonfeed.org/version/1',
             'title' => (!empty($extraInfos['name'])) ? $extraInfos['name'] : $urlHost,
             'home_page_url' => (!empty($extraInfos['uri'])) ? $extraInfos['uri'] : REPOSITORY,
-            'feed_url' => $urlPrefix . $urlHost . $urlRequest
+            'feed_url' => $urlPrefix . $urlHost . $urlRequest,
         ];
 
         if (!empty($extraInfos['icon'])) {
@@ -72,7 +72,7 @@ class JsonFormat extends FormatAbstract
             }
             if (!empty($entryAuthor)) {
                 $entry['author'] = [
-                    'name' => $entryAuthor
+                    'name' => $entryAuthor,
                 ];
             }
             if (!empty($entryTimestamp)) {
@@ -93,7 +93,7 @@ class JsonFormat extends FormatAbstract
                 foreach ($entryEnclosures as $enclosure) {
                     $entry['attachments'][] = [
                         'url' => $enclosure,
-                        'mime_type' => getMimeType($enclosure)
+                        'mime_type' => getMimeType($enclosure),
                     ];
                 }
             }

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -33,7 +33,7 @@ class MrssFormat extends FormatAbstract
     protected const MRSS_NS = 'http://search.yahoo.com/mrss/';
 
     const ALLOWED_IMAGE_EXT = [
-        '.gif', '.jpg', '.png'
+        '.gif', '.jpg', '.png',
     ];
 
     public function stringify()

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -93,9 +93,9 @@ abstract class BridgeAbstract implements BridgeInterface
      * Can be inlined and modified if necessary.
      */
     protected const LIMIT = [
-        'name'          => 'Limit',
-        'type'          => 'number',
-        'title'         => 'Maximum number of items to return',
+        'name' => 'Limit',
+        'type' => 'number',
+        'title' => 'Maximum number of items to return',
     ];
 
     /**
@@ -162,7 +162,7 @@ abstract class BridgeAbstract implements BridgeInterface
                     continue;
                 }
 
-                $type = isset($properties['type']) ? $properties['type'] : 'text';
+                $type = $properties['type'] ?? 'text';
 
                 switch ($type) {
                     case 'checkbox':

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -32,15 +32,15 @@ final class BridgeCard
     private static function getFormHeader($bridgeName, $isHttps = false, $parameterName = '')
     {
         $form = <<<EOD
-			<form method="GET" action="?">
-				<input type="hidden" name="action" value="display" />
-				<input type="hidden" name="bridge" value="{$bridgeName}" />
-EOD;
+            			<form method="GET" action="?">
+            				<input type="hidden" name="action" value="display" />
+            				<input type="hidden" name="bridge" value="{$bridgeName}" />
+            EOD;
 
         if (!empty($parameterName)) {
             $form .= <<<EOD
-				<input type="hidden" name="context" value="{$parameterName}" />
-EOD;
+                				<input type="hidden" name="context" value="{$parameterName}" />
+                EOD;
         }
 
         if (!$isHttps) {
@@ -327,7 +327,7 @@ This bridge is not fetching its content through a secure connection</div>';
         if (defined('PROXY_URL') && PROXY_BYBRIDGE) {
             $parameters['global']['_noproxy'] = [
                 'name' => 'Disable proxy (' . ((defined('PROXY_NAME') && PROXY_NAME) ? PROXY_NAME : PROXY_URL) . ')',
-                'type' => 'checkbox'
+                'type' => 'checkbox',
             ];
         }
 
@@ -335,17 +335,17 @@ This bridge is not fetching its content through a secure connection</div>';
             $parameters['global']['_cache_timeout'] = [
                 'name' => 'Cache timeout in seconds',
                 'type' => 'number',
-                'defaultValue' => $bridge->getCacheTimeout()
+                'defaultValue' => $bridge->getCacheTimeout(),
             ];
         }
 
         $card = <<<CARD
-			<section id="bridge-{$bridgeName}" data-ref="{$name}">
-				<h2><a href="{$uri}">{$name}</a></h2>
-				<p class="description">{$description}</p>
-				<input type="checkbox" class="showmore-box" id="showmore-{$bridgeName}" />
-				<label class="showmore" for="showmore-{$bridgeName}">Show more</label>
-CARD;
+            			<section id="bridge-{$bridgeName}" data-ref="{$name}">
+            				<h2><a href="{$uri}">{$name}</a></h2>
+            				<p class="description">{$description}</p>
+            				<input type="checkbox" class="showmore-box" id="showmore-{$bridgeName}" />
+            				<label class="showmore" for="showmore-{$bridgeName}">Show more</label>
+            CARD;
 
         // If we don't have any parameter for the bridge, we print a generic form to load it.
         if (count($parameters) === 0) {

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -30,24 +30,24 @@ final class BridgeList
     private static function getHead()
     {
         return <<<EOD
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<meta name="description" content="RSS-Bridge" />
-	<title>RSS-Bridge</title>
-	<link href="static/style.css" rel="stylesheet">
-	<link rel="icon" type="image/png" href="static/favicon.png">
-	<script src="static/search.js"></script>
-	<script src="static/select.js"></script>
-	<noscript>
-		<style>
-			.searchbar {
-				display: none;
-			}
-		</style>
-	</noscript>
-</head>
-EOD;
+            <head>
+            	<meta charset="utf-8">
+            	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            	<meta name="description" content="RSS-Bridge" />
+            	<title>RSS-Bridge</title>
+            	<link href="static/style.css" rel="stylesheet">
+            	<link rel="icon" type="image/png" href="static/favicon.png">
+            	<script src="static/search.js"></script>
+            	<script src="static/select.js"></script>
+            	<noscript>
+            		<style>
+            			.searchbar {
+            				display: none;
+            			}
+            		</style>
+            	</noscript>
+            </head>
+            EOD;
     }
 
     /**
@@ -100,23 +100,23 @@ EOD;
         if (Debug::isEnabled()) {
             if (!Debug::isSecure()) {
                 $warning .= <<<EOD
-<section class="critical-warning">Warning : Debug mode is active from any location,
- make sure only you can access RSS-Bridge.</section>
-EOD;
+                    <section class="critical-warning">Warning : Debug mode is active from any location,
+                     make sure only you can access RSS-Bridge.</section>
+                    EOD;
             } else {
                 $warning .= <<<EOD
-<section class="warning">Warning : Debug mode is active from your IP address,
- your requests will bypass the cache.</section>
-EOD;
+                    <section class="warning">Warning : Debug mode is active from your IP address,
+                     your requests will bypass the cache.</section>
+                    EOD;
             }
         }
 
         return <<<EOD
-<header>
-	<div class="logo"></div>
-	{$warning}
-</header>
-EOD;
+            <header>
+            	<div class="logo"></div>
+            	{$warning}
+            </header>
+            EOD;
     }
 
     /**
@@ -129,13 +129,13 @@ EOD;
         $query = filter_input(INPUT_GET, 'q', FILTER_SANITIZE_SPECIAL_CHARS);
 
         return <<<EOD
-<section class="searchbar">
-	<h3>Search</h3>
-	<input type="text" name="searchfield"
-		id="searchfield" placeholder="Insert URL or bridge name"
-		onchange="search()" onkeyup="search()" value="{$query}">
-</section>
-EOD;
+            <section class="searchbar">
+            	<h3>Search</h3>
+            	<input type="text" name="searchfield"
+            		id="searchfield" placeholder="Insert URL or bridge name"
+            		onchange="search()" onkeyup="search()" value="{$query}">
+            </section>
+            EOD;
     }
 
     /**
@@ -156,12 +156,12 @@ EOD;
         $admininfo = '';
         if (!empty($email)) {
             $admininfo = <<<EOD
-<br />
-<span>
-   You may email the administrator of this RSS-Bridge instance
-   at <a href="mailto:{$email}">{$email}</a>
-</span>
-EOD;
+                <br />
+                <span>
+                   You may email the administrator of this RSS-Bridge instance
+                   at <a href="mailto:{$email}">{$email}</a>
+                </span>
+                EOD;
         }
 
         $inactive = '';
@@ -175,14 +175,14 @@ EOD;
         }
 
         return <<<EOD
-<section class="footer">
-	<a href="https://github.com/rss-bridge/rss-bridge">RSS-Bridge ~ Public Domain</a><br>
-	<p class="version">{$version}</p>
-	{$totalActiveBridges}/{$totalBridges} active bridges.<br>
-	{$inactive}
-	{$admininfo}
-</section>
-EOD;
+            <section class="footer">
+            	<a href="https://github.com/rss-bridge/rss-bridge">RSS-Bridge ~ Public Domain</a><br>
+            	<p class="version">{$version}</p>
+            	{$totalActiveBridges}/{$totalBridges} active bridges.<br>
+            	{$inactive}
+            	{$admininfo}
+            </section>
+            EOD;
     }
 
     /**

--- a/lib/Debug.php
+++ b/lib/Debug.php
@@ -114,7 +114,7 @@ class Debug
         $calling = end($backtrace);
         $message = $calling['file'] . ':'
             . $calling['line'] . ' class '
-            . (isset($calling['class']) ? $calling['class'] : '<no-class>') . '->'
+            . ($calling['class'] ?? '<no-class>') . '->'
             . $calling['function'] . ' - '
             . $text;
 

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -77,7 +77,7 @@ function buildBridgeException(\Throwable $e, BridgeInterface $bridge): string
     $body = 'Error message: `'
     . $e->getMessage()
     . "`\nQuery string: `"
-    . (isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '')
+    . ($_SERVER['QUERY_STRING'] ?? '')
     . "`\nVersion: `"
     . Configuration::getVersion()
     . '`';
@@ -88,10 +88,10 @@ function buildBridgeException(\Throwable $e, BridgeInterface $bridge): string
 
     $header = buildHeader($e, $bridge);
     $message = <<<EOD
-<strong>{$bridge->getName()}</strong> was unable to receive or process the
-remote website's content!<br>
-{$body_html}
-EOD;
+        <strong>{$bridge->getName()}</strong> was unable to receive or process the
+        remote website's content!<br>
+        {$body_html}
+        EOD;
     $section = buildSection($e, $bridge, $message, $link, $searchQuery);
 
     return $section;
@@ -105,7 +105,7 @@ function buildTransformException(\Throwable $e, BridgeInterface $bridge): string
     $body = 'Error message: `'
     . $e->getMessage()
     . "`\nQuery string: `"
-    . (isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '')
+    . ($_SERVER['QUERY_STRING'] ?? '')
     . '`';
 
     $link = buildGitHubIssueQuery($title, $body, 'Bridge-Broken', $bridge->getMaintainer());
@@ -130,12 +130,12 @@ function buildTransformException(\Throwable $e, BridgeInterface $bridge): string
 function buildHeader($e, $bridge)
 {
     return <<<EOD
-<header>
-	<h1>Error {$e->getCode()}</h1>
-	<h2>{$e->getMessage()}</h2>
-	<p class="status">{$bridge->getName()}</p>
-</header>
-EOD;
+        <header>
+        	<h1>Error {$e->getCode()}</h1>
+        	<h2>{$e->getMessage()}</h2>
+        	<p class="status">{$bridge->getName()}</p>
+        </header>
+        EOD;
 }
 
 /**
@@ -153,24 +153,24 @@ EOD;
 function buildSection($e, $bridge, $message, $link, $searchQuery)
 {
     return <<<EOD
-<section>
-	<p class="exception-message">{$message}</p>
-	<div class="advice">
-		<ul class="advice">
-			<li>Press Return to check your input parameters</li>
-			<li>Press F5 to retry</li>
-			<li>Check if this issue was already reported on <a href="{$searchQuery}">GitHub</a> (give it a thumbs-up)</li>
-			<li>Open a <a href="{$link}">GitHub Issue</a> if this error persists</li>
-		</ul>
-	</div>
-	<a href="{$searchQuery}" title="Opens GitHub to search for similar issues">
-		<button>Search GitHub Issues</button>
-	</a>
-	<a href="{$link}" title="After clicking this button you can review
-	the issue before submitting it"><button>Open GitHub Issue</button></a>
-	<p class="maintainer">{$bridge->getMaintainer()}</p>
-</section>
-EOD;
+        <section>
+        	<p class="exception-message">{$message}</p>
+        	<div class="advice">
+        		<ul class="advice">
+        			<li>Press Return to check your input parameters</li>
+        			<li>Press F5 to retry</li>
+        			<li>Check if this issue was already reported on <a href="{$searchQuery}">GitHub</a> (give it a thumbs-up)</li>
+        			<li>Open a <a href="{$link}">GitHub Issue</a> if this error persists</li>
+        		</ul>
+        	</div>
+        	<a href="{$searchQuery}" title="Opens GitHub to search for similar issues">
+        		<button>Search GitHub Issues</button>
+        	</a>
+        	<a href="{$link}" title="After clicking this button you can review
+        	the issue before submitting it"><button>Open GitHub Issue</button></a>
+        	<p class="maintainer">{$bridge->getMaintainer()}</p>
+        </section>
+        EOD;
 }
 
 /**
@@ -186,16 +186,16 @@ EOD;
 function buildPage($title, $header, $section)
 {
     return <<<EOD
-<!DOCTYPE html>
-<html lang="en">
-<head>
-	<title>{$title}</title>
-	<link href="static/style.css" rel="stylesheet">
-</head>
-<body>
-	{$header}
-	{$section}
-</body>
-</html>
-EOD;
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        	<title>{$title}</title>
+        	<link href="static/style.css" rel="stylesheet">
+        </head>
+        <body>
+        	{$header}
+        	{$section}
+        </body>
+        </html>
+        EOD;
 }

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -405,10 +405,11 @@ abstract class FeedExpander extends BridgeAbstract
             foreach ($feedItem->guid->attributes() as $attribute => $value) {
                 if (
                     $attribute === 'isPermaLink'
-                    && ($value === 'true' || (
-                            filter_var($feedItem->guid, FILTER_VALIDATE_URL)
+                    && (
+                        $value === 'true' || (
+                        filter_var($feedItem->guid, FILTER_VALIDATE_URL)
                             && (empty($item['uri']) || !filter_var($item['uri'], FILTER_VALIDATE_URL))
-                        )
+                    )
                     )
                 ) {
                     $item['uri'] = (string)$feedItem->guid;
@@ -430,7 +431,7 @@ abstract class FeedExpander extends BridgeAbstract
         } elseif (isset($dc->creator)) {
             $item['author'] = (string)$dc->creator;
         } elseif (isset($media->credit)) {
-                $item['author'] = (string)$media->credit;
+            $item['author'] = (string)$media->credit;
         }
 
         if (isset($feedItem->enclosure) && !empty($feedItem->enclosure['url'])) {

--- a/lib/ParameterValidator.php
+++ b/lib/ParameterValidator.php
@@ -35,7 +35,7 @@ class ParameterValidator
     {
         $this->invalid[] = [
             'name' => $name,
-            'reason' => $reason
+            'reason' => $reason,
         ];
     }
 
@@ -65,8 +65,8 @@ class ParameterValidator
                 $value,
                 FILTER_VALIDATE_REGEXP,
                 ['options' => [
-                    'regexp' => '/^' . $pattern . '$/'
-                ]
+                    'regexp' => '/^' . $pattern . '$/',
+                ],
                 ]
             );
         } else {

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -44,7 +44,7 @@ const RSSBRIDGE_HTTP_STATUS_CODES = [
     '502' => 'Bad Gateway',
     '503' => 'Service Unavailable',
     '504' => 'Gateway Timeout',
-    '505' => 'HTTP Version Not Supported'
+    '505' => 'HTTP Version Not Supported',
 ];
 
 /**
@@ -212,10 +212,10 @@ function _http_request(string $url, array $config = []): array
     $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
     return [
-        'code'      => $statusCode,
+        'code' => $statusCode,
         'status_lines' => $responseStatusLines,
-        'headers'   => $responseHeaders,
-        'body'      => $data,
+        'headers' => $responseHeaders,
+        'body' => $data,
     ];
 }
 

--- a/lib/html.php
+++ b/lib/html.php
@@ -140,7 +140,8 @@ function extractFromDelimiters($string, $start, $end)
         $section_retrieved = substr($string, strpos($string, $start) + strlen($start));
         $section_retrieved = substr($section_retrieved, 0, strpos($section_retrieved, $end));
         return $section_retrieved;
-    } return false;
+    }
+    return false;
 }
 
 /**

--- a/tests/Actions/ListActionTest.php
+++ b/tests/Actions/ListActionTest.php
@@ -61,12 +61,12 @@ class ListActionTest extends TestCase
             'icon',
             'parameters',
             'maintainer',
-            'description'
+            'description',
         ];
 
         $allowedStatus = [
             'active',
-            'inactive'
+            'inactive',
         ];
 
         foreach ($items['bridges'] as $bridge) {

--- a/tests/Bridges/BridgeImplementationTest.php
+++ b/tests/Bridges/BridgeImplementationTest.php
@@ -71,7 +71,7 @@ class BridgeImplementationTest extends TestCase
             'text',
             'number',
             'list',
-            'checkbox'
+            'checkbox',
         ];
 
         foreach ($this->obj::PARAMETERS as $context => $params) {


### PR DESCRIPTION
```
$ composer require --dev friendsofphp/php-cs-fixer

$ echo >.php-cs-fixer.dist.php "<?php

$finder = PhpCsFixer\Finder::create()
    ->exclude('squizlabsD')
    ->in(__DIR__);

$rules = [
    '@PSR12' => true,
    '@PSR12:risky' => true,
    '@PHP74Migration' => true,
    '@PHP74Migration:risky' => true,
    // buggy, duplicates existing comment sometimes
    'no_break_comment' => false,
    'array_syntax' => true,
    'binary_operator_spaces' => true,
    'lowercase_static_reference' => true,
    'visibility_required' => false,
];

$config = new PhpCsFixer\Config();

return $config
    ->setRules($rules)
    ->setRiskyAllowed(true)
    ->setFinder($finder);
"

$ vendor/bin/php-cs-fixer --version
PHP CS Fixer 3.8.0 BerSzcz against war! by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 7.4.30

$ vendor/bin/php-cs-fixer fix
```
