### PR TITLE
fix: improve FeedExpander

### DIFF
--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -126,6 +126,9 @@ abstract class FeedExpander extends BridgeAbstract
         // Restore previous behaviour in case other code relies on it being off
         libxml_use_internal_errors(false);
 
+        // Commented out because it's spammy
+        // Debug::log(sprintf("RSS content is ===========\n%s===========", var_export($rssContent, true)));
+
         switch (true) {
             case isset($rssContent->item[0]):
                 Debug::log('Detected RSS 1.0 format');
@@ -167,7 +170,6 @@ abstract class FeedExpander extends BridgeAbstract
     {
         $this->loadRss2Data($rssContent->channel[0]);
         foreach ($rssContent->item as $item) {
-            Debug::log(sprintf('Parsing item %s', var_export($item, true)));
             $tmp_item = $this->parseItem($item);
             if (!empty($tmp_item)) {
                 $this->items[] = $tmp_item;
@@ -183,24 +185,16 @@ abstract class FeedExpander extends BridgeAbstract
      *
      * @link http://www.rssboard.org/rss-specification RSS 2.0 Specification
      *
-     * @param object $rssContent The RSS content
-     * @param int $maxItems Maximum number of items to collect from the feed
-     * (`-1`: no limit).
+     * @param int $maxItems Maximum number of items to collect from the feed (`-1`: no limit).
      * @return void
      *
-     * @todo Instead of passing $maxItems to all functions, just add all items
-     * and remove excessive items later.
+     * @todo Instead of passing $maxItems to all functions, just add all items and remove excessive items later.
      */
-    protected function collectRss2($rssContent, $maxItems)
+    protected function collectRss2(\SimpleXMLElement $rssContent, $maxItems)
     {
         $rssContent = $rssContent->channel[0];
-        Debug::log('RSS content is ===========\n'
-        . var_export($rssContent, true)
-        . '===========');
-
         $this->loadRss2Data($rssContent);
         foreach ($rssContent->item as $item) {
-            Debug::log('parsing item ' . var_export($item, true));
             $tmp_item = $this->parseItem($item);
             if (!empty($tmp_item)) {
                 $this->items[] = $tmp_item;
@@ -228,7 +222,6 @@ abstract class FeedExpander extends BridgeAbstract
     {
         $this->loadAtomData($content);
         foreach ($content->entry as $item) {
-            Debug::log('parsing item ' . var_export($item, true));
             $tmp_item = $this->parseItem($item);
             if (!empty($tmp_item)) {
                 $this->items[] = $tmp_item;

--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -321,7 +321,7 @@ class FeedItem
         if (is_string($content)) {
             $this->content = $content;
         } else {
-            Debug::log('Content must be a string!');
+            Debug::log(sprintf('Feed content must be a string but got %s', gettype($content)));
         }
 
         return $this;

--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -6,7 +6,9 @@ final class Logger
 {
     public static function debug(string $message, array $context = [])
     {
-        self::log('DEBUG', $message, $context);
+        if (Debug::isEnabled()) {
+            self::log('DEBUG', $message, $context);
+        }
     }
 
     public static function info(string $message, array $context = []): void

--- a/lib/RssBridge.php
+++ b/lib/RssBridge.php
@@ -45,6 +45,24 @@ final class RssBridge
             }
         });
 
+        // There might be some fatal errors which are not caught by set_error_handler() or \Throwable.
+        register_shutdown_function(function () {
+            $error = error_get_last();
+            if ($error) {
+                $message = sprintf(
+                    'Fatal Error %s: %s in %s line %s',
+                    $error['type'],
+                    $error['message'],
+                    trim_path_prefix($error['file']),
+                    $error['line']
+                );
+                Logger::error($message);
+                if (Debug::isEnabled()) {
+                    print sprintf("<pre>%s</pre>\n", e($message));
+                }
+            }
+        });
+
         date_default_timezone_set(Configuration::getConfig('system', 'timezone'));
 
         $authenticationMiddleware = new AuthenticationMiddleware();

--- a/lib/RssBridge.php
+++ b/lib/RssBridge.php
@@ -41,7 +41,7 @@ final class RssBridge
             // Drop the current frame
             Logger::warning($text);
             if (Debug::isEnabled()) {
-                print sprintf('<pre>%s</pre>', $text);
+                print sprintf("<pre>%s</pre>\n", e($text));
             }
         });
 

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -348,7 +348,7 @@ function getSimpleHTMLDOMCached(
     $defaultBRText = DEFAULT_BR_TEXT,
     $defaultSpanText = DEFAULT_SPAN_TEXT
 ) {
-    Debug::log('Caching url ' . $url . ', duration ' . $duration);
+    Logger::debug(sprintf('Caching url %s, duration %d', $url, $duration));
 
     // Initialize cache
     $cacheFactory = new CacheFactory();


### PR DESCRIPTION
* Include the first libxml error in exception.
* Give better error message if trying to parse the empty string.
* Log all libxml errors if debug mode is enabled.

This piece of code is a little bit hard to follow but I don't think I introduced any bugs here.
Interesting to note that the previous behavior ignored the libxml errors due to the silencing operator.
Might be excessive to log all libxml errors in debug mode.
It is recommended to move away from libxml and use e.g. https://www.php.net/domdocument