### PR TITLE
[XPathAbstract] Fix relative URLs in entry content

### DIFF
--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -577,7 +577,8 @@ abstract class XPathAbstract extends BridgeAbstract
             if ($item instanceof \DOMElement) {
                 // Don't escape XML
                 if ($returnXML) {
-                    return ($item->ownerDocument ?? $item)->saveXML($item);
+                    $text = ($item->ownerDocument ?? $item)->saveXML($item);
+                    return defaultLinkTo($text, $this->getSourceUrl());
                 }
                 $text = $item->nodeValue;
             } elseif ($item instanceof \DOMAttr) {


### PR DESCRIPTION
Many websites use relative URLs in their page content for linking to local resources (e.g. a href-attribute, img src-attribute).

Since HTML is now preserved in entry content (see #3366) this converts all relative URLs in the entry content to absolute ones.