### PR TITLE
fix(cache): bug in cache logic

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -140,7 +140,7 @@ function getContents(
     $cache->setScope('server');
     $cache->setKey([$url]);
 
-    if (!Debug::isEnabled() && $cache->getTime()) {
+    if (!Debug::isEnabled() && $cache->getTime() && $cache->loadData(86400 * 7)) {
         $config['if_not_modified_since'] = $cache->getTime();
     }
 


### PR DESCRIPTION
It is possible to have a cached item with a very old mtime and it's older than 24h which would cause later calls to `loadData()` to return null.

So, check for presence of time and whether cached item it is within 7 days

(yes caching logic is apparently hard to grok)