### PR TITLE
[Sfeed] Fixed category separator and random white spaces

### DIFF
--- a/formats/SfeedFormat.php
+++ b/formats/SfeedFormat.php
@@ -7,8 +7,8 @@ class SfeedFormat extends FormatAbstract
     private function escape(string $str)
     {
         $str = str_replace('\\', '\\\\', $str);
-        $str = str_replace("\n", "\\n", $str);
-        return str_replace("\t", "\\t", $str);
+        $str = str_replace("\n", '\\n', $str);
+        return str_replace("\t", '\\t', $str);
     }
 
     private function getFirstEnclosure(array $enclosures)
@@ -22,13 +22,12 @@ class SfeedFormat extends FormatAbstract
     private function getCategories(array $cats)
     {
         $toReturn = '';
-        $i = 0;
+        $i = 1;
         foreach ($cats as $cat) {
-            $toReturn .= $cat;
-            if (count($cats) < $i) {
+            $toReturn .= trim($cat);
+            if (count($cats) > $i++) {
                 $toReturn .= '|';
             }
-            $i++;
         }
         return $toReturn;
     }
@@ -42,12 +41,18 @@ class SfeedFormat extends FormatAbstract
             $toReturn .= sprintf(
                 "%s\t%s\t%s\t%s\thtml\t\t%s\t%s\t%s\n",
                 $item->toArray()['timestamp'],
-                $this->escape($item->toArray()['title']),
+                preg_replace('/\s/', ' ', $item->toArray()['title']),
                 $item->toArray()['uri'],
                 $this->escape($item->toArray()['content']),
                 $item->toArray()['author'],
-                $this->getFirstEnclosure($item->toArray()['enclosures']),
-                $this->getCategories($item->toArray()['categories'])
+                $this->getFirstEnclosure(
+                    $item->toArray()['enclosures']
+                ),
+                $this->escape(
+                    $this->getCategories(
+                        $item->toArray()['categories']
+                    )
+                )
             );
         }
 


### PR DESCRIPTION
I assumed the categories already fit, but for example the CVEDetails
bridge categories have random spaces (including tabs) that need to be
trimmed. The category separator was also broken. Can be tested on my
rss-bridge instance on OpenBSD's CVEDetails:
https://rss.madreyk.xyz?action=display&bridge=CVEDetails&format=sfeed&product_id=&vendor_id=97
