### PR TITLE
feat: add health check action

### DIFF
--- a/actions/HealthAction.php
+++ b/actions/HealthAction.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+class HealthAction implements ActionInterface
+{
+    public function execute(array $request)
+    {
+        $response = [
+            'code' => 200,
+            'message' => 'all is good',
+        ];
+        return new Response(Json::encode($response), 200, ['content-type' => 'application/json']);
+    }
+}


### PR DESCRIPTION
allows for easier programmatic health inspection of an rss-bridge instance.

could later expand with more health data and also check whether the cache is working properly etc.

example:

```bash
$ curl -i http://rssbridge.localhost/?action=health
HTTP/1.1 200 OK
Server: nginx/1.18.0
Date: Tue, 04 Jul 2023 10:06:30 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive

{
    "code": 200,
    "message": "all is good"
}
```