### PR TITLE
[FacebookBridge] Support 2 types of shared URI posts

### DIFF
--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -275,11 +275,30 @@ class FacebookBridge extends BridgeAbstract
         $elements = $post->find('a')
             or returnServerError('Unable to find URI!');
 
+        // Find the one that is a permalink
         foreach ($elements as $anchor) {
-            // Find the one that is a permalink
             if (strpos($anchor->href, 'permalink') !== false) {
                 $arr = explode('?', $anchor->href, 2);
                 return $arr[0];
+            }
+        }
+
+        // Take the second link for post that are shared
+        $secondAnchor = $elements[2]->href;
+
+        // Transform to permanent link by removing fluctuating parameters
+        if (isset($secondAnchor)) {
+            // Link like /groupname/photos
+            if (strpos($secondAnchor, '.php') === false) {
+                $arr = explode('?', $secondAnchor, 2);
+                return $arr[0];
+            }
+
+            // Link like story.php?
+            if (strpos($secondAnchor, 'story.php') !== false) {
+                // id & story_fbid parameters are the only ones needed to keep
+                $arr = explode('&amp;m_entstream_source', $secondAnchor, 2);
+                return html_entity_decode($arr[0]);
             }
         }
 


### PR DESCRIPTION
Support two kinds (and perhaps more) of posts URI for shared posts:

- Standard "Story" Post
- Picture post (and perhaps other media)

Shared posts URI doesn't have a permalink, so we try to have one by removing unnecessary URL parameters that are variable.

Currently, those shared posts have a generated id that is changing every time that we reload the feed (because the content of the post has dynamic content like class names that are changing for example). So most of feed reader will consider to create a new post every time the id is different. Providing a URI fix this issue as well as having a link directly to the content.