### PR TITLE
Add Steam Group Announcements Bridge

### DIFF
--- a/bridges/SteamGroupAnnouncementsBridge.php
+++ b/bridges/SteamGroupAnnouncementsBridge.php
@@ -16,18 +16,9 @@ class SteamGroupAnnouncementsBridge extends FeedExpander
         ]
     ];
 
-    public function getURI()
-    {
-        return self::URI . 'groups/' . $this->getInput('g') . '/rss';
-    }
-
     public function collectData()
     {
-        $this->collectExpandableDatas($this->getURI(), 10);
-    }
-
-    public function parseItem($newsItem)
-    {
-        return parent::parseItem($newsItem);
+        $uri = self::URI . 'groups/' . $this->getInput('g') . '/rss';
+        $this->collectExpandableDatas($uri, 10);
     }
 }

--- a/bridges/SteamGroupAnnouncementsBridge.php
+++ b/bridges/SteamGroupAnnouncementsBridge.php
@@ -6,6 +6,7 @@ class SteamGroupAnnouncementsBridge extends FeedExpander
     const NAME = 'Steam Group Announcements';
     const URI = 'https://steamcommunity.com/';
     const DESCRIPTION = 'Returns latest announcements from a steam group.';
+
     const PARAMETERS = [
         [
             'g' => [

--- a/bridges/SteamGroupAnnouncementsBridge.php
+++ b/bridges/SteamGroupAnnouncementsBridge.php
@@ -1,0 +1,33 @@
+<?php
+
+class SteamGroupAnnouncementsBridge extends FeedExpander
+{
+    const MAINTAINER = 'Jisagi';
+    const NAME = 'Steam Group Announcements';
+    const URI = 'https://steamcommunity.com/';
+    const DESCRIPTION = 'Returns latest announcements from a steam group.';
+    const PARAMETERS = [
+        [
+            'g' => [
+                'name' => 'Group name',
+                'exampleValue' => 'freegamesfinders',
+                'required' => true
+            ]
+        ]
+    ];
+
+    public function getURI()
+    {
+        return self::URI . 'groups/' . $this->getInput('g') . '/rss';
+    }
+
+    public function collectData()
+    {
+        $this->collectExpandableDatas($this->getURI(), 10);
+    }
+
+    public function parseItem($newsItem)
+    {
+        return parent::parseItem($newsItem);
+    }
+}


### PR DESCRIPTION
This PR adds a configurable bridge to fetch the announcement rss for a user defined steam group. The original rss is autocreated by steam for every exisiting group.

The group name to use is from the url of the steam group. Example: Using this group `https://steamcommunity.com/groups/freegamesfinders/rss`, the group name would be `freegamesfinders`. The actual name of the group can differ!

This will implement the following request: https://github.com/RSS-Bridge/rss-bridge/issues/3512