### PR TITLE
added iframe to $bad in GolemBridge

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -114,7 +114,7 @@ class GolemBridge extends FeedExpander
 
         // delete known bad elements
         foreach (
-            $article->find('div[id*="adtile"], #job-market, #seminars,
+            $article->find('div[id*="adtile"], #job-market, #seminars, iframe,
 			div.gbox_affiliate, div.toc, .embedcontent') as $bad
         ) {
             $bad->remove();


### PR DESCRIPTION
iframe can't be rendered in feed reader, so we can delete it

here an example article with iframe included:
https://www.golem.de/news/15-jahre-speed-racer-die-cgi-zukunft-die-wir-nie-bekommen-haben-2305-173665.html
