### PR TITLE
[BridgeCard] add example value to info hint and allow using it by right click

### DIFF
--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -177,9 +177,18 @@ This bridge is not fetching its content through a secure connection</div>';
                     $form .= self::getCheckboxInput($inputEntry, $idArg, $id);
                 }
 
+                $infoText = [];
+                $infoTextScript = '';
                 if (isset($inputEntry['title'])) {
-                    $title_filtered = filter_var($inputEntry['title'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-                    $form .= '<i class="info" title="' . $title_filtered . '">i</i>';
+                    $infoText[] = filter_var($inputEntry['title'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+                }
+                if ($inputEntry['exampleValue'] !== '') {
+                    $infoText[] = "Example (right click to use):\n" . filter_var($inputEntry['exampleValue'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+                    $infoTextScript = 'rssbridge_use_placeholder_value(this);';
+                }
+
+                if (count($infoText) > 0) {
+                    $form .= '<i class="info" data-for="' . $idArg . '" title="' . implode("\n\n", $infoText) . '" oncontextmenu="' . $infoTextScript . 'return false">i</i>';
                 } else {
                     $form .= '<i class="no-info"></i>';
                 }

--- a/static/rss-bridge.js
+++ b/static/rss-bridge.js
@@ -48,6 +48,12 @@ function rssbridge_toggle_bridge(){
     }
 }
 
+function rssbridge_use_placeholder_value(sender) {
+    let inputId = sender.getAttribute('data-for');
+    let inputElement = document.getElementById(inputId);
+    inputElement.value = inputElement.getAttribute("placeholder");
+}
+
 var rssbridge_feed_finder = (function() {
     /*
      * Code for "Find feed by URL" feature


### PR DESCRIPTION
This PR adds the example value of an input to the info hint, because some example values are to long for the input element and there is no way for the user to see the full example (except opening the dev inspect view).
Additionally it adds the ability to use the example value by right clicking on the info icon.

| before | after |
| - | - |
| ![image](https://github.com/RSS-Bridge/rss-bridge/assets/1911682/817480da-b92b-4b0a-8714-36d899a82cb6)| ![image](https://github.com/RSS-Bridge/rss-bridge/assets/1911682/d4b38242-c261-4c4d-9328-dc828c50b61c) |

