### PR TITLE
[UI] Remove excessive top margin in all pages and logo in HTML feed preview

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -66,7 +66,6 @@ p {
 
 /* Header */
 header {
-    margin-top: 40px;
     padding: 15px;
     color: #1182DB;
     text-align: center;
@@ -133,7 +132,7 @@ input:focus:-ms-input-placeholder { opacity: 0; }
 
 .container {
     width: 60%;
-    margin: 30px auto;
+    margin: 0 auto 30px auto;
 }
 
 /* Section */

--- a/templates/base.html.php
+++ b/templates/base.html.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="RSS-Bridge" />
     <title><?= e($_title ?? 'RSS-Bridge') ?></title>
-    <link href="static/style.css" rel="stylesheet">
+    <link href="static/style.css?2023-03-24" rel="stylesheet">
     <link rel="icon" type="image/png" href="static/favicon.png">
 </head>
 

--- a/templates/html-format.html.php
+++ b/templates/html-format.html.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/ >
     <meta name="description" content="RSS-Bridge" />
     <title><?= e($title) ?></title>
-    <link href="static/style.css" rel="stylesheet">
+    <link href="static/style.css?2023-03-24" rel="stylesheet">
     <link rel="icon" type="image/png" href="static/favicon.png">
 
 	<?php foreach ($linkTags as $link): ?>
@@ -23,12 +23,6 @@
 <body>
 
     <div class="container">
-
-        <header>
-            <a href="./">
-                <img width="400" src="static/logo_600px.png">
-            </a>
-        </header>
 
         <h1 class="pagetitle">
             <a href="<?= e($uri) ?>" target="_blank"><?= e($title) ?></a>


### PR DESCRIPTION
In my smartphone, logo and top margins take almost 50% of the screen, when viewing HTML feed preview

<details>
<summary>Screenshot</summary>

![photo_2023-03-24_06-53-33](https://user-images.githubusercontent.com/15870400/227404352-4cb887b5-67e1-4e15-98eb-52cba3979450.jpg)
</details>

Also this commit slighly decreases top margin in frontpage.