### PR TITLE
[prtester] improvements and fixes for prtester

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,0 +1,6 @@
+# Visual Studio Code
+.vscode/*
+
+# Generated files
+comment*.md
+comment*.txt

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -8,6 +8,8 @@ jobs:
   test-pr:
     name: Generate HTML
     runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: 1
     # Needs additional permissions https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989
     steps:
       - name: Check out self

--- a/templates/exception.html.php
+++ b/templates/exception.html.php
@@ -60,7 +60,7 @@
     <h2>Details</h2>
 
     <div style="margin-bottom: 15px">
-        <div>
+        <div class="error-type">
             <strong>Type:</strong> <?= e(get_class($e)) ?>
         </div>
 
@@ -68,7 +68,7 @@
             <strong>Code:</strong> <?= e($e->getCode()) ?>
         </div>
 
-        <div>
+        <div class="error-message">
             <strong>Message:</strong> <?= e(sanitize_root($e->getMessage())) ?>
         </div>
 


### PR DESCRIPTION
This PR improves the `prtester.py`/"request artifacts comment" overhaul of https://github.com/RSS-Bridge/rss-bridge/pull/3705
- In https://github.com/RSS-Bridge/rss-bridge/pull/3712 the preview of the MozillaBugTracker bridge failed with a `out of range` error
  - This was caused by an empty `<pre>` tag. The script can handle that now
  - The empty `<pre>` tag was actually from the feed items. `<pre>` tags in the feed items are now ignored (by removing/`.decompose()` the feed items before selecting the `<pre>` tags)
  - The error message was not at the right postion in the GitHub action log, which is why I first thought the Crewbay bridge was the cause
    - Added the env var `PYTHONUNBUFFERED=1` which tells python to output in real-time instead of buffering. This should fix it
- Improved the status messages
  - The exception type and error message are now included in the status column
    - For this to work reliably, I added two new classes to the html tags
  - Removes chars that can break the table or formatting
  - Removes dates
  - Removes duplicate messages
  - Truncates the message to 250 chars max
- Added more cli arguments for debugging
  - `--reduced-upload` only uploads the response if it has status messages
  - `--output-file` to optionally change the output file location