### PR TITLE
Dockerfile: zip ext twice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update && \
       nss-plugin-pem \
       libicu-dev && \
     docker-php-ext-install zip && \
-    docker-php-ext-install zip && \
     docker-php-ext-install intl && \
     pecl install memcached && \
     docker-php-ext-enable memcached && \


### PR DESCRIPTION
Update Dockerfile: zip extension should be installed only once.

Linked to issue 3170:
https://github.com/RSS-Bridge/rss-bridge/issues/3170