### PR TITLE
index: Support running with PHP built-in web server

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,13 @@
 <?php
 
+if (PHP_SAPI === 'cli-server') {
+    $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    // Serves frontend.
+    if (preg_match('/^\/static/', $path)) {
+        return false;
+    }
+}
+
 require_once __DIR__ . '/lib/rssbridge.php';
 
 /*


### PR DESCRIPTION
PHP contains has a [simple web server](https://www.php.net/manual/en/features.commandline.webserver.php) built-in, which is useful for quick testing when developing. It can be started with:

    php -S 127.0.0.1:8000

Let’s make it work properly by passing through the static assets.
