### PR TITLE
[JustWatchBridge] Add ability to choose providers, fixes

### DIFF
--- a/bridges/JustWatchBridge.php
+++ b/bridges/JustWatchBridge.php
@@ -165,7 +165,7 @@ class JustWatchBridge extends BridgeAbstract
         $providers = $today->find('div.provider-timeline');
 
         foreach ($providers as $provider) {
-            $titles = $html->find('div.horizontal-title-list__item');
+            $titles = $provider->find('div.horizontal-title-list__item');
             foreach ($titles as $title) {
                 $item = [];
                 $item['uri'] = $title->find('a', 0)->href;

--- a/bridges/JustWatchBridge.php
+++ b/bridges/JustWatchBridge.php
@@ -155,11 +155,9 @@ class JustWatchBridge extends BridgeAbstract
 
     public function collectData()
     {
-        $basehtml = getSimpleHTMLDOM($this->getURI());
-        $basehtml = defaultLinkTo($basehtml, self::URI);
-        $overviewhtml = getSimpleHTMLDOM($basehtml->find('.navbar__button__link', 1)->href);
-        $overviewhtml = defaultLinkTo($overviewhtml, self::URI);
-        $html = getSimpleHTMLDOM($overviewhtml->find('.filter-bar-content-type__item', $this->getInput('mediatype'))->find('a', 0)->href);
+        $type_fragment = array('','/movies','/tv-series');
+        $url = $this->getURI() . $type_fragment[$this->getInput('mediatype')] . '/new';
+        $html = getSimpleHTMLDOM($url);
         $html = defaultLinkTo($html, self::URI);
         $today = $html->find('div.title-timeline', 0);
         $providers = $today->find('div.provider-timeline');

--- a/bridges/JustWatchBridge.php
+++ b/bridges/JustWatchBridge.php
@@ -149,6 +149,12 @@ class JustWatchBridge extends BridgeAbstract
                     'Movies' => 1,
                     'Series' => 2
                 ]
+            ],
+            'providers' => [
+                'name' => 'Provider IDs',
+                'exampleValue' => 'nfx,dnp,bbc',
+                'title' => 'Comma separated list of content provider ids. (find these in your cookies under jw/user/settings/providers)',
+                'defaultValue' => 'nfx,dnp,bbc'            
             ]
         ]
     ];
@@ -156,7 +162,8 @@ class JustWatchBridge extends BridgeAbstract
     public function collectData()
     {
         $type_fragment = array('','/movies','/tv-series');
-        $url = $this->getURI() . $type_fragment[$this->getInput('mediatype')] . '/new';
+        $myproviders = '?providers=' . $this->getInput('providers');
+        $url = $this->getURI() . $type_fragment[$this->getInput('mediatype')] . '/new' . $myproviders;
         $html = getSimpleHTMLDOM($url);
         $html = defaultLinkTo($html, self::URI);
         $today = $html->find('div.title-timeline', 0);


### PR DESCRIPTION
- Add option for user to give a list of provider short_names and only results from those services will be returned
- Only use 1 request to getSimpleHTMLDOM. Old code was making 3.
- Bugfix: use of $html should be $providers, else all shows are duplicated for all providers.