### PR TITLE
fix: TypeError (0): setlocale(): Argument #1 ($category) must be of type int

### DIFF
--- a/bridges/IvooxBridge.php
+++ b/bridges/IvooxBridge.php
@@ -121,6 +121,10 @@ class IvooxBridge extends BridgeAbstract
         foreach ($originalLocales as $localeSetting) {
             if (strpos($localeSetting, '=') !== false) {
                 [$category, $locale] = explode('=', $localeSetting);
+                if (! defined($category)) {
+                    continue;
+                }
+                $category = constant($category);
             } else {
                 $category = LC_ALL;
                 $locale = $localeSetting;


### PR DESCRIPTION
TypeError (0): setlocale(): Argument #1 ($category) must be of type int, string given

This was upgraded from a warning to an error in php 8.