### PR TITLE
[core] add bridge not found warning message to frontpage

### DIFF
--- a/actions/FrontpageAction.php
+++ b/actions/FrontpageAction.php
@@ -4,11 +4,19 @@ final class FrontpageAction implements ActionInterface
 {
     public function execute(array $request)
     {
+        $messages = [];
         $showInactive = (bool) ($request['show_inactive'] ?? null);
         $activeBridges = 0;
 
         $bridgeFactory = new BridgeFactory();
         $bridgeClassNames = $bridgeFactory->getBridgeClassNames();
+
+        foreach ($bridgeFactory->getMissingEnabledBridges() as $missingEnabledBridge) {
+            $messages[] = [
+                'body' => sprintf('Warning : Bridge "%s" not found', $missingEnabledBridge),
+                'level' => 'warning'
+            ];
+        }
 
         $formatFactory = new FormatFactory();
         $formats = $formatFactory->getFormatNames();
@@ -24,7 +32,7 @@ final class FrontpageAction implements ActionInterface
         }
 
         return render(__DIR__ . '/../templates/frontpage.html.php', [
-            'messages' => [],
+            'messages' => $messages,
             'admin_email' => Configuration::getConfig('admin', 'email'),
             'admin_telegram' => Configuration::getConfig('admin', 'telegram'),
             'bridges' => $body,

--- a/lib/BridgeFactory.php
+++ b/lib/BridgeFactory.php
@@ -4,6 +4,7 @@ final class BridgeFactory
 {
     private $bridgeClassNames = [];
     private $enabledBridges = [];
+    private $missingEnabledBridges = [];
 
     public function __construct()
     {
@@ -27,6 +28,7 @@ final class BridgeFactory
             if ($bridgeClassName) {
                 $this->enabledBridges[] = $bridgeClassName;
             } else {
+                $this->missingEnabledBridges[] = $enabledBridge;
                 Logger::info(sprintf('Bridge not found: %s', $enabledBridge));
             }
         }
@@ -68,5 +70,10 @@ final class BridgeFactory
     public function getBridgeClassNames(): array
     {
         return $this->bridgeClassNames;
+    }
+
+    public function getMissingEnabledBridges(): array
+    {
+        return $this->missingEnabledBridges;
     }
 }


### PR DESCRIPTION
A small improvement/suggestion to #3589. It will add a warning message to the frontpage for each missing bridge.
![image](https://github.com/RSS-Bridge/rss-bridge/assets/1911682/c2c290ea-ebbb-48f7-be0e-13c5322d11b5)
