### PR TITLE
feat: add filecache config to enable/disable real purge

### DIFF
--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -2,11 +2,13 @@
 
 class FileCache implements CacheInterface
 {
+    private array $config;
     protected $path;
     protected $key;
 
-    public function __construct()
+    public function __construct(array $config = [])
     {
+        $this->config = $config;
         if (!is_writable(PATH_CACHE)) {
             throw new \Exception('The cache folder is not writeable');
         }
@@ -46,6 +48,10 @@ class FileCache implements CacheInterface
 
     public function purgeCache($seconds)
     {
+        if (! $this->config['enable_purge']) {
+            return;
+        }
+
         $cachePath = $this->getPath();
         if (!file_exists($cachePath)) {
             return;

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -95,6 +95,10 @@ report_limit = 1
 
 ; --- Cache specific configuration ---------------------------------------------
 
+[FileCache]
+; Whether to actually delete files when purging. Can be useful to turn off to increase performance.
+enable_purge = true
+
 [SQLiteCache]
 file = "cache.sqlite"
 

--- a/lib/CacheFactory.php
+++ b/lib/CacheFactory.php
@@ -38,7 +38,9 @@ class CacheFactory
             case NullCache::class:
                 return new NullCache();
             case FileCache::class:
-                return new FileCache();
+                return new FileCache([
+                    'enable_purge' => Configuration::getConfig('FileCache', 'enable_purge'),
+                ]);
             case SQLiteCache::class:
                 return new SQLiteCache();
             case MemcachedCache::class:

--- a/lib/CacheFactory.php
+++ b/lib/CacheFactory.php
@@ -24,19 +24,30 @@ class CacheFactory
         if (preg_match('/(.+)(?:Cache)$/i', $name, $matches)) {
             $name = $matches[1];
         }
-        if (in_array(strtolower($name), array_map('strtolower', $cacheNames))) {
-            $index = array_search(strtolower($name), array_map('strtolower', $cacheNames));
-            $name = $cacheNames[$index];
-        } else {
+
+        $index = array_search(strtolower($name), array_map('strtolower', $cacheNames));
+        if ($index === false) {
             throw new \InvalidArgumentException(sprintf('Invalid cache name: "%s"', $name));
         }
-        if (! preg_match('/^[A-Z][a-zA-Z0-9-]*$/', $name)) {
-            throw new \InvalidArgumentException(sprintf('Invalid cache name: "%s"', $name));
+        $className = $cacheNames[$index] . 'Cache';
+        if (!preg_match('/^[A-Z][a-zA-Z0-9-]*$/', $className)) {
+            throw new \InvalidArgumentException(sprintf('Invalid cache classname: "%s"', $className));
         }
-        $className = $name . 'Cache';
-        if (!file_exists(PATH_LIB_CACHES . $className . '.php')) {
-            throw new \Exception('Unable to find the cache file');
+
+        switch ($className) {
+            case NullCache::class:
+                return new NullCache();
+            case FileCache::class:
+                return new FileCache();
+            case SQLiteCache::class:
+                return new SQLiteCache();
+            case MemcachedCache::class:
+                return new MemcachedCache();
+            default:
+                if (!file_exists(PATH_LIB_CACHES . $className . '.php')) {
+                    throw new \Exception('Unable to find the cache file');
+                }
+                return new $className();
         }
-        return new $className();
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -28,7 +28,7 @@ final class UtilsTest extends TestCase
 
     public function testFileCache()
     {
-        $sut = new \FileCache();
+        $sut = new \FileCache(['enable_purge' => true]);
         $sut->setScope('scope');
         $sut->purgeCache(-1);
         $sut->setKey(['key']);


### PR DESCRIPTION
I have a need to turn of the actual file deletes in the `purgeCache()` of `FileCache` and instead run it as a cronjob.

This change adds a config to optionally turn of the actual file deletes that `FileCache`'s `purgeCache()` does.

An alternative implementation is a new cache e.g. `CronFileCache` or `AppendOnlyFileCache`.