### PR TITLE
[TwitterBridge] Add support for OAuth authorization.

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -358,7 +358,7 @@ EOD
             $item = [];
 
             $realtweet = $tweet;
-	    $tweetId = (isset($tweetIds[$i]) ? $tweetIds[$i] : $realtweet->conversation_id_str);
+            $tweetId = (isset($tweetIds[$i]) ? $tweetIds[$i] : $realtweet->conversation_id_str);
             if (isset($tweet->retweeted_status)) {
                 // Tweet is a Retweet, so set author based on original tweet and set realtweet for reference to the right content
                 $realtweet = $tweet->retweeted_status;

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -306,7 +306,7 @@ EOD
             }
         }
 
-	// Array of Tweet IDs
+        // Array of Tweet IDs
         $tweetIds = [];
         // Filter out unwanted tweets
         foreach ($data->tweets as $tweet) {
@@ -386,7 +386,8 @@ EOD
                     $item['username']  = $data->user_info->legacy->screen_name;
                     $item['fullname']  = $data->user_info->legacy->name;
                     $item['avatar']    = $data->user_info->legacy->profile_image_url_https;
-                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : (isset($tweetIds[$i]) ? $tweetIds[$i] : $realtweet->conversation_id_str));
+                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : 
+                                            (isset($tweetIds[$i]) ? $tweetIds[$i] : $realtweet->conversation_id_str));
                     break;
                 case 'By list':
                 case 'By list ID':

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -306,10 +306,12 @@ EOD
             }
         }
 
+	// Array of Tweet IDs
+        $tweetIds = [];
         // Filter out unwanted tweets
         foreach ($data->tweets as $tweet) {
             if (isset($tweet->rest_id)) {
-                $tweetId = $tweet->rest_id;
+                $tweetIds[] = $tweet->rest_id;
                 $tweet = $tweet->legacy;
             }
 
@@ -384,7 +386,7 @@ EOD
                     $item['username']  = $data->user_info->legacy->screen_name;
                     $item['fullname']  = $data->user_info->legacy->name;
                     $item['avatar']    = $data->user_info->legacy->profile_image_url_https;
-                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : $tweetId);
+                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : (isset($tweetIds[$i]) ? $tweetIds[$i] : $realtweet->conversation_id_str));
                     break;
                 case 'By list':
                 case 'By list ID':

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -358,6 +358,7 @@ EOD
             $item = [];
 
             $realtweet = $tweet;
+	    $tweetId = (isset($tweetIds[$i]) ? $tweetIds[$i] : $realtweet->conversation_id_str);
             if (isset($tweet->retweeted_status)) {
                 // Tweet is a Retweet, so set author based on original tweet and set realtweet for reference to the right content
                 $realtweet = $tweet->retweeted_status;
@@ -386,8 +387,7 @@ EOD
                     $item['username']  = $data->user_info->legacy->screen_name;
                     $item['fullname']  = $data->user_info->legacy->name;
                     $item['avatar']    = $data->user_info->legacy->profile_image_url_https;
-                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : 
-                                            (isset($tweetIds[$i]) ? $tweetIds[$i] : $realtweet->conversation_id_str));
+                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : $tweetId);
                     break;
                 case 'By list':
                 case 'By list ID':

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -308,13 +308,18 @@ EOD
 
         // Filter out unwanted tweets
         foreach ($data->tweets as $tweet) {
+            if (isset($tweet->rest_id)) {
+                $tweetId = $tweet->rest_id;
+                $tweet = $tweet->legacy;
+            }
+
             if (!$tweet) {
                 continue;
             }
             // Filter out retweets to remove possible duplicates of original tweet
             switch ($this->queriedContext) {
                 case 'By keyword or hashtag':
-                    if (isset($tweet->retweeted_status) && substr($tweet->full_text, 0, 4) === 'RT @') {
+                    if ((isset($tweet->retweeted_status) || isset($tweet->retweeted_status_result)) && substr($tweet->full_text, 0, 4) === 'RT @') {
                         continue 2;
                     }
                     break;
@@ -355,6 +360,7 @@ EOD
                 // Tweet is a Retweet, so set author based on original tweet and set realtweet for reference to the right content
                 $realtweet = $tweet->retweeted_status;
             } elseif (isset($tweet->retweeted_status_result)) {
+                $tweetId = $tweet->retweeted_status_result->result->rest_id;
                 $realtweet = $tweet->retweeted_status_result->result->legacy;
             }
 
@@ -378,7 +384,7 @@ EOD
                     $item['username']  = $data->user_info->legacy->screen_name;
                     $item['fullname']  = $data->user_info->legacy->name;
                     $item['avatar']    = $data->user_info->legacy->profile_image_url_https;
-                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : $realtweet->conversation_id_str);
+                    $item['id']        = (isset($realtweet->id_str) ? $realtweet->id_str : $tweetId);
                     break;
                 case 'By list':
                 case 'By list ID':

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -7,7 +7,7 @@ class TwitterBridge extends BridgeAbstract
     const API_URI = 'https://api.twitter.com';
     const GUEST_TOKEN_USES = 100;
     const GUEST_TOKEN_EXPIRY = 10800; // 3hrs
-    const CACHE_TIMEOUT = 60 * 2; // 15min
+    const CACHE_TIMEOUT = 60 * 15; // 15min
     const DESCRIPTION = 'returns tweets';
     const MAINTAINER = 'arnd-s';
     const PARAMETERS = [
@@ -133,6 +133,7 @@ EOD
         // By keyword or hashtag (search)
         $regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/search.*(\?|&)q=([^\/&?\n]+)/';
         if (preg_match($regex, $url, $matches) > 0) {
+            $params['context'] = 'By keyword or hashtag';
             $params['q'] = urldecode($matches[4]);
             return $params;
         }
@@ -140,6 +141,7 @@ EOD
         // By hashtag
         $regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/hashtag\/([^\/?\n]+)/';
         if (preg_match($regex, $url, $matches) > 0) {
+            $params['context'] = 'By keyword or hashtag';
             $params['q'] = urldecode($matches[3]);
             return $params;
         }
@@ -147,6 +149,7 @@ EOD
         // By list
         $regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/([^\/?\n]+)\/lists\/([^\/?\n]+)/';
         if (preg_match($regex, $url, $matches) > 0) {
+            $params['context'] = 'By list';
             $params['user'] = urldecode($matches[3]);
             $params['list'] = urldecode($matches[4]);
             return $params;
@@ -155,6 +158,7 @@ EOD
         // By username
         $regex = '/^(https?:\/\/)?(www\.)?twitter\.com\/([^\/?\n]+)/';
         if (preg_match($regex, $url, $matches) > 0) {
+            $params['context'] = 'By username';
             $params['u'] = urldecode($matches[3]);
             return $params;
         }

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -335,7 +335,7 @@ EOD
         if ($this->queriedContext === 'By username') {
             $this->feedIconUrl = $data->user_info->legacy->profile_image_url_https ?? null;
         }
-        
+
         $i = 0;
         foreach ($tweets as $tweet) {
             // Skip own Retweets...

--- a/lib/TwitterClient.php
+++ b/lib/TwitterClient.php
@@ -149,14 +149,14 @@ class TwitterClient
                 if (!isset($entry->content->itemContent->tweet_results->result->legacy)) {
                     continue;
                 }
-                $tweets[] = $entry->content->itemContent->tweet_results->result->legacy;
+                $tweets[] = $entry->content->itemContent->tweet_results->result;
 
                 $userIds[] = $entry->content->itemContent->tweet_results->result->core->user_results->result;
             } else {
                 if (!isset($entry->content->content->tweetResult->result->legacy)) {
                     continue;
                 }
-                $tweets[] = $entry->content->content->tweetResult->result->legacy;
+                $tweets[] = $entry->content->content->tweetResult->result;
 
                 $userIds[] = $entry->content->content->tweetResult->result->core->user_result->result;
             }

--- a/lib/TwitterClient.php
+++ b/lib/TwitterClient.php
@@ -18,6 +18,76 @@ class TwitterClient
 
         $this->data = $this->cache->loadData() ?? [];
         $this->authorization = 'AAAAAAAAAAAAAAAAAAAAAGHtAgAAAAAA%2Bx7ILXNILCqkSGIzy6faIHZ9s3Q%3DQy97w6SIrzE7lQwPJEYQBsArEE2fC25caFwRBvAGi456G09vGR';
+        $this->tw_consumer_key = "3nVuSoBZnx6U4vzUxf5w";
+        $this->tw_consumer_secret = "Bcs59EFbbsdF6Sl9Ng71smgStWEGwXXKSjYvPVt7qys";
+        $this->oauth_token = ""; // Fill here
+        $this->oauth_token_secret = ""; // Fill here
+    }
+
+    private function getOauthAuthorization(
+        $oauth_token,
+        $oauth_token_secret,
+        $method = "GET",
+        $url = "",
+        $body = "",
+        $timestamp = null,
+        $oauth_nonce = null
+    ) {
+        if (!$url) {
+            return "";
+        }
+        $method = strtoupper($method);
+        $parseUrl = parse_url($url);
+        $link = $parseUrl['scheme'] . '://' . $parseUrl['host'] . $parseUrl['path'];
+        parse_str($parseUrl['query'], $query_params);
+        if ($body) {
+            parse_str($body, $body_params);
+            $query_params = array_merge($query_params, $body_params);
+        }
+        $payload = array(
+            'oauth_version' => '1.0',
+            'oauth_signature_method' => 'HMAC-SHA1',
+            'oauth_consumer_key' => $this->tw_consumer_key,
+            'oauth_token' => $oauth_token,
+            'oauth_nonce' => $oauth_nonce ? $oauth_nonce : implode("", array_fill(0, 3, strval(time()))),
+            'oauth_timestamp' => $timestamp ? $timestamp : time(),
+        );
+        $payload = array_merge($payload, $query_params);
+        ksort($payload);
+
+        $url_parts = parse_url($url);
+        $url_parts['query'] = http_build_query($payload, '', '&', PHP_QUERY_RFC3986);
+        $base_url = $url_parts['scheme'] . '://' . $url_parts['host'] . $url_parts['path'];
+        $signature_base_string = strtoupper($method) . '&' . rawurlencode($base_url) . '&' . rawurlencode($url_parts['query']);
+        $hmac_key = $this->tw_consumer_secret . '&' . $oauth_token_secret;
+
+        // Reference: https://stackoverflow.com/questions/37207221/php-generate-hmac-sha1-signature
+        // $hexStr = $hmac_key;
+        // $c = explode('-',chunk_split($hexStr,2,'-'));
+        // $hexArr = array($c[3],$c[2],$c[1],$c[0],$c[5],$c[4],$c[7],$c[6],$c[8],$c[9],$c[10],$c[11],$c[12],$c[13],$c[14],$c[15]);
+        // $keyStr = '';
+        // for ($i = 0; $i < 16; ++$i) {
+        //     $num = hexdec($hexArr[$i]);
+        //     $keyStr .= chr($num);
+        // }
+        $hex_signature = hash_hmac('sha1', $signature_base_string, $hmac_key, true);
+        $signature = base64_encode($hex_signature);
+
+        $header_params = array(
+            'oauth_version' => '1.0',
+            'oauth_token' => $oauth_token,
+            'oauth_nonce' => $payload['oauth_nonce'],
+            'oauth_timestamp' => $payload['oauth_timestamp'],
+            'oauth_signature' => $signature,
+            'oauth_consumer_key' => $this->tw_consumer_key,
+            'oauth_signature_method' => 'HMAC-SHA1',
+        );
+        // ksort($header_params);
+        $header_values = array();
+        foreach ($header_params as $key => $value) {
+            $header_values[] = rawurlencode($key) . '="' . (is_int($value) ? $value : rawurlencode($value)) . '"';
+        }
+        return 'OAuth realm="http://api.twitter.com/", ' . implode(', ', $header_values);
     }
 
     private function extractTweetAndUsersFromGraphQL($timeline)
@@ -25,13 +95,24 @@ class TwitterClient
         if (isset($timeline->data->user)) {
             $result = $timeline->data->user->result;
             $instructions = $result->timeline_v2->timeline->instructions;
-        } else {
-            $result = $timeline->data->list->timeline_response;
+        } elseif (isset($timeline->data->user_result)) {
+            $result = $timeline->data->user_result->result->timeline_response;
             $instructions = $result->timeline->instructions;
         }
+
         if (isset($result->__typename) && $result->__typename === 'UserUnavailable') {
             throw new \Exception('UserUnavailable');
         }
+
+        if (isset($timeline->data->list)) {
+            $result = $timeline->data->list->timeline_response;
+            $instructions = $result->timeline->instructions;
+        }
+
+        if(!isset($result) && !isset($instructions)) {
+            throw new \Exception('Unable to fetch user/list timeline');
+        }
+
         $instructionTypes = [
             'TimelineAddEntries',
             'TimelineClearCache',
@@ -117,19 +198,22 @@ class TwitterClient
             }
         }
 
-        try {
-            $timeline = $this->fetchTimelineUsingSearch($screenName);
-        } catch (HttpException $e) {
-            if ($e->getCode() === 403) {
-                $this->data['guest_token'] = null;
-                $this->fetchGuestToken();
-                $timeline = $this->fetchTimelineUsingSearch($screenName);
-            } else {
-                throw $e;
-            }
-        }
+        $timeline = $this->fetchTimeline($userInfo->rest_id);
+        // try {
+        //     // $timeline = $this->fetchTimelineUsingSearch($screenName);
+        // } catch (HttpException $e) {
+        //     if ($e->getCode() === 403) {
+        //         $this->data['guest_token'] = null;
+        //         $this->fetchGuestToken();
+        //         // $timeline = $this->fetchTimelineUsingSearch($screenName);
+        //         $timeline = $this->fetchTimeline($userInfo->rest_id);
+        //     } else {
+        //         throw $e;
+        //     }
+        // }
 
-        $tweets = $this->extractTweetFromSearch($timeline);
+        // $tweets = $this->extractTweetFromSearch($timeline);
+        $tweets = $this->extractTweetAndUsersFromGraphQL($timeline)->tweets;
 
         return (object) [
             'user_info' => $userInfo,
@@ -155,7 +239,7 @@ class TwitterClient
                     throw $e;
                 }
             }
-        } elseif ($operation === 'By list ID') {
+        } else if ($operation == 'By list ID') {
             $id = $query['listId'];
         } else {
             throw new \Exception('Unknown operation to make list tweets');
@@ -223,43 +307,40 @@ class TwitterClient
     private function fetchTimeline($userId)
     {
         $variables = [
-            'userId' => $userId,
+            'autoplay_enabled' => true,
             'count' => 40,
-            'includePromotedContent' => true,
-            'withQuickPromoteEligibilityTweetFields' => true,
-            'withSuperFollowsUserFields' => true,
-            'withDownvotePerspective' => false,
-            'withReactionsMetadata' => false,
-            'withReactionsPerspective' => false,
-            'withSuperFollowsTweetFields' => true,
-            'withVoice' => true,
-            'withV2Timeline' => true,
+            'includeEditControl' => true,
+            'includeEditPerspective' => false,
+            'includeHasBirdwatchNotes' => false,
+            'includeTweetImpression' => true,
+            'includeTweetVisibilityNudge' => true,
+            'rest_id' => $userId
         ];
         $features = [
-            'responsive_web_twitter_blue_verified_badge_is_enabled' => true,
-            'responsive_web_graphql_exclude_directive_enabled' => false,
-            'verified_phone_label_enabled' => false,
-            'responsive_web_graphql_timeline_navigation_enabled' => true,
-            'responsive_web_graphql_skip_user_profile_image_extensions_enabled' => false,
+            'android_graphql_skip_api_media_color_palette' => true,
+            'blue_business_profile_image_shape_enabled' => true,
+            'creator_subscriptions_subscription_count_enabled' => true,
+            'creator_subscriptions_tweet_preview_api_enabled' => true,
+            'freedom_of_speech_not_reach_fetch_enabled' => true,
             'longform_notetweets_consumption_enabled' => true,
+            'longform_notetweets_inline_media_enabled' => true,
+            'longform_notetweets_rich_text_read_enabled' => true,
+            'subscriptions_verification_info_enabled' => true,
+            'super_follow_badge_privacy_enabled' => true,
+            'super_follow_exclusive_tweet_notifications_enabled' => true,
+            'super_follow_tweet_api_enabled' => true,
+            'super_follow_user_api_enabled' => true,
+            'tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled' => true,
             'tweetypie_unmention_optimization_enabled' => true,
-            'vibe_api_enabled' => true,
-            'responsive_web_edit_tweet_api_enabled' => true,
-            'graphql_is_translatable_rweb_tweet_is_translatable_enabled' => true,
-            'view_counts_everywhere_api_enabled' => true,
-            'freedom_of_speech_not_reach_appeal_label_enabled' => false,
-            'standardized_nudges_misinfo' => true,
-            'tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled' => false,
-            'interactive_text_enabled' => true,
-            'responsive_web_text_conversations_enabled' => false,
-            'responsive_web_enhance_cards_enabled' => false,
+            'unified_cards_ad_metadata_container_dynamic_card_content_query_enabled' => true,
         ];
         $url = sprintf(
-            'https://twitter.com/i/api/graphql/WZT7sCTrLvSOaWOXLDsWbQ/UserTweets?variables=%s&features=%s',
+            'https://api.twitter.com/graphql/3JNH4e9dq1BifLxAa3UMWg/UserWithProfileTweetsQueryV2?variables=%s&features=%s',
             urlencode(json_encode($variables)),
             urlencode(json_encode($features))
         );
-        $response = Json::decode(getContents($url, $this->createHttpHeaders()), false);
+        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, "GET", $url);
+        $response = Json::decode(getContents($url, $this->createHttpHeaders($oauth)), false);
         return $response;
     }
 
@@ -280,7 +361,8 @@ class TwitterClient
              'https://api.twitter.com/1.1/search/tweets.json?%s',
              http_build_query($queryParam)
          );
-        $response = Json::decode(getContents($url, $this->createHttpHeaders()), false);
+        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, "GET", $url);
+        $response = Json::decode(getContents($url, $this->createHttpHeaders($oauth)), false);
         return $response;
     }
 
@@ -348,11 +430,6 @@ class TwitterClient
             // Grab the first error message
             throw new \Exception(sprintf('From twitter api: "%s"', $response->errors[0]->message));
         }
-        if (!isset($response->data->user_by_screen_name->list)) {
-            throw new \Exception(
-                sprintf('Unable to find list in twitter response for %s, %s', $screenName, $listSlug)
-            );
-        }
         $listInfo = $response->data->user_by_screen_name->list;
         $this->data[$screenName . '-' . $listSlug] = $listInfo;
 
@@ -412,23 +489,28 @@ class TwitterClient
         ];
 
         $url = sprintf(
-            'https://twitter.com/i/api/graphql/BbGLL1ZfMibdFNWlk7a0Pw/ListTimeline?variables=%s&features=%s',
+            'https://api.twitter.com/graphql/BbGLL1ZfMibdFNWlk7a0Pw/ListTimeline?variables=%s&features=%s',
             urlencode(json_encode($variables)),
             urlencode(json_encode($features))
         );
-        $response = Json::decode(getContents($url, $this->createHttpHeaders()), false);
+        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, "GET", $url);
+        $response = Json::decode(getContents($url, $this->createHttpHeaders($oauth)), false);
         return $response;
     }
 
-    private function createHttpHeaders(): array
+    private function createHttpHeaders($oauth = null): array
     {
         $headers = [
             'authorization' => sprintf('Bearer %s', $this->authorization),
             'x-guest-token' => $this->data['guest_token'] ?? null,
         ];
-        foreach ($headers as $key => $value) {
-            $headers[] = sprintf('%s: %s', $key, $value);
+        if (isset($oauth)) {
+            $headers['authorization'] = $oauth;
+            unset($headers['x-guest-token']);
         }
-        return $headers;
+        foreach ($headers as $key => $value) {
+            $headers2[] = sprintf('%s: %s', $key, $value);
+        }
+        return $headers2;
     }
 }

--- a/lib/TwitterClient.php
+++ b/lib/TwitterClient.php
@@ -44,14 +44,14 @@ class TwitterClient
             parse_str($body, $body_params);
             $query_params = array_merge($query_params, $body_params);
         }
-        $payload = array(
+        $payload = [
             'oauth_version' => '1.0',
             'oauth_signature_method' => 'HMAC-SHA1',
             'oauth_consumer_key' => $this->tw_consumer_key,
             'oauth_token' => $oauth_token,
             'oauth_nonce' => $oauth_nonce ? $oauth_nonce : implode('', array_fill(0, 3, strval(time()))),
             'oauth_timestamp' => $timestamp ? $timestamp : time(),
-        );
+        ];
         $payload = array_merge($payload, $query_params);
         ksort($payload);
 

--- a/lib/TwitterClient.php
+++ b/lib/TwitterClient.php
@@ -20,8 +20,8 @@ class TwitterClient
         $this->authorization = 'AAAAAAAAAAAAAAAAAAAAAGHtAgAAAAAA%2Bx7ILXNILCqkSGIzy6faIHZ9s3Q%3DQy97w6SIrzE7lQwPJEYQBsArEE2fC25caFwRBvAGi456G09vGR';
         $this->tw_consumer_key = '3nVuSoBZnx6U4vzUxf5w';
         $this->tw_consumer_secret = 'Bcs59EFbbsdF6Sl9Ng71smgStWEGwXXKSjYvPVt7qys';
-        $this->oauth_token = '1692750343510335488-RDoNrQYUxlNe9A5wygl1JZMJs4oS3F';
-        $this->oauth_token_secret = 'upMwgZvGr3ZSPiQA4YCanvEaesuFYri4HRrvdRl2MTeOq';
+        $this->oauth_token = ''; //Fill here
+        $this->oauth_token_secret = ''; //Fill here
     }
 
     private function getOauthAuthorization(

--- a/lib/TwitterClient.php
+++ b/lib/TwitterClient.php
@@ -18,23 +18,23 @@ class TwitterClient
 
         $this->data = $this->cache->loadData() ?? [];
         $this->authorization = 'AAAAAAAAAAAAAAAAAAAAAGHtAgAAAAAA%2Bx7ILXNILCqkSGIzy6faIHZ9s3Q%3DQy97w6SIrzE7lQwPJEYQBsArEE2fC25caFwRBvAGi456G09vGR';
-        $this->tw_consumer_key = "3nVuSoBZnx6U4vzUxf5w";
-        $this->tw_consumer_secret = "Bcs59EFbbsdF6Sl9Ng71smgStWEGwXXKSjYvPVt7qys";
-        $this->oauth_token = ""; // Fill here
-        $this->oauth_token_secret = ""; // Fill here
+        $this->tw_consumer_key = '3nVuSoBZnx6U4vzUxf5w';
+        $this->tw_consumer_secret = 'Bcs59EFbbsdF6Sl9Ng71smgStWEGwXXKSjYvPVt7qys';
+        $this->oauth_token = '1692750343510335488-RDoNrQYUxlNe9A5wygl1JZMJs4oS3F';
+        $this->oauth_token_secret = 'upMwgZvGr3ZSPiQA4YCanvEaesuFYri4HRrvdRl2MTeOq';
     }
 
     private function getOauthAuthorization(
         $oauth_token,
         $oauth_token_secret,
-        $method = "GET",
-        $url = "",
-        $body = "",
+        $method = 'GET',
+        $url = '',
+        $body = '',
         $timestamp = null,
         $oauth_nonce = null
     ) {
         if (!$url) {
-            return "";
+            return '';
         }
         $method = strtoupper($method);
         $parseUrl = parse_url($url);
@@ -49,7 +49,7 @@ class TwitterClient
             'oauth_signature_method' => 'HMAC-SHA1',
             'oauth_consumer_key' => $this->tw_consumer_key,
             'oauth_token' => $oauth_token,
-            'oauth_nonce' => $oauth_nonce ? $oauth_nonce : implode("", array_fill(0, 3, strval(time()))),
+            'oauth_nonce' => $oauth_nonce ? $oauth_nonce : implode('', array_fill(0, 3, strval(time()))),
             'oauth_timestamp' => $timestamp ? $timestamp : time(),
         );
         $payload = array_merge($payload, $query_params);
@@ -60,20 +60,10 @@ class TwitterClient
         $base_url = $url_parts['scheme'] . '://' . $url_parts['host'] . $url_parts['path'];
         $signature_base_string = strtoupper($method) . '&' . rawurlencode($base_url) . '&' . rawurlencode($url_parts['query']);
         $hmac_key = $this->tw_consumer_secret . '&' . $oauth_token_secret;
-
-        // Reference: https://stackoverflow.com/questions/37207221/php-generate-hmac-sha1-signature
-        // $hexStr = $hmac_key;
-        // $c = explode('-',chunk_split($hexStr,2,'-'));
-        // $hexArr = array($c[3],$c[2],$c[1],$c[0],$c[5],$c[4],$c[7],$c[6],$c[8],$c[9],$c[10],$c[11],$c[12],$c[13],$c[14],$c[15]);
-        // $keyStr = '';
-        // for ($i = 0; $i < 16; ++$i) {
-        //     $num = hexdec($hexArr[$i]);
-        //     $keyStr .= chr($num);
-        // }
         $hex_signature = hash_hmac('sha1', $signature_base_string, $hmac_key, true);
         $signature = base64_encode($hex_signature);
 
-        $header_params = array(
+        $header_params = [
             'oauth_version' => '1.0',
             'oauth_token' => $oauth_token,
             'oauth_nonce' => $payload['oauth_nonce'],
@@ -81,9 +71,9 @@ class TwitterClient
             'oauth_signature' => $signature,
             'oauth_consumer_key' => $this->tw_consumer_key,
             'oauth_signature_method' => 'HMAC-SHA1',
-        );
+        ];
         // ksort($header_params);
-        $header_values = array();
+        $header_values = [];
         foreach ($header_params as $key => $value) {
             $header_values[] = rawurlencode($key) . '="' . (is_int($value) ? $value : rawurlencode($value)) . '"';
         }
@@ -109,7 +99,7 @@ class TwitterClient
             $instructions = $result->timeline->instructions;
         }
 
-        if(!isset($result) && !isset($instructions)) {
+        if (!isset($result) && !isset($instructions)) {
             throw new \Exception('Unable to fetch user/list timeline');
         }
 
@@ -339,7 +329,7 @@ class TwitterClient
             urlencode(json_encode($variables)),
             urlencode(json_encode($features))
         );
-        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, "GET", $url);
+        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, 'GET', $url);
         $response = Json::decode(getContents($url, $this->createHttpHeaders($oauth)), false);
         return $response;
     }
@@ -361,7 +351,7 @@ class TwitterClient
              'https://api.twitter.com/1.1/search/tweets.json?%s',
              http_build_query($queryParam)
          );
-        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, "GET", $url);
+        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, 'GET', $url);
         $response = Json::decode(getContents($url, $this->createHttpHeaders($oauth)), false);
         return $response;
     }
@@ -493,7 +483,7 @@ class TwitterClient
             urlencode(json_encode($variables)),
             urlencode(json_encode($features))
         );
-        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, "GET", $url);
+        $oauth = $this->getOauthAuthorization($this->oauth_token, $this->oauth_token_secret, 'GET', $url);
         $response = Json::decode(getContents($url, $this->createHttpHeaders($oauth)), false);
         return $response;
     }


### PR DESCRIPTION
[TwitterClient]
- Add OAuth authorization header.
- Add new endpoint for user tweet.
- Use GraphQL API instead of search for user tweet.
- User, List Timeline and Search now using OAuth header.

[TwitterBridge]
- Make some changes.

NOTE: This latest change requires you to get the guest account to generate OAuth headers in order to use the bridge. Detail about how to get it is on [zedeus/nitter#issuecomment-1681199357](https://github.com/zedeus/nitter/issues/983#issuecomment-1681199357). After that, put it on the TwitterClient file and you will be good to go. Also it's not recommended to use one guest account for larger instance, i saw nitter use a lot of guest accounts over there to handle large requests.