### PR TITLE
ci: Fix PHPCompatibility again

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,8 +30,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-      - run: composer global require dealerdirect/phpcodesniffer-composer-installer
       - run: composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+      - run: composer global require dealerdirect/phpcodesniffer-composer-installer
       - run: composer global require phpcompatibility/php-compatibility
       - run: ~/.composer/vendor/bin/phpcs . --standard=phpcompatibility.xml --warning-severity=0 --extensions=php -p
 


### PR DESCRIPTION
The fix in 66568e3a39c61546c09a47a5688914a0bdf3c60c prevented an error when installing phpcompatibility/php-compatibility but there was still a warning before that when installing dealerdirect/phpcodesniffer-composer-installer. With [Composer 2.3.9](https://getcomposer.org/changelog/2.3.9), this is now an error too, so we need to move the config change before that.
