### PR TITLE
[XPathAbstract] Fix encoding on feed title

### DIFF
--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -348,7 +348,7 @@ abstract class XPathAbstract extends BridgeAbstract
     {
         $title = $xpath->query($this->getParam('feed_title'));
         if (count($title) === 1) {
-            return $this->getItemValueOrNodeValue($title);
+            return $this->fixEncoding($this->getItemValueOrNodeValue($title));
         }
     }
 


### PR DESCRIPTION
I think it's safe to say if `Fix encoding` is helpful for feed entries, it's helpful for the feed title too. Two websites I know of that benefit from this are [Artoriuz's blog](https://rss-bridge.org/bridge01/?action=display&bridge=XPathBridge&url=https%3A//artoriuz.github.io/blog/index.html&item=//*[%40id%3D%22posts%22]/ul/li&title=.&content=&uri=descendant%3A%3Aa/%40href&author=//header//h1&timestamp=&enclosures=&categories=&fix_encoding=on&format=Html) and [Pokemon Go News](https://rss-bridge.org/bridge01/?action=display&bridge=XPathBridge&url=https%3A//pokemongolive.com/en/news/&item=//*[contains(concat(%22%20%22%2C%20normalize-space(%40class)%2C%20%22%20%22)%2C%20%22%20blogList__post%20%22)]&title=descendant%3A%3A*[contains(concat(%22%20%22%2C%20normalize-space(%40class)%2C%20%22%20%22)%2C%20%22%20blogList__post__content__title%20%22)]&content=&uri=descendant-or-self%3A%3Aa/%40href&author=&timestamp=descendant%3A%3A*[contains(concat(%22%20%22%2C%20normalize-space(%40class)%2C%20%22%20%22)%2C%20%22%20blogList__post__content__date%20%22)]&enclosures=descendant%3A%3Aimg/%40src&categories=&fix_encoding=on&format=Html).