### PR TITLE
Dockerfile: Use libcurl-impersonate in place of libcurl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:7.4.29-fpm
+FROM lwthiker/curl-impersonate:0.5-ff-slim-buster AS curlimpersonate
+
+FROM php:7.4.29-fpm AS rssbridge
 
 LABEL description="RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for websites that don't have one."
 LABEL repository="https://github.com/RSS-Bridge/rss-bridge"
@@ -9,7 +11,8 @@ RUN apt-get update && \
       nginx \
       zlib1g-dev \
       libzip-dev \
-      libmemcached-dev && \
+      libmemcached-dev \
+      nss-plugin-pem && \
     docker-php-ext-install zip && \
     pecl install memcached && \
     docker-php-ext-enable memcached && \
@@ -18,6 +21,12 @@ RUN apt-get update && \
 COPY ./config/nginx.conf /etc/nginx/sites-enabled/default
 
 COPY --chown=www-data:www-data ./ /app/
+
+COPY --from=curlimpersonate /usr/local/lib/libcurl-impersonate-ff.so /usr/local/lib/curl-impersonate/
+
+ENV LD_PRELOAD /usr/local/lib/curl-impersonate/libcurl-impersonate-ff.so
+
+ENV CURL_IMPERSONATE ff91esr
 
 EXPOSE 80
 


### PR DESCRIPTION
Note that this is a similar fix to the one proposed in #2925, except it does so by using Docker multi-staging build. 

Also note that this doesn't currently work for ARM, due to https://github.com/lwthiker/curl-impersonate/issues/92, but that seems like an easy fix.

Also requires `user_agent` not to be set, otherwise curl_impersonate will honor it (https://github.com/lwthiker/curl-impersonate/pull/96) and, as a result, ignore its own defaults.

Fixes #2547

EDIT: ~~also requires https://github.com/lwthiker/curl-impersonate/issues/93 to be fixed upstream~~ now done.