### PR TITLE
fix: force HTTP 1.1 in curl requests

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -181,6 +181,8 @@ function _http_request(string $url, array $config = []): array
     curl_setopt($ch, CURLOPT_TIMEOUT, $config['timeout']);
     curl_setopt($ch, CURLOPT_ENCODING, '');
     curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+    // Force HTTP 1.1 because newer versions of libcurl defaults to HTTP/2
+    curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
     if ($config['proxy']) {
         curl_setopt($ch, CURLOPT_PROXY, $config['proxy']);
     }


### PR DESCRIPTION
I'm not 100% sure on this one because I'm unfamiliar with HTTP/2. But it does fix #2947.