### PR TITLE
Fix "chat on matrix" button (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for website
 [![LICENSE](https://img.shields.io/badge/license-UNLICENSE-blue.svg)](UNLICENSE)
 [![GitHub release](https://img.shields.io/github/release/rss-bridge/rss-bridge.svg?logo=github)](https://github.com/rss-bridge/rss-bridge/releases/latest)
 [![irc.libera.chat](https://img.shields.io/badge/irc.libera.chat-%23rssbridge-blue.svg)](https://web.libera.chat/#rssbridge)
-[![Chat on Matrix](https://matrix.to/images-nohash/matrix-badge.svg)](https://matrix.to/#/#rssbridge:libera.chat)
+[![Chat on Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#rssbridge:libera.chat)
 [![Actions Status](https://img.shields.io/github/workflow/status/RSS-Bridge/rss-bridge/Tests/master?label=GitHub%20Actions&logo=github)](https://github.com/RSS-Bridge/rss-bridge/actions)
 
 Screenshot of the Twitter bridge configuration:


### PR DESCRIPTION
Hi there!
This fixes the "chat on matrix" button in the readme again (related to #3075) because the original URL got fixed by the matrix.to team. See https://github.com/matrix-org/matrix.to/issues/281#issuecomment-1276297224 for more details.
_An_
