### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Reformat code base to PSR12
+4f75591060d95208a301bc6bf460d875631b29cc
+# Fix coding style missed by phpbcf
+951092eef374db048b77bac85e75e3547bfac702


### PR DESCRIPTION
This will ignore coding style change commits in GitHub’s blame UI.

Same thing can be achieved locally using either `git blame --ignore-revs-file .git-blame-ignore-revs`
or `git config blame.ignoreRevsFile .git-blame-ignore-revs`

https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
