### PR TITLE
Use standard Docker logs

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,8 +2,8 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
     root /app;
-    access_log /var/log/nginx/rssbridge.access.log;
-    error_log /var/log/nginx/rssbridge.error.log;
+    access_log /dev/stdout;
+    error_log /dev/stderr;
     index index.php;
 
     location ~ /(\.|vendor|tests) {


### PR DESCRIPTION
Instead of storing logs inside the container (where they cannot easily be seen nor rotated), consider using the standard Docker approach of writing to standard output https://docs.docker.com/config/containers/logging/