### PR TITLE
[nginx] Add ipv6 listener

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80 default_server;
+    listen [::]:80 default_server;
     root /app;
     access_log /var/log/nginx/rssbridge.access.log;
     error_log /var/log/nginx/rssbridge.error.log;


### PR DESCRIPTION
Added ipv6 listener. IPv4 access still works (tested), ipv6 access should work (the syntax is the same as other nginx configs that provide ipv6 listeners, so I have no reason to believe it shouldnt work). but is not tested.

It definitely doesnt break production and probably solves #3290