### PR TITLE
[FacebookEvent] feat: add new bridge FacebookEventBridge

### DIFF
--- a/bridges/FacebookEventBridge.php
+++ b/bridges/FacebookEventBridge.php
@@ -1,0 +1,49 @@
+<?php
+
+class FacebookEventBridge extends BridgeAbstract
+{
+    const NAME = 'Facebook events';
+    const URI = 'https://www.facebook.com/';
+    const CACHE_TIMEOUT = 60 * 60 * 12; // 12h
+    const DESCRIPTION = 'Fetches the events for a facebook page.';
+    const MAINTAINER = 'dvikan';
+    const PARAMETERS = [
+        [
+            'url' => [
+                'name' => 'Url (or page name)',
+                'type' => 'text',
+                'defaultValue' => 'https://www.facebook.com/meta',
+            ],
+        ],
+    ];
+
+    public function collectData()
+    {
+        $url = trim($this->getInput('url'));
+        if (preg_match('#https?://.*\.facebook\.com/([\w.]+)#i', $url, $m)) {
+            $url = $m[1];
+        }
+        $url = sprintf('https://m.facebook.com/%s/events/', $url);
+        $dom = getSimpleHTMLDOMCached($url);
+
+        $d = $dom->find('#pages_msite_body_contents', 0);
+        if (!$d) {
+            throw new \Exception('Unable to find #pages_msite_body_contents');
+        }
+        $eventTitles = $d->find('h3');
+        if (!$eventTitles) {
+            throw new \Exception('Unable to find event titles');
+        }
+        foreach ($eventTitles as $eventTitle) {
+            $eventDom = $eventTitle->parent();
+            $eventUrl = $eventDom->find('a', 0);
+            $eventUrl->innertext = 'Browse to event';
+
+            $this->items[] = [
+                'title' => $eventTitle->plaintext,
+                'uri' => urljoin(self::URI, $eventUrl->href),
+                'content' => defaultLinkTo($eventDom->innertext, self::URI),
+            ];
+        }
+    }
+}

--- a/bridges/FacebookEventBridge.php
+++ b/bridges/FacebookEventBridge.php
@@ -26,6 +26,9 @@ class FacebookEventBridge extends BridgeAbstract
         $url = sprintf('https://m.facebook.com/%s/events/', $url);
         $dom = getSimpleHTMLDOMCached($url);
 
+        if (strstr($dom->innertext, '<title>Log in to Facebook | Facebook</title>')) {
+            throw new \Exception('Got hit by anti-bot');
+        }
         $d = $dom->find('#pages_msite_body_contents', 0);
         if (!$d) {
             throw new \Exception('Unable to find #pages_msite_body_contents');


### PR DESCRIPTION
I thought i'd give fb events a shot. Need testers. I suspect they periodically mangle the dom. Not putting much effort into parsing out data.

The datetime seems to be i18n based off geo-location. This pr uses `m.facebook.com` which I think is the older "mobile" solution.

Half of these events are future dates so that's another reason for not populating the feed item `timestamp` value.

I suspect these urls are heavily protected by anti-bot. Gave it `12h` cache timeout. And the less popular a page is the sooner it kicks in (I suspect).