### PR TITLE
fix: wrong accept header in mastodonbridge

### DIFF
--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -165,7 +165,7 @@ class MastodonBridge extends BridgeAbstract
             $resource = 'acct:' . $this->getUsername() . '@' . $this->getInstance();
             $webfingerUrl = 'https://' . $this->getInstance() . '/.well-known/webfinger?resource=' . $resource;
             $webfingerHeader = [
-                'Content-Type: application/jrd+json'
+                'Accept: application/jrd+json'
             ];
             $webfinger = json_decode(getContents($webfingerUrl, $webfingerHeader), true);
             foreach ($webfinger['links'] as $link) {


### PR DESCRIPTION
Fix bug introduced by afcc38786e85cfe99efacfddb3a222989bd09f5e because of the default Accept header which caused xml to be returned.

Fix #3024