### PR TITLE
[CssSelectorBridge] Handling of missing links

### DIFF
--- a/bridges/CssSelectorBridge.php
+++ b/bridges/CssSelectorBridge.php
@@ -198,6 +198,9 @@ class CssSelectorBridge extends BridgeAbstract
             }
             if ($link->tag != 'a') {
                 $link = $link->find('a', 0);
+                if (is_null($link)) {
+                    continue;
+                }
             }
             $item['uri'] = $link->href;
             $item['title'] = $link->plaintext;
@@ -207,6 +210,10 @@ class CssSelectorBridge extends BridgeAbstract
                 $item['content'] = $this->cleanArticleContent($item['content'], $content_cleanup);
             }
             $link_to_item[$link->href] = $item;
+        }
+
+        if (empty($link_to_item)) {
+            returnClientError('The provided URL selector matches some elements, but they do not contain links.');
         }
 
         $links = $this->filterUrlList(array_keys($link_to_item), $url_pattern, $limit);


### PR DESCRIPTION
In CssSelectorBridge, when using parent element as URL selector (making truncated feed from home page), the user-provided selector may match DOM elements that _don't_ have links inside (`<a>` elements).

This Pull Request adds handling for that situation:

* If _some_ matching elements don't have links -> ignore them and proceed (suboptimal selector?)
* But if _all_ matching elements don't have links -> treat as an error and abort (invalid selector)

Fixes https://github.com/RSS-Bridge/rss-bridge/pull/3573#issuecomment-1656943318