### PR TITLE
[NyaaTorrentsBridge] Add published date

### DIFF
--- a/bridges/NyaaTorrentsBridge.php
+++ b/bridges/NyaaTorrentsBridge.php
@@ -76,6 +76,7 @@ class NyaaTorrentsBridge extends BridgeAbstract
             $item = [
                 'title' => (string) $feedItem->title,
                 'uri' => (string) $feedItem->link,
+                'date_modified' => (string) $feedItem->pubDate,
             ];
 
 


### PR DESCRIPTION
This PR adds the pubDate again. Since it was called date_modified before, I just named it as it was before. Before it was at the top level of the result item, but it now is added to the `_rssbridge` custom fields.