### PR TITLE
[NyaaTorrentsBridge] Add custom fields

### DIFF
--- a/bridges/NyaaTorrentsBridge.php
+++ b/bridges/NyaaTorrentsBridge.php
@@ -88,16 +88,16 @@ class NyaaTorrentsBridge extends FeedExpander
     private function fixCustomFields($content)
     {
         $broken = [
-            "nyaa:seeders",
-            "nyaa:leechers",
-            "nyaa:downloads",
-            "nyaa:infoHash",
-            "nyaa:categoryId",
-            "nyaa:category",
-            "nyaa:size",
-            "nyaa:comments",
-            "nyaa:trusted",
-            "nyaa:remake"
+            'nyaa:seeders',
+            'nyaa:leechers',
+            'nyaa:downloads',
+            'nyaa:infoHash',
+            'nyaa:categoryId',
+            'nyaa:category',
+            'nyaa:size',
+            'nyaa:comments',
+            'nyaa:trusted',
+            'nyaa:remake'
         ];
         $fixed = ['seeders', 'leechers', 'downloads', 'infoHash', 'categoryId', 'category', 'size', 'comments', 'trusted', 'remake'];
         return str_replace($broken, $fixed, $content);

--- a/bridges/NyaaTorrentsBridge.php
+++ b/bridges/NyaaTorrentsBridge.php
@@ -87,7 +87,18 @@ class NyaaTorrentsBridge extends FeedExpander
 
     private function fixCustomFields($content)
     {
-        $broken = ['nyaa:seeders', 'nyaa:leechers', 'nyaa:downloads', 'nyaa:infoHash', 'nyaa:categoryId', 'nyaa:category', 'nyaa:size', 'nyaa:comments', 'nyaa:trusted', 'nyaa:remake'];
+        $broken = [
+            "nyaa:seeders",
+            "nyaa:leechers",
+            "nyaa:downloads",
+            "nyaa:infoHash",
+            "nyaa:categoryId",
+            "nyaa:category",
+            "nyaa:size",
+            "nyaa:comments",
+            "nyaa:trusted",
+            "nyaa:remake"
+        ];
         $fixed = ['seeders', 'leechers', 'downloads', 'infoHash', 'categoryId', 'category', 'size', 'comments', 'trusted', 'remake'];
         return str_replace($broken, $fixed, $content);
     }

--- a/bridges/NyaaTorrentsBridge.php
+++ b/bridges/NyaaTorrentsBridge.php
@@ -65,7 +65,7 @@ class NyaaTorrentsBridge extends FeedExpander
     {
         return self::URI . 'static/favicon.png';
     }
-    
+
     public function getURI()
     {
         return self::URI . '?page=rss&s=id&o=desc&'
@@ -84,11 +84,11 @@ class NyaaTorrentsBridge extends FeedExpander
         $rssContent = simplexml_load_string(trim($content));
         $this->collectRss2($rssContent, self::MAX_ITEMS);
     }
-    
+
     private function fixCustomFields($content)
     {
-        $broken = ["nyaa:seeders", "nyaa:leechers", "nyaa:downloads", "nyaa:infoHash", "nyaa:categoryId", "nyaa:category", "nyaa:size", "nyaa:comments", "nyaa:trusted", "nyaa:remake"];
-        $fixed = ["seeders", "leechers", "downloads", "infoHash", "categoryId", "category", "size", "comments", "trusted", "remake"];
+        $broken = ['nyaa:seeders', 'nyaa:leechers', 'nyaa:downloads', 'nyaa:infoHash', 'nyaa:categoryId', 'nyaa:category', 'nyaa:size', 'nyaa:comments', 'nyaa:trusted', 'nyaa:remake'];
+        $fixed = ['seeders', 'leechers', 'downloads', 'infoHash', 'categoryId', 'category', 'size', 'comments', 'trusted', 'remake'];
         return str_replace($broken, $fixed, $content);
     }
 

--- a/bridges/NyaaTorrentsBridge.php
+++ b/bridges/NyaaTorrentsBridge.php
@@ -108,6 +108,7 @@ class NyaaTorrentsBridge extends FeedExpander
         $item = parent::parseRss2Item($newItem);
 
         // Add nyaa custom fields
+        $item['id'] = str_replace(['https://nyaa.si/download/', '.torrent'], '', $item['uri']);
         $item['seeders'] = (string) $newItem->{'seeders'};
         $item['leechers'] = (string) $newItem->{'leechers'};
         $item['downloads'] = (string) $newItem->{'downloads'};
@@ -120,8 +121,7 @@ class NyaaTorrentsBridge extends FeedExpander
         $item['remake'] = (string) $newItem->{'remake'};
 
         //Convert URI from torrent file to web page
-        $item['uri'] = str_replace('/download/', '/view/', $item['uri']);
-        $item['uri'] = str_replace('.torrent', '', $item['uri']);
+        $item['uri'] = str_replace(['/download/', '.torrent'], ['/view/', ''], $item['uri']);
 
         if ($item_html = getSimpleHTMLDOMCached($item['uri'])) {
             //Retrieve full description from page contents


### PR DESCRIPTION
This will fix https://github.com/RSS-Bridge/rss-bridge/issues/3418 and add all custom fields from the nyaa-torrents rss feeds. The problem are the `:` in the xml fields which lead to the whole fields getting removed by `simplexml_load_string()`. This is fixed by removing `nyaa:` from the feed result and then parsing everything as before.

@ORelio Feel free to comment or suggest changes as well!