### PR TITLE
[PatreonBridge] resolve comment

### DIFF
--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -135,7 +135,7 @@ class PatreonBridge extends BridgeAbstract
                     $thumbnail = $post->attributes->thumbnail->large ?? null;
                     $thumbnail = $thumbnail ?? $post->attributes->thumbnail->url ?? null;
                     $thumbnail = $thumbnail ?? $post->attributes->image->thumb_url ?? null;
-                    $thumbnail = $thumbnail ?? $post->attributes->image->url;
+                    $thumbnail = $thumbnail ?? $post->attributes->image->url ?? null;
                     $audio_filename = $audio->file_name ?? $item['title'];
                     $download_url = $audio->download_url ?? $item['uri'];
                     $item['content'] .= "<p><a href\"{$download_url}\"><img src=\"{$thumbnail}\"><br/>🎧 {$audio_filename}</a><br/>";
@@ -150,7 +150,7 @@ class PatreonBridge extends BridgeAbstract
                     $thumbnail = $post->attributes->thumbnail->large ?? null;
                     $thumbnail = $thumbnail ?? $post->attributes->thumbnail->url ?? null;
                     $thumbnail = $thumbnail ?? $post->attributes->image->thumb_url ?? null;
-                    $thumbnail = $thumbnail ?? $post->attributes->image->url;
+                    $thumbnail = $thumbnail ?? $post->attributes->image->url ?? null;
                     $item['content'] .= "<p><a href=\"{$item['uri']}\">🎬 {$item['title']}<br><img src=\"{$thumbnail}\"></a></p>";
                     break;
 
@@ -158,7 +158,7 @@ class PatreonBridge extends BridgeAbstract
                     $thumbnail = $post->attributes->thumbnail->large ?? null;
                     $thumbnail = $thumbnail ?? $post->attributes->thumbnail->url ?? null;
                     $thumbnail = $thumbnail ?? $post->attributes->image->thumb_url ?? null;
-                    $thumbnail = $thumbnail ?? $post->attributes->image->url;
+                    $thumbnail = $thumbnail ?? $post->attributes->image->url ?? null;
                     $item['content'] .= "<p><a href=\"{$item['uri']}\">🎬 {$item['title']}<br><img src=\"{$thumbnail}\"></a></p>";
                     break;
 
@@ -166,9 +166,9 @@ class PatreonBridge extends BridgeAbstract
                     $item['content'] .= '<p>';
                     foreach ($post->relationships->images->data as $key => $image) {
                         $image = $this->findInclude($posts, 'media', $image->id)->attributes;
-                        $image_fullres = $image->download_url ?? $image->image_urls->url ?? $image->image_urls->original;
+                        $image_fullres = $image->download_url ?? $image->image_urls->url ?? $image->image_urls->original ?? null;
                         $filename = $image->file_name ?? '';
-                        $image_url = $image->image_urls->url ?? $image->image_urls->original;
+                        $image_url = $image->image_urls->url ?? $image->image_urls->original ?? null;
                         $item['enclosures'][] = $image_fullres;
                         $item['content'] .= "<a href=\"{$image_fullres}\">{$filename}<br/><img src=\"{$image_url}\"></a><br/><br/>";
                     }


### PR DESCRIPTION
https://github.com/RSS-Bridge/rss-bridge/pull/3617#issuecomment-1730244049

Didn't expect this to be an issue at all - PR now just resolve image urls to `null` to discard the image url entirely. There should still be contextual hints that an image should have existed.