### PR TITLE
Fix defaultLinkTo for simple_html_dom objects

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -187,18 +187,12 @@ function defaultLinkTo($dom, $url)
 
     // Use long method names for compatibility with simple_html_dom and DOMDocument
 
-    $images = $dom->getElementsByTagName('img');
-    if (is_array($images)) {
-        foreach ($images as $image) {
-            $image->setAttribute('src', urljoin($url, $image->getAttribute('src')));
-        }
+    foreach ($dom->getElementsByTagName('img', null) as $image) {
+        $image->setAttribute('src', urljoin($url, $image->getAttribute('src')));
     }
 
-    $anchors = $dom->getElementsByTagName('a');
-    if (is_array($anchors)) {
-        foreach ($anchors as $anchor) {
-            $anchor->setAttribute('href', urljoin($url, $anchor->getAttribute('href')));
-        }
+    foreach ($dom->getElementsByTagName('a', null) as $anchor) {
+        $anchor->setAttribute('href', urljoin($url, $anchor->getAttribute('href')));
     }
 
     // Will never be true for DOMDocument


### PR DESCRIPTION
`$idx` should be `null` by default for `simple_html_dom` objects, and passing it to `DOMDocument` doesn't cause errors.