### PR TITLE
[TikTokBridge] Use another way to get videos infos to include video link

### DIFF
--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -45,13 +45,24 @@ class TikTokBridge extends BridgeAbstract
                 $image = $value->video->cover;
             }
             $views = $value->stats->playCount;
+            $hastags = [];
+            foreach ($value->textExtra as $tag) {
+                $hastags[] = $tag->hashtagName;
+            }
+            $hastags_str = '';
+            foreach ($hastags as $tag) {
+                $hastags_str .= '<a href="https://www.tiktok.com/tag/' . $tag . '">#' . $tag . '</a> ';
+            }
 
-            $item['title'] = $value->desc;
             $item['uri'] = $link;
+            $item['title'] = $value->desc;
+            $item['timestamp'] = $value->createTime;
+            $item['author'] = '@' . $value->author;
             $item['enclosures'][] = $image;
+            $item['categories'] = $hastags;
             $item['content'] = <<<EOD
 <a href="{$link}"><img src="{$image}"/></a>
-<p>{$views} views<p>
+<p>{$views} views<p><br/>Hashtags: {$hastags_str}
 EOD;
 
             $this->items[] = $item;

--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -41,6 +41,9 @@ class TikTokBridge extends BridgeAbstract
 
             $link = 'https://www.tiktok.com/@' . $value->author . '/video/' . $value->id;
             $image = $value->video->dynamicCover;
+            if (empty($image)) {
+                $image = $value->video->cover;
+            }
             $views = $value->stats->playCount;
 
             $item['title'] = $value->desc;

--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -33,29 +33,19 @@ class TikTokBridge extends BridgeAbstract
         $title = $html->find('h1', 0)->plaintext ?? self::NAME;
         $this->feedName = htmlspecialchars_decode($title);
 
-        foreach ($html->find('div.tiktok-x6y88p-DivItemContainerV2') as $div) {
+        $SIGI_STATE_RAW = $html->find('script[id=SIGI_STATE]', 0)->innertext;
+        $SIGI_STATE = json_decode($SIGI_STATE_RAW);
+
+        foreach ($SIGI_STATE->ItemModule as $key => $value) {
             $item = [];
 
-            // todo: find proper link to tiktok item
-            $link = $div->find('a', 0)->href;
+            $link = 'https://www.tiktok.com/@' . $value->author . '/video/' . $value->id;
+            $image = $value->video->dynamicCover;
+            $views = $value->stats->playCount;
 
-            $image = $div->find('img', 0)->src ?? '';
-
-            $views = $div->find('strong.video-count', 0)->plaintext;
-
-            if ($link === 'https://www.tiktok.com/') {
-                $link = $this->getURI();
-            }
+            $item['title'] = $value->desc;
             $item['uri'] = $link;
-
-            $a = $div->find('a', 1);
-            if ($a) {
-                $item['title'] = $a->plaintext;
-            } else {
-                $item['title'] = $this->getName();
-            }
             $item['enclosures'][] = $image;
-
             $item['content'] = <<<EOD
 <a href="{$link}"><img src="{$image}"/></a>
 <p>{$views} views<p>


### PR DESCRIPTION
This PR improves the TikTok bridge by using JSON data that's included in the DOM, it lists the last 25 videos data of the user.
- Now links to the video directly.
- Makes use of `dynamicCover` value of that data for the image, which is a preview gif of the video.
- Added items `timestamp`, `author`, and `categories` (list of hashtags).