### PR TITLE
feat: add max file size to http responses

### DIFF
--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -16,6 +16,9 @@ timezone = "UTC"
 timeout = 60
 useragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0"
 
+; Max http response size in MB
+max_filesize = 20
+
 [cache]
 
 ; Defines the cache type used by RSS-Bridge


### PR DESCRIPTION
Add a restriction to the size of http responses fetched by curl.

edit: this pr adds limit to http message size. It actually fixes a potential dos issue.