### PR TITLE
[Core] Activate live linting in codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,4 +4,5 @@ RUN  apt-get update && \
     apt-get install --yes --no-install-recommends \
       git && \
     pecl install xdebug && \
+    pear install PHP_CodeSniffer && \
     docker-php-ext-enable xdebug

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
 			"settings": {
 				"php.validate.executablePath": "/usr/local/bin/php",
 				"phpSniffer.executablesFolder": "/usr/local/bin/",
-				"phpcs.executablePath": "/usr/local/bin/phpcs"
+				"phpcs.executablePath": "/usr/local/bin/phpcs",
+				"phpcs.lintOnType": false
 			},
 
 			// Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
-				"php.validate.executablePath": "/usr/local/bin/php"
+				"php.validate.executablePath": "/usr/local/bin/php",
+				"phpSniffer.executablesFolder": "/usr/local/bin/",
+				"phpcs.executablePath": "/usr/local/bin/phpcs"
 			},
 
 			// Add the IDs of extensions you want installed when the container is created.
@@ -14,7 +16,8 @@
 				"xdebug.php-debug",
 				"bmewburn.vscode-intelephense-client",
 				"philfontaine.autolaunch",
-				"eamodio.gitlens"
+				"eamodio.gitlens",
+				"shevaua.phpcs"
 			]
 		}
 	},

--- a/.devcontainer/xdebug.ini
+++ b/.devcontainer/xdebug.ini
@@ -1,5 +1,3 @@
-zend_extension=xdebug.so
-
 [xdebug]
 xdebug.mode=develop,debug
 xdebug.client_host=localhost


### PR DESCRIPTION
Expect some iterative changes while I'm finding out more about what this thing can do :)

This will add live linting checks to the codespace container. This means, everytime you save a .php file, it will mark lines that break a rule written in the phpcs.xml file (also giving you the info on what the problem is, inline and in the console).

This could/should lower the amount of failed linting runs on the PRs that are made with the devcontainer.

If you have a suggestion on what should be added dvikan, shoot.