### PR TITLE
[RutubeBridge] Fix regex for retreiving reduxState

### DIFF
--- a/bridges/RutubeBridge.php
+++ b/bridges/RutubeBridge.php
@@ -55,7 +55,7 @@ class RutubeBridge extends BridgeAbstract
 
     private function getJSONData($html)
     {
-        $jsonDataRegex = '/window.reduxState = (.*?);/';
+        $jsonDataRegex = '/window.reduxState = (.*);/';
         preg_match($jsonDataRegex, $html, $matches) or returnServerError('Could not find reduxState');
         return json_decode(str_replace('\x', '\\\x', $matches[1]));
     }


### PR DESCRIPTION
Before this commit regex captured window.reduxState value until first semicolon.
This is incorrect since it produces invalid json, if semicolon is
also somethere in the middle of stringified json.

After this commit regex will capture window.reduxState value until last semicolon.