### PR TITLE
[InstituteForTheStudyOfWarBridge] Do not put HTML tags in title

### DIFF
--- a/bridges/InstituteForTheStudyOfWarBridge.php
+++ b/bridges/InstituteForTheStudyOfWarBridge.php
@@ -32,7 +32,7 @@ class InstituteForTheStudyOfWarBridge extends BridgeAbstract
     private function processEntry($entry)
     {
         $h2 = $entry->find('h2', 0);
-        $title = $h2->innertext;
+        $title = $h2->plaintext;
         $uri = $h2->find('a', 0)->href;
 
         $date_span = $entry->find('span.datespan', 0);


### PR DESCRIPTION
Apologies, somehow I lost one change in #2984.

The commited version puts unnecessary HTML in the title.