### PR TITLE
[Sfeed] Added new format

### DIFF
--- a/formats/SfeedFormat.php
+++ b/formats/SfeedFormat.php
@@ -1,52 +1,63 @@
 <?PHP
-function escape(string $str) {
-    $str = str_replace('\\', '\\\\', $str);
-    $str = str_replace('\n', '\\n', $str);
-    return str_replace('\t', '\\t', $str);
-}
 
-function getFirstEnclosure(array $enclosures) {
-    if(count($enclosures) >= 1)
-        return $enclosures[0];
-    return '';
-}
-
-function getCategories(array $cats) {
-    $toReturn = '';
-    $i = 0;
-    foreach($cats as $cat) {
-        $toReturn .= $cat;
-        if(count($cats) < $i)
-            $toReturn .= '|';
-        $i++;
-    }
-    return $toReturn;
-}
-
-class SfeedFormat extends FormatAbstract {
+class SfeedFormat extends FormatAbstract
+{
     const MIME_TYPE = 'text/plain';
 
-    public function stringify() {
+    private function escape(string $str)
+    {
+        $str = str_replace('\\', '\\\\', $str);
+        $str = str_replace("\n", "\\n", $str);
+        return str_replace("\t", "\\t", $str);
+    }
+
+    private function getFirstEnclosure(array $enclosures)
+    {
+        if (count($enclosures) >= 1) {
+            return $enclosures[0];
+        }
+        return '';
+    }
+
+    private function getCategories(array $cats)
+    {
+        $toReturn = '';
+        $i = 0;
+        foreach ($cats as $cat) {
+            $toReturn .= $cat;
+            if (count($cats) < $i) {
+                $toReturn .= '|';
+            }
+            $i++;
+        }
+        return $toReturn;
+    }
+
+    public function stringify()
+    {
         $items = $this->getItems();
 
         $toReturn = '';
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $toReturn .= sprintf(
-                    '%s\t%s\t%s\t%s\thtml\t\t%s\t%s\t%s\n',
-                    $item->toArray()['timestamp'],
-                    escape($item->toArray()['title']),
-                    $item->toArray()['uri'],
-                    escape($item->toArray()['content']),
-                    $item->toArray()['author'],
-                    getFirstEnclosure($item->toArray()['enclosures']),
-                    getCategories($item->toArray()['categories'])
-                    );
+                "%s\t%s\t%s\t%s\thtml\t\t%s\t%s\t%s\n",
+                $item->toArray()['timestamp'],
+                $this->escape($item->toArray()['title']),
+                $item->toArray()['uri'],
+                $this->escape($item->toArray()['content']),
+                $item->toArray()['author'],
+                $this->getFirstEnclosure($item->toArray()['enclosures']),
+                $this->getCategories($item->toArray()['categories'])
+            );
         }
 
         // Remove invalid non-UTF8 characters
         ini_set('mbstring.substitute_character', 'none');
-        $toReturn = mb_convert_encoding($toReturn, 
-                $this->getCharset(), 'UTF-8');
+        $toReturn = mb_convert_encoding(
+            $toReturn,
+            $this->getCharset(),
+            'UTF-8'
+        );
         return $toReturn;
     }
 }

--- a/formats/SfeedFormat.php
+++ b/formats/SfeedFormat.php
@@ -1,50 +1,53 @@
 <?PHP
 function escape(string $str) {
-	$str = str_replace("\\", "\\\\", $str);
-	$str = str_replace("\n", "\\n", $str);
-	return str_replace("\t", "\\t", $str);
+    $str = str_replace('\\', '\\\\', $str);
+    $str = str_replace('\n', '\\n', $str);
+    return str_replace('\t', '\\t', $str);
 }
 
 function getFirstEnclosure(array $enclosures) {
-	if(count($enclosures) >= 1)
-		return $enclosures[0];
-	return "";
+    if(count($enclosures) >= 1)
+        return $enclosures[0];
+    return '';
 }
 
 function getCategories(array $cats) {
-	$toReturn = "";
-	$i = 0;
-	foreach($cats as $cat) {
-		$toReturn .= $cat;
-		if(count($cats) < $i)
-			$toReturn .= '|';
-		$i++;
-	}
-	return $toReturn;
+    $toReturn = '';
+    $i = 0;
+    foreach($cats as $cat) {
+        $toReturn .= $cat;
+        if(count($cats) < $i)
+            $toReturn .= '|';
+        $i++;
+    }
+    return $toReturn;
 }
 
 class SfeedFormat extends FormatAbstract {
-	const MIME_TYPE = 'text/plain';
+    const MIME_TYPE = 'text/plain';
 
-	public function stringify() {
-		$items = $this->getItems();
+    public function stringify() {
+        $items = $this->getItems();
 
-		$toReturn = "";
-		foreach($items as $item) {
-			$toReturn .= sprintf("%s\t%s\t%s\t%s\thtml\t\t%s\t%s\t%s\n",
-					$item->toArray()["timestamp"],
-					escape($item->toArray()["title"]),
-					$item->toArray()["uri"],
-					escape($item->toArray()["content"]),
-					$item->toArray()["author"],
-					getFirstEnclosure($item->toArray()["enclosures"]),
-					getCategories($item->toArray()["categories"])
-					);
-		}
+        $toReturn = '';
+        foreach($items as $item) {
+            $toReturn .= sprintf(
+                    '%s\t%s\t%s\t%s\thtml\t\t%s\t%s\t%s\n',
+                    $item->toArray()['timestamp'],
+                    escape($item->toArray()['title']),
+                    $item->toArray()['uri'],
+                    escape($item->toArray()['content']),
+                    $item->toArray()['author'],
+                    getFirstEnclosure($item->toArray()['enclosures']),
+                    getCategories($item->toArray()['categories'])
+                    );
+        }
 
-		// Remove invalid non-UTF8 characters
-		ini_set('mbstring.substitute_character', 'none');
-		$toReturn = mb_convert_encoding($toReturn, $this->getCharset(), 'UTF-8');
-		return $toReturn;
-	}
+        // Remove invalid non-UTF8 characters
+        ini_set('mbstring.substitute_character', 'none');
+        $toReturn = mb_convert_encoding($toReturn, 
+                $this->getCharset(), 'UTF-8');
+        return $toReturn;
+    }
 }
+// vi: expandtab

--- a/formats/SfeedFormat.php
+++ b/formats/SfeedFormat.php
@@ -1,0 +1,50 @@
+<?PHP
+function escape(string $str) {
+	$str = str_replace("\\", "\\\\", $str);
+	$str = str_replace("\n", "\\n", $str);
+	return str_replace("\t", "\\t", $str);
+}
+
+function getFirstEnclosure(array $enclosures) {
+	if(count($enclosures) >= 1)
+		return $enclosures[0];
+	return "";
+}
+
+function getCategories(array $cats) {
+	$toReturn = "";
+	$i = 0;
+	foreach($cats as $cat) {
+		$toReturn .= $cat;
+		if(count($cats) < $i)
+			$toReturn .= '|';
+		$i++;
+	}
+	return $toReturn;
+}
+
+class SfeedFormat extends FormatAbstract {
+	const MIME_TYPE = 'text/plain';
+
+	public function stringify() {
+		$items = $this->getItems();
+
+		$toReturn = "";
+		foreach($items as $item) {
+			$toReturn .= sprintf("%s\t%s\t%s\t%s\thtml\t\t%s\t%s\t%s\n",
+					$item->toArray()["timestamp"],
+					escape($item->toArray()["title"]),
+					$item->toArray()["uri"],
+					escape($item->toArray()["content"]),
+					$item->toArray()["author"],
+					getFirstEnclosure($item->toArray()["enclosures"]),
+					getCategories($item->toArray()["categories"])
+					);
+		}
+
+		// Remove invalid non-UTF8 characters
+		ini_set('mbstring.substitute_character', 'none');
+		$toReturn = mb_convert_encoding($toReturn, $this->getCharset(), 'UTF-8');
+		return $toReturn;
+	}
+}


### PR DESCRIPTION
Sfeed is a simple feed format. Specification from sfeed(5) manual:
```
TAB-SEPARATED FORMAT FIELDS
     The items are output per line in a TAB-separated format.

     For the fields title, id and author each whitespace character is
     replaced by a SPACE character.  Control characters are removed.

     The content field can contain newlines and these are escaped.
     TABs, newlines and '\' are escaped with '\', so it becomes: '\t',
     '\n' and '\\'.  Other whitespace characters except spaces are
     removed.  Control characters are removed.

     The order and content of the fields are:

     1. timestamp     UNIX timestamp in UTC+0, empty if missing or on a
                      parse failure.

     2. title         Title text, HTML code in titles is ignored and is
                      treated as plain-text.

     3. link          Link

     4. content       Content, can have plain-text or HTML code
                      depending on the content-type field.

     5. content-type  "html" or "plain" if it has content.

     6. id            RSS item GUID or Atom id.

     7. author        Item, first author.

     8. enclosure     Item, first enclosure.

     9. category      Item, categories, multiple values are separated by
                      the '|' character.
```

Those who use sfeed and RSS-bridge can now view any feed directly
with no overhead. In fact sfeed(1) is so fast that it didn't change 
anything, but now everything is architecturally correct.

Sfeed done homepage: https://codemadness.org/sfeed-simple-feed-parser.html
Sfeed toolbox Git repository: https://codemadness.org/git/sfeed/

This patch is used on my RSS-bridge instance: http://rss.madreyk.xyz/
