### PR TITLE
[FicbookBridge] Fix new lines in content

### DIFF
--- a/bridges/FicbookBridge.php
+++ b/bridges/FicbookBridge.php
@@ -136,7 +136,7 @@ class FicbookBridge extends BridgeAbstract
 
             if ($this->getInput('include_contents')) {
                 $content = getSimpleHTMLDOMCached($item['uri'], 86400, [], [], true, true, DEFAULT_TARGET_CHARSET, false);
-                $item['content'] = str_replace("\n",'<br>',$content->find('#content', 0)->innertext);
+                $item['content'] = str_replace("\n", '<br>', $content->find('#content', 0)->innertext);
             }
 
             $this->items[] = $item;

--- a/bridges/FicbookBridge.php
+++ b/bridges/FicbookBridge.php
@@ -135,8 +135,8 @@ class FicbookBridge extends BridgeAbstract
             ];
 
             if ($this->getInput('include_contents')) {
-                $content = getSimpleHTMLDOMCached($item['uri']);
-                $item['content'] = $content->find('#content', 0);
+                $content = getSimpleHTMLDOMCached($item['uri'], 86400, [], [], true, true, DEFAULT_TARGET_CHARSET, false);
+                $item['content'] = str_replace("\n",'<br>',$content->find('#content', 0)->innertext);
             }
 
             $this->items[] = $item;


### PR DESCRIPTION
Sets `$stripRN` in `getSimpleHTMLDOMCached` to `false` and replace new line to `br` through `str_replace()`.