### PR TITLE
[PixivBridge] Add cookie auth and options

### DIFF
--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -213,6 +213,7 @@ class PixivBridge extends BridgeAbstract
 
     /**
      * todo: remove manual file cache
+     * See bridge specific documentation for alternative option.
      */
     private function cacheImage($url, $illustId, $isImage)
     {

--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -156,10 +156,18 @@ class PixivBridge extends BridgeAbstract
             if ($this->getOption('cookie') !== null) {
                 switch ($json_key) {
                     case 'illust':
-                        $json = array_reduce($json, function ($acc, $i) {if ($i['illustType'] === 0) {$acc[] = $i;}return $acc;}, []);
+                        $json = array_reduce($json, function ($acc, $i) {
+                            if ($i['illustType'] === 0) {
+                                $acc[] = $i;
+                            }return $acc;
+                        }, []);
                         break;
                     case 'manga':
-                        $json = array_reduce($json, function ($acc, $i) {if ($i['illustType'] === 1) {$acc[] = $i;}return $acc;}, []);
+                        $json = array_reduce($json, function ($acc, $i) {
+                            if ($i['illustType'] === 1) {
+                                $acc[] = $i;
+                            }return $acc;
+                        }, []);
                         break;
                 }
             }
@@ -308,12 +316,21 @@ class PixivBridge extends BridgeAbstract
         $proxy = $this->getOption('proxy_url');
         if ($proxy) {
             if (
-                strlen($proxy) > 0 &&
-                preg_match('/https?:\/\/.*/', $proxy)
+                !(strlen($proxy) > 0 && preg_match('/https?:\/\/.*/', $proxy))
             ) {
-                return;
-            } else {
                 return returnServerError('Invalid proxy_url value set. The proxy must include the HTTP/S at the beginning of the url.');
+            }
+        }
+
+        $cookie = $this->getCookie();
+        if ($cookie) {
+            $isAuth = $this->loadCacheValue('is_authenticated');
+            if (!$isAuth) {
+                $res = $this->getData('https://www.pixiv.net/ajax/webpush', true, true)
+                    or returnServerError('Invalid PHPSESSID cookie provided. Please check the 🍪 and try again.');
+                if ($res['error'] === false) {
+                    $this->saveCacheValue('is_authenticated', true);
+                }
             }
         }
     }

--- a/docs/10_Bridge_Specific/PixivBridge.md
+++ b/docs/10_Bridge_Specific/PixivBridge.md
@@ -1,0 +1,12 @@
+PixivBridge
+===============
+
+# Authentication
+
+Authentication is required to view and search R-18+ and non-public images. To enable this, set the following in this bridge's configuration in `config.ini.php`.
+
+```
+[PixivBridge]
+; from cookie "PHPSESSID". Recommend to get in incognito browser. 
+cookie = "00000000_hashedsessionidhere"
+```

--- a/docs/10_Bridge_Specific/PixivBridge.md
+++ b/docs/10_Bridge_Specific/PixivBridge.md
@@ -1,0 +1,15 @@
+PixivBridge
+===============
+
+As Pixiv requires images to be loaded with the `Referer "https://www.pixiv.net/"` header set, caching or image proxy is required to use this bridge.
+
+To turn off image caching, set the `proxy_url` value in this bridge's configuration section of `config.ini.php` to the url of the proxy. The bridge will then use the proxy in this format (essentially replacing `https://i.pximg.net` with the proxy): 
+
+Before: `https://i.pximg.net/img-original/img/0000/00/00/00/00/00/12345678_p0.png`
+
+After: `https://proxy.example.com/img-original/img/0000/00/00/00/00/00/12345678_p0.png`
+
+```
+[PixivBridge]
+proxy_url = "https://proxy.example.com"
+```


### PR DESCRIPTION
Add:
- Cookie authentication in `config.ini.php`
- AI and Mature submission filters
- Image proxy option (enabled by setting it in `config.ini.php`)

Related:
https://github.com/RSS-Bridge/rss-bridge/issues/2759