### PR TITLE
[refactoring] replace direct use of curl with getContents

### DIFF
--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1909,6 +1909,7 @@ class DealabsBridge extends PepperBridgeAbstract
         'context-group' => 'Deals par groupe',
         'context-talk' => 'Surveillance Discussion',
         'uri-group' => 'groupe/',
+        'uri-deal' => 'bons-plans/',
         'request-error' => 'Impossible de joindre Dealabs',
         'thread-error' => 'Impossible de déterminer l\'ID de la discussion. Vérifiez l\'URL que vous avez entré',
         'no-results' => 'Il n&#039;y a rien à afficher pour le moment :(',

--- a/bridges/FDroidBridge.php
+++ b/bridges/FDroidBridge.php
@@ -21,34 +21,18 @@ class FDroidBridge extends BridgeAbstract
 
     public function getIcon()
     {
-        return self::URI . 'assets/favicon.ico?v=8j6PKzW9Mk';
+        return self::URI . 'assets/favicon.ico';
     }
 
     private function getTimestamp($url)
     {
         $curlOptions = [
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_HEADER         => true,
-            CURLOPT_NOBODY         => true,
-            CURLOPT_CONNECTTIMEOUT => 19,
-            CURLOPT_TIMEOUT        => 19,
+            CURLOPT_CUSTOMREQUEST => 'HEAD',
+            CURLOPT_NOBODY => true,
         ];
-        $ch = curl_init($url);
-        curl_setopt_array($ch, $curlOptions);
-        $curlHeaders = curl_exec($ch);
-        $curlError = curl_error($ch);
-        curl_close($ch);
-        if (!empty($curlError)) {
-            return false;
-        }
-        $curlHeaders = explode("\n", $curlHeaders);
-        $timestamp = false;
-        foreach ($curlHeaders as $header) {
-            if (strpos($header, 'Last-Modified') !== false) {
-                $timestamp = str_replace('Last-Modified: ', '', $header);
-                $timestamp = strtotime($timestamp);
-            }
-        }
+        $reponse = getContents($url, [], $curlOptions, true);
+        $lastModified = $reponse['headers']['last-modified'][0] ?? null;
+        $timestamp = strtotime($lastModified ?? 'today');
         return $timestamp;
     }
 

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -3273,6 +3273,7 @@ class HotUKDealsBridge extends PepperBridgeAbstract
         'context-group' => 'Deals per group',
         'context-talk' => 'Discussion Monitoring',
         'uri-group' => 'tag/',
+        'uri-deal' => 'deals/',
         'request-error' => 'Could not request HotUKDeals',
         'thread-error' => 'Unable to determine the thread ID. Check the URL you entered',
         'no-results' => 'Ooops, looks like we could',

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -2020,6 +2020,7 @@ class MydealsBridge extends PepperBridgeAbstract
         'context-group' => 'Deals pro Gruppen',
         'context-talk' => 'Überwachung Diskussion',
         'uri-group' => 'gruppe/',
+        'uri-deal' => 'deals/',
         'request-error' => 'Could not request mydeals',
         'thread-error' => 'Die ID der Diskussion kann nicht ermittelt werden. Überprüfen Sie die eingegebene URL',
         'no-results' => 'Ups, wir konnten keine Deals zu',

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -52,7 +52,11 @@ function getContents(
         $config['proxy'] = Configuration::getConfig('proxy', 'url');
     }
 
-    $cacheKey = 'server_' . $url;
+    $requestBodyHash = null;
+    if (isset($curlOptions[CURLOPT_POSTFIELDS])) {
+        $requestBodyHash = md5(json_encode($curlOptions[CURLOPT_POSTFIELDS]));
+    }
+    $cacheKey = implode('_', ['server',  $url, $requestBodyHash]);
 
     /** @var Response $cachedResponse */
     $cachedResponse = $cache->get($cacheKey);


### PR DESCRIPTION
This PR removes direct use of curl and replaces it with `getContents`.
- The `cacheKey` in `getContents` now includes the request body as hash, because else you could get the wrong cache back in case the same url gets used for different requests like in the pepper bridges
- The discussion title was missing from all pepper bridges. Fixed the selector (fixes `Attempt to read property "plaintext" on null at bridges/PepperBridgeAbstract.php line 333`)
- Some pepper bridges deal items where missing uris (because the `<a>` tags are sometimes replaced with a login wall). I replaced scraping the seo friendly uri with building the perma uri using the deal id (fixes `Not a valid url: ""`)
- `getTimestamp` in `FDroidBridge` did not work, because the headers key names are always lower case. Now works again (fixes `Unable to parse timestamp!` and `Timestamp must be greater than zero!`)