### PR TITLE
fix(sqlitecache): store blob as blob

### DIFF
--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -69,7 +69,7 @@ class SQLiteCache implements CacheInterface
 
         $stmt = $this->db->prepare('INSERT OR REPLACE INTO storage (key, value, updated) VALUES (:key, :value, :updated)');
         $stmt->bindValue(':key', $this->getCacheKey());
-        $stmt->bindValue(':value', $blob);
+        $stmt->bindValue(':value', $blob, \SQLITE3_BLOB);
         $stmt->bindValue(':updated', time());
         $stmt->execute();
     }


### PR DESCRIPTION
serialize() can return output with null bytes and other non-text data. The prior behavior truncated data
which later results in unserialize() errors.

This happens when e.g. caching an object with a private field or when caching e.g. a JPEG file (starts with 0xFFD8FFE1)

Fixes errors such as e.g.:

unserialize(): Error at offset 20 of 24 bytes at caches/SQLiteCache.php line 51