### PR TITLE
[Core] github codespaces setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM rssbridge/rss-bridge:latest
+
+RUN  apt-get update && \
+    apt-get install --yes --no-install-recommends \
+      git && \
+    pecl install xdebug && \
+    docker-php-ext-enable xdebug

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "rss-bridge dev",
+	"build": { "dockerfile": "Dockerfile" },
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"php.validate.executablePath": "/usr/local/bin/php"
+			},
+
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"xdebug.php-debug",
+				"bmewburn.vscode-intelephense-client",
+				"philfontaine.autolaunch",
+				"eamodio.gitlens"
+			]
+		}
+	},
+	"forwardPorts": [3100, 9000, 9003],
+	"postCreateCommand": "cp .devcontainer/nginx.conf /etc/nginx/conf.d/default.conf && cp .devcontainer/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini && mkdir .vscode && cp .devcontainer/launch.json .vscode && echo '*' > whitelist.txt && chmod a+x \"$(pwd)\" && rm -rf /var/www/html && ln -s \"$(pwd)\" /var/www/html && nginx && php-fpm -D"
+}

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -1,0 +1,49 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "auto": true
+        },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 0,
+            "runtimeArgs": [
+                "-dxdebug.start_with_request=yes"
+            ],
+            "env": {
+                "XDEBUG_MODE": "debug,develop",
+                "XDEBUG_CONFIG": "client_port=${port}"
+            }
+        },
+        {
+            "name": "Launch Built-in web server",
+            "type": "php",
+            "request": "launch",
+            "runtimeArgs": [
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-S",
+                "localhost:0"
+            ],
+            "program": "",
+            "cwd": "${workspaceRoot}",
+            "port": 9003,
+            "serverReadyAction": {
+                "pattern": "Development Server \\(http://localhost:([0-9]+)\\) started",
+                "uriFormat": "http://localhost:%s",
+                "action": "openExternally"
+            }
+        }
+    ]
+}

--- a/.devcontainer/nginx.conf
+++ b/.devcontainer/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 3100 default_server;
+    root /workspaces/rss-bridge;
+    access_log /var/log/nginx/rssbridge.access.log;
+    error_log /var/log/nginx/rssbridge.error.log;
+    index index.php;
+
+    location ~ /(\.|vendor|tests) {
+        deny all;
+        return 403; # Forbidden
+    }
+
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass 127.0.0.1:9000;
+    }
+}

--- a/.devcontainer/xdebug.ini
+++ b/.devcontainer/xdebug.ini
@@ -1,0 +1,9 @@
+zend_extension=xdebug.so
+
+[xdebug]
+xdebug.mode=develop,debug
+xdebug.client_host=localhost
+xdebug.client_port=9003
+xdebug.start_with_request=yes
+xdebug.discover_client_host=false
+xdebug.log='/var/www/html/xdebug.log'


### PR DESCRIPTION
Greetings,

this is an automated development setup for github codespaces to develop bridges and/or functionality for rss-bridge.

What this does:
- Custom configuration for github codespaces ( https://github.com/features/codespaces )
- Installed and configured xdebug with breakpoints etc all available within a code-server IDE
- Full git integration, this means users can create branches in their fork, create commits etc all from within the codespace
- Always up to date with the latest released rssbridge container

How to use it:
- After merging, this will automatically be picked up if a user creates a new codespace on their fork
- Starting the codespace will open a new browser window to xxx.github.dev, a custom dev environment for a user and specified branch (you can switch github to a different branch and start a new codespace on that branch)
- This new browser window is a full fledged vscode with a few addins (see devcontainer.json), the rssbridge code and all of the things preconfigured that we do in the docker image (alternate curl version for example).
- Rss bridge is preconfigured to show all bridges (to make dev easier) etc so a user can go directly in and create a new bridge in /bridges and it will be picked up. breakpoints can be set and debug values can be read in the debug tab (to see which variables are using what etc... debugging... )
- A debug session and php-fpm is already running after starting the codespace, to open the instance and browse it, just go to the "ports" tab in the bottom field and open the site for port 3100. This will open a separate window with your rssbridge instance.

Benefits:
- Instead of users having to setup dev environments or juggling with different dev approaches, this can be used as an alternative for everyone.
- Very low initial hurdle to start developing. Its enough to fork the main repo and hit the codespaces button and the user can start developing immediately. 
- Things that were harder to develop before (everything apart from bridges, which could be picked up by using the config folder of the docker image for example) are now as easily available as bridges.

I will do a longer how-to writeup with screenshots after merging.

Enhancements:
- Right now, everything basically works. You can add code, change code, do commits, debug etc. Some advanced functions of gitlens (like a visual rebase editor) dont work yet but could probably be configured.
- I added a few extensions (php intelliphense, gitlens and xdebug) but we can add more, whichever extension makes sense. Can be done by just adding it to the devcontainer.json

Here are some screenshots of how it looks like in use:
- View in repo
![image](https://user-images.githubusercontent.com/16492843/223420390-98f0462d-66ea-4f30-b710-37b7f054ee7b.png)

- View of the codespace
![image](https://user-images.githubusercontent.com/16492843/223420736-72e29e92-0e7f-402c-929e-d9ef25387f85.png)
