### PR TITLE
[CssSelectorBridge] Fix URL filtering (#3676)

### DIFF
--- a/bridges/CssSelectorBridge.php
+++ b/bridges/CssSelectorBridge.php
@@ -114,7 +114,7 @@ class CssSelectorBridge extends BridgeAbstract
     {
         if (!empty($url_pattern)) {
             $url_pattern = '/' . str_replace('/', '\/', $url_pattern) . '/';
-            $links = array_filter($links, function ($url) {
+            $links = array_filter($links, function ($url) use ($url_pattern) {
                 return preg_match($url_pattern, $url) === 1;
             });
         }


### PR DESCRIPTION
Implement fix proposed by @tougaj in #3676:

> The issue where the value of the variable $url_pattern is null within the filtering function can arise due to limited variable visibility in anonymous functions (lambda functions) in PHP. Lambda functions do not automatically capture variables from the outer context.
> To use a variable from the outer context inside an anonymous function, you need to include it in the function's scope using the use keyword