### PR TITLE
feat: hide deprecated bridges

### DIFF
--- a/bridges/CodebergBridge.php
+++ b/bridges/CodebergBridge.php
@@ -2,7 +2,7 @@
 
 class CodebergBridge extends BridgeAbstract
 {
-    const NAME = 'Codeberg Bridge';
+    const NAME = 'Codeberg Bridge (DEPRECATED: use GiteaBridge)';
     const URI = 'https://codeberg.org/';
     const DESCRIPTION = 'Returns commits, issues, pull requests or releases for a repository.';
     const MAINTAINER = 'VerifiedJoseph';

--- a/lib/BridgeList.php
+++ b/lib/BridgeList.php
@@ -61,20 +61,26 @@ EOD;
      */
     private static function getBridges($showInactive, &$totalBridges, &$totalActiveBridges)
     {
-        $body = '';
         $totalActiveBridges = 0;
         $inactiveBridges = '';
 
-        $bridgeFac = new \BridgeFactory();
-        $bridgeList = $bridgeFac->getBridgeNames();
+        // Hide these bridges. But they still work.
+        $deprecatedBridges = [
+            'Codeberg',
+            'MozillaBugTracker',
+            'KernelBugTracker',
+        ];
+        $bridgeFactory = new BridgeFactory();
+        $bridgeNames = array_diff($bridgeFactory->getBridgeNames(), $deprecatedBridges);
 
-        $formatFac = new FormatFactory();
-        $formats = $formatFac->getFormatNames();
+        $formatFactory = new FormatFactory();
+        $formats = $formatFactory->getFormatNames();
 
-        $totalBridges = count($bridgeList);
+        $totalBridges = count($bridgeNames);
 
-        foreach ($bridgeList as $bridgeName) {
-            if ($bridgeFac->isWhitelisted($bridgeName)) {
+        $body = '';
+        foreach ($bridgeNames as $bridgeName) {
+            if ($bridgeFactory->isWhitelisted($bridgeName)) {
                 $body .= BridgeCard::displayBridgeCard($bridgeName, $formats);
                 $totalActiveBridges++;
             } elseif ($showInactive) {


### PR DESCRIPTION
I suggest that we hide deprecated bridges from the frontpage (bridge list). Existing feed urls still work.