### PR TITLE
NyaaTorrentsBridge - add max items

### DIFF
--- a/bridges/NyaaTorrentsBridge.php
+++ b/bridges/NyaaTorrentsBridge.php
@@ -62,7 +62,7 @@ class NyaaTorrentsBridge extends FeedExpander
 
     public function collectData()
     {
-        $this->collectExpandableDatas($this->getURI());
+        $this->collectExpandableDatas($this->getURI(), 20);
     }
 
     protected function parseItem($newItem)


### PR DESCRIPTION
I was wrong when I said, nyaa doesn't have too many items in their feed. They do, it's more than 70 and the fetching takes ages compared to before which might lead to timeouts here and there. The old limit was 20, so I did just add it again.