### PR TITLE
[Core] Fix Find Feed URL encoding

### DIFF
--- a/static/rss-bridge.js
+++ b/static/rss-bridge.js
@@ -56,7 +56,7 @@ var rssbridge_feed_finder = (function() {
     // Start the Feed search
     async function rssbridge_feed_search(event) {
         const input = document.getElementById('searchfield');
-        let content = input.value;
+        let content = encodeURI(input.value);
         if (content) {
             const findfeedresults = document.getElementById('findfeedresults');
             findfeedresults.innerHTML = 'Searching for matching feeds ...';


### PR DESCRIPTION
The URL entered by the user was not URL encoded for the find feed feature : this had lead to wrong content sent back to he server