### PR TITLE
Fix: content.php: last-modified/if-unmodified-since (#3771)

### DIFF
--- a/lib/contents.php
+++ b/lib/contents.php
@@ -66,7 +66,7 @@ function getContents(
             try {
                 // Some servers send Unix timestamp instead of RFC7231 date. Prepend it with @ to allow parsing as DateTime
                 $cachedLastModified = new \DateTimeImmutable((is_numeric($cachedLastModified) ? '@' : '') . $cachedLastModified);
-                $config['if_not_modified_since'] = $cachedLastModified->format(DateTimeInterface::RFC7231);
+                $config['if_not_modified_since'] = $cachedLastModified->getTimestamp();
             } catch (Exception $dateTimeParseFailue) {
                 // Ignore invalid 'Last-Modified' HTTP header value
             }

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -63,8 +63,13 @@ function getContents(
     if ($cachedResponse) {
         $cachedLastModified = $cachedResponse->getHeader('last-modified');
         if ($cachedLastModified) {
-            $cachedLastModified = new \DateTimeImmutable($cachedLastModified);
-            $config['if_not_modified_since'] = $cachedLastModified->getTimestamp();
+            try {
+                // Some servers send Unix timestamp instead of RFC7231 date. Prepend it with @ to allow parsing as DateTime
+                $cachedLastModified = new \DateTimeImmutable((is_numeric($cachedLastModified) ? '@' : '') . $cachedLastModified);
+                $config['if_not_modified_since'] = $cachedLastModified->format(DateTimeInterface::RFC7231);
+            } catch (Exception $dateTimeParseFailue) {
+                // Ignore invalid 'Last-Modified' HTTP header value
+            }
         }
     }
 


### PR DESCRIPTION
Fix #3771
* Add support for Unix timestamps in  `Last-Modified` HTTP header
* Send `If-Unmodified-Since` in IMF-fixdate format instead of Unix timestamps
* If invalid, ignore `Last-Modified` HTTP header instead of raising an exception

See also:
* https://www.rfc-editor.org/rfc/rfc9110#http.date
* https://stackoverflow.com/questions/21120882/