### PR TITLE
[ItchioBridge] Add error handling for password-protected pages

### DIFF
--- a/bridges/ItchioBridge.php
+++ b/bridges/ItchioBridge.php
@@ -19,7 +19,10 @@ class ItchioBridge extends BridgeAbstract
     {
         $url = $this->getInput('url');
         $html = getSimpleHTMLDOM($url);
-
+        // if the page is password protected, abort
+        if ($html->find('.game_password_page', 0) !== null) {
+            returnClientError('The requested page is password protected.');
+        }
         $title = $html->find('.game_title', 0)->innertext;
 
         $content = 'The following files are available to download:<br/>';


### PR DESCRIPTION
my first PR, hoping i haven't messed up anything...

aside from that, it now gives an error to the user that it can't generate the feed, due to the page being password protected, instead of giving no files.