### PR TITLE
fix(cache): new interface

### DIFF
--- a/lib/CacheInterface.php
+++ b/lib/CacheInterface.php
@@ -2,15 +2,11 @@
 
 interface CacheInterface
 {
-    public function setScope(string $scope): void;
+    public function set(string $key, $value = true, int $ttl = null): void;
 
-    public function setKey(array $key): void;
+    public function get(string $key, $default = null);
 
-    public function loadData();
+    public function delete(string $key): void;
 
-    public function saveData($data): void;
-
-    public function getTime(): ?int;
-
-    public function purgeCache(int $seconds): void;
+    public function clear(): void;
 }


### PR DESCRIPTION
There is a need for better control of the cache. So i suggest this interface which is not uncommon[0]:

```php
interface CacheInterface
{
    public function set(string $key, $value = true, int $ttl = null): void;

    public function get(string $key, $default = null);

    public function delete(string $key): void;

    public function clear(): void;
}
```

this requires tweaking so that caches operate with **expiration time** and not **modification time**.

examples:

```php
// fetch cache item by key, returns empty array if absent
$data = $cache->get('data', []); 

if ($response->code === 429) {
    // cache this for 60 seconds
    $cache->set('response', $response, 60);
} else {
    // cache this forever
    $cache->set('response', $response); 
}

// delete all items
$cache->clear();

// delete this cache item by key
$cache->delete('response');
```

i dont think we need the `purgeCache` method. Its purpose is to delete old/expired cache items for space managment issues mainly. It's also being constantly called which clogs the cpu on high traffic.

thoughts?

@em92 @Mynacol @LogMANOriginal 

[0] https://www.php-fig.org/psr/psr-16/