### PR TITLE
[FeedExpander] support xhtml content / content with child elements

### DIFF
--- a/bridges/FilterBridge.php
+++ b/bridges/FilterBridge.php
@@ -12,7 +12,7 @@ class FilterBridge extends FeedExpander
         'url' => [
             'name' => 'Feed URL',
             'type'  => 'text',
-            'defaultValue' => 'https://lorem-rss.herokuapp.com/feed?unit=day',
+            'exampleValue' => 'https://lorem-rss.herokuapp.com/feed?unit=day',
             'required' => true,
         ],
         'filter' => [

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -308,10 +308,10 @@ abstract class FeedExpander extends BridgeAbstract
             $item['author'] = (string)$feedItem->author->name;
         }
         if (isset($feedItem->content)) {
-            $contentType = (string)$feedItem->content->attributes()['type'];
-            if ($contentType === 'xhtml') {
+            $contentChildren = $feedItem->content->children();
+            if (count($contentChildren) > 0) {
                 $content = '';
-                foreach ($feedItem->content->children() as $contentChild) {
+                foreach ($contentChildren as $contentChild) {
                     $content .= $contentChild->asXML();
                 }
                 $item['content'] = $content;

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -308,7 +308,16 @@ abstract class FeedExpander extends BridgeAbstract
             $item['author'] = (string)$feedItem->author->name;
         }
         if (isset($feedItem->content)) {
-            $item['content'] = (string)$feedItem->content;
+            $contentType = (string)$feedItem->content->attributes()['type'];
+            if ($contentType === 'xhtml') {
+                $content = '';
+                foreach ($feedItem->content->children() as $contentChild) {
+                    $content .= $contentChild->asXML();
+                }
+                $item['content'] = $content;
+            } else {
+                $item['content'] = (string)$feedItem->content;
+            }
         }
 
         //When "link" field is present, URL is more reliable than "id" field


### PR DESCRIPTION
I tried to use this feed https://feed.phenx.de/lootscraper_amazon_loot.xml in the `FilterBridge`, but the item content was missing.
That feed uses `xhtml` as item content type. The content are child elements instead of a string, e.g.:
```
<entry>
    <id>https://phenx.de/loot/4576</id>
    <title>...</title>
    <content type="xhtml">
        <div xmlns="http://www.w3.org/1999/xhtml">
            <img src="https://m.media-amazon.com/images/I/61jHo4Kq1WL._FMwebp_.jpg"/>
            <ul>
                <li><b>Offer valid from:</b> 2023-08-03 - 18:34</li>
                <li><b>Offer valid to:</b> 2023-09-10 - 00:00</li>
            </ul>
            ...
        </div>
    </content>
</entry>
```
With this PR, the `FeedExpander` (base of `FilterBridge`) now checks if the `content` element has child elements. When that's the case, all child elements get converted to a string. When that's not the case, it will work as before.
Originally I limited that new behavior to `content` elements with attribute `type`=`xhtml`, but now I think it makes sense to always return children as string instead of returning empty content.

One additional small fix. While debugging I noticed that `defaultValue` of `url` in `FilterBridge`  should be `exampleValue` instead.