### PR TITLE
[ZeitBridge] Re-add paywall workaround

### DIFF
--- a/bridges/ZeitBridge.php
+++ b/bridges/ZeitBridge.php
@@ -66,6 +66,8 @@ class ZeitBridge extends FeedExpander
         $item['enclosures'] = [];
 
         $headers = [
+            'User-Agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+            'X-Forwarded-For: 66.249.66.1',
             'Cookie: zonconsent=' . date('Y-m-d\TH:i:s.v\Z'),
         ];
 


### PR DESCRIPTION
Additionally to the Googlebot User-Agent, a Googlebot IP address has to be used. For now, we can use `X-Forwarded-For` for this.