### PR TITLE
[GenshinImpactBridge] fix missing articles

### DIFF
--- a/bridges/GenshinImpactBridge.php
+++ b/bridges/GenshinImpactBridge.php
@@ -28,7 +28,7 @@ class GenshinImpactBridge extends BridgeAbstract
         $category = $this->getInput('category');
 
         $url = 'https://genshin.mihoyo.com/content/yuanshen/getContentList';
-        $url = $url . '?pageSize=3&pageNum=1&channelId=' . $category;
+        $url = $url . '?pageSize=5&pageNum=1&channelId=' . $category;
         $api_response = getContents($url);
         $json_list = json_decode($api_response, true);
 


### PR DESCRIPTION
The official website set a pageSize of 5 instead of 3.
I don't why but the value of `3` made some articles not appear.