### PR TITLE
Add 'itunes:duration' tag for items with duration

### DIFF
--- a/bridges/Arte7Bridge.php
+++ b/bridges/Arte7Bridge.php
@@ -156,6 +156,10 @@ class Arte7Bridge extends BridgeAbstract
             . $element['mainImage']['url']
             . '" /></a>';
 
+            $item['itunes'] = [
+                'duration' => $durationSeconds,
+            ];
+
             $this->items[] = $item;
         }
     }

--- a/formats/AtomFormat.php
+++ b/formats/AtomFormat.php
@@ -147,11 +147,13 @@ class AtomFormat extends FormatAbstract
                     $entry->appendChild($itunesProperty);
                     $itunesProperty->appendChild($document->createTextNode($itunesValue));
                 }
-                $itunesEnclosure = $document->createElement('enclosure');
-                $entry->appendChild($itunesEnclosure);
-                $itunesEnclosure->setAttribute('url', $itemArray['enclosure']['url']);
-                $itunesEnclosure->setAttribute('length', $itemArray['enclosure']['length']);
-                $itunesEnclosure->setAttribute('type', $itemArray['enclosure']['type']);
+                if (isset($itemArray['enclosure'])) {
+                    $itunesEnclosure = $document->createElement('enclosure');
+                    $entry->appendChild($itunesEnclosure);
+                    $itunesEnclosure->setAttribute('url', $itemArray['enclosure']['url']);
+                    $itunesEnclosure->setAttribute('length', $itemArray['enclosure']['length']);
+                    $itunesEnclosure->setAttribute('type', $itemArray['enclosure']['type']);
+                }
             } elseif (!empty($entryUri)) {
                 $entryLinkAlternate = $document->createElement('link');
                 $entry->appendChild($entryLinkAlternate);

--- a/formats/MrssFormat.php
+++ b/formats/MrssFormat.php
@@ -135,11 +135,13 @@ class MrssFormat extends FormatAbstract
                     $entry->appendChild($itunesProperty);
                     $itunesProperty->appendChild($document->createTextNode($itunesValue));
                 }
-                $itunesEnclosure = $document->createElement('enclosure');
-                $entry->appendChild($itunesEnclosure);
-                $itunesEnclosure->setAttribute('url', $itemArray['enclosure']['url']);
-                $itunesEnclosure->setAttribute('length', $itemArray['enclosure']['length']);
-                $itunesEnclosure->setAttribute('type', $itemArray['enclosure']['type']);
+                if (isset($itemArray['enclosure'])) {
+                    $itunesEnclosure = $document->createElement('enclosure');
+                    $entry->appendChild($itunesEnclosure);
+                    $itunesEnclosure->setAttribute('url', $itemArray['enclosure']['url']);
+                    $itunesEnclosure->setAttribute('length', $itemArray['enclosure']['length']);
+                    $itunesEnclosure->setAttribute('type', $itemArray['enclosure']['type']);
+                }
             } if (!empty($itemUri)) {
                 $entryLink = $document->createElement('link');
                 $entry->appendChild($entryLink);


### PR DESCRIPTION
Support items with a duration by adding an `$item['itunes']['duration']` value and render it in Atom and Mrss formats. This PR adds it only to the Arte7 bridge, but other bridges may find this useful as well.

Atom and Mrss feeds currently require an 'enclosure' array to be set in the item if an 'itunes' array is present. Remove this requirement so that items without an enclosure can have a duration in the output.

(My previous PR #2801 was closed as fixed, but the solution there falls a bit short on what I need, so here's another try.)
