### PR TITLE
fix: use default headers in getContents()

### DIFF
--- a/contrib/prepare_release/fetch_contributors.php
+++ b/contrib/prepare_release/fetch_contributors.php
@@ -12,9 +12,9 @@ $next = true;
 
 while ($next) { /* Collect all contributors */
     $headers = [
-        'Accept: application/json',
-        'Content-Type: application/json',
-        'User-Agent: RSS-Bridge'
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'User-Agent' => 'RSS-Bridge',
     ];
     $result = _http_request($url, ['headers' => $headers]);
 


### PR DESCRIPTION
The purpose of this pr is to decrease chance of anti-bot detection.
Modify `getContents()` so that it by default uses the `firefox 102` headers as suggested by [0]. Tweak `_http_request()` so that its http headers are passed as an associative array.

Unfortunately the http headers as not passed as an associative array to `getContents()`. So they must be normalized first and then merged with the default values. Might be some issues regarding header name casing but not doing anything about now.

[0] https://github.com/lwthiker/curl-impersonate/blob/main/firefox/curl_ff102