### PR TITLE
Add one-click install to PikaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Browse http://localhost:3000/
 [![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/sebsauvage/rss-bridge)
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 [![Deploy to Cloudron](https://cloudron.io/img/button.svg)](https://www.cloudron.io/store/com.rssbridgeapp.cloudronapp.html)
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=rssbridge)
 
 The Heroku quick deploy currently does not work. It might possibly work if you fork this repo and
 modify the `repository` in `scalingo.json`. See https://github.com/RSS-Bridge/rss-bridge/issues/2688


### PR DESCRIPTION
Over at [PikaPods.com](https://www.pikapods.com/), we are on a mission to make great open source apps, like RSS-Bridge more accessible and simpler to get started with.

We already [offer](https://www.pikapods.com/pods?run=rssbridge) RSS-Bridge in our “app store” and fine-tuned our deployment based on the feedback we got from users.

So I'm suggesting to add PikaPods as additional install option in the README. This would help an even wider audience to benefit from the project.

Preview: https://github.com/m3nu/rss-bridge/tree/add-pikapods#other-installation-methods

Thanks for the consideration!

