### PR TITLE
Fix coding style missed by phpbcf

### DIFF
--- a/bridges/AssociatedPressNewsBridge.php
+++ b/bridges/AssociatedPressNewsBridge.php
@@ -119,7 +119,7 @@ class AssociatedPressNewsBridge extends BridgeAbstract
         foreach ($tagContents['cards'] as $card) {
             $item = [];
 
-             // skip hub peeks & Notifications
+            // skip hub peeks & Notifications
             if ($card['cardType'] == 'Hub Peek' || $card['cardType'] == 'Notification') {
                 continue;
             }

--- a/bridges/CeskaTelevizeBridge.php
+++ b/bridges/CeskaTelevizeBridge.php
@@ -33,7 +33,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
             returnServerError('Could not get date from Česká televize string');
         }
 
-        $date = sprintf('%04d-%02d-%02d', isset($match[3]) ? $match[3] : date('Y'), $match[2], $match[1]);
+        $date = sprintf('%04d-%02d-%02d', $match[3] ?? date('Y'), $match[2], $match[1]);
         return strtotime($date);
     }
 
@@ -46,7 +46,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
             returnServerError('Invalid url');
         }
 
-        $category = isset($match[4]) ? $match[4] : 'nove';
+        $category = $match[4] ?? 'nove';
         $fixedUrl = "{$match[1]}dily/{$category}/";
 
         $html = getSimpleHTMLDOM($fixedUrl);
@@ -78,11 +78,11 @@ class CeskaTelevizeBridge extends BridgeAbstract
 
     public function getURI()
     {
-        return isset($this->feedUri) ? $this->feedUri : parent::getURI();
+        return $this->feedUri ?? parent::getURI();
     }
 
     public function getName()
     {
-        return isset($this->feedName) ? $this->feedName : parent::getName();
+        return $this->feedName ?? parent::getName();
     }
 }

--- a/bridges/Drive2ruBridge.php
+++ b/bridges/Drive2ruBridge.php
@@ -182,7 +182,7 @@ class Drive2ruBridge extends BridgeAbstract
 
     private function addCommentsLink($content, $url)
     {
-                return $content . '<br><a href="' . $url . '#comments">Перейти к комментариям</a>';
+        return $content . '<br><a href="' . $url . '#comments">Перейти к комментариям</a>';
     }
 
     private function addReadMoreLink($content, $url)

--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -85,12 +85,14 @@ class FB2Bridge extends BridgeAbstract
             $pageInfo = $this->getPageInfos($page, $cookies);
 
             if ($pageInfo['userId'] === null) {
-                returnClientError(<<<EOD
+                returnClientError(
+                    <<<EOD
 Unable to get the page id. You should consider getting the ID by hand, then importing it into FB2Bridge
 EOD
                 );
             } elseif ($pageInfo['userId'] == -1) {
-                returnClientError(<<<EOD
+                returnClientError(
+                    <<<EOD
 This page is not accessible without being logged in.
 EOD
                 );
@@ -120,7 +122,7 @@ EOD
 
             //Decode images
             $imagecleaned = preg_replace_callback('/<i [^>]* style="[^"]*url\(\'(.*?)\'\).*?><\/i>/m', function ($matches) {
-                    return "<img src='" . str_replace(['\\3a ', '\\3d ', '\\26 '], [':', '=', '&'], $matches[1]) . "' />";
+                return "<img src='" . str_replace(['\\3a ', '\\3d ', '\\26 '], [':', '=', '&'], $matches[1]) . "' />";
             }, $content);
             $content = str_get_html($imagecleaned);
 
@@ -158,7 +160,7 @@ EOD
                 'rel',
                 'id'] as $property_name
             ) {
-                    $content = preg_replace('/ ' . $property_name . '=\"[^"]*\"/i', '', $content);
+                $content = preg_replace('/ ' . $property_name . '=\"[^"]*\"/i', '', $content);
             }
             $content = preg_replace('/<\/a [^>]+>/i', '</a>', $content);
 

--- a/bridges/FDroidBridge.php
+++ b/bridges/FDroidBridge.php
@@ -72,17 +72,17 @@ class FDroidBridge extends BridgeAbstract
         // and now extracting app info from the selected widget (and yeah turns out icons are of heterogeneous sizes)
 
         foreach ($html_widget->find('a') as $element) {
-                $item = [];
-                $item['uri'] = self::URI . $element->href;
-                $item['title'] = $element->find('h4', 0)->plaintext;
-                $item['icon'] = $element->find('img', 0)->src;
-                $item['timestamp'] = $this->getTimestamp($item['icon']);
-                $item['summary'] = $element->find('span.package-summary', 0)->plaintext;
-                $item['content'] = '
+            $item = [];
+            $item['uri'] = self::URI . $element->href;
+            $item['title'] = $element->find('h4', 0)->plaintext;
+            $item['icon'] = $element->find('img', 0)->src;
+            $item['timestamp'] = $this->getTimestamp($item['icon']);
+            $item['summary'] = $element->find('span.package-summary', 0)->plaintext;
+            $item['content'] = '
 					<a href="' . $item['uri'] . '">
 						<img alt="" style="max-height:128px" src="' . $item['icon'] . '">
 					</a><br>' . $item['summary'];
-                $this->items[] = $item;
+            $this->items[] = $item;
         }
     }
 }

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -67,7 +67,7 @@ class FacebookBridge extends BridgeAbstract
         switch ($this->queriedContext) {
             case 'User':
                 if (!empty($this->authorName)) {
-                    return isset($this->extraInfos['name']) ? $this->extraInfos['name'] : $this->authorName;
+                    return $this->extraInfos['name'] ?? $this->authorName;
                 }
                 break;
 
@@ -425,7 +425,7 @@ class FacebookBridge extends BridgeAbstract
     private function unescapeFacebookEmote($content)
     {
         return preg_replace_callback('/<i><u>([^ <>]+) ([^<>]+)<\/u><\/i>/i', function ($matches) {
-                static $facebook_emoticons = [
+            static $facebook_emoticons = [
                     'smile' => ':)',
                     'frown' => ':(',
                     'tongue' => ':P',
@@ -448,19 +448,19 @@ class FacebookBridge extends BridgeAbstract
                     'colonthree' => ':3',
                     'like' => '&#x1F44D;'];
 
-                $len = count($matches);
+            $len = count($matches);
 
-                if ($len > 1) {
-                    for ($i = 1; $i < $len; $i++) {
-                        foreach ($facebook_emoticons as $name => $emote) {
-                            if ($matches[$i] === $name) {
-                                return $emote;
-                            }
+            if ($len > 1) {
+                for ($i = 1; $i < $len; $i++) {
+                    foreach ($facebook_emoticons as $name => $emote) {
+                        if ($matches[$i] === $name) {
+                            return $emote;
                         }
                     }
                 }
+            }
 
-                return $matches[0];
+            return $matches[0];
         }, $content);
     }
 

--- a/bridges/FeedMergeBridge.php
+++ b/bridges/FeedMergeBridge.php
@@ -51,7 +51,7 @@ TEXT;
         }
 
         // Sort by timestamp descending
-        usort($this->items, fn($a, $b) => $b['timestamp'] <=> $a['timestamp']);
+        usort($this->items, fn ($a, $b) => $b['timestamp'] <=> $a['timestamp']);
 
         // Remove duplicates
         $items = [];

--- a/bridges/FurAffinityBridge.php
+++ b/bridges/FurAffinityBridge.php
@@ -795,37 +795,37 @@ class FurAffinityBridge extends BridgeAbstract
 
     private function postFASimpleHTMLDOM($data)
     {
-            $opts = [
+        $opts = [
                 CURLOPT_CUSTOMREQUEST => 'POST',
                 CURLOPT_POSTFIELDS => http_build_query($data)
             ];
-            $header = [
+        $header = [
                 'Host: ' . parse_url(self::URI, PHP_URL_HOST),
                 'Content-Type: application/x-www-form-urlencoded',
                 'Cookie: ' . self::FA_AUTH_COOKIE
             ];
 
-            $html = getSimpleHTMLDOM($this->getURI(), $header, $opts);
-            $html = defaultLinkTo($html, $this->getURI());
+        $html = getSimpleHTMLDOM($this->getURI(), $header, $opts);
+        $html = defaultLinkTo($html, $this->getURI());
 
-            return $html;
+        return $html;
     }
 
     private function getFASimpleHTMLDOM($url, $cache = false)
     {
-            $header = [
+        $header = [
                 'Cookie: ' . self::FA_AUTH_COOKIE
             ];
 
-            if ($cache) {
-                $html = getSimpleHTMLDOMCached($url, 86400, $header); // 24 hours
-            } else {
-                $html = getSimpleHTMLDOM($url, $header);
-            }
+        if ($cache) {
+            $html = getSimpleHTMLDOMCached($url, 86400, $header); // 24 hours
+        } else {
+            $html = getSimpleHTMLDOM($url, $header);
+        }
 
-            $html = defaultLinkTo($html, $url);
+        $html = defaultLinkTo($html, $url);
 
-            return $html;
+        return $html;
     }
 
     private function itemsFromJournalList($html, $limit)

--- a/bridges/GithubIssueBridge.php
+++ b/bridges/GithubIssueBridge.php
@@ -274,18 +274,18 @@ class GithubIssueBridge extends BridgeAbstract
 
         switch (count($path_segments)) {
             case 2: // Project issues
-                list($user, $project) = $path_segments;
+                [$user, $project] = $path_segments;
                 $show_comments = 'off';
                 break;
             case 3: // Project issues with issue comments
                 if ($path_segments[2] !== static::URL_PATH) {
                     return null;
                 }
-                list($user, $project) = $path_segments;
+                [$user, $project] = $path_segments;
                 $show_comments = 'on';
                 break;
             case 4: // Issue comments
-                list($user, $project, /* issues */, $issue) = $path_segments;
+                [$user, $project, /* issues */, $issue] = $path_segments;
                 break;
             default:
                 return null;
@@ -294,8 +294,8 @@ class GithubIssueBridge extends BridgeAbstract
         return [
             'u' => $user,
             'p' => $project,
-            'c' => isset($show_comments) ? $show_comments : null,
-            'i' => isset($issue) ? $issue : null,
+            'c' => $show_comments ?? null,
+            'i' => $issue ?? null,
         ];
     }
 }

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -66,7 +66,7 @@ class GolemBridge extends FeedExpander
     protected function parseItem($item)
     {
         $item = parent::parseItem($item);
-        $item['content'] = $item['content'] ?? '';
+        $item['content'] ??= '';
         $uri = $item['uri'];
 
         while ($uri) {

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -47,7 +47,7 @@ class GoodreadsBridge extends BridgeAbstract
             $dateSpan = $row->find('.uitext', 0)->plaintext;
             $date = null;
 
-        // If book is not yet published, ignore for now
+            // If book is not yet published, ignore for now
             if (preg_match('/published\s+(\d{4})/', $dateSpan, $matches) === 1) {
                 // Goodreads doesn't give us exact publication date here, only a year
                 // We are skipping future dates anyway, so this is def published

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -106,7 +106,7 @@ class InstagramBridge extends BridgeAbstract
         $key = $cache->loadData();
 
         if ($key == null) {
-                $data = $this->getContents(self::URI . 'web/search/topsearch/?query=' . $username);
+            $data = $this->getContents(self::URI . 'web/search/topsearch/?query=' . $username);
             foreach (json_decode($data)->users as $user) {
                 if (strtolower($user->user->username) === strtolower($username)) {
                     $key = $user->user->pk;
@@ -115,7 +115,7 @@ class InstagramBridge extends BridgeAbstract
             if ($key == null) {
                 returnServerError('Unable to find username in search result.');
             }
-                $cache->saveData($key);
+            $cache->saveData($key);
         }
         return $key;
     }

--- a/bridges/InternetArchiveBridge.php
+++ b/bridges/InternetArchiveBridge.php
@@ -196,7 +196,7 @@ EOD;
 
         $item['content'] = <<<EOD
 <p><strong>Subject: {$result->find('div.review-title', 0)->plaintext}</strong></p>
-<p>{$result->find('div.hidden-lists.review' , 0)->children(1)->plaintext}</p>
+<p>{$result->find('div.hidden-lists.review', 0)->children(1)->plaintext}</p>
 EOD;
 
         $item['enclosures'][] = self::URI . $result->find('img.item-img', 0)->source;

--- a/bridges/IvooxBridge.php
+++ b/bridges/IvooxBridge.php
@@ -120,7 +120,7 @@ class IvooxBridge extends BridgeAbstract
 
         foreach ($originalLocales as $localeSetting) {
             if (strpos($localeSetting, '=') !== false) {
-                list($category, $locale) = explode('=', $localeSetting);
+                [$category, $locale] = explode('=', $localeSetting);
             } else {
                 $category = LC_ALL;
                 $locale = $localeSetting;

--- a/bridges/MallTvBridge.php
+++ b/bridges/MallTvBridge.php
@@ -66,11 +66,11 @@ class MallTvBridge extends BridgeAbstract
 
     public function getURI()
     {
-        return isset($this->feedUri) ? $this->feedUri : parent::getURI();
+        return $this->feedUri ?? parent::getURI();
     }
 
     public function getName()
     {
-        return isset($this->feedName) ? $this->feedName : parent::getName();
+        return $this->feedName ?? parent::getName();
     }
 }

--- a/bridges/MarktplaatsBridge.php
+++ b/bridges/MarktplaatsBridge.php
@@ -126,8 +126,8 @@ class MarktplaatsBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('q'))) {
-                return $this->getInput('q') . ' - Marktplaats';
+            return $this->getInput('q') . ' - Marktplaats';
         }
-                return parent::getName();
+        return parent::getName();
     }
 }

--- a/bridges/NationalGeographicBridge.php
+++ b/bridges/NationalGeographicBridge.php
@@ -230,17 +230,17 @@ class NationalGeographicBridge extends BridgeAbstract
                 if (isset($image['crdt'])) {
                     $image_credit = $image['crdt'];
                 }
-                $caption = (isset($image_module['caption']) ? $image_module['caption'] : '');
+                $caption = ($image_module['caption'] ?? '');
                 break;
             case 'photogallery':
-                $image_credit = (isset($image_module['caption']['credit']) ? $image_module['caption']['credit'] : '');
+                $image_credit = ($image_module['caption']['credit'] ?? '');
                 $caption = $image_module['caption']['text'];
                 $image_src = $image_module['img']['src'];
                 $image_alt = $image_module['img']['altText'];
                 break;
             case 'video':
-                $image_credit = (isset($image_module['credit']) ? $image_module['credit'] : '');
-                $description = (isset($image_module['description']) ? $image_module['description'] : '');
+                $image_credit = ($image_module['credit'] ?? '');
+                $description = ($image_module['description'] ?? '');
                 $caption = $description . ' Video can be watched on the article\'s page';
                 $image = $image_module['image'];
                 $image_alt = $image['altText'];
@@ -325,7 +325,7 @@ EOD;
                             if (isset($module['image'])) {
                                 $content .= $this->handleImages($module['image'], $module['image']['cmsType']);
                             }
-                            $content .= '<p>' . (isset($module['text']) ? $module['text'] : '') . '</p>';
+                            $content .= '<p>' . ($module['text'] ?? '') . '</p>';
                             break;
                         case 'photogallery':
                             $gallery = $body['cntnt']['media'];
@@ -339,9 +339,9 @@ EOD;
                         case 'pullquote':
                             $quote = $module['quote'];
                             $author_name = '';
-                            $authors = (isset($module['byLineProps']['authors']) ? $module['byLineProps']['authors'] : []);
+                            $authors = ($module['byLineProps']['authors'] ?? []);
                             foreach ($authors as $author) {
-                                $author_desc = (isset($author['authorDesc']) ? $author['authorDesc'] : '');
+                                $author_desc = ($author['authorDesc'] ?? '');
                                 $author_name .= $author['displayName'] . ', ' . $author_desc;
                             }
                             $content .= <<<EOD

--- a/bridges/NotAlwaysBridge.php
+++ b/bridges/NotAlwaysBridge.php
@@ -2,13 +2,13 @@
 
 class NotAlwaysBridge extends BridgeAbstract
 {
-        const MAINTAINER = 'mozes';
-        const NAME = 'Not Always family Bridge';
-        const URI = 'https://notalwaysright.com/';
-        const DESCRIPTION = 'Returns the latest stories';
-        const CACHE_TIMEOUT = 1800; // 30 minutes
+    const MAINTAINER = 'mozes';
+    const NAME = 'Not Always family Bridge';
+    const URI = 'https://notalwaysright.com/';
+    const DESCRIPTION = 'Returns the latest stories';
+    const CACHE_TIMEOUT = 1800; // 30 minutes
 
-        const PARAMETERS = [ [
+    const PARAMETERS = [ [
                 'filter' => [
                         'type' => 'list',
                         'name' => 'Filter',
@@ -26,39 +26,39 @@ class NotAlwaysBridge extends BridgeAbstract
                 ]
         ]];
 
-        public function getIcon()
-        {
-            return self::URI . 'favicon_nar.png';
+    public function getIcon()
+    {
+        return self::URI . 'favicon_nar.png';
+    }
+
+    public function collectData()
+    {
+        $html = getSimpleHTMLDOM($this->getURI());
+        foreach ($html->find('.post') as $post) {
+            #print_r($post);
+            $item = [];
+            $item['uri'] = $post->find('h1', 0)->find('a', 0)->href;
+            $item['content'] = $post;
+            $item['title'] = $post->find('h1', 0)->find('a', 0)->innertext;
+            $this->items[] = $item;
+        }
+    }
+
+    public function getName()
+    {
+        if (!is_null($this->getInput('filter'))) {
+            return $this->getInput('filter') . ' - NotAlways Bridge';
         }
 
-        public function collectData()
-        {
-                $html = getSimpleHTMLDOM($this->getURI());
-            foreach ($html->find('.post') as $post) {
-                    #print_r($post);
-                    $item = [];
-                    $item['uri'] = $post->find('h1', 0)->find('a', 0)->href;
-                    $item['content'] = $post;
-                    $item['title'] = $post->find('h1', 0)->find('a', 0)->innertext;
-                    $this->items[] = $item;
-            }
+        return parent::getName();
+    }
+
+    public function getURI()
+    {
+        if (!is_null($this->getInput('filter'))) {
+            return self::URI . $this->getInput('filter') . '/';
         }
 
-        public function getName()
-        {
-            if (!is_null($this->getInput('filter'))) {
-                    return $this->getInput('filter') . ' - NotAlways Bridge';
-            }
-
-                return parent::getName();
-        }
-
-        public function getURI()
-        {
-            if (!is_null($this->getInput('filter'))) {
-                    return self::URI . $this->getInput('filter') . '/';
-            }
-
-                return parent::getURI();
-        }
+        return parent::getURI();
+    }
 }

--- a/bridges/NovelUpdatesBridge.php
+++ b/bridges/NovelUpdatesBridge.php
@@ -38,12 +38,12 @@ class NovelUpdatesBridge extends BridgeAbstract
         $html = stristr($html, '<tr>'); //remove tbody
         $html = str_get_html(stristr($html, '</tbody>', true)); //remove last tbody and get back as an array
         foreach ($html->find('tr') as $element) {
-                $item = [];
-                $item['uri'] = $element->find('td', 2)->find('a', 0)->href;
-                $item['title'] = $element->find('td', 2)->find('a', 0)->plaintext;
-                $item['team'] = $element->find('td', 1)->innertext;
-                $item['timestamp'] = strtotime($element->find('td', 0)->plaintext);
-                $item['content'] = '<a href="'
+            $item = [];
+            $item['uri'] = $element->find('td', 2)->find('a', 0)->href;
+            $item['title'] = $element->find('td', 2)->find('a', 0)->plaintext;
+            $item['team'] = $element->find('td', 1)->innertext;
+            $item['timestamp'] = strtotime($element->find('td', 0)->plaintext);
+            $item['content'] = '<a href="'
                 . $item['uri']
                 . '">'
                 . $this->seriesTitle
@@ -57,7 +57,7 @@ class NovelUpdatesBridge extends BridgeAbstract
                 . $fullhtml->find('div.seriesimg', 0)->innertext
                 . '</a>';
 
-                $this->items[] = $item;
+            $this->items[] = $item;
         }
     }
 

--- a/bridges/NpciBridge.php
+++ b/bridges/NpciBridge.php
@@ -84,7 +84,7 @@ class NpciBridge extends BridgeAbstract
             $item = [
                 'uri' => $uri,
                 'title' => $title,
-                'content' => $title ,
+                'content' => $title,
                 'uid' => sha1($pdfLink),
                 'enclosures' => [
                     $uri

--- a/bridges/OneFortuneADayBridge.php
+++ b/bridges/OneFortuneADayBridge.php
@@ -76,7 +76,9 @@ class OneFortuneADayBridge extends BridgeAbstract
 
     private function getQuote($seed)
     {
-        $quotes = explode('//', <<<QUOTES
+        $quotes = explode(
+            '//',
+            <<<QUOTES
 People are naturally attracted to you.
 //You learn from your mistakes... You will learn a lot today.
 //If you have something good in your life, don't let it go!

--- a/bridges/ParuVenduImmoBridge.php
+++ b/bridges/ParuVenduImmoBridge.php
@@ -58,7 +58,7 @@ class ParuVenduImmoBridge extends BridgeAbstract
                 $price = '';
             }
 
-            list($href) = explode('#', $element->href);
+            [$href] = explode('#', $element->href);
 
             $item = [];
             $item['uri'] = self::URI . $href;

--- a/bridges/PillowfortBridge.php
+++ b/bridges/PillowfortBridge.php
@@ -214,7 +214,7 @@ EOD;
          */
         $item['categories'] = $post['tags'];
         if ($embPost) {
-            if ($this -> getInput('noretags') || ($post['tags'] == null )) {
+            if ($this -> getInput('noretags') || ($post['tags'] == null)) {
                 $item['categories'] = $post['original_post']['tag_list'];
             }
         }

--- a/bridges/PresidenciaPTBridge.php
+++ b/bridges/PresidenciaPTBridge.php
@@ -73,7 +73,7 @@ class PresidenciaPTBridge extends BridgeAbstract
                             return ' de ' . $name . ' de ';
                         }, self::PT_MONTH_NAMES),
                         array_map(function ($num) {
-                                return sprintf('-%02d-', $num);
+                            return sprintf('-%02d-', $num);
                         }, range(1, sizeof(self::PT_MONTH_NAMES))),
                         $edt
                     );

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -212,7 +212,7 @@ class RedditBridge extends BridgeAbstract
                         $this->encodePermalink($data->permalink),
                         '<img src="' . $data->url . '" />'
                     );
-                } elseif (isset($data->is_gallery) ? $data->is_gallery : false) {
+                } elseif ($data->is_gallery ?? false) {
                     // Multiple images
 
                     $images = [];

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -2,10 +2,10 @@
 
 class ReporterreBridge extends BridgeAbstract
 {
-        const MAINTAINER = 'nyutag';
-        const NAME = 'Reporterre Bridge';
-        const URI = 'https://www.reporterre.net/';
-        const DESCRIPTION = 'Returns the newest articles.';
+    const MAINTAINER = 'nyutag';
+    const NAME = 'Reporterre Bridge';
+    const URI = 'https://www.reporterre.net/';
+    const DESCRIPTION = 'Returns the newest articles.';
 
     private function extractContent($url)
     {

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -253,7 +253,7 @@ class ReutersBridge extends BridgeAbstract
             case 'section':
                 if ($this->useWireAPI) {
                     if (strpos($endpoint, 'chan:') !== false) {
-                    // Now checking whether that feed has unique ID or not.
+                        // Now checking whether that feed has unique ID or not.
                         $feed_uri = "/feed/rapp/us/wirefeed/$endpoint";
                     } else {
                         $feed_uri = "/feed/rapp/us/tabbar/feeds/$endpoint";

--- a/bridges/ScmbBridge.php
+++ b/bridges/ScmbBridge.php
@@ -30,9 +30,9 @@ class ScmbBridge extends BridgeAbstract
 
             // get publication date
             $str_date = $article->find('time', 0)->datetime;
-            list($date, $time) = explode(' ', $str_date);
-            list($y, $m, $d) = explode('-', $date);
-            list($h, $i) = explode(':', $time);
+            [$date, $time] = explode(' ', $str_date);
+            [$y, $m, $d] = explode('-', $date);
+            [$h, $i] = explode(':', $time);
             $timestamp = mktime($h, $i, 0, $m, $d, $y);
             $item['timestamp'] = $timestamp;
 

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -33,7 +33,7 @@ class ShanaprojectBridge extends BridgeAbstract
 
     public function getURI()
     {
-        return isset($this->uri) ? $this->uri : parent::getURI();
+        return $this->uri ?? parent::getURI();
     }
 
     public function collectData()
@@ -47,11 +47,11 @@ class ShanaprojectBridge extends BridgeAbstract
         $min_total_episodes = $this->getInput('min_total_episodes') ?: 0;
 
         foreach ($animes as $anime) {
-            list(
+            [
                 $episodes_released,
                 /* of */,
                 $episodes_total
-            ) = explode(' ', $this->extractAnimeEpisodeInformation($anime));
+            ] = explode(' ', $this->extractAnimeEpisodeInformation($anime));
 
             // Skip if not enough episodes yet
             if ($episodes_released < $min_episodes) {

--- a/bridges/SkimfeedBridge.php
+++ b/bridges/SkimfeedBridge.php
@@ -646,7 +646,7 @@ class SkimfeedBridge extends BridgeAbstract
         $query = parse_url($anchor->href, PHP_URL_QUERY);
 
         foreach (explode('&', $query) as $parameter) {
-            list($key, $value) = explode('=', $parameter);
+            [$key, $value] = explode('=', $parameter);
 
             if ($key !== 'u') {
                 continue;

--- a/bridges/TheYeteeBridge.php
+++ b/bridges/TheYeteeBridge.php
@@ -14,26 +14,26 @@ class TheYeteeBridge extends BridgeAbstract
 
         $div = $html->find('.module_timed-item.is--full');
         foreach ($div as $element) {
-                $item = [];
-                $item['enclosures'] = [];
+            $item = [];
+            $item['enclosures'] = [];
 
-                $title = $element->find('h2', 0)->plaintext;
-                $item['title'] = $title;
+            $title = $element->find('h2', 0)->plaintext;
+            $item['title'] = $title;
 
-                $author = trim($element->find('.module_timed-item--artist a', 0)->plaintext);
-                $item['author'] = $author;
+            $author = trim($element->find('.module_timed-item--artist a', 0)->plaintext);
+            $item['author'] = $author;
 
-                $item['uri'] = static::URI;
+            $item['uri'] = static::URI;
 
-                $content = '<p>' . $title . ' by ' . $author . '</p>';
-                $photos = $element->find('a.img');
+            $content = '<p>' . $title . ' by ' . $author . '</p>';
+            $photos = $element->find('a.img');
             foreach ($photos as $photo) {
                 $content = $content . "<br /><img src='$photo->href' />";
                 $item['enclosures'][] = $photo->src;
             }
-                $item['content'] = $content;
+            $item['content'] = $content;
 
-                $this->items[] = $item;
+            $this->items[] = $item;
         }
     }
 }

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -339,7 +339,7 @@ EOD
             $item['timestamp'] = $realtweet->created_at;
             $item['id']        = $realtweet->id_str;
             $item['uri']       = self::URI . $item['username'] . '/status/' . $item['id'];
-            $item['author']    = (isset($tweet->retweeted_status) ? 'RT: ' : '' )
+            $item['author']    = (isset($tweet->retweeted_status) ? 'RT: ' : '')
                          . $item['fullname']
                          . ' (@'
                          . $item['username'] . ')';
@@ -430,7 +430,7 @@ EOD;
                                 $video = null;
                                 $maxBitrate = -1;
                                 foreach ($media->video_info->variants as $variant) {
-                                    $bitRate = isset($variant->bitrate) ? $variant->bitrate : -100;
+                                    $bitRate = $variant->bitrate ?? -100;
                                     if ($bitRate > $maxBitrate) {
                                         $maxBitrate = $bitRate;
                                         $video = $variant->url;
@@ -543,7 +543,7 @@ EOD;
                 }
             }
             if (!$jsLink) {
-                 returnServerError('Could not locate main.js link');
+                returnServerError('Could not locate main.js link');
             }
 
             $jsContent = getContents($jsLink);
@@ -646,7 +646,8 @@ EOD;
                     default:
                         $code = $e->getCode();
                         $data = $e->getMessage();
-                        returnServerError(<<<EOD
+                        returnServerError(
+                            <<<EOD
 Failed to make api call: $api
 HTTP Status: $code
 Errormessage: $data

--- a/bridges/TwitterV2Bridge.php
+++ b/bridges/TwitterV2Bridge.php
@@ -193,7 +193,7 @@ EOD
 
                 // Set default params
                 $params = [
-                'max_results'   => (empty($maxResults) ? '10' : $maxResults ),
+                'max_results'   => (empty($maxResults) ? '10' : $maxResults),
                 'tweet.fields'
                 => 'created_at,referenced_tweets,entities,attachments',
                 'user.fields'   => 'pinned_tweet_id',
@@ -219,7 +219,7 @@ EOD
             case 'By keyword or hashtag':
                 $params = [
                 'query'         => $this->getInput('query'),
-                'max_results'   => (empty($maxResults) ? '10' : $maxResults ),
+                'max_results'   => (empty($maxResults) ? '10' : $maxResults),
                 'tweet.fields'
                 => 'created_at,referenced_tweets,entities,attachments',
                 'expansions'
@@ -241,7 +241,7 @@ EOD
             case 'By list ID':
                 // Set default params
                 $params = [
-                'max_results' => (empty($maxResults) ? '10' : $maxResults ),
+                'max_results' => (empty($maxResults) ? '10' : $maxResults),
                 'tweet.fields'
                 => 'created_at,referenced_tweets,entities,attachments',
                 'expansions'
@@ -429,7 +429,7 @@ EOD
             $this->item['timestamp'] = $tweet->created_at;
             $this->item['uri']
             = self::URI . $this->item['username'] . '/status/' . $this->item['id'];
-            $this->item['author']    = ($isRetweet ? 'RT: ' : '' )
+            $this->item['author']    = ($isRetweet ? 'RT: ' : '')
                          . $this->item['fullname']
                          . ' (@'
                          . $this->item['username'] . ')';
@@ -440,8 +440,8 @@ EOD
                 $onlyMediaTweets && !isset($tweet->attachments->media_keys) &&
                 (($isQuote && !isset($quotedTweet->attachments->media_keys)) || !$isQuote)
             ) {
-                    // There is no media in current tweet or quoted tweet, skip to next
-                    continue;
+                // There is no media in current tweet or quoted tweet, skip to next
+                continue;
             }
 
             // Search for and replace URLs in Tweet text

--- a/bridges/WorldCosplayBridge.php
+++ b/bridges/WorldCosplayBridge.php
@@ -103,7 +103,7 @@ class WorldCosplayBridge extends BridgeAbstract
         $list = $json->list;
 
         foreach ($list as $img) {
-            $image = isset($img->photo) ? $img->photo : $img;
+            $image = $img->photo ?? $img;
             $item = [
                 'uri' => self::URI . substr($image->url, 1),
                 'title' => $image->subject,

--- a/bridges/XPathBridge.php
+++ b/bridges/XPathBridge.php
@@ -15,8 +15,7 @@ class XPathBridge extends XPathAbstract
                 'title' => <<<"EOL"
 You can specify any website URL which serves data suited for display in RSS feeds
 (for example a news blog).
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => 'https://news.blizzard.com/en-en',
                 'defaultValue' => 'https://news.blizzard.com/en-en',
                 'required' => true
@@ -29,8 +28,7 @@ Enter an XPath expression matching a list of dom nodes, each node containing one
 feed article item in total (usually a surrounding &lt;div&gt; or &lt;span&gt; tag). This will
 be the context nodes for all of the following expressions. This expression usually
 starts with a single forward slash.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => '/html/body/div/div[4]/div[2]/div[2]/div/div/section/ol/li/article',
                 'defaultValue' => '/html/body/div/div[4]/div[2]/div[2]/div/div/section/ol/li/article',
                 'required' => true
@@ -42,8 +40,7 @@ EOL
 This expression should match a node contained within each article item node
 containing the article headline. It should start with a dot followed by two
 forward slashes, referring to any descendant nodes of the article item node.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => './/div/div[2]/h2',
                 'defaultValue' => './/div/div[2]/h2',
                 'required' => true
@@ -56,8 +53,7 @@ This expression should match a node contained within each article item node
 containing the article content or description. It should start with a dot
 followed by two forward slashes, referring to any descendant nodes of the
 article item node.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => './/div[@class="ArticleListItem-description"]/div[@class="h6"]',
                 'defaultValue' => './/div[@class="ArticleListItem-description"]/div[@class="h6"]',
                 'required' => false
@@ -71,8 +67,7 @@ This expression should match a node's attribute containing the article URL
 followed by two forward slashes, referring to any descendant nodes of
 the article item node. Attributes can be selected by prepending an @ char
 before the attributes name.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => './/a[@class="ArticleLink ArticleLink"]/@href',
                 'defaultValue' => './/a[@class="ArticleLink ArticleLink"]/@href',
                 'required' => false
@@ -85,8 +80,7 @@ This expression should match a node contained within each article item
 node containing the article author's name. It should start with a dot
 followed by two forward slashes, referring to any descendant nodes of
 the article item node.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'required' => false
             ],
 
@@ -98,8 +92,7 @@ article timestamp or date (parsable by PHP's strtotime function). It
 should start with a dot followed by two forward slashes, referring to
 any descendant nodes of the article item node. Attributes can be
 selected by prepending an @ char before the attributes name.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => './/time[@class="ArticleListItem-footerTimestamp"]/@timestamp',
                 'defaultValue' => './/time[@class="ArticleListItem-footerTimestamp"]/@timestamp',
                 'required' => false
@@ -113,8 +106,7 @@ image URL (usually the src attribute of an &lt;img&gt; tag or a style
 attribute). It should start with a dot followed by two forward slashes,
 referring to any descendant nodes of the article item node. Attributes
 can be selected by prepending an @ char before the attributes name.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => './/div[@class="ArticleListItem-image"]/@style',
                 'defaultValue' => './/div[@class="ArticleListItem-image"]/@style',
                 'required' => false
@@ -130,8 +122,7 @@ in a data attribute. It should start with a dot followed by two
 forward slashes, referring to any descendant nodes of the article
 item node. Attributes can be selected by prepending an @ char
 before the attributes name.
-EOL
-                , 'type' => 'text',
+EOL, 'type' => 'text',
                 'exampleValue' => './/div[@class="ArticleListItem-label"]',
                 'defaultValue' => './/div[@class="ArticleListItem-label"]',
                 'required' => false
@@ -144,8 +135,7 @@ Check this to fix feed encoding by invoking PHP's utf8_decode
 function on all extracted texts. Try this in case you see "broken" or
 "weird" characters in your feed where you'd normally expect umlauts
 or any other non-ascii characters.
-EOL
-                , 'type' => 'checkbox',
+EOL, 'type' => 'checkbox',
                 'required' => false
             ],
 

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -77,7 +77,7 @@ class YoutubeBridge extends BridgeAbstract
     private $feeduri = '';
     private $channel_name = '';
     // This took from repo BetterVideoRss of VerifiedJoseph.
-	const URI_REGEX = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2    ,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"\'!?&\/\/=\-*]+|\/)?)/ims'; //phpcs:ignore
+    const URI_REGEX = '/(https?:\/\/(?:www\.)?(?:[a-zA-Z0-9-.]{2,256}\.[a-z]{2,20})(\:[0-9]{2    ,4})?(?:\/[a-zA-Z0-9@:%_\+.,~#"\'!?&\/\/=\-*]+|\/)?)/ims'; //phpcs:ignore
 
     private function ytBridgeQueryVideoInfo($vid, &$author, &$desc, &$time)
     {
@@ -433,7 +433,7 @@ class YoutubeBridge extends BridgeAbstract
 
     public function getName()
     {
-      // Name depends on queriedContext:
+        // Name depends on queriedContext:
         switch ($this->queriedContext) {
             case 'By username':
             case 'By channel id':

--- a/contrib/prepare_release/fetch_contributors.php
+++ b/contrib/prepare_release/fetch_contributors.php
@@ -26,7 +26,7 @@ while ($next) { /* Collect all contributors */
 
     // Check if there is a link with 'rel="next"'
     foreach ($links as $link) {
-        list($url, $type) = explode(';', $link, 2);
+        [$url, $type] = explode(';', $link, 2);
 
         if (trim($type) === 'rel="next"') {
             $url = trim(preg_replace('/([<>])/', '', $url));

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -162,7 +162,7 @@ abstract class BridgeAbstract implements BridgeInterface
                     continue;
                 }
 
-                $type = isset($properties['type']) ? $properties['type'] : 'text';
+                $type = $properties['type'] ?? 'text';
 
                 switch ($type) {
                     case 'checkbox':

--- a/lib/Debug.php
+++ b/lib/Debug.php
@@ -114,7 +114,7 @@ class Debug
         $calling = end($backtrace);
         $message = $calling['file'] . ':'
             . $calling['line'] . ' class '
-            . (isset($calling['class']) ? $calling['class'] : '<no-class>') . '->'
+            . ($calling['class'] ?? '<no-class>') . '->'
             . $calling['function'] . ' - '
             . $text;
 

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -77,7 +77,7 @@ function buildBridgeException(\Throwable $e, BridgeInterface $bridge): string
     $body = 'Error message: `'
     . $e->getMessage()
     . "`\nQuery string: `"
-    . (isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '')
+    . ($_SERVER['QUERY_STRING'] ?? '')
     . "`\nVersion: `"
     . Configuration::getVersion()
     . '`';
@@ -105,7 +105,7 @@ function buildTransformException(\Throwable $e, BridgeInterface $bridge): string
     $body = 'Error message: `'
     . $e->getMessage()
     . "`\nQuery string: `"
-    . (isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '')
+    . ($_SERVER['QUERY_STRING'] ?? '')
     . '`';
 
     $link = buildGitHubIssueQuery($title, $body, 'Bridge-Broken', $bridge->getMaintainer());

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -405,7 +405,8 @@ abstract class FeedExpander extends BridgeAbstract
             foreach ($feedItem->guid->attributes() as $attribute => $value) {
                 if (
                     $attribute === 'isPermaLink'
-                    && ($value === 'true' || (
+                    && (
+                        $value === 'true' || (
                             filter_var($feedItem->guid, FILTER_VALIDATE_URL)
                             && (empty($item['uri']) || !filter_var($item['uri'], FILTER_VALIDATE_URL))
                         )
@@ -430,7 +431,7 @@ abstract class FeedExpander extends BridgeAbstract
         } elseif (isset($dc->creator)) {
             $item['author'] = (string)$dc->creator;
         } elseif (isset($media->credit)) {
-                $item['author'] = (string)$media->credit;
+            $item['author'] = (string)$media->credit;
         }
 
         if (isset($feedItem->enclosure) && !empty($feedItem->enclosure['url'])) {

--- a/lib/html.php
+++ b/lib/html.php
@@ -140,7 +140,8 @@ function extractFromDelimiters($string, $start, $end)
         $section_retrieved = substr($string, strpos($string, $start) + strlen($start));
         $section_retrieved = substr($section_retrieved, 0, strpos($section_retrieved, $end));
         return $section_retrieved;
-    } return false;
+    }
+    return false;
 }
 
 /**


### PR DESCRIPTION
More conservative config than https://github.com/RSS-Bridge/rss-bridge/pull/2875:

```ShellSession
$ composer require --dev friendsofphp/php-cs-fixer

$ echo >.php-cs-fixer.dist.php "<?php

$finder = PhpCsFixer\Finder::create()
    ->in(__DIR__);

$rules = [
    '@PSR12' => true,
    // '@PSR12:risky' => true,
    '@PHP74Migration' => true,
    // '@PHP74Migration:risky' => true,
    // buggy, duplicates existing comment sometimes
    'no_break_comment' => false,
    'array_syntax' => true,
    'lowercase_static_reference' => true,
    'visibility_required' => false,
    // Too much noise
    'binary_operator_spaces' => false,
    'heredoc_indentation' => false,
    'trailing_comma_in_multiline' => false,
];

$config = new PhpCsFixer\Config();

return $config
    ->setRules($rules)
    // ->setRiskyAllowed(true)
    ->setFinder($finder);

"

$ vendor/bin/php-cs-fixer --version
PHP CS Fixer 3.8.0 BerSzcz against war! by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.1.7

$ vendor/bin/php-cs-fixer fix
$ rm .php-cs-fixer.cache
$ vendor/bin/php-cs-fixer fix
```
