### PR TITLE
[SteamAppNewsBridge] Add tags filter

### DIFF
--- a/bridges/SteamAppNewsBridge.php
+++ b/bridges/SteamAppNewsBridge.php
@@ -27,18 +27,26 @@ class SteamAppNewsBridge extends BridgeAbstract
             'title' => '# of posts to retrieve (default 20)',
             'type' => 'number',
             'defaultValue' => 20
+        ],
+        'tags' => [
+            'name' => 'Tag Filter',
+            'title' => 'Comma-separated list of tags to filter by',
+            'type' => 'text',
+            'exampleValue' => 'patchnotes'
         ]
     ]];
 
     public function collectData()
     {
-        $api = 'https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/';
+        $apiTarget = 'https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/';
         // Example with params: https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=730&maxlength=0&count=20
         // More info at dev docs https://partner.steamgames.com/doc/webapi/ISteamNews
-        $url = $api . '?appid='
-        . $this->getInput('appid') . '&maxlength='
-        . $this->getInput('maxlength') . '&count='
-        . $this->getInput('count');
+        $url =
+            $apiTarget
+            . '?appid=' . $this->getInput('appid')
+            . '&maxlength=' . $this->getInput('maxlength')
+            . '&count=' . $this->getInput('count')
+            . '&tags=' . $this->getInput('tags');
 
         // Get the JSON content
         $json = getContents($url);


### PR DESCRIPTION
Adds a tag filter that retrieves `newsitems` entries containing the listed tag(s).

The most common use-case is for retrieving entries with the `patchnotes` tag.

This uses the [currently undocumented](https://partner.steamgames.com/doc/webapi/ISteamNews) `tags` parameter, which can be discovered through a [GetSupportedAPIList query](https://api.steampowered.com/ISteamWebAPIUtil/GetSupportedAPIList/v1/). It takes a comma-separated list as an argument, and  it's allowed to be an empty string.

<details>
<summary><b>GetNewsForApp v2 entry via /ISteamWebAPIUtil/GetSupportedAPIList/v1/</b></summary>

```json
{
  "name": "GetNewsForApp",
  "version": 2,
  "httpmethod": "GET",
  "parameters": [
    {
      "name": "appid",
      "type": "uint32",
      "optional": false,
      "description": "AppID to retrieve news for"
    },
    {
      "name": "maxlength",
      "type": "uint32",
      "optional": true,
      "description": "Maximum length for the content to return, if this is 0 the full content is returned, if it's less then a blurb is generated to fit."
    },
    {
      "name": "enddate",
      "type": "uint32",
      "optional": true,
      "description": "Retrieve posts earlier than this date (unix epoch timestamp)"
    },
    {
      "name": "count",
      "type": "uint32",
      "optional": true,
      "description": "# of posts to retrieve (default 20)"
    },
    {
      "name": "feeds",
      "type": "string",
      "optional": true,
      "description": "Comma-separated list of feed names to return news for"
    },
    {
      "name": "tags",
      "type": "string",
      "optional": true,
      "description": "Comma-separated list of tags to filter by (e.g. 'patchnodes')"
    }
  ]
}
```
<sup>_I think the example in `tags`'s description is supposed to be 'patchnotes', not 'patchnodes'._</sup>
</details>

Because I haven't been able to come across any news entries that have more than one tag, I refrained from making this bridge parameter the `list` type, as I felt that might suggest it utilizes an OR list rather than an AND list.