### PR TITLE
[EconomistBridge] Fix strange image urls

### DIFF
--- a/bridges/EconomistBridge.php
+++ b/bridges/EconomistBridge.php
@@ -159,7 +159,7 @@ class EconomistBridge extends FeedExpander
             $svelte->parent->removeChild($svelte);
         }
         foreach ($elem->find('img') as $strange_img) {
-            if (!str_contains($strange_img->src, 'https://economist.com')) {
+            if (!str_contains($strange_img->src, 'economist.com')) {
                 $strange_img->src = 'https://economist.com' . $strange_img->src;
             }
         }


### PR DESCRIPTION
The bridge occasionally generated image URLs like `https://economist.comhttps://www.economist.com/...` because of the bug.

It's interesting that browsers handle that gracefully. I only noticed that when I set up a proxy for images.