### PR TITLE
fix: disallow non-strings in GET parameters

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,23 +2,21 @@
 
 require_once __DIR__ . '/lib/rssbridge.php';
 
-/*
-Move the CLI arguments to the $_GET array, in order to be able to use
-rss-bridge from the command line
-*/
-if (isset($argv)) {
-    parse_str(implode('&', array_slice($argv, 1)), $cliArgs);
-    $request = array_merge($_GET, $cliArgs);
-} else {
-    $request = $_GET;
-}
-
 try {
-    foreach ($request as $value) {
+    if (isset($argv)) {
+        parse_str(implode('&', array_slice($argv, 1)), $cliArgs);
+        $request = $cliArgs;
+    } else {
+        $request = $_GET;
+    }
+    foreach ($request as $key => $value) {
         if (! is_string($value)) {
             http_response_code(400);
-            print render('error.html.php', ['message' => '400 Bad Request']);
-            exit;
+            print render('error.html.php', [
+                'title' => '400 Bad Request',
+                'message' => "Query parameter \"$key\" is not a string.",
+            ]);
+            exit(1);
         }
     }
 

--- a/index.php
+++ b/index.php
@@ -14,6 +14,14 @@ if (isset($argv)) {
 }
 
 try {
+    foreach ($request as $value) {
+        if (! is_string($value)) {
+            http_response_code(400);
+            print render('error.html.php', ['message' => '400 Bad Request']);
+            exit;
+        }
+    }
+
     $actionFactory = new ActionFactory();
 
     if (array_key_exists('action', $request)) {

--- a/templates/base.html.php
+++ b/templates/base.html.php
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="RSS-Bridge" />
-    <title><?= e($title ?? 'RSS-Bridge') ?></title>
+    <title><?= e($_title ?? 'RSS-Bridge') ?></title>
     <link href="static/style.css" rel="stylesheet">
     <link rel="icon" type="image/png" href="static/favicon.png">
 </head>

--- a/templates/error.html.php
+++ b/templates/error.html.php
@@ -1,6 +1,9 @@
 <div style="width: 60%; margin: 30px auto">
 
-    <h1>Something went wrong</h1>
+    <h1>
+        <?= e($title ?? 'Something went wrong') ?>
+    </h1>
+
     <br>
     <?= e($message) ?>
     <br>


### PR DESCRIPTION
None of our code expects arrays in GET parameters. This pr is a quickfix for problems that arise when code expects a string but gets an array. 