### PR TITLE
[Dockerfile] Enable opcache for improved performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
     docker-php-ext-install zip && \
     pecl install memcached && \
     docker-php-ext-enable memcached && \
+    docker-php-ext-enable opcache && \
     mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY ./config/nginx.conf /etc/nginx/sites-enabled/default


### PR DESCRIPTION
Opcache is a PHP extension that caches the bytecode PHP converts each script into to reduce the work that needs to happen each request. It's universally recommended for production use, to the extent it's hard to find modern benchmarks with the opcache extension excluded.