### PR TITLE
[DailyShirts] Add daily shirt sites

### DIFF
--- a/bridges/QwerteeBridge.php
+++ b/bridges/QwerteeBridge.php
@@ -14,7 +14,7 @@ class QwerteeBridge extends BridgeAbstract
     {
         $html = getSimpleHTMLDOM(self::URI);
 
-        foreach($html->find('div.big-slides', 0)->find('div.big-slide') as $element) {
+        foreach ($html->find('div.big-slides', 0)->find('div.big-slide') as $element) {
             $title = $element->find('div.index-tee', 0)->getAttribute('data-name', 0);
             $today = date('m/d/Y');
             $item = [];
@@ -26,8 +26,7 @@ class QwerteeBridge extends BridgeAbstract
             . $item['uri']
             . '"><img src="'
             . $element->find('img', 0)->getAttribute('src', 0)
-            . '" /></a>'
-            ;
+            . '" /></a>';
 
             $this->items[] = $item;
         }

--- a/bridges/QwerteeBridge.php
+++ b/bridges/QwerteeBridge.php
@@ -1,0 +1,35 @@
+<?php
+
+class QwerteeBridge extends BridgeAbstract
+{
+    const NAME = 'Qwertee';
+    const URI = 'https://www.qwertee.com';
+    const DESCRIPTION = 'Returns the daily designs';
+    const MAINTAINER = 'Bockiii';
+    const PARAMETERS = [];
+
+    const CACHE_TIMEOUT = 60 * 60 * 3; // 3 hours
+
+    public function collectData()
+    {
+        $html = getSimpleHTMLDOM(self::URI);
+
+        foreach($html->find('div.big-slides', 0)->find('div.big-slide') as $element) {
+            $title = $element->find('div.index-tee', 0)->getAttribute('data-name', 0);
+            $today = date('m/d/Y');
+            $item = [];
+            $item['uri'] = self::URI;
+            $item['title'] = $title;
+            $item['uid'] = $title;
+            $item['timestamp'] = $today;
+            $item['content'] = '<a href="'
+            . $item['uri']
+            . '"><img src="'
+            . $element->find('img', 0)->getAttribute('src', 0)
+            . '" /></a>'
+            ;
+
+            $this->items[] = $item;
+        }
+    }
+}

--- a/bridges/RiptApparelBridge.php
+++ b/bridges/RiptApparelBridge.php
@@ -1,0 +1,39 @@
+<?php
+
+class RiptApparelBridge extends BridgeAbstract
+{
+    const NAME = 'RIPT Apparel';
+    const URI = 'https://www.riptapparel.com';
+    const DESCRIPTION = 'Returns the daily designs';
+    const MAINTAINER = 'Bockiii';
+    const PARAMETERS = [];
+
+    const CACHE_TIMEOUT = 60 * 60 * 3; // 3 hours
+
+    public function collectData()
+    {
+        $html = getSimpleHTMLDOM(self::URI);
+
+        foreach($html->find('div.daily-designs', 0)->find('div.collection') as $element) {
+            $title = $element->find('div.design-info', 0)->find('div.title', 0)->innertext;
+            $uri = self::URI . $element->find('div.design-info', 0)->find('a', 0)->href;
+            $today = date('m/d/Y');
+            $imagesrcset = $element->find('div.design-images', 0)->find('div[data-subtype="Mens"]', 0)->find('img', 0)->getAttribute('data-srcset');
+            $image = rtrim(explode(',', $imagesrcset)[2], ' 900w');
+            $item = [];
+            $item['uri'] = $uri;
+            $item['title'] = $title;
+            $item['uid'] = $title;
+            $item['timestamp'] = $today;
+            $item['content'] = '<a href="'
+            . $uri
+            . '"><img src="'
+            . $image
+            . '" /></a>'
+            ;
+
+            $this->items[] = $item;
+        }
+    }
+
+}

--- a/bridges/RiptApparelBridge.php
+++ b/bridges/RiptApparelBridge.php
@@ -14,7 +14,7 @@ class RiptApparelBridge extends BridgeAbstract
     {
         $html = getSimpleHTMLDOM(self::URI);
 
-        foreach($html->find('div.daily-designs', 0)->find('div.collection') as $element) {
+        foreach ($html->find('div.daily-designs', 0)->find('div.collection') as $element) {
             $title = $element->find('div.design-info', 0)->find('div.title', 0)->innertext;
             $uri = self::URI . $element->find('div.design-info', 0)->find('a', 0)->href;
             $today = date('m/d/Y');
@@ -29,11 +29,9 @@ class RiptApparelBridge extends BridgeAbstract
             . $uri
             . '"><img src="'
             . $image
-            . '" /></a>'
-            ;
+            . '" /></a>';
 
             $this->items[] = $item;
         }
     }
-
 }

--- a/bridges/RiptApparelBridge.php
+++ b/bridges/RiptApparelBridge.php
@@ -18,8 +18,8 @@ class RiptApparelBridge extends BridgeAbstract
             $title = $element->find('div.design-info', 0)->find('div.title', 0)->innertext;
             $uri = self::URI . $element->find('div.design-info', 0)->find('a', 0)->href;
             $today = date('m/d/Y');
-            $imagesrcset = $element->find('div.design-images', 0)->find('div[data-subtype="Mens"]', 0)->find('img', 0)->getAttribute('data-srcset');
-            $image = rtrim(explode(',', $imagesrcset)[2], ' 900w');
+            $imagesrcset = $element->find('div.design-images', 0)->find('div[data-subtype="Mens"]', 0)->find('img', 0);
+            $image = rtrim(explode(',', $imagesrcset->getAttribute('data-srcset'))[2], ' 900w');
             $item = [];
             $item['uri'] = $uri;
             $item['title'] = $title;

--- a/bridges/TeefuryBridge.php
+++ b/bridges/TeefuryBridge.php
@@ -1,0 +1,39 @@
+<?php
+
+class TeefuryBridge extends BridgeAbstract
+{
+    const NAME = 'Teefury';
+    const URI = 'https://www.teefury.com';
+    const DESCRIPTION = 'Returns the daily designs';
+    const MAINTAINER = 'Bockiii';
+    const PARAMETERS = [];
+
+    const CACHE_TIMEOUT = 60 * 60 * 3; // 3 hours
+
+    public function collectData()
+    {
+        $html = getSimpleHTMLDOM(self::URI);
+        $html = defaultLinkTo($html, self::URI);
+
+        foreach($html->find('div.odad-card__wrapper') as $element) {
+            $titletext = $element->find('p', 0)->innertext;
+            $title = trim(explode('<br>', $titletext)[0]);
+            $today = date('m/d/Y');
+            $uri = self::URI . $element->find('div.js-odad-link', 1)->attr['data-link'];
+            $item = [];
+            $item['uri'] = $uri;
+            $item['title'] = $title;
+            $item['uid'] = $title;
+            $item['timestamp'] = $today;
+            $item['content'] = $element->find('p', 0)
+            . '<br><a href="'
+            . $uri
+            . '"><img src="'
+            . $element->find('div.js-odad-link', 1)->find('img', 0)->attr['src']
+            . '" /></a>'
+            ;
+
+            $this->items[] = $item;
+        }
+    }
+}

--- a/bridges/TeefuryBridge.php
+++ b/bridges/TeefuryBridge.php
@@ -15,7 +15,7 @@ class TeefuryBridge extends BridgeAbstract
         $html = getSimpleHTMLDOM(self::URI);
         $html = defaultLinkTo($html, self::URI);
 
-        foreach($html->find('div.odad-card__wrapper') as $element) {
+        foreach ($html->find('div.odad-card__wrapper') as $element) {
             $titletext = $element->find('p', 0)->innertext;
             $title = trim(explode('<br>', $titletext)[0]);
             $today = date('m/d/Y');
@@ -30,8 +30,7 @@ class TeefuryBridge extends BridgeAbstract
             . $uri
             . '"><img src="'
             . $element->find('div.js-odad-link', 1)->find('img', 0)->attr['src']
-            . '" /></a>'
-            ;
+            . '" /></a>';
 
             $this->items[] = $item;
         }


### PR DESCRIPTION
Hi,

this commit includes 3 daily shirt-design sites.

2 Options
- Go the usual way of including every single site as a separate bridge. Either commit them in this singular PR or add 3 separate PRs.
- Add one "DailyShirts" bridge with a selection list of sites that should be polled. This would keep it a little more organized (its all in one bridge) and adding more sites (because there are a bunch more that do the same thing) would be easier manageable. Added bonus is that people who might know one site might also find out about other sites and subscribe to them too.

We could also add an option (where available) to select the image type to display. Most sites have example images of "just the design", mens shirts, womens shirts, kids shirts, hoodie and so on. At least for these three sites, the logic would be pretty easy to implement (and could also be used in a one-for-all bridge).

I prepared them in single bridges, but tbh I would prefer to do it all in one.

@dvikan what's your opinion? The argument "one bridge per site" vs "added user experience by providing alternatives"?