### PR TITLE
fix: case-insensitive config from env, fix #2935

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -46,7 +46,7 @@ class DisplayAction implements ActionInterface
         }
 
         if (array_key_exists('_cache_timeout', $request)) {
-            if (!CUSTOM_CACHE_TIMEOUT) {
+            if (! Configuration::getConfig('cache', 'custom_timeout')) {
                 unset($request['_cache_timeout']);
                 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . '?' . http_build_query($request);
                 header('Location: ' . $uri, true, 301);

--- a/caches/MemcachedCache.php
+++ b/caches/MemcachedCache.php
@@ -20,22 +20,22 @@ class MemcachedCache implements CacheInterface
         $port = Configuration::getConfig($section, 'port');
 
         if (empty($host) && empty($port)) {
-            throw new \Exception('Configuration for ' . $section . ' missing. Please check your ' . FILE_CONFIG);
+            throw new \Exception('Configuration for ' . $section . ' missing.');
         }
         if (empty($host)) {
-            throw new \Exception('"host" param is not set for ' . $section . '. Please check your ' . FILE_CONFIG);
+            throw new \Exception('"host" param is not set for ' . $section);
         }
         if (empty($port)) {
-            throw new \Exception('"port" param is not set for ' . $section . '. Please check your ' . FILE_CONFIG);
+            throw new \Exception('"port" param is not set for ' . $section);
         }
         if (!ctype_digit($port)) {
-            throw new \Exception('"port" param is invalid for ' . $section . '. Please check your ' . FILE_CONFIG);
+            throw new \Exception('"port" param is invalid for ' . $section);
         }
 
         $port = intval($port);
 
         if ($port < 1 || $port > 65535) {
-            throw new \Exception('"port" param is invalid for ' . $section . '. Please check your ' . FILE_CONFIG);
+            throw new \Exception('"port" param is invalid for ' . $section);
         }
 
         $conn = new \Memcached();

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -22,7 +22,7 @@ class SQLiteCache implements CacheInterface
 
         $section = 'SQLiteCache';
         $file = Configuration::getConfig($section, 'file');
-        if (empty($file)) {
+        if (!$file) {
             throw new \Exception(sprintf('Configuration for %s missing.', $section));
         }
 

--- a/contrib/prepare_release/fetch_contributors.php
+++ b/contrib/prepare_release/fetch_contributors.php
@@ -4,8 +4,6 @@
 
 require __DIR__ . '/../../lib/rssbridge.php';
 
-Configuration::loadConfiguration();
-
 $url = 'https://api.github.com/repos/rss-bridge/rss-bridge/contributors';
 $contributors = [];
 $next = true;

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -50,7 +50,7 @@ final class BridgeCard
             ];
         }
 
-        if (CUSTOM_CACHE_TIMEOUT) {
+        if (Configuration::getConfig('cache', 'custom_timeout')) {
             $parameters['global']['_cache_timeout'] = [
                 'name' => 'Cache timeout in seconds',
                 'type' => 'number',

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -88,24 +88,27 @@ final class Configuration
         if (!$config) {
             throw new \Exception('Error parsing config');
         }
+        foreach ($config as $header => $section) {
+            foreach ($section as $key => $value) {
+                self::setConfig($header, $key, $value);
+            }
+        }
         foreach ($customConfig as $header => $section) {
             foreach ($section as $key => $value) {
-                $config[$header][$key] = $value;
+                self::setConfig($header, $key, $value);
             }
         }
         foreach ($env as $envName => $envValue) {
             $nameParts = explode('_', $envName);
             if ($nameParts[0] === 'RSSBRIDGE') {
-                $header = strtolower($nameParts[1]);
-                $key = strtolower($nameParts[2]);
+                $header = $nameParts[1];
+                $key = $nameParts[2];
                 if ($envValue === 'true' || $envValue === 'false') {
                     $envValue = filter_var($envValue, FILTER_VALIDATE_BOOLEAN);
                 }
-                $config[$header][$key] = $envValue;
+                self::setConfig($header, $key, $envValue);
             }
         }
-
-        self::$config = $config;
 
         if (
             !is_string(self::getConfig('system', 'timezone'))
@@ -173,6 +176,11 @@ final class Configuration
     public static function getConfig(string $section, string $key)
     {
         return self::$config[strtolower($section)][strtolower($key)] ?? null;
+    }
+
+    private static function setConfig(string $section, string $key, $value): void
+    {
+        self::$config[strtolower($section)][strtolower($key)] = $value;
     }
 
     public static function getVersion()

--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -314,8 +314,7 @@ class FeedItem
      *
      * Use {@see FeedItem::getContent()} to get the current item content.
      *
-     * @param string|object $content The item content as text or simple_html_dom
-     * object.
+     * @param string|object $content The item content as text or simple_html_dom object.
      * @return self
      */
     public function setContent($content)

--- a/lib/RssBridge.php
+++ b/lib/RssBridge.php
@@ -33,11 +33,14 @@ final class RssBridge
     private function run($request): void
     {
         Configuration::verifyInstallation();
-        Configuration::loadConfiguration();
+
+        $customConfig = [];
+        if (file_exists(__DIR__ . '/../config.ini.php')) {
+            $customConfig = parse_ini_file(__DIR__ . '/../config.ini.php', true, INI_SCANNER_TYPED);
+        }
+        Configuration::loadConfiguration($customConfig, getenv());
 
         date_default_timezone_set(Configuration::getConfig('system', 'timezone'));
-
-        define('CUSTOM_CACHE_TIMEOUT', Configuration::getConfig('cache', 'custom_timeout'));
 
         $authenticationMiddleware = new AuthenticationMiddleware();
         if (Configuration::getConfig('authentication', 'enable')) {

--- a/lib/rssbridge.php
+++ b/lib/rssbridge.php
@@ -36,12 +36,6 @@ const WHITELIST = __DIR__ . '/../whitelist.txt';
 /** Path to the default whitelist file */
 const WHITELIST_DEFAULT = __DIR__ . '/../whitelist.default.txt';
 
-/** Path to the configuration file */
-const FILE_CONFIG = __DIR__ . '/../config.ini.php';
-
-/** Path to the default configuration file */
-const FILE_CONFIG_DEFAULT = __DIR__ . '/../config.default.ini.php';
-
 /** URL to the RSS-Bridge repository */
 const REPOSITORY = 'https://github.com/RSS-Bridge/rss-bridge/';
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -33,5 +33,6 @@ final class ConfigurationTest extends TestCase
         $this->assertSame('Europe/Berlin', Configuration::getConfig('system', 'timezone'));
         $this->assertSame('aaa', Configuration::getConfig('TwitterV2Bridge', 'twitterv2apitoken'));
         $this->assertSame('bbb', Configuration::getConfig('SQLiteCache', 'file'));
+        $this->assertSame('bbb', Configuration::getConfig('sqlitecache', 'file'));
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -9,17 +9,29 @@ use PHPUnit\Framework\TestCase;
 
 final class ConfigurationTest extends TestCase
 {
-    public function test()
+    public function testValueFromDefaultConfig()
     {
-        putenv('RSSBRIDGE_system_timezone=Europe/Berlin');
         Configuration::loadConfiguration();
-
-        // test nonsense
         $this->assertSame(null, Configuration::getConfig('foobar', ''));
         $this->assertSame(null, Configuration::getConfig('foo', 'bar'));
         $this->assertSame(null, Configuration::getConfig('cache', ''));
+        $this->assertSame('UTC', Configuration::getConfig('system', 'timezone'));
+    }
 
-        // test value from env
+    public function testValueFromCustomConfig()
+    {
+        Configuration::loadConfiguration(['system' => ['timezone' => 'Europe/Berlin']]);
         $this->assertSame('Europe/Berlin', Configuration::getConfig('system', 'timezone'));
+    }
+
+    public function testValueFromEnv()
+    {
+        putenv('RSSBRIDGE_system_timezone=Europe/Berlin');
+        putenv('RSSBRIDGE_TwitterV2Bridge_twitterv2apitoken=aaa');
+        putenv('RSSBRIDGE_SQLiteCache_file=bbb');
+        Configuration::loadConfiguration([], getenv());
+        $this->assertSame('Europe/Berlin', Configuration::getConfig('system', 'timezone'));
+        $this->assertSame('aaa', Configuration::getConfig('TwitterV2Bridge', 'twitterv2apitoken'));
+        $this->assertSame('bbb', Configuration::getConfig('SQLiteCache', 'file'));
     }
 }


### PR DESCRIPTION
Fixes #2935

Let's solve this by making config sections and keys case-insensitive.
The bugfix is in lowercasing the `section` and `key` in `Configuration::getConfig($section, $key)`.
Some refactors are not directly related.