### PR TITLE
[core] fix new bridge PRs not generating html preview artifacts

### DIFF
--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -22,7 +22,7 @@ jobs:
           wget https://raw.githubusercontent.com/RSS-Bridge/rss-bridge/master/.github/prtester.py;
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
           touch DEBUG;
-          cat $PR.patch | grep " bridges/.*\.php" | sed "s= bridges/\(.*\)Bridge.php.*=\1=g" | sort | uniq > whitelist.txt
+          cat $PR.patch | grep "\bbridges/.*Bridge\.php\b" | sed "s=.*\bbridges/\(.*\)Bridge\.php\b.*=\1=g" | sort | uniq > whitelist.txt
       - name: Start Docker - Current
         run: |
           docker run -d -v $GITHUB_WORKSPACE/whitelist.txt:/app/whitelist.txt -v $GITHUB_WORKSPACE/DEBUG:/app/DEBUG -p 3000:80 ghcr.io/rss-bridge/rss-bridge:latest

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Check out rss-bridge
         run: |
           PR=${{github.event.number}};
-          wget -O requirements.txt https://raw.githubusercontent.com/RSS-Bridge/rss-bridge/master/.github/prtester-requirements.txt;
-          wget https://raw.githubusercontent.com/RSS-Bridge/rss-bridge/master/.github/prtester.py;
+          wget -O requirements.txt https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester-requirements.txt;
+          wget https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester.py;
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
           touch DEBUG;
           cat $PR.patch | grep "\bbridges/.*Bridge\.php\b" | sed "s=.*\bbridges/\(.*\)Bridge\.php\b.*=\1=g" | sort | uniq > whitelist.txt

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -113,7 +113,7 @@ final class Configuration
             if ($enabledBridges === '*') {
                 self::setConfig('system', 'enabled_bridges', ['*']);
             } else {
-                self::setConfig('system', 'enabled_bridges', array_filter(explode("\n", $enabledBridges)));
+                self::setConfig('system', 'enabled_bridges', array_filter(array_map('trim', explode("\n", $enabledBridges))));
             }
         }
 


### PR DESCRIPTION
While working on a new bridge and testing it in my fork I noticed that the very helpful html preview artifacts are not being generated. You can also see this behaviors in previous PRs like e.g. #3550.

The cause was the generated `whitelist.txt`. It gets generated from the PR diff using `grep` and `sed`. The `sed` command was only removing the right side text. The text on the left side was kept. This causes the `whitelist.txt` to look like this:
```
create mode 100644FancyNewBridge
FancyNewBridge
```
This than resulted in the PR bridge container displaying the error message `Bridge name invalid: create mode 100644FancyNewBridge`. The following python script, which generates the html previews, than could not detect any bridge.

During debugging I noticed that bridge names in `whitelist.txt` are not allowed to have white-spaces at the line start or end. It was not the cause of this problem, but could cause other people generating the `whitelist.txt` some headache, as noticing this error is not very obvious. Therefore I also added a `trim` to each line of `whitelist.txt`.

While debugging I got tripped by the fact that the workflow always downloads the `prtester.py` script from this main repository instead of my modified fork. I replaced the hard-coded repository path and branch name by corresponding workflow variables.