### PR TITLE
fix: change default curl user agent

### DIFF
--- a/bridges/NovelUpdatesBridge.php
+++ b/bridges/NovelUpdatesBridge.php
@@ -66,7 +66,6 @@ class NovelUpdatesBridge extends BridgeAbstract
         if (!empty($this->seriesTitle)) {
             return $this->seriesTitle . ' - ' . static::NAME;
         }
-
         return parent::getName();
     }
 }

--- a/bridges/NovelUpdatesBridge.php
+++ b/bridges/NovelUpdatesBridge.php
@@ -30,7 +30,7 @@ class NovelUpdatesBridge extends BridgeAbstract
     {
         $fullhtml = getSimpleHTMLDOM($this->getURI());
 
-        $this->seriesTitle = $fullhtml->find('h4.seriestitle', 0)->plaintext;
+        $this->seriesTitle = $fullhtml->find('div.seriestitlenu', 0)->plaintext;
         // dirty fix for nasty simpledom bug: https://github.com/sebsauvage/rss-bridge/issues/259
         // forcefully removes tbody
         $html = $fullhtml->find('table#myTable', 0)->innertext;

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -14,7 +14,7 @@ timezone = "UTC"
 
 [http]
 timeout = 60
-useragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+useragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0"
 
 [cache]
 


### PR DESCRIPTION
The previous ua is `Chrome 74 on Windows 10` which is the most common one. The new one in here is `firefox 102` which I snagged from https://github.com/lwthiker/curl-impersonate/blob/main/firefox/curl_ff102

For some reason I had better luck with this new ua when testing `NovelUpdatesBridge`. So maybe we should switch to this new one. The behaviour can possibly be explained by that cloudflare has intimate knowledge on how the chrome 74 on windows 10 acts which is different from the current usage via curl.

One issue that remains is that if users have copied `config.default.ini.php` to `config.ini.php` the old ua remains in use.

EDIT: I also had improvements with SlusheBridge which no longer returned `403 Forbidden`
EDIT: Could consider dropping the ua from config in order to prevent the old one from being used in old custom configs.

[0] https://developers.whatismybrowser.com/useragents/parse/#parse-useragent