### PR TITLE
[XPathAbstract] Use baseURI to fix relative links (if available)

### DIFF
--- a/lib/XPathAbstract.php
+++ b/lib/XPathAbstract.php
@@ -388,7 +388,7 @@ abstract class XPathAbstract extends BridgeAbstract
         libxml_use_internal_errors(false);
 
         // fix relative links
-        defaultLinkTo($webPageHtml, $this->feedUri);
+        defaultLinkTo($webPageHtml, $webPageHtml->baseURI ?? $this->feedUri);
 
         $xpath = new \DOMXPath($webPageHtml);
 


### PR DESCRIPTION
Websites may specify a "document base URL" for relative links (`base`-element in the HTML `head`). If this URL has been populated it must be used instead of the current page URL for fixing relative links.