### PR TITLE
[PikabuBridge] Skip sponsored posts

### DIFF
--- a/bridges/PikabuBridge.php
+++ b/bridges/PikabuBridge.php
@@ -132,7 +132,10 @@ class PikabuBridge extends BridgeAbstract
             }
 
             $title_element = $post->find('.story__title-link', 0);
-            if (str_contains($title_element->href, 'from=cpm')) continue; // skip sponsored posts
+            if (str_contains($title_element->href, 'from=cpm')) {
+                // skip sponsored posts
+                continue;
+            }
 
             $title = $title_element->plaintext;
             $community_link = $post->find('.story__community-link', 0);

--- a/bridges/PikabuBridge.php
+++ b/bridges/PikabuBridge.php
@@ -132,6 +132,7 @@ class PikabuBridge extends BridgeAbstract
             }
 
             $title_element = $post->find('.story__title-link', 0);
+            if (str_contains($title_element->href, 'from=cpm')) continue; // skip sponsored posts
 
             $title = $title_element->plaintext;
             $community_link = $post->find('.story__community-link', 0);


### PR DESCRIPTION
Sponsored posts appear very rarely in html code.
But when they appear, they always have different url that results junk feed.

One of the example is [1]. After visiting it, you will be redirected to [2] that is marked as
"Партнёрский материал" in Russian, or "Sponsored post" in English.

[1] https://pikabu.ru/story/a_mla_posa_m_memu_seyla_otorathche_idomikhlenonoikhmyav_sseyla_otoratazoed__9388770?from=cpm
[2] https://pikabu.ru/story/kakim_dolzhen_byit_vash_noutbuk_9388770