### PR TITLE
fix: absolute urls for images in pixivbridge

### DIFF
--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -224,6 +224,6 @@ class PixivBridge extends BridgeAbstract
             file_put_contents($path, $illust);
         }
 
-        return 'cache/pixiv_img/' . preg_replace('/.*\//', '', $path);
+        return get_home_page_url() . 'cache/pixiv_img/' . preg_replace('/.*\//', '', $path);
     }
 }

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -18,6 +18,21 @@ final class Json
     }
 }
 
+/**
+ * Returns e.g. 'https://example.com/' or 'https://example.com/bridge/'
+ */
+function get_home_page_url(): string
+{
+    $https = $_SERVER['HTTPS'] ?? null;
+    $host = $_SERVER['HTTP_HOST'] ?? null;
+    $uri = $_SERVER['REQUEST_URI'] ?? null;
+    if (($pos = strpos($uri, '?')) !== false) {
+        $uri = substr($uri, 0, $pos);
+    }
+    $scheme = $https === 'on' ? 'https' : 'http';
+    return "$scheme://$host$uri";
+}
+
 function create_sane_stacktrace(\Throwable $e): array
 {
     $frames = array_reverse($e->getTrace());


### PR DESCRIPTION
This utility function can be reused other places too e.g. in the format classes but I found it a bit annoying to do that.

Other candidates for names are `get_base_url()` or `get_home_url()`.

fix #2981