### PR TITLE
fix: too strict url validation in feed item

### DIFF
--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -154,27 +154,17 @@ class FeedItem
                 Debug::log('The item provided as URI is unknown!');
             }
         }
-
         if (!is_string($uri)) {
-            Debug::log('URI must be a string!');
-        } elseif (
-            !filter_var(
-                $uri,
-                FILTER_VALIDATE_URL,
-                FILTER_FLAG_PATH_REQUIRED
-            )
-        ) {
-            Debug::log(sprintf('Not a valid url: "%s"', $uri));
-        } else {
-            $scheme = parse_url($uri, PHP_URL_SCHEME);
-
-            if ($scheme !== 'http' && $scheme !== 'https') {
-                Debug::log('URI scheme must be "http" or "https"!');
-            } else {
-                $this->uri = trim($uri);
-            }
+            Debug::log(sprintf('Expected $uri to be string but got %s', gettype($uri)));
+            return $this;
         }
-
+        $uri = trim($uri);
+        // Intentionally doing a weak url validation here because FILTER_VALIDATE_URL is too strict
+        if (!preg_match('#^https?://#i', $uri)) {
+            Debug::log(sprintf('Not a valid url: "%s"', $uri));
+            return $this;
+        }
+        $this->uri = $uri;
         return $this;
     }
 


### PR DESCRIPTION
Urls such as https://example.com/réponse were rejected. I always thought this validation was a bit too strict.
E.g. disallowing empty paths.

Fix https://github.com/RSS-Bridge/rss-bridge/issues/3018#issuecomment-1254159203

An alternative fix is:
```
filter_var(idn_to_ascii('https://example.com/réponse'), FILTER_VALIDATE_URL);
```

This change feels a bit risky but I don't think it is.