### PR TITLE
chore: introduce a new document root

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ Example config for nginx:
 server {
     listen 80;
     server_name example.com;
-    root /var/www/rss-bridge;
+    root /var/www/rss-bridge/public;
     index index.php;
+
+    location /static {
+        alias /var/www/rss-bridge/static;
+    }
 
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
@@ -70,6 +74,9 @@ server {
     }
 }
 ```
+
+For legacy reasons it is possible to straight up clone this repo into a folder in a shared hosting environment.
+It's advised against due to the security risk of all files being directly accessible by the web server.
 
 ### Install with Docker:
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,10 +1,16 @@
+# This file is used by docker to build the docker image
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    root /app;
+    root /app/public;
     access_log /dev/stdout;
     error_log /dev/stderr;
     index index.php;
+
+    location /static {
+        alias /app/static;
+    }
 
     location ~ /(\.|vendor|tests) {
         deny all;

--- a/index.php
+++ b/index.php
@@ -1,5 +1,8 @@
 <?php
 
+# This file is kept for legacy reasons in order to not break existing installations.
+# If you have access to nginx config you should instead use the public folder as document root.
+
 require_once __DIR__ . '/lib/bootstrap.php';
 
 $rssBridge = new RssBridge();

--- a/index.php
+++ b/index.php
@@ -1,10 +1,7 @@
 <?php
 
 # This file is kept for legacy reasons in order to not break existing installations.
-# If you have access to nginx config you should instead use the public folder as document root.
+# If you have access to web server config you should instead use the "public" folder as document root.
+# Also remember to alias the "static" directory. See the README.md
 
-require_once __DIR__ . '/lib/bootstrap.php';
-
-$rssBridge = new RssBridge();
-
-$rssBridge->main($argv ?? []);
+require_once __DIR__ . '/public/index.php';

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once __DIR__ . '/../lib/bootstrap.php';
+
+$rssBridge = new RssBridge();
+
+$rssBridge->main($argv ?? []);


### PR DESCRIPTION
Add a new document root at `public`.

This change opens up some possibilities and increases security.

Preserving the old way of deploying.

See https://github.com/RSS-Bridge/rss-bridge/issues/3341

@em92 