### PR TITLE
[Itaku] extend the number of images shown in a post

### DIFF
--- a/bridges/ItakuBridge.php
+++ b/bridges/ItakuBridge.php
@@ -201,7 +201,7 @@ class ItakuBridge extends BridgeAbstract
                 'rating_e' => $this->getInput('rating_e')
             ];
 
-            $tag_arr = explode(' ', $this->getInput('tags'));
+            $tag_arr = explode(' ', $this->getInput('tags') ?? '');
             foreach ($tag_arr as $str) {
                 switch ($str[0]) {
                     case '-':

--- a/bridges/ItakuBridge.php
+++ b/bridges/ItakuBridge.php
@@ -446,6 +446,9 @@ class ItakuBridge extends BridgeAbstract
 
     private function getPost($id, array $metadata = null)
     {
+        if(sizeof($metadata['gallery_images']) < $metadata['num_images']){
+            $metadata = null; //force re-fetch of metadata
+        }
         $uri = self::URI . '/posts/' . $id;
         $url = self::URI . '/api/posts/' . $id . '/?format=json';
         $data = $metadata ?? $this->getData($url, true, true)

--- a/bridges/ItakuBridge.php
+++ b/bridges/ItakuBridge.php
@@ -446,7 +446,7 @@ class ItakuBridge extends BridgeAbstract
 
     private function getPost($id, array $metadata = null)
     {
-        if(sizeof($metadata['gallery_images']) < $metadata['num_images']){
+        if (sizeof($metadata['gallery_images']) < $metadata['num_images']) {
             $metadata = null; //force re-fetch of metadata
         }
         $uri = self::URI . '/posts/' . $id;

--- a/bridges/ItakuBridge.php
+++ b/bridges/ItakuBridge.php
@@ -446,7 +446,7 @@ class ItakuBridge extends BridgeAbstract
 
     private function getPost($id, array $metadata = null)
     {
-        if (sizeof($metadata['gallery_images']) < $metadata['num_images']) {
+        if (isset($metadata) && sizeof($metadata['gallery_images']) < $metadata['num_images']) {
             $metadata = null; //force re-fetch of metadata
         }
         $uri = self::URI . '/posts/' . $id;


### PR DESCRIPTION
When fetching a user's feed, their post may not show all the images attached with the post. This small PR fixes this.