### PR TITLE
[FicbookBridge] Fix for timestamp

### DIFF
--- a/bridges/FicbookBridge.php
+++ b/bridges/FicbookBridge.php
@@ -184,6 +184,7 @@ class FicbookBridge extends BridgeAbstract
         ];
 
         $fixed_date = str_replace($ru_month, $en_month, $date);
+        $fixed_date = str_replace(' г.', '', $fixed_date);
 
         if ($fixed_date === $date) {
             Debug::log('Unable to fix date: ' . $date);


### PR DESCRIPTION
Delete a year word after date digits: `DD m YYYY г., HH:MM` to `DD m YYYY, HH:MM`