### PR TITLE
Fix default HTTP headers

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -115,7 +115,7 @@ function getContents(
         'Sec-Fetch-Mode' => 'navigate',
         'Sec-Fetch-Site' => 'none',
         'Sec-Fetch-User' => '?1',
-        'TE' => 'Trailers',
+        'TE' => 'trailers',
     ];
     $httpHeadersNormalized = [];
     foreach ($httpHeaders as $httpHeader) {


### PR DESCRIPTION
I noticed the Explosm bridge returning errors:

```
Details

Type: HttpException
Code: 400
Message: https://explosm.net/comics/latest#comic resulted in 400 Bad Request
File: lib/contents.php
Line: 202

Trace

#0 index.php(7): RssBridge->main()
#1 lib/RssBridge.php(15): RssBridge->run()
#2 lib/RssBridge.php(92): DisplayAction->execute()
#3 actions/DisplayAction.php(133): ExplosmBridge->collectData()
#4 bridges/ExplosmBridge.php(36): getSimpleHTMLDOM()
#5 lib/contents.php(367): getContents()
#6 lib/contents.php(202) 
```

I couldn't find a error within the bridge.
After a lot of debugging I found the root of the problem:

In `lib/contents.php` one of the default headers getting set is this one:
`'TE' => 'Trailers'`.

According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/TE valid values are
* `compress`
* `deflate`
* `gzip`
* `trailers`
* `q`.

And oh surprise:
When changing `'TE' => 'Trailers'` to `'TE' => 'trailers'` (using all lower case), Explosm bridge works again!

Could be beneficial to other bridges, too.