### PR TITLE
[Core] Add getKey function

### DIFF
--- a/bridges/JustWatchBridge.php
+++ b/bridges/JustWatchBridge.php
@@ -204,26 +204,10 @@ class JustWatchBridge extends BridgeAbstract
         return 'https://www.justwatch.com/' . $this->getInput('country');
     }
 
-    protected function getKeyName($input = '')
-    {
-        $parameters = $this->getParameters();
-        if (strlen($input) < 2) {
-            return array_search((int)$input, $parameters[0]['mediatype']['values'], true);
-        } else {
-            $returnkey = '';
-            foreach ($parameters[0]['country']['values'] as $valuearray) {
-                if (strlen($returnkey) < 2) {
-                    $returnkey = array_search($input, $valuearray, true);
-                }
-            }
-            return $returnkey;
-        }
-    }
-
     public function getName()
     {
         if (!is_null($this->getInput('country'))) {
-            return 'JustWatch - ' . $this->getKeyName($this->getInput('country')) . ' - ' . $this->getKeyName($this->getInput('mediatype'));
+            return 'JustWatch - ' . $this->getKey('country') . ' - ' . $this->getKey('mediatype');
         }
         return parent::getName();
     }

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -295,6 +295,32 @@ abstract class BridgeAbstract implements BridgeInterface
     }
 
     /**
+     * Get the key name of a given input
+     * Can process multilevel arrays with two levels, the max level a list can have
+     * 
+     * @param string $input The input name
+     * @return string|null The accompaning key to a given input or null if the input is not defined
+     */
+    public function getKey($input)
+    {
+        if (!isset($this->inputs[$this->queriedContext][$input]['value'])) {
+            return null;
+        }
+        $needle = $this->inputs[$this->queriedContext][$input]['value'];
+        foreach(static::PARAMETERS[$this->queriedContext][$input]['values'] as $first_level_key=>$first_level_value) {
+            if ($needle === (string)$first_level_value) {
+                return $first_level_key;
+            } elseif (is_array($first_level_value)) {
+                foreach($first_level_value as $second_level_key=>$second_level_value) {
+                    if ($needle === (string)$second_level_value) {
+                        return $second_level_key;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Get bridge configuration value
      */
     public function getOption($name)

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -297,7 +297,7 @@ abstract class BridgeAbstract implements BridgeInterface
     /**
      * Get the key name of a given input
      * Can process multilevel arrays with two levels, the max level a list can have
-     * 
+     *
      * @param string $input The input name
      * @return string|null The accompaning key to a given input or null if the input is not defined
      */
@@ -307,11 +307,11 @@ abstract class BridgeAbstract implements BridgeInterface
             return null;
         }
         $needle = $this->inputs[$this->queriedContext][$input]['value'];
-        foreach(static::PARAMETERS[$this->queriedContext][$input]['values'] as $first_level_key=>$first_level_value) {
+        foreach (static::PARAMETERS[$this->queriedContext][$input]['values'] as $first_level_key => $first_level_value) {
             if ($needle === (string)$first_level_value) {
                 return $first_level_key;
             } elseif (is_array($first_level_value)) {
-                foreach($first_level_value as $second_level_key=>$second_level_value) {
+                foreach ($first_level_value as $second_level_key => $second_level_value) {
                     if ($needle === (string)$second_level_value) {
                         return $second_level_key;
                     }


### PR DESCRIPTION
This will add a general "getKey" function to the BridgeAbstract that can retrieve key names from multidimensional arrays.

Problem:
There is currently no prepared way to retrieve the key name of a selected value for use in the output.

Example:
You have an array that contains countries and country codes ( eg 'United States' => 'us') and want to use the key name 'United States' in your feed output (a common use case for feed names). There is no onboard way to retrieve the key name and you will have to write your own code to match your exact use case. It gets even worse if the array is nested ( 'North America' => [ 'United States' => 'us'] ). 

This code solves this. To show, I removed my own, exact matching use case from the JustWatch bridge and added the usage of the general function. It works with strings and integers and all of my personal tests have succeeded. 

If you want this, I can also add documentation to the docs part before you merge.