### PR TITLE
[YouTubeCommunityTabBridge] Fix PHP warnings for posts w/o text

### DIFF
--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -92,7 +92,7 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
             $item['author'] = $details->authorText->runs[0]->text;
             $item['content'] = '';
 
-            if (isset($details->contentText)) {
+            if (isset($details->contentText->runs)) {
                 $text = $this->getText($details->contentText->runs);
 
                 $this->itemTitle = $this->ellipsisTitle($text);


### PR DESCRIPTION
Because "contentText" is always present, PHP warnings were previously generated for posts without text.
Existence of sub-property "runs" gets checked now to avoid this.

----

Examples PHP warnings that are fixed by this commit:

[15-Jul-2023 12:27:42 UTC] [2023-07-15 12:27:42] rssbridge.WARNING Undefined property: stdClass::$runs at bridges/YouTubeCommunityTabBridge.php line 96 

[15-Jul-2023 12:27:42 UTC] [2023-07-15 12:27:42] rssbridge.WARNING foreach() argument must be of type array|object, null given at bridges/YouTubeCommunityTabBridge.php line 198 