### PR TITLE
[XPathAbstract] Fix relative links in fetched HTML

### DIFF
--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -387,6 +387,9 @@ abstract class XPathAbstract extends BridgeAbstract
         libxml_clear_errors();
         libxml_use_internal_errors(false);
 
+        // fix relative links
+        defaultLinkTo($webPageHtml, $this->feedUri);
+
         $xpath = new \DOMXPath($webPageHtml);
 
         $this->feedName = $this->provideFeedTitle($xpath);

--- a/lib/html.php
+++ b/lib/html.php
@@ -185,14 +185,17 @@ function defaultLinkTo($dom, $url)
         $dom = str_get_html($dom);
     }
 
-    foreach ($dom->find('img') as $image) {
-        $image->src = urljoin($url, $image->src);
+    // Use long method names for compatibility with simple_html_dom and DOMDocument
+
+    foreach ($dom->getElementsByTagName('img') as $image) {
+        $image->setAttribute('src', urljoin($url, $image->getAttribute('src')));
     }
 
-    foreach ($dom->find('a') as $anchor) {
-        $anchor->href = urljoin($url, $anchor->href);
+    foreach ($dom->getElementsByTagName('a') as $anchor) {
+        $anchor->setAttribute('href', urljoin($url, $anchor->getAttribute('href')));
     }
 
+    // Will never be true for DOMDocument
     if ($string_convert) {
         $dom = $dom->outertext;
     }


### PR DESCRIPTION
`defaultLinkTo` only used very basic operations so it was very simple to modify it to allow passing DOMDocument objects to it.
Obsoletes #3398