### PR TITLE
Use HTTP/2 by default for TLS connections (for recent curl versions)

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -244,8 +244,6 @@ function _http_request(string $url, array $config = []): array
     curl_setopt($ch, CURLOPT_TIMEOUT, $config['timeout']);
     curl_setopt($ch, CURLOPT_ENCODING, '');
     curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-    // Force HTTP 1.1 because newer versions of libcurl defaults to HTTP/2
-    curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 
     if ($config['max_filesize']) {
         // This option inspects the Content-Length header


### PR DESCRIPTION
This essentially reverts 492288d57b2fc60d32e7fde74e6a51c6474029f8, as YouTube seems to have fixed their servers.
At least I was able to query the YouTube endpoint around 150 times with CURL_HTTP_VERSION_2TLS recently. They even advertise HTTP/3 support with an `alt-svc` HTTP header.

Setting CURL_HTTP_VERSION_2TLS explicitly leads to consistent behavior regardless of the curl version.
On the other hand that requires at least PHP 7.0.7 (we require PHP 7.4 already) and curl 7.47.0 [1], released on Jan 27 2016 [2]. Is this requirement a problem for this project?

Alternatively, we could set CURL_HTTP_VERSION_NONE and let curl decide on the version. This would support all curl versions and opens the possibility for HTTP/3, but leads again to inconsistent behavior depending on the underlying curl version.

I'm open to comments.

[1] https://www.php.net/manual/curl.constants.php
[2] https://curl.se/docs/releases.html