### PR TITLE
Docker from Debian base image

### DIFF
--- a/.devcontainer/nginx.conf
+++ b/.devcontainer/nginx.conf
@@ -12,6 +12,6 @@ server {
 
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
-        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,9 @@ pip-log.txt
 DEBUG
 config.ini.php
 config/*
+!config/nginx.conf
+!config/php-fpm.conf
+!config/php.ini
 
 ######################
 ## VisualStudioCode ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 
 COPY ./config/nginx.conf /etc/nginx/sites-available/default
 COPY ./config/php-fpm.conf /etc/php/8.2/fpm/pool.d/rss-bridge.conf
-COPY ./config/php.ini /etc/php/8.2/cli/conf.d/90-rss-bridge.conf
+COPY ./config/php.ini /etc/php/8.2/fpm/conf.d/90-rss-bridge.conf
 
 # logs should go to stdout / stderr
 RUN ln -sfT /dev/stderr /var/log/nginx/error.log; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
       ca-certificates \
       nginx \
+      nss-plugin-pem \
       php-curl \
       php-fpm \
       php-intl \
@@ -23,26 +24,23 @@ RUN apt-get update && \
       php-xml \
       php-zip \
       # php-zlib is enabled by default with PHP 8.2 in Debian 12
-      nss-plugin-pem \
       && \
     rm -rf /var/lib/apt/lists/*
-
-COPY ./config/nginx.conf /etc/nginx/sites-available/default
-COPY ./config/php-fpm.conf /etc/php/8.2/fpm/pool.d/rss-bridge.conf
-COPY ./config/php.ini /etc/php/8.2/fpm/conf.d/90-rss-bridge.conf
 
 # logs should go to stdout / stderr
 RUN ln -sfT /dev/stderr /var/log/nginx/error.log; \
 	ln -sfT /dev/stdout /var/log/nginx/access.log; \
 	chown -R --no-dereference www-data:adm /var/log/nginx/
 
-COPY --chown=www-data:www-data ./ /app/
-
 COPY --from=curlimpersonate /usr/local/lib/libcurl-impersonate-ff.so /usr/local/lib/curl-impersonate/
-
 ENV LD_PRELOAD /usr/local/lib/curl-impersonate/libcurl-impersonate-ff.so
-
 ENV CURL_IMPERSONATE ff91esr
+
+COPY ./config/nginx.conf /etc/nginx/sites-available/default
+COPY ./config/php-fpm.conf /etc/php/8.2/fpm/pool.d/rss-bridge.conf
+COPY ./config/php.ini /etc/php/8.2/fpm/conf.d/90-rss-bridge.conf
+
+COPY --chown=www-data:www-data ./ /app/
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,40 @@
 FROM lwthiker/curl-impersonate:0.5-ff-slim-buster AS curlimpersonate
 
-FROM php:8.0.27-fpm-buster AS rssbridge
+FROM debian:12-slim AS rssbridge
 
 LABEL description="RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for websites that don't have one."
 LABEL repository="https://github.com/RSS-Bridge/rss-bridge"
 LABEL website="https://github.com/RSS-Bridge/rss-bridge"
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
+      ca-certificates \
       nginx \
-      zlib1g-dev \
-      libzip-dev \
-      libmemcached-dev \
+      php-curl \
+      php-fpm \
+      php-intl \
+      # php-json is enabled by default with PHP 8.2 in Debian 12
+      php-mbstring \
+      php-memcached \
+      # php-opcache is enabled by default with PHP 8.2 in Debian 12
+      # php-openssl is enabled by default with PHP 8.2 in Debian 12
+      php-sqlite3 \
+      php-xml \
+      php-zip \
+      # php-zlib is enabled by default with PHP 8.2 in Debian 12
       nss-plugin-pem \
-      libicu-dev && \
-    docker-php-ext-install zip && \
-    docker-php-ext-install intl && \
-    pecl install memcached && \
-    docker-php-ext-enable memcached && \
-    docker-php-ext-enable opcache && \
-    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+      && \
+    rm -rf /var/lib/apt/lists/*
 
-COPY ./config/nginx.conf /etc/nginx/sites-enabled/default
+COPY ./config/nginx.conf /etc/nginx/sites-available/default
+COPY ./config/php-fpm.conf /etc/php/8.2/fpm/pool.d/rss-bridge.conf
+COPY ./config/php.ini /etc/php/8.2/cli/conf.d/90-rss-bridge.conf
+
+# logs should go to stdout / stderr
+RUN ln -sfT /dev/stderr /var/log/nginx/error.log; \
+	ln -sfT /dev/stdout /var/log/nginx/access.log; \
+	chown -R --no-dereference www-data:adm /var/log/nginx/
 
 COPY --chown=www-data:www-data ./ /app/
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,8 +2,8 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
     root /app;
-    access_log /dev/stdout;
-    error_log /dev/stderr;
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
     index index.php;
 
     location ~ /(\.|vendor|tests) {
@@ -13,6 +13,6 @@ server {
 
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
-        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
     }
 }

--- a/config/php-fpm.conf
+++ b/config/php-fpm.conf
@@ -1,0 +1,18 @@
+; Inspired by https://github.com/docker-library/php/blob/master/8.2/bookworm/fpm/Dockerfile
+
+[global]
+error_log = /proc/self/fd/2
+
+; https://github.com/docker-library/php/pull/725#issuecomment-443540114
+log_limit = 8192
+
+[www]
+; php-fpm closes STDOUT on startup, so sending logs to /proc/self/fd/1 does not work.
+; https://bugs.php.net/bug.php?id=73886
+access.log = /proc/self/fd/2
+
+clear_env = no
+
+; Ensure worker stdout and stderr are sent to the main error log.
+catch_workers_output = yes
+decorate_workers_output = no

--- a/config/php.ini
+++ b/config/php.ini
@@ -1,0 +1,4 @@
+; Inspired by https://github.com/docker-library/php/blob/master/8.2/bookworm/fpm/Dockerfile
+
+; https://github.com/docker-library/php/issues/878#issuecomment-938595965'
+fastcgi.logging = Off

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,5 +41,5 @@ fi
 # nginx will daemonize
 nginx
 
-# php-fpm will not
-php-fpm
+# php-fpm should not daemonize
+php-fpm8.2 --nodaemonize


### PR DESCRIPTION
* Fix expose https://github.com/RSS-Bridge/rss-bridge/discussions/3234
* Re-fix better logs https://github.com/RSS-Bridge/rss-bridge/pull/3333
* Update to Debian 12 Bookworm instead of Debian 10 Buster
* Use Debian packaging instead of having to keep track of and manually install -dev libraries, and with LTS support
* Update to PHP 8.2 instead of PHP 8.0
* Divided by two the size of the Docker image (from 485MB down to 202MB)
