### PR TITLE
[DiscogsBridge] Add optional image, if personal access token is configured

### DIFF
--- a/bridges/DiscogsBridge.php
+++ b/bridges/DiscogsBridge.php
@@ -14,6 +14,12 @@ class DiscogsBridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => '28104',
                 'title' => 'Only the ID from an artist page. EG /artist/28104-Aesop-Rock is 28104'
+            ],
+            'image' => [
+                'name' => 'Include Image',
+                'type' => 'checkbox',
+                'defaultValue' => 'checked',
+                'title' => 'Whether to include image (if bridge is configured with a personal access token)',
             ]
         ],
         'Label Releases' => [
@@ -23,6 +29,12 @@ class DiscogsBridge extends BridgeAbstract
                 'required' => true,
                 'exampleValue' => '8201',
                 'title' => 'Only the ID from a label page. EG /label/8201-Rhymesayers-Entertainment is 8201'
+            ],
+            'image' => [
+                'name' => 'Include Image',
+                'type' => 'checkbox',
+                'defaultValue' => 'checked',
+                'title' => 'Whether to include image (if bridge is configured with a personal access token)',
             ]
         ],
         'User Wantlist' => [
@@ -31,6 +43,12 @@ class DiscogsBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'TheBlindMaster',
+            ],
+            'image' => [
+                'name' => 'Include Image',
+                'type' => 'checkbox',
+                'defaultValue' => 'checked',
+                'title' => 'Whether to include image (if bridge is configured with a personal access token)',
             ]
         ],
         'User Folder' => [
@@ -41,24 +59,50 @@ class DiscogsBridge extends BridgeAbstract
             'folderid' => [
                 'name' => 'Folder ID',
                 'type' => 'number',
+            ],
+            'image' => [
+                'name' => 'Include Image',
+                'type' => 'checkbox',
+                'defaultValue' => 'checked',
+                'title' => 'Whether to include image (if bridge is configured with a personal access token)',
             ]
-        ]
+        ],
+    ];
+    const CONFIGURATION = [
+        /**
+         * When a personal access token is provided, Discogs' API will
+         * return images as part of artist and label information.
+         *
+         * @see https://www.discogs.com/settings/developers
+         */
+        'personal_access_token' => [
+            'required' => false,
+        ],
     ];
 
     public function collectData()
     {
+        $headers = [];
+
+        if ($this->getOption('personal_access_token')) {
+            $headers = ['Authorization: Discogs token=' . $this->getOption('personal_access_token')];
+        }
+
         if (!empty($this->getInput('artistid')) || !empty($this->getInput('labelid'))) {
             if (!empty($this->getInput('artistid'))) {
-                $data = getContents('https://api.discogs.com/artists/'
-                        . $this->getInput('artistid')
-                        . '/releases?sort=year&sort_order=desc');
+                $url = 'https://api.discogs.com/artists/'
+                . $this->getInput('artistid')
+                . '/releases?sort=year&sort_order=desc';
+                $data = getContents($url, $headers);
             } elseif (!empty($this->getInput('labelid'))) {
-                $data = getContents('https://api.discogs.com/labels/'
-                        . $this->getInput('labelid')
-                        . '/releases?sort=year&sort_order=desc');
+                $url = 'https://api.discogs.com/labels/'
+                . $this->getInput('labelid')
+                . '/releases?sort=year&sort_order=desc';
+                $data = getContents($url, $headers);
             }
 
             $jsonData = json_decode($data, true);
+
             foreach ($jsonData['releases'] as $release) {
                 $item = [];
                 $item['author'] = $release['artist'];
@@ -72,20 +116,31 @@ class DiscogsBridge extends BridgeAbstract
                 }
 
                 $item['content'] = $item['author'] . ' - ' . $item['title'];
+
+                if (isset($release['thumb']) && $this->getInput('image') === true) {
+                    $item['content'] = sprintf(
+                        '<img src="%s"/><br/><br/>%s',
+                        $release['thumb'],
+                        $item['content'],
+                    );
+                }
+
                 $this->items[] = $item;
             }
         } elseif (!empty($this->getInput('username_wantlist')) || !empty($this->getInput('username_folder'))) {
             if (!empty($this->getInput('username_wantlist'))) {
-                $data = getContents('https://api.discogs.com/users/'
-                        . $this->getInput('username_wantlist')
-                        . '/wants?sort=added&sort_order=desc');
+                $url = 'https://api.discogs.com/users/'
+                . $this->getInput('username_wantlist')
+                . '/wants?sort=added&sort_order=desc';
+                $data = getContents($url, $headers);
                 $jsonData = json_decode($data, true)['wants'];
             } elseif (!empty($this->getInput('username_folder'))) {
-                $data = getContents('https://api.discogs.com/users/'
-                        . $this->getInput('username_folder')
-                        . '/collection/folders/'
-                        . $this->getInput('folderid')
-                        . '/releases?sort=added&sort_order=desc');
+                $url = 'https://api.discogs.com/users/'
+                . $this->getInput('username_folder')
+                . '/collection/folders/'
+                . $this->getInput('folderid')
+                . '/releases?sort=added&sort_order=desc';
+                $data = getContents($url, $headers);
                 $jsonData = json_decode($data, true)['releases'];
             }
             foreach ($jsonData as $element) {
@@ -97,6 +152,15 @@ class DiscogsBridge extends BridgeAbstract
                 $item['uri'] = self::URI . $infos['artists'][0]['id'] . '/release/' . $infos['id'];
                 $item['timestamp'] = strtotime($element['date_added']);
                 $item['content'] = $item['author'] . ' - ' . $item['title'];
+
+                if (isset($infos['thumb']) && $this->getInput('image') === true) {
+                    $item['content'] = sprintf(
+                        '<img src="%s"/><br/><br/>%s',
+                        $infos['thumb'],
+                        $item['content'],
+                    );
+                }
+
                 $this->items[] = $item;
             }
         }

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -90,3 +90,13 @@ file = "cache.sqlite"
 [MemcachedCache]
 host = "localhost"
 port = 11211
+
+; --- Bridge specific configuration ------
+
+[DiscogsBridge]
+
+; Sets the personal access token for interactions with Discogs. When
+; provided, images can be included in generated feeds.
+;
+; "" = no token used (default)
+personal_access_token = ""


### PR DESCRIPTION
The current bridge interacts with Discogs' API anonymously, which provides all information except images. This change adds support for authenticating using a configured personal access token.

I took a shot and added the newly supported configuration to `config.default.ini.php`. If bridge-specific configuration should be excluded, let me know and I'll remove the change.

Resolves #1536