### PR TITLE
[html] clean data attributes

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -269,7 +269,15 @@ function convertLazyLoading($dom)
         } else {
             continue; // Proceed to next element without removing attributes
         }
-        // Remove attributes that may be processed by the client (data-* are not)
+
+        // Remove data attributes, no longer necessary
+        foreach ($img->getAllAttributes() as $attr => $val) {
+            if (str_starts_with($attr, 'data-')) {
+                $img->removeAttribute($attr);
+            }
+        }
+
+        // Remove other attributes that may be processed by the client
         foreach (['loading', 'decoding', 'srcset'] as $attr) {
             if ($img->hasAttribute($attr)) {
                 $img->removeAttribute($attr);


### PR DESCRIPTION
Some feed readers such as [FeedMe](https://github.com/seazon/FeedMe) had difficulties with attributes containing html tags:

https://hackaday.com/2023/10/19/new-type-of-ferroelectric-memory-constructed-using-%ce%b1-in2se3-material/

![Screenshot_20231020-152835_FeedMe_1](https://github.com/RSS-Bridge/rss-bridge/assets/1128206/c105ece4-2c0b-4623-9be1-d03620a09f7c)
