### PR TITLE
Add new bridge for the game Dofus

### DIFF
--- a/bridges/DofusBridge.php
+++ b/bridges/DofusBridge.php
@@ -2,53 +2,53 @@
 
 class DofusBridge extends FeedExpander
 {
-  const MAINTAINER = 'Jisagi';
-  const NAME = 'Dofus';
-  const URI = 'https://www.dofus.com/';
-  const DESCRIPTION = 'Returns latest news for the MMORPG dofus.';
+    const MAINTAINER = 'Jisagi';
+    const NAME = 'Dofus';
+    const URI = 'https://www.dofus.com/';
+    const DESCRIPTION = 'Returns latest news for the MMORPG dofus.';
 
-  const PARAMETERS = [
-    [
-      'c' => [
-        'name' => 'Category',
-        'type' => 'list',
-        'required' => true,
-        'values' => [
-          'News' => 'news',
-          'Changelog' => 'changelog',
-          'Dev Blog' => 'devblog'
+    const PARAMETERS = [
+        [
+            'c' => [
+                'name' => 'Category',
+                'type' => 'list',
+                'required' => true,
+                'values' => [
+                    'News' => 'news',
+                    'Changelog' => 'changelog',
+                    'Dev Blog' => 'devblog'
+                ]
+            ],
+            'l' => [
+                'name' => 'Language',
+                'type' => 'list',
+                'required' => true,
+                'values' => [
+                    'English' => 'en',
+                    'French' => 'fr',
+                    'Spanish' => 'es',
+                    'Portuguese' => 'pt'
+                ]
+            ]
         ]
-      ],
-      'l' => [
-        'name' => 'Language',
-        'type' => 'list',
-        'required' => true,
-        'values' => [
-          'English' => 'en',
-          'French' => 'fr',
-          'Spanish' => 'es',
-          'Portuguese' => 'pt'
-        ]
-      ]
-    ]
-  ];
+    ];
 
-  public function getIcon()
-  {
-    return self::URI . 'favicon.ico';
-  }
+    public function getIcon()
+    {
+        return self::URI . 'favicon.ico';
+    }
 
-  public function getURI()
-  {
-    return self::URI
-      . $this->getInput('l')
-      . '/rss/'
-      . $this->getInput('c')
-      . '.xml';
-  }
+    public function getURI()
+    {
+        return self::URI
+            . $this->getInput('l')
+            . '/rss/'
+            . $this->getInput('c')
+            . '.xml';
+    }
 
-  public function collectData()
-  {
-    $this->collectExpandableDatas($this->getURI(), 10);
-  }
+    public function collectData()
+    {
+        $this->collectExpandableDatas($this->getURI(), 10);
+    }
 }

--- a/bridges/DofusBridge.php
+++ b/bridges/DofusBridge.php
@@ -12,7 +12,6 @@ class DofusBridge extends FeedExpander
             'c' => [
                 'name' => 'Category',
                 'type' => 'list',
-                'required' => true,
                 'values' => [
                     'News' => 'news',
                     'Changelog' => 'changelog',
@@ -22,7 +21,6 @@ class DofusBridge extends FeedExpander
             'l' => [
                 'name' => 'Language',
                 'type' => 'list',
-                'required' => true,
                 'values' => [
                     'English' => 'en',
                     'French' => 'fr',

--- a/bridges/DofusBridge.php
+++ b/bridges/DofusBridge.php
@@ -1,0 +1,54 @@
+<?php
+
+class DofusBridge extends FeedExpander
+{
+  const MAINTAINER = 'Jisagi';
+  const NAME = 'Dofus';
+  const URI = 'https://www.dofus.com/';
+  const DESCRIPTION = 'Returns latest news for the MMORPG dofus.';
+
+  const PARAMETERS = [
+    [
+      'c' => [
+        'name' => 'Category',
+        'type' => 'list',
+        'required' => true,
+        'values' => [
+          'News' => 'news',
+          'Changelog' => 'changelog',
+          'Dev Blog' => 'devblog'
+        ]
+      ],
+      'l' => [
+        'name' => 'Language',
+        'type' => 'list',
+        'required' => true,
+        'values' => [
+          'English' => 'en',
+          'French' => 'fr',
+          'Spanish' => 'es',
+          'Portuguese' => 'pt'
+        ]
+      ]
+    ]
+  ];
+
+  public function getIcon()
+  {
+    return self::URI . 'favicon.ico';
+  }
+
+  public function getURI()
+  {
+    return self::URI
+      . $this->getInput('l')
+      . '/rss/'
+      . $this->getInput('c')
+      . '.xml';
+  }
+
+  public function collectData()
+  {
+    $this->collectExpandableDatas($this->getURI(), 10);
+  }
+}


### PR DESCRIPTION
This PR adds a bridge for the MMORPG Dofus. Because Twitter shut down their public API, this enables people to auto fetch news on the game again.