### PR TITLE
[VideoCardzBridge] category name and url fixes

### DIFF
--- a/bridges/VideoCardzBridge.php
+++ b/bridges/VideoCardzBridge.php
@@ -6,7 +6,6 @@ class VideoCardzBridge extends BridgeAbstract
     const URI = 'https://videocardz.com/';
     const DESCRIPTION = 'Returns news from VideoCardz.com';
     const MAINTAINER = 'rmscoelho';
-    const CACHE_TIMEOUT = 300;
     const PARAMETERS = [
         [
             'feed' => [
@@ -16,7 +15,7 @@ class VideoCardzBridge extends BridgeAbstract
                 'values' => [
                     'News' => 'sections/news',
                     'Featured' => 'sections/featured',
-                    'Leak' => 'sections/leak',
+                    'Leaks' => 'sections/leaks',
                     'Press Releases' => 'sections/press-releases',
                     'Preview Roundup' => 'sections/review-roundup',
                     'Rumour' => 'sections/rumor',
@@ -30,16 +29,26 @@ class VideoCardzBridge extends BridgeAbstract
         return 'https://videocardz.com/favicon-32x32.png?x66580';
     }
 
+    public function getName()
+    {
+        $feed = $this->getInput( 'feed');
+        $feed = explode('/', $feed);
+        $feed = $feed[1];
+        if (str_contains($feed, '-')) {
+            $feed = explode('-', $feed);
+            $word1 = $feed[0];
+            $word2 = $feed[1];
+            $feed = ucfirst($word1) . ' ' . ucfirst($word2);
+        }
+        if ($this->getInput('feed') !== null && $this->getInput('feed') !== '') {
+            return self::NAME . ' | ' . $feed;
+        }
+        return self::NAME;
+    }
+
     public function getURI()
     {
-        switch ($this->queriedContext) {
-            case 'feed':
-                $url = self::URI . $this->getInput('feed');
-                break;
-            default:
-                $url = self::URI;
-        }
-        return $url;
+        return self::URI . $this->getInput('feed');
     }
 
     public function collectData()

--- a/bridges/VideoCardzBridge.php
+++ b/bridges/VideoCardzBridge.php
@@ -32,7 +32,7 @@ class VideoCardzBridge extends BridgeAbstract
 
     public function getName()
     {
-        $feed = $this->getInput( 'feed');
+        $feed = $this->getInput('feed');
         if ($this->getInput('feed') !== null && $this->getInput('feed') !== '') {
             $feed = explode('/', $feed);
             $feed = $feed[1];

--- a/bridges/VideoCardzBridge.php
+++ b/bridges/VideoCardzBridge.php
@@ -6,6 +6,7 @@ class VideoCardzBridge extends BridgeAbstract
     const URI = 'https://videocardz.com/';
     const DESCRIPTION = 'Returns news from VideoCardz.com';
     const MAINTAINER = 'rmscoelho';
+    const CACHE_TIMEOUT = 10;
     const PARAMETERS = [
         [
             'feed' => [
@@ -32,16 +33,16 @@ class VideoCardzBridge extends BridgeAbstract
     public function getName()
     {
         $feed = $this->getInput( 'feed');
-        $feed = explode('/', $feed);
-        $feed = $feed[1];
-        if (str_contains($feed, '-')) {
-            $feed = explode('-', $feed);
-            $word1 = $feed[0];
-            $word2 = $feed[1];
-            $feed = ucfirst($word1) . ' ' . ucfirst($word2);
-        }
         if ($this->getInput('feed') !== null && $this->getInput('feed') !== '') {
-            return self::NAME . ' | ' . $feed;
+            $feed = explode('/', $feed);
+            $feed = $feed[1];
+            if (str_contains($feed, '-')) {
+                $feed = explode('-', $feed);
+                $word1 = $feed[0];
+                $word2 = $feed[1];
+                $feed = ucfirst($word1) . ' ' . ucfirst($word2);
+            }
+            return self::NAME . ' | ' . ucfirst($feed);
         }
         return self::NAME;
     }

--- a/bridges/VideoCardzBridge.php
+++ b/bridges/VideoCardzBridge.php
@@ -6,7 +6,6 @@ class VideoCardzBridge extends BridgeAbstract
     const URI = 'https://videocardz.com/';
     const DESCRIPTION = 'Returns news from VideoCardz.com';
     const MAINTAINER = 'rmscoelho';
-    const CACHE_TIMEOUT = 10;
     const PARAMETERS = [
         [
             'feed' => [


### PR DESCRIPTION
Fixed the Leaks category incorrectly being written as "leak" instead of using the plural form.
Fixed the categories name and link, as they were incorrectly pointing to the homepage.

EDIT: fixed mistake where I was exploding the name string before checking if it was a feed page, as the Bridges list doesn't have the information, thus was trying to get a null value.