### PR TITLE
[New Bridge] FiderBridge

### DIFF
--- a/bridges/FiderBridge.php
+++ b/bridges/FiderBridge.php
@@ -1,0 +1,132 @@
+<?php
+
+class FiderBridge extends BridgeAbstract
+{
+    const NAME = 'Fider Bridge';
+    const URI = 'https://fider.io/';
+    const DESCRIPTION = 'Bridge for any Fider instance';
+    const MAINTAINER = 'Oliver Nutter';
+    const PARAMETERS = [
+        'global' => [
+            'instance' => [
+                'name' => 'Instance URL',
+                'required' => true,
+                'example' => 'https://feedback.fider.io',
+            ],
+        ],
+        'Post' => [
+            'num' => [
+                'name' => 'Post Number',
+                'type' => 'number',
+                'required' => true,
+            ],
+            'limit' => [
+                'name' => 'Number of comments to return',
+                'type' => 'number',
+                'required' => false,
+                'title' => 'Specify number of comments to return',
+            ],
+        ],
+    ];
+
+    private $instance;
+    private $posturi;
+    private $title;
+
+    public function getName()
+    {
+        return $this->title ?? parent::getName();
+    }
+
+    public function getURI()
+    {
+        return $this->posturi ?? parent::getURI();
+    }
+
+    protected function setTitle($title)
+    {
+        $html = getSimpleHTMLDOMCached($this->instance);
+        $name = $html->find('title', 0)->innertext;
+
+        $this->title = "$title - $name";
+    }
+
+    protected function getItem($post, $response = false, $first = false)
+    {
+        $item = [];
+        $item['uri'] = $this->getURI();
+        $item['timestamp'] = $response ? $post->respondedAt : $post->createdAt;
+        $item['author'] = $post->user->name;
+
+        $datetime = new DateTime($item['timestamp']);
+        if ($response) {
+            $item['uid'] = 'response';
+            $item['content'] = $post->text;
+            $item['title'] = "{$item['author']} marked as $post->status {$datetime->format('M d, Y')}";
+        } elseif ($first) {
+            $item['uid'] = 'post';
+            $item['content'] = $post->description;
+            $item['title'] = $post->title;
+        } else {
+            $item['uid'] = 'comment';
+            $item['content'] = $post->content;
+            $item['title'] = "{$item['author']} commented {$datetime->format('M d, Y')}";
+        }
+
+        $item['uid'] .= $item['author'] . $item['timestamp'];
+
+        // parse markdown with implicit line breaks
+        $item['content'] = markdownToHtml($item['content'], ['breaksEnabled' => true]);
+
+        if (property_exists($post, 'editedAt')) {
+            $item['title'] .= ' (edited)';
+        }
+
+        if ($first) {
+            $item['categories'] = $post->tags;
+        }
+
+        return $item;
+    }
+
+    public function collectData()
+    {
+        // collect first post
+        $this->instance = rtrim($this->getInput('instance'), '/');
+
+        $num = $this->getInput('num');
+        $this->posturi = "$this->instance/posts/$num";
+
+        $post_api_uri = "$this->instance/api/v1/posts/$num";
+        $post = json_decode(getContents($post_api_uri));
+
+        $this->setTitle($post->title);
+
+        $item = $this->getItem($post, false, true);
+        $this->items[] = $item;
+
+        // collect response to first post
+        if (property_exists($post, 'response')) {
+            $response = $post->response;
+            $response->status = $post->status;
+            $this->items[] = $this->getItem($response, true);
+        }
+
+        // collect comments
+        $comment_api_uri = "$post_api_uri/comments";
+        $comments = json_decode(getContents($comment_api_uri));
+
+        foreach ($comments as $post) {
+            $item = $this->getItem($post);
+            $this->items[] = $item;
+        }
+
+        usort($this->items, function ($a, $b) {
+            return $b['timestamp'] <=> $a['timestamp'];
+        });
+
+        if ($this->getInput('limit') ?? 0 > 0) {
+            $this->items = array_slice($this->items, 0, $this->getInput('limit'));
+        }
+    }
+}

--- a/docs/06_Helper_functions/index.md
+++ b/docs/06_Helper_functions/index.md
@@ -194,8 +194,20 @@ $cleaned = stripRecursiveHTMLSection($string, $tag_name, $tag_start);
 # markdownToHtml
 Converts markdown input to HTML using [Parsedown](https://parsedown.org/).
 
+| Parameter | Type   | Optional   | Description
+| --------- | ------ | ---------- | ----------
+| `string`  | string | *required* | The URL of the contents to acquire
+| `config`  | array  | *optional* | An array of Parsedown options in the format `['breaksEnabled' => true]`
+
+Valid options:
+| Option          | Default | Description
+| --------------- | ------- | -----------
+| `breaksEnabled` | `false` | Enable automatic line breaks
+| `markupEscaped` | `false` | Escape inline markup (HTML)
+| `urlsLinked`    | `true`  | Automatically convert URLs to links
+
 ```php
-function markdownToHtml(string $string) : string
+function markdownToHtml(string $string, array $config = []) : string
 ```
 
 **Example**

--- a/lib/html.php
+++ b/lib/html.php
@@ -361,10 +361,22 @@ function stripRecursiveHTMLSection($string, $tag_name, $tag_start)
  * @link https://parsedown.org/ Parsedown
  *
  * @param string $string Input string in Markdown format
+ * @param array $config Parsedown options to control output
  * @return string output string in HTML format
  */
-function markdownToHtml($string)
+function markdownToHtml($string, $config = [])
 {
     $Parsedown = new Parsedown();
+    foreach ($config as $option => $value) {
+        if ($option === 'breaksEnabled') {
+            $Parsedown->setBreaksEnabled($value);
+        } elseif ($option === 'markupEscaped') {
+            $Parsedown->setMarkupEscaped($value);
+        } elseif ($option === 'urlsLinked') {
+            $Parsedown->setUrlsLinked($value);
+        } else {
+            throw new \InvalidArgumentException("Invalid Parsedown option \"$option\"");
+        }
+    }
     return $Parsedown->text($string);
 }


### PR DESCRIPTION
[Fider](https://fider.io/) is a self-hostable feedback platform. The only clients I'm aware of at the moment are [Fider itself](https://feedback.fider.io) and [Jellyfin](https://features.jellyfin.org). I've been using it to track [this issue](https://features.jellyfin.org/posts/13) for a while now and I haven't encountered any issues. I based the basic format of feed/entry titles on GithubIssueBridge. Below is an example of a URL for the bridge (hostname excluded):
```/?action=display&bridge=FiderBridge&context=Post&num=13&instance=https%3A%2F%2Ffeatures.jellyfin.org&format=Atom```

Also, Fider serves its messages in Markdown format, except it implicitly adds line breaks. Parsedown is capable of this, but not via the `markdownToHtml` wrapper in rss-bridge. I used the Parsedown interface directly to fix that, but it could easily be added as a parameter to `markdownToHtml`. The second commit could also be squashed if desired.