### PR TITLE
fix(feedmerge): allow a single feed to break, and dont break the whol…

### DIFF
--- a/bridges/FeedMergeBridge.php
+++ b/bridges/FeedMergeBridge.php
@@ -58,9 +58,21 @@ TEXT;
         $feeds = array_filter($feeds);
 
         foreach ($feeds as $feed) {
-            // Fetch all items from the feed
-            // todo: consider wrapping this in a try..catch to not let a single feed break the entire bridge?
-            $this->collectExpandableDatas($feed);
+            if (count($feeds) > 1) {
+                // Allow one or more feeds to fail
+                try {
+                    $this->collectExpandableDatas($feed);
+                } catch (HttpException $e) {
+                    $this->items[] = [
+                        'title' => 'RSS-Bridge: ' . $e->getMessage(),
+                        // Give current time so it sorts to the top
+                        'timestamp' => time(),
+                    ];
+                    continue;
+                }
+            } else {
+                $this->collectExpandableDatas($feed);
+            }
         }
 
         // Sort by timestamp descending


### PR DESCRIPTION
This change is debatable. The current behaviour is that entire bridge fails if at least one of the feeds fail.
The pr allows for individual feed failure to preserve the other feeds and keep the bridge not erroring out.