### PR TITLE
fix: php7.3 parser error in Configuration.php

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -21,7 +21,7 @@ final class Configuration
 {
     private const VERSION = 'dev.2022-06-14';
 
-    private static array $config = [];
+    private static $config = [];
 
     private function __construct()
     {


### PR DESCRIPTION
Dont fail a basic lint so that the proper error message can be shown when on unsupported versions.

