### PR TITLE
[FeedExpander] Decode HTML entities in title

### DIFF
--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -290,7 +290,7 @@ abstract class FeedExpander extends BridgeAbstract
             $item['uri'] = (string)$feedItem->id;
         }
         if (isset($feedItem->title)) {
-            $item['title'] = (string)$feedItem->title;
+            $item['title'] = html_entity_decode((string)$feedItem->title);
         }
         if (isset($feedItem->updated)) {
             $item['timestamp'] = strtotime((string)$feedItem->updated);
@@ -336,7 +336,7 @@ abstract class FeedExpander extends BridgeAbstract
             $item['uri'] = (string)$feedItem->link;
         }
         if (isset($feedItem->title)) {
-            $item['title'] = (string)$feedItem->title;
+            $item['title'] = html_entity_decode((string)$feedItem->title);
         }
         // rss 0.91 doesn't support timestamps
         // rss 0.91 doesn't support authors


### PR DESCRIPTION
Noticed HTML entities in some of my feeds. Tracking down the issue, this happens in FeedExpander. Feed item title may contain HTML entities that we need to decode, else they are encoded twice when generating the expanded feed.

The change is fairly simple and should not conflict with #3103 as it affects different lines of the file.