### PR TITLE
feat: add a proper feed item uid when the bridge errors out

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -160,7 +160,7 @@ class DisplayAction implements ActionInterface
                     Logger::error(sprintf('Exception in %s', $bridgeClassName), ['e' => $e]);
                 }
 
-                $errorCount = self::logBridgeError($bridge::NAME, $e->getCode());
+                $errorCount = self::logBridgeError($bridge->getName(), $e->getCode());
 
                 if ($errorCount >= Configuration::getConfig('error', 'report_limit')) {
                     if (Configuration::getConfig('error', 'output') === 'feed') {
@@ -216,7 +216,7 @@ class DisplayAction implements ActionInterface
         $cacheFactory = new CacheFactory();
         $cache = $cacheFactory->create();
         $cache->setScope('error_reporting');
-        $cache->setkey($bridgeName . '_' . $code);
+        $cache->setkey([$bridgeName . '_' . $code]);
         $cache->purgeCache(86400); // 24 hours
         if ($report = $cache->loadData()) {
             $report = Json::decode($report);

--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -193,16 +193,15 @@ class DisplayAction implements ActionInterface
     {
         $item = new FeedItem();
 
-        // Create "new" error message every 24 hours
-        $dailyUid = urlencode((int)(time() / 86400));
-        $itemTitle = sprintf('Bridge returned error %s! (%s)', $e->getCode(), $dailyUid);
+        // Create a unique identifier every 24 hours
+        $uniqueIdentifier = urlencode((int)(time() / 86400));
+        $itemTitle = sprintf('Bridge returned error %s! (%s)', $e->getCode(), $uniqueIdentifier);
         $item->setTitle($itemTitle);
         $item->setURI(get_current_url());
         $item->setTimestamp(time());
 
-        // Create a unique id for feed readers e.g. "staysafetv twitch videos_2023_19389"
-        $itemUid = $bridge->getName() . '_' . date('Y') . '_' . $dailyUid;
-        $item->setUid($itemUid);
+        // Create a item identifier for feed readers e.g. "staysafetv twitch videos_19389"
+        $item->setUid($bridge->getName() . '_' . $uniqueIdentifier);
 
         $content = render_template(__DIR__ . '/../templates/bridge-error.html.php', [
             'error' => render_template(__DIR__ . '/../templates/error.html.php', ['e' => $e]),

--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -197,13 +197,16 @@ class DisplayAction implements ActionInterface
         $item = new FeedItem();
 
         // Create "new" error message every 24 hours
-        $_error_time = urlencode((int)(time() / 86400));
-        $itemTitle = sprintf('Bridge returned error %s! (%s)', $e->getCode(), $_error_time);
+        $dailyUid = urlencode((int)(time() / 86400));
+        $itemTitle = sprintf('Bridge returned error %s! (%s)', $e->getCode(), $dailyUid);
         $item->setTitle($itemTitle);
         $item->setURI(get_current_url());
         $item->setTimestamp(time());
 
-        // todo: consider giving more helpful error messages
+        // Create a unique id for feed readers e.g. "staysafetv twitch videos_2023_19389"
+        $itemUid = $bridge->getName() . '_' . date('Y') . '_' . $dailyUid;
+        $item->setUid($itemUid);
+
         $content = render_template(__DIR__ . '/../templates/bridge-error.html.php', [
             'error' => render_template(__DIR__ . '/../templates/error.html.php', ['e' => $e]),
             'searchUrl' => self::createGithubSearchUrl($bridge),

--- a/lib/error.php
+++ b/lib/error.php
@@ -45,5 +45,3 @@ function returnServerError($message)
 {
     returnError($message, 500);
 }
-
-

--- a/lib/error.php
+++ b/lib/error.php
@@ -46,36 +46,4 @@ function returnServerError($message)
     returnError($message, 500);
 }
 
-/**
- * Stores bridge-specific errors in a cache file.
- *
- * @param string $bridgeName The name of the bridge that failed.
- * @param int $code The error code
- *
- * @return int The total number the same error has appeared
- */
-function logBridgeError($bridgeName, $code)
-{
-    $cacheFactory = new CacheFactory();
 
-    $cache = $cacheFactory->create();
-    $cache->setScope('error_reporting');
-    $cache->setkey($bridgeName . '_' . $code);
-    $cache->purgeCache(86400); // 24 hours
-
-    if ($report = $cache->loadData()) {
-        $report = Json::decode($report);
-        $report['time'] = time();
-        $report['count']++;
-    } else {
-        $report = [
-            'error' => $code,
-            'time' => time(),
-            'count' => 1,
-        ];
-    }
-
-    $cache->saveData(Json::encode($report));
-
-    return $report['count'];
-}


### PR DESCRIPTION
The previous uid was simply the bridge url, which is not unique across errors.
This change will let users know if a bridge has errored out a second time (or additional times).
Also some refactoring.