### PR TITLE
[Core] Find Feed : fix CSS for search results

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -462,6 +462,7 @@ button {
   display: flex;
   position: relative;
   text-align: left;
+  margin-bottom: 15px;
 }
 @media (prefers-color-scheme: dark) {
     .search-result {


### PR DESCRIPTION
There was no margin at the bottom of the search result : in case of two or more results, the two blocks had no space between them.