### PR TITLE
Fix php8.2 deprecated warning when using bridge specific configurations

### DIFF
--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -58,8 +58,6 @@ abstract class BridgeAbstract implements BridgeInterface
 
     /**
      * Configuration for the bridge
-     *
-     * Use {@see BridgeAbstract::getConfiguration()} to read this parameter
      */
     const CONFIGURATION = [];
 
@@ -364,12 +362,6 @@ abstract class BridgeAbstract implements BridgeInterface
     public function getIcon()
     {
         return static::URI . '/favicon.ico';
-    }
-
-    /** {@inheritdoc} */
-    public function getConfiguration()
-    {
-        return static::CONFIGURATION;
     }
 
     /** {@inheritdoc} */

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -112,16 +112,11 @@ abstract class BridgeAbstract implements BridgeInterface
      * @var string
      */
     protected $queriedContext = '';
-    
+
     /**
      * Holds the list of bridge-specific configurations from config.ini.php, used by the bridge.
-     *
-     * Do not access this parameter directly!
-     * Use {@see BridgeAbstract::getConfiguration()} and {@see BridgeAbstract::getOption(string $name)} instead.
-     *
-     * @var array
      */
-    protected array $configuration = [];
+    private array $configuration = [];
 
     /** {@inheritdoc} */
     public function getItems()

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -112,6 +112,16 @@ abstract class BridgeAbstract implements BridgeInterface
      * @var string
      */
     protected $queriedContext = '';
+    
+    /**
+     * Holds the list of bridge-specific configurations from config.ini.php, used by the bridge.
+     *
+     * Do not access this parameter directly!
+     * Use {@see BridgeAbstract::getConfiguration()} and {@see BridgeAbstract::getOption(string $name)} instead.
+     *
+     * @var array
+     */
+    protected array $configuration = [];
 
     /** {@inheritdoc} */
     public function getItems()

--- a/lib/BridgeInterface.php
+++ b/lib/BridgeInterface.php
@@ -61,11 +61,6 @@ interface BridgeInterface
     public function collectData();
 
     /**
-    * Get the user's supplied configuration for the bridge
-    */
-    public function getConfiguration();
-
-    /**
      * Returns the value for the selected configuration
      *
      * @param string $input The option name


### PR DESCRIPTION
Fix php8.2 warning: `Deprecated: Creation of dynamic property is deprecated` when using bridge specific configurations