### PR TITLE
feat: always sort feed items by timestamp

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -145,6 +145,14 @@ class DisplayAction implements ActionInterface
                     $items = $feedItems;
                 }
 
+                usort($items, function (FeedItem $a, FeedItem $b) {
+                    // Always sort items by timestamp descending
+                    // Items without a timestamp are considered equal
+                    $ts1 = $a->getTimestamp() ?? 0;
+                    $ts2 = $b->getTimestamp() ?? 0;
+                    return $ts2 <=> $ts1;
+                });
+
                 $infos = [
                     'name' => $bridge->getName(),
                     'uri'  => $bridge->getURI(),


### PR DESCRIPTION
The benefit here is that bridges don't have to do sorting themselves.

Does this make sense? Are there any bridges which intentionally orders the items by something other than timestamp descending?

Yes e.g. VkBridge if there's a pinned post:

```php
usort($this->items, function ($item1, $item2) {
    return $item2['post_id'] - $item1['post_id'];
});
```

@em92 