### PR TITLE
[YouTubeCommunityTabBridge] Fix getURI implementation

### DIFF
--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -114,8 +114,8 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
 
     public function getURI()
     {
-        if (!empty($this->feedUri)) {
-            return $this->feedUri;
+        if (!empty($this->feedUrl)) {
+            return $this->feedUrl;
         }
 
         return parent::getURI();


### PR DESCRIPTION
Previously the undefined property "feedUri" was accessed here, always causing a fallback to the parent class