### PR TITLE
fix: make filecache be case-sensitive on key

### DIFF
--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -79,9 +79,6 @@ class FileCache implements CacheInterface
 
     public function setKey($key)
     {
-        if (!empty($key) && is_array($key)) {
-            $key = array_map('strtolower', $key);
-        }
         $key = json_encode($key);
 
         if (!is_string($key)) {


### PR DESCRIPTION
This change fixes a problem in `FileCache` where these urls produced identical cache keys.

```
action=display&bridge=GettrBridge&user=Warroom&limit=5&format=Html
action=display&bridge=GettrBridge&user=warroom&limit=5&format=Html
```

The previous behavior is intentional. They probably wanted to ignore casing on other parts of the url such as
`format=Html` and `format=html`.

```patch
commit 5639b158e77479dd4e47548bdd0e0bdddd53e76a
Author: logmanoriginal <logmanoriginal@users.noreply.github.com>
Date:   Sat Oct 8 15:34:17 2016 +0200

    [FileCache] Change parameters to lower-case
    
    This prevents creating multiple cache files for the same request.

diff --git a/caches/FileCache.php b/caches/FileCache.php
index 2ece7e2d..3691fe51 100644
--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -55,7 +55,7 @@ class FileCache implements CacheInterface {
        * @return self
        */
        public function setParameters(array $param){
-               $this->param = $param;
+               $this->param = array_map('strtolower', $param);
 
                return $this;
        }
```

@LogMANOriginal 