### PR TITLE
[VkBridge] Follow changes on HTTP redirection

### DIFF
--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -446,7 +446,7 @@ class VkBridge extends BridgeAbstract
                 returnServerError('VK responded "Too many requests"');
             }
 
-            if (!preg_match('#^https?://vk.com/(club|public)#', $uri)) {
+            if (!preg_match('#^https?://vk.com/#', $uri)) {
                 returnServerError('Unexpected redirect location');
             }
 


### PR DESCRIPTION
When visiting canonical link like https://vk.com/club1, VK returns redirection response to non-canical link, which raises "Unexpected redirect location" exception.

This patch removes path check in order to handle this situation

Fixes https://github.com/RSS-Bridge/rss-bridge/issues/3049