### PR TITLE
[contents] Split HttpException to itself and TrasportException by usage

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -1,9 +1,5 @@
 <?php
 
-final class HttpException extends \Exception
-{
-}
-
 final class Json
 {
     public static function encode($value): string


### PR DESCRIPTION
After this commit HttpException
1. deals only with http responses with different response codes
2. has response header attribute

Naming is based on Symfony's existing HttpException and TrasportException