### PR TITLE
[html] add data-orig-file attribute

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -249,7 +249,7 @@ function convertLazyLoading($dom)
     // Example: convert "header640.png 640w, header960.png 960w, header1024.png 1024w" to "header1024.png"
     $srcset_to_src = function ($srcset) {
         $sources = explode(',', $srcset);
-        $last_entry = trim(end($sources));
+        $last_entry = trim($sources[array_key_last($sources)]);
         $url = explode(' ', $last_entry)[0];
         return $url;
     };
@@ -262,12 +262,15 @@ function convertLazyLoading($dom)
             $img->src = $srcset_to_src($img->getAttribute('data-srcset'));
         } elseif (!empty($img->getAttribute('data-lazy-src'))) {
             $img->src = $img->getAttribute('data-lazy-src');
+        } elseif (!empty($img->getAttribute('data-orig-file'))) {
+            $img->src = $img->getAttribute('data-orig-file');
         } elseif (!empty($img->getAttribute('srcset'))) {
             $img->src = $srcset_to_src($img->getAttribute('srcset'));
         } else {
             continue; // Proceed to next element without removing attributes
         }
-        foreach (['loading', 'decoding', 'srcset', 'data-src', 'data-srcset'] as $attr) {
+        // Remove attributes that may be processed by the client (data-* are not)
+        foreach (['loading', 'decoding', 'srcset'] as $attr) {
             if ($img->hasAttribute($attr)) {
                 $img->removeAttribute($attr);
             }
@@ -284,7 +287,7 @@ function convertLazyLoading($dom)
                 $img->tag = 'img';
             }
             // Adding/removing node would change its position inside the parent element,
-            // So instead we rewrite the node in-place though the outertext attribute
+            // So instead we rewrite the node in-place through the outertext attribute
             $picture->outertext = $img->outertext;
         }
     }


### PR DESCRIPTION
* Add support for `data-orig-file` attribute used in some WordPress sites
* Remplace `end()` with `array_key_last()` as discussed in #3769
* Fix typo in comment