### PR TITLE
[ARDAudiothekBridge] added bridge ARDAudiothek.de

### DIFF
--- a/bridges/ARDAudiothekBridge.php
+++ b/bridges/ARDAudiothekBridge.php
@@ -1,0 +1,150 @@
+<?php
+
+class ARDAudiothekBridge extends BridgeAbstract
+{
+    const NAME = 'ARD-Audiothek Bridge';
+    const URI = 'https://www.ardaudiothek.de';
+    const DESCRIPTION = 'Feed of any show in the ARD-Audiothek, specified by its path';
+    const MAINTAINER = 'Mar-Koeh';
+    /*
+     * The URL Prefix of the API
+     * @const APIENDPOINT https-URL of the used endpoint, ending in `/`
+     */
+    const APIENDPOINT = 'https://api.ardaudiothek.de/';
+    /*
+     * The requested width of the preview image
+     * 448 and 128 have been observed on the wild
+     * @const IMAGEWIDTH width in px of the preview image
+     */
+    const IMAGEWIDTH = 448;
+    /*
+     * Placeholder that will be replace by IMAGEWIDTH in the preview image URL
+     * @const IMAGEWIDTHPLACEHOLDER
+     */
+    const IMAGEWIDTHPLACEHOLDER = '{width}';
+
+    const PARAMETERS = [
+        [
+            'path' => [
+                'name' => 'Show Link or ID',
+                'required' => true,
+                'title' => 'Link to the show page or just its numeric suffix',
+                'defaultValue' => 'https://www.ardaudiothek.de/sendung/kalk-welk/10777871/'
+            ],
+            'limit' => self::LIMIT,
+        ]
+    ];
+
+
+    /**
+     * Holds the title of the current show
+     *
+     * @var string
+     */
+    private $title;
+
+    /**
+     * Holds the URI of the show
+     *
+     * @var string
+     */
+    private $uri;
+
+    /**
+     * Holds the icon of the feed
+     *
+     */
+    private $icon;
+
+    public function collectData()
+    {
+        $oldTz = date_default_timezone_get();
+
+        date_default_timezone_set('Europe/Berlin');
+
+        $pathComponents = explode('/', $this->getInput('path'));
+        if (empty($pathComponents)) {
+            returnClientError('Path may not be empty');
+        }
+        if (count($pathComponents) < 2) {
+            $showID = $pathComponents[0];
+        } else {
+            $lastKey = count($pathComponents) - 1;
+            $showID = $pathComponents[$lastKey];
+            if (strlen($showID) === 0) {
+                $showID = $pathComponents[$lastKey - 1];
+            }
+        }
+
+        $url = self::APIENDPOINT . 'programsets/' . $showID . '/';
+        $rawJSON = getContents($url);
+        $processedJSON = json_decode($rawJSON)->data->programSet;
+
+        $limit = $this->getInput('limit');
+        $answerLength = 1;
+        $offset = 0;
+        $numberOfElements = 1;
+
+        while ($answerLength != 0 && $offset < $numberOfElements && (is_null($limit) || $offset < $limit)) {
+            $rawJSON = getContents($url . '?offset=' . $offset);
+            $processedJSON = json_decode($rawJSON)->data->programSet;
+
+            $answerLength = count($processedJSON->items->nodes);
+            $offset = $offset + $answerLength;
+            $numberOfElements = $processedJSON->numberOfElements;
+
+            foreach ($processedJSON->items->nodes as $audio) {
+                $item = [];
+                $item['uri'] = $audio->sharingUrl;
+                $item['title'] = $audio->title;
+                $imageSquare = str_replace(self::IMAGEWIDTHPLACEHOLDER, self::IMAGEWIDTH, $audio->image->url1X1);
+                $image = str_replace(self::IMAGEWIDTHPLACEHOLDER, self::IMAGEWIDTH, $audio->image->url);
+                $item['enclosures'] = [
+                    $audio->audios[0]->url,
+                    $imageSquare
+                ];
+                // synopsis in list is shortened, full synopsis is available using one request per item
+                $item['content'] = '<img src="' . $image . '" /><p>'.$audio->synopsis.'</p>';
+                $item['timestamp'] = $audio->publicationStartDateAndTime;
+                $item['uid'] = $audio->id;
+                $item['author'] = $audio->programSet->publicationService->title;
+                $item['categories'] = [ $audio->programSet->editorialCategories->title ];
+                $this->items[] = $item;
+            }
+        }
+        $this->title = $processedJSON->title;
+        $this->uri = $processedJSON->sharingUrl;
+        $this->icon = str_replace(self::IMAGEWIDTHPLACEHOLDER, self::IMAGEWIDTH, $processedJSON->image->url1X1);
+
+        $this->items = array_slice($this->items, 0, $limit);
+
+        date_default_timezone_set($oldTz);
+    }
+
+    /** {@inheritdoc} */
+    public function getURI()
+    {
+        if (!empty($this->uri)) {
+            return $this->uri;
+        }
+        return parent::getURI();
+    }
+
+    /** {@inheritdoc} */
+    public function getName()
+    {
+        if (!empty($this->title)) {
+            return $this->title;
+        }
+        return parent::getName();
+    }
+
+    /** {@inheritdoc} */
+    public function getIcon()
+    {
+        if (!empty($this->icon)) {
+            return $this->icon;
+        }
+        return parent::getIcon();
+    }
+}

--- a/bridges/ARDAudiothekBridge.php
+++ b/bridges/ARDAudiothekBridge.php
@@ -104,7 +104,7 @@ class ARDAudiothekBridge extends BridgeAbstract
                     $imageSquare
                 ];
                 // synopsis in list is shortened, full synopsis is available using one request per item
-                $item['content'] = '<img src="' . $image . '" /><p>'.$audio->synopsis.'</p>';
+                $item['content'] = '<img src="' . $image . '" /><p>' . $audio->synopsis . '</p>';
                 $item['timestamp'] = $audio->publicationStartDateAndTime;
                 $item['uid'] = $audio->id;
                 $item['author'] = $audio->programSet->publicationService->title;


### PR DESCRIPTION
ARD, the union of Germany's regional public-service broadcasters, operates a video and an audio streaming service. The video streaming service is ARDMediathek, for which a bridge already exists. The audio streaming service is ARDAudiothek. This commit adds initial support for ARDAudiothek. It currently supports turning shows to feeds.

Historically, ARDAudiothek did have RSS Feeds. For example https://api.ardaudiothek.de/programsets/89554110/synd_rss If available, these links now redirect to externally hosted RSS feeds. Some shows just redirect to a externally hosted website that does not have an RSS feed. For example https://api.ardaudiothek.de/programsets/10777871/synd_rss This bridge brings back the feeds to all shows on ARDAudiothek.

Features:

- De-Pagination: The bridge joins the results of multiple API requests until either all or the requested limit of episodes are fetched
- Feed-Metadata: Name, URI, Icon  of the feed are adjusted to match the requested show
- Audio Files as enclosures: Each item contains a link to the audio file as an enclosure
- Cover Art: Each item contains a link to a square shaped cover art image as an enclosure, and an html image in the contents
- All item parameters: All documented item parameters are provided
- Tested against AntennaPod: Episodes can be played in AntennaPod

Current Design Decisions:

- Abbreviated Content: The content text is a abbreviated. This is a limitation by the used source. Its episode lists only provide the abbreviated text. The full text can be obtained by doing one additional request per episode. This is not done yet in order to reduce the number of requests.