### PR TITLE
fix: Call to a member function find() on bool

### DIFF
--- a/bridges/GitlabIssueBridge.php
+++ b/bridges/GitlabIssueBridge.php
@@ -158,7 +158,10 @@ class GitlabIssueBridge extends BridgeAbstract
 
         $item['timestamp'] = $description->created_at ?? $description->updated_at;
 
-        $item['author'] = $this->parseAuthor($description_html);
+        $author = $this->parseAuthor($description_html);
+        if ($author) {
+            $item['author'] = $author;
+        }
 
         $item['title'] = $description->title;
         $item['content'] = markdownToHtml($description->description);
@@ -179,7 +182,10 @@ class GitlabIssueBridge extends BridgeAbstract
 
         $item['timestamp'] = $description_html->find('.merge-request-details time', 0)->datetime;
 
-        $item['author'] = $this->parseAuthor($description_html);
+        $author = $this->parseAuthor($description_html);
+        if ($author) {
+            $item['author'] = $author;
+        }
 
         $item['title'] = 'Merge Request ' . $description->title;
         $item['content'] = markdownToHtml($description->description);
@@ -205,6 +211,9 @@ class GitlabIssueBridge extends BridgeAbstract
 
         $authors = $description_html->find('.issuable-meta a.author-link, .merge-request a.author-link');
         $editors = $description_html->find('.edited-text a.author-link');
+        if ($authors === [] && $editors === []) {
+            return null;
+        }
         $author_str = implode(' ', $authors);
         if ($editors) {
             $author_str .= ', ' . implode(' ', $editors);

--- a/lib/html.php
+++ b/lib/html.php
@@ -169,35 +169,35 @@ function backgroundToImg($htmlContent)
  *
  * @link https://github.com/plaidfluff/php-urljoin php-urljoin
  *
- * @param string|object $content The HTML content. Supports HTML objects or string objects
- * @param string $server Fully qualified URL to the page containing relative links
+ * @param string|object $dom The HTML content. Supports HTML objects or string objects
+ * @param string $url Fully qualified URL to the page containing relative links
  * @return string|object Content with fixed URLs.
  */
-function defaultLinkTo($content, $server)
+function defaultLinkTo($dom, $url)
 {
-    if ($content === '') {
-        return $server;
+    if ($dom === '') {
+        return $url;
     }
 
     $string_convert = false;
-    if (is_string($content)) {
+    if (is_string($dom)) {
         $string_convert = true;
-        $content = str_get_html($content);
+        $dom = str_get_html($dom);
     }
 
-    foreach ($content->find('img') as $image) {
-        $image->src = urljoin($server, $image->src);
+    foreach ($dom->find('img') as $image) {
+        $image->src = urljoin($url, $image->src);
     }
 
-    foreach ($content->find('a') as $anchor) {
-        $anchor->href = urljoin($server, $anchor->href);
+    foreach ($dom->find('a') as $anchor) {
+        $anchor->href = urljoin($url, $anchor->href);
     }
 
     if ($string_convert) {
-        $content = $content->outertext;
+        $dom = $dom->outertext;
     }
 
-    return $content;
+    return $dom;
 }
 
 /**

--- a/lib/html.php
+++ b/lib/html.php
@@ -171,10 +171,14 @@ function backgroundToImg($htmlContent)
  *
  * @param string|object $content The HTML content. Supports HTML objects or string objects
  * @param string $server Fully qualified URL to the page containing relative links
- * @return object Content with fixed URLs.
+ * @return string|object Content with fixed URLs.
  */
 function defaultLinkTo($content, $server)
 {
+    if ($content === '') {
+        return $server;
+    }
+
     $string_convert = false;
     if (is_string($content)) {
         $string_convert = true;


### PR DESCRIPTION
Happens when defaultLinkTo() is passed the empty string.