### PR TITLE
[PatreonBridge] Resolve creator name in feed name

### DIFF
--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -6,8 +6,8 @@ class PatreonBridge extends BridgeAbstract
     const URI = 'https://www.patreon.com/';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Returns posts by creators on Patreon';
-    const MAINTAINER = 'Roliga';
-    const PARAMETERS = [ [
+    const MAINTAINER = 'Roliga, mruac';
+    const PARAMETERS = [[
         'creator' => [
             'name' => 'Creator',
             'type' => 'text',
@@ -189,7 +189,13 @@ class PatreonBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('creator'))) {
-            return $this->getInput('creator') . ' posts';
+            $html = getSimpleHTMLDOMCached($this->getURI());
+            if ($html) {
+                preg_match('#"name": "(.*)"#', $html->save(), $matches);
+                return 'Patreon posts from ' . stripcslashes($matches[1]);
+            } else {
+                return $this->getInput('creator') . 'posts from Patreon';
+            }
         }
 
         return parent::getName();

--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -12,7 +12,7 @@ class PatreonBridge extends BridgeAbstract
             'name' => 'Creator',
             'type' => 'text',
             'required' => true,
-            'exampleValue' => 'sanityinc',
+			'exampleValue' => 'user?u=13425451',
             'title' => 'Creator name as seen in their page URL'
         ]
     ]];

--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -12,7 +12,7 @@ class PatreonBridge extends BridgeAbstract
             'name' => 'Creator',
             'type' => 'text',
             'required' => true,
-			'exampleValue' => 'user?u=13425451',
+            'exampleValue' => 'user?u=13425451',
             'title' => 'Creator name as seen in their page URL'
         ]
     ]];


### PR DESCRIPTION
Some creators do not have a custom url, but instead have a useable "name" such as `user?u=13425451`.

This PR resolves the user submitted name into the full campaign name to use as the Feed name.