### PR TITLE
[GolemBridge] Strip <script> tags

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -115,7 +115,7 @@ class GolemBridge extends FeedExpander
         // delete known bad elements
         foreach (
             $article->find('div[id*="adtile"], #job-market, #seminars, iframe,
-			div.gbox_affiliate, div.toc, .embedcontent') as $bad
+			div.gbox_affiliate, div.toc, .embedcontent, script') as $bad
         ) {
             $bad->remove();
         }


### PR DESCRIPTION
Golem articles referencing their podcast contain a JavaScript reference to Podigee. We don't want JS, so we strip it.

Example page: https://www.golem.de/news/podcast-besser-wissen-von-schlangenoel-und-sicherheit-2306-175185.html