### PR TITLE
[Core] Fix Find Feed URL encoding (Really this time)

### DIFF
--- a/static/rss-bridge.js
+++ b/static/rss-bridge.js
@@ -56,7 +56,7 @@ var rssbridge_feed_finder = (function() {
     // Start the Feed search
     async function rssbridge_feed_search(event) {
         const input = document.getElementById('searchfield');
-        let content = encodeURI(input.value);
+        let content = encodeURIComponent(input.value);
         if (content) {
             const findfeedresults = document.getElementById('findfeedresults');
             findfeedresults.innerHTML = 'Searching for matching feeds ...';


### PR DESCRIPTION
- the URL was only partially encoded because encodeURI() was used instead of encodeURIComponent()
Now the whole URL is urlencoded, and the whole URL is passed "as is" in the GET parameter 'url'