### PR TITLE
Fix broken "chat on matrix" button in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for website
 [![LICENSE](https://img.shields.io/badge/license-UNLICENSE-blue.svg)](UNLICENSE)
 [![GitHub release](https://img.shields.io/github/release/rss-bridge/rss-bridge.svg?logo=github)](https://github.com/rss-bridge/rss-bridge/releases/latest)
 [![irc.libera.chat](https://img.shields.io/badge/irc.libera.chat-%23rssbridge-blue.svg)](https://web.libera.chat/#rssbridge)
-[![Chat on Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#rssbridge:libera.chat)
+[![Chat on Matrix](https://matrix.to/images-nohash/matrix-badge.svg)](https://matrix.to/#/#rssbridge:libera.chat)
 [![Actions Status](https://img.shields.io/github/workflow/status/RSS-Bridge/rss-bridge/Tests/master?label=GitHub%20Actions&logo=github)](https://github.com/RSS-Bridge/rss-bridge/actions)
 
 Screenshot of the Twitter bridge configuration:


### PR DESCRIPTION
Hi there!
Just a tiny fix for the Readme:
```diff
-https://matrix.to/img/matrix-badge.svg
+https://matrix.to/images-nohash/matrix-badge.svg
```
I noticed that the image used as the "chat on matrix" button didn't load anymore, so I replaced it with the url of the still working button.
See https://github.com/matrix-org/matrix.to/issues/281 for more details.
