### PR TITLE
[TelegramBridge] Support new username URL format

### DIFF
--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -369,7 +369,7 @@ EOD;
                 $params['username'] = $matches[1];
             }
 
-            if ($matches[2] !== '') {
+            if (isset($matches[2]) && $matches[2] !== '') {
                 $params['username'] = $matches[2];
             }
 

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -22,6 +22,8 @@ class TelegramBridge extends BridgeAbstract
         'https://telegram.me/s/rssbridge' => ['username' => 'rssbridge'],
         'https://telegram.me/rssbridge' => ['username' => 'rssbridge'],
         'http://telegram.me/rssbridge' => ['username' => 'rssbridge'],
+        'http://rssbridge.t.me/' => ['username' => 'rssbridge'],
+        'https://rssbridge.t.me/' => ['username' => 'rssbridge'],
     ];
 
     const CACHE_TIMEOUT = 60 * 15; // 15 mins
@@ -360,10 +362,17 @@ EOD;
 
     public function detectParameters($url)
     {
-        $detectParamsRegex = '/^https?:\/\/(?:t|telegram)\.me\/(?:s\/)?([\w]+)$/';
+        $detectParamsRegex = '/^https?:\/\/(?:(?:t|telegram)\.me\/(?:s\/)?([\w]+)|([\w]+)\.t\.me\/?)$/';
         $params = [];
         if (preg_match($detectParamsRegex, $url, $matches) > 0) {
-            $params['username'] = $matches[1];
+            if ($matches[1] !== '') {
+                $params['username'] = $matches[1];
+            }
+
+            if ($matches[2] !== '') {
+                $params['username'] = $matches[2];
+            }
+
             return $params;
         }
         return null;


### PR DESCRIPTION
Adds support for the newish (https://t.me/telegram/192) username URL format `username.t.me`.