### PR TITLE
[Core] Add html/convertLazyLoading (+ document stripRecursiveHTMLSection)

### DIFF
--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -74,20 +74,8 @@ class WordPressBridge extends FeedExpander
             }
         }
 
-        // Convert lazy-loading images and iframes (videos...)
-        foreach ($article->find('img, iframe') as $img) {
-            if (!empty($img->getAttribute('data-src'))) {
-                $img->src = $img->getAttribute('data-src');
-            } elseif (!empty($img->getAttribute('data-srcset'))) {
-                $img->src = explode(' ', $img->getAttribute('data-srcset'))[0];
-            } elseif (!empty($img->getAttribute('data-lazy-src'))) {
-                $img->src = $img->getAttribute('data-lazy-src');
-            } elseif (!empty($img->getAttribute('srcset'))) {
-                $img->src = explode(' ', $img->getAttribute('srcset'))[0];
-            }
-        }
-
         // Find article main image
+        $article = convertLazyLoading($article);
         $article_image = $article_html->find('img.wp-post-image', 0);
         if (!empty($item['content']) && (!is_object($article_image) || empty($article_image->src))) {
             $article_image = str_get_html($item['content'])->find('img.wp-post-image', 0);

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -93,6 +93,11 @@ class WordPressBridge extends FeedExpander
             }
         }
 
+        // Unwrap images figures
+        foreach ($article->find('figure.wp-block-image') as $figure) {
+            $figure->outertext = $figure->innertext;
+        }
+
         if (!is_null($article)) {
             $item['content'] = $this->cleanContent($article->innertext);
             $item['content'] = defaultLinkTo($item['content'], $item['uri']);

--- a/bridges/ZDNetBridge.php
+++ b/bridges/ZDNetBridge.php
@@ -208,7 +208,7 @@ class ZDNetBridge extends FeedExpander
         $contents = stripWithDelimiters($contents, '<meta itemprop="image"', '>');
         $contents = stripWithDelimiters($contents, '<svg class="svg-symbol', '</svg>');
         $contents = trim(stripWithDelimiters($contents, '<section class="sharethrough-top', '</section>'));
-        $item['content'] = $contents;
+        $item['content'] = convertLazyLoading($contents);
 
         return $item;
     }

--- a/lib/html.php
+++ b/lib/html.php
@@ -327,7 +327,7 @@ function stripRecursiveHTMLSection($string, $tag_name, $tag_start)
 
     // Make sure the provided $tag_start argument matches the provided $tag_name argument
     if (strpos($tag_start, $open_tag) === 0) {
-        // While stag_start is present, there is at least one remaining section to remove
+        // While tag_start is present, there is at least one remaining section to remove
         while (strpos($string, $tag_start) !== false) {
             // In order to locate the end of the section, we attempt each closing tag until we find the right one
             // We know we found the right one when the amount of "<tag" is the same as amount of "</tag"


### PR DESCRIPTION
Hi,

As more and more sites are using lazy loading images and `<picture>` tags, I often encounter articles with unreadable images in my RSS reader. I initially wrote a solution for this inside the WordPress bridge, but this problem can happen on any bridge, so I'm proposing to make this a dedicated core function inside the `html` lib. This function works similarly as `defaultLinkTo()`: Takes the DOM as string or object, process it, returns the processed DOM.

This pull Request implements `convertLazyLoading()` in two bridges I'm maintaining: WordPressBridge and ZDNetBrige.
While working on this, I noticed that `stripRecursiveHTMLSection()` was pending documentation, so I added that as well.