### PR TITLE
[ActionFactory] Allow camel-case action names

### DIFF
--- a/lib/ActionFactory.php
+++ b/lib/ActionFactory.php
@@ -26,7 +26,8 @@ class ActionFactory
      */
     public function create(string $name): ActionInterface
     {
-        $name = ucfirst(strtolower($name)) . 'Action';
+        $name = strtolower($name) . 'Action';
+        $name = implode(array_map('ucfirst', explode('-', $name)));
         $filePath = $this->folder . $name . '.php';
         if (!file_exists($filePath)) {
             throw new \Exception('Invalid action');


### PR DESCRIPTION
Dash symbol is used to convert dash-seperated string to camel-cased string.

Example: `action=set-bridge-cache` in query params matches `SetBridgeCacheAction`