### PR TITLE
fix(CacheInterface): logic bug in getTime

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -95,7 +95,7 @@ class DisplayAction implements ActionInterface
         $mtime = $cache->getTime();
 
         if (
-            $mtime !== false
+            $mtime
             && (time() - $cache_timeout < $mtime)
             && !Debug::isEnabled()
         ) {

--- a/bridges/SpotifyBridge.php
+++ b/bridges/SpotifyBridge.php
@@ -203,7 +203,7 @@ class SpotifyBridge extends BridgeAbstract
             $time = (new DateTime())->getTimestamp() - $cache->getTime();
         }
 
-        if ($cache->getTime() == false || $time >= 3600) {
+        if (!$cache->getTime() || $time >= 3600) {
             $this->fetchToken();
             $cache->saveData($this->token);
         } else {

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -48,7 +48,7 @@ class FileCache implements CacheInterface
         return $this;
     }
 
-    public function getTime()
+    public function getTime(): ?int
     {
         $cacheFile = $this->getCacheFile();
         clearstatcache(false, $cacheFile);

--- a/caches/MemcachedCache.php
+++ b/caches/MemcachedCache.php
@@ -6,7 +6,7 @@ class MemcachedCache implements CacheInterface
     private $key;
     private $conn;
     private $expiration = 0;
-    private $time = false;
+    private $time = null;
     private $data = null;
 
     public function __construct()
@@ -76,9 +76,9 @@ class MemcachedCache implements CacheInterface
         return $this;
     }
 
-    public function getTime()
+    public function getTime(): ?int
     {
-        if ($this->time === false) {
+        if ($this->time === null) {
             $this->loadData();
         }
         return $this->time;

--- a/caches/NullCache.php
+++ b/caches/NullCache.php
@@ -20,8 +20,9 @@ class NullCache implements CacheInterface
     {
     }
 
-    public function getTime()
+    public function getTime(): ?int
     {
+        return null;
     }
 
     public function purgeCache($seconds)

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -70,7 +70,7 @@ class SQLiteCache implements CacheInterface
         return $this;
     }
 
-    public function getTime()
+    public function getTime(): ?int
     {
         $Qselect = $this->db->prepare('SELECT updated FROM storage WHERE key = :key');
         $Qselect->bindValue(':key', $this->getCacheKey());

--- a/docs/07_Cache_API/02_CacheInterface.md
+++ b/docs/07_Cache_API/02_CacheInterface.md
@@ -27,12 +27,6 @@ saveData(mixed $data): self
 
 ## The `getTime` function
 
-This function returns the last write time for the cache, or `false` if the cache does not yet exist. Please notice that 'cache' refers to one specific item in the cache repository and might require additional data to identify a specific item (introduce custom functions where necessary!).
-
-```PHP
-getTime(): int, false
-```
-
 ## The `purgeCache` function
 
 This function removes any data from the cache that is not within the given duration. The duration is specified in seconds and defines the period between now and the oldest item to keep.

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -423,7 +423,13 @@ abstract class BridgeAbstract implements BridgeInterface
         $scope = $this->getShortName();
         $cache->setScope($scope);
         $cache->setKey($key);
-        if ($duration && $cache->getTime() < time() - $duration) {
+        $timestamp = $cache->getTime();
+
+        if (
+            $duration
+            && $timestamp
+            && $timestamp < time() - $duration
+        ) {
             return null;
         }
         return $cache->loadData();

--- a/lib/CacheInterface.php
+++ b/lib/CacheInterface.php
@@ -53,11 +53,11 @@ interface CacheInterface
     public function saveData($data);
 
     /**
-     * Returns the timestamp for the curent cache data
-     *
-     * @return ?int Timestamp
+     * Returns the modification time of the current cache item.
+     * In unix timestamp.
+     * Example: 1688570578
      */
-    public function getTime();
+    public function getTime(): ?int;
 
     /**
      * Removes any data that is older than the specified age from cache

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -432,8 +432,8 @@ function getSimpleHTMLDOMCached(
     // Determine if cached file is within duration
     $time = $cache->getTime();
     if (
-        $time !== false
-        && (time() - $duration < $time)
+        $time
+        && time() - $duration < $time
         && !Debug::isEnabled()
     ) {
         // Contents within duration and debug mode is disabled

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -31,6 +31,7 @@ class CacheTest extends TestCase
         $sut->purgeCache(-1);
         $sut->setKey(['key']);
 
+        $this->assertNull($sut->getTime());
         $this->assertNull($sut->loadData());
 
         $sut->saveData('data');


### PR DESCRIPTION
the `getTime()` method MUST return a unix ts or `null`.

i dont think this bug was ever exposed anywhere. 