### PR TITLE
display feed icons on frontpage

### DIFF
--- a/actions/FeedIconAction.php
+++ b/actions/FeedIconAction.php
@@ -98,7 +98,8 @@ class FeedIconAction implements ActionInterface
     {
         $context = stream_context_create([
             'http' => [
-                'timeout' => 10,
+                'timeout' => 5,
+                'user_agent' => Configuration::getConfig('http', 'useragent'),
             ],
         ]);
 

--- a/actions/FeedIconAction.php
+++ b/actions/FeedIconAction.php
@@ -28,8 +28,7 @@ class FeedIconAction implements ActionInterface
 
         if ($imageData && $mimeType) {
             $this->sendImageResponse($mimeType, $imageData);
-        }
-        elseif('' === $imageData && '' === $mimeType) {
+        } elseif ('' === $imageData && '' === $mimeType) {
             // empty values means that the image was broken and could not be loaded
             $this->sendNotFoundResponse();
         }

--- a/actions/FeedIconAction.php
+++ b/actions/FeedIconAction.php
@@ -11,63 +11,119 @@ class FeedIconAction implements ActionInterface
         $this->bridgeFactory = new BridgeFactory();
     }
 
-    public function execute(array $request)
+    public function execute(array $request): void
     {
         $bridgeClassName = $request['bridgeClassName'] ?? null;
 
-        if (!$bridgeClassName) {
+        if (!$bridgeClassName || !class_exists($bridgeClassName)) {
             $this->sendNotFoundResponse();
         }
 
         $cacheKey = $this->buildCacheKey($bridgeClassName);
 
-        if ($cachedImageData = $this->cache->get($cacheKey)) {
-            $mimeType = $this->cache->get($cacheKey . 'mimeType');
-            if ($mimeType) {
-                $this->sendImageResponse($mimeType, $cachedImageData);
-            }
+        list(
+            'imageData' => $imageData,
+            'mimeType' => $mimeType
+        ) = $this->readCache($cacheKey);
+
+        if ($imageData && $mimeType) {
+            $this->sendImageResponse($mimeType, $imageData);
+        }
+        elseif('' === $imageData && '' === $mimeType) {
+            // empty values means that the image was broken and could not be loaded
+            $this->sendNotFoundResponse();
         }
 
         $bridge = $this->bridgeFactory->create($bridgeClassName);
-        $image_url = $bridge->getIcon();
+        $imageUrl = $bridge->getIcon();
 
-        if (!filter_var($image_url, FILTER_VALIDATE_URL)) {
+        $imageUrl = $this->cleanImageUrl($imageUrl);
+
+        if (!filter_var($imageUrl, FILTER_VALIDATE_URL)) {
+            //store empty values to prevent further attempts to load broken image
+            $this->writeCache($cacheKey, '', '');
             $this->sendNotFoundResponse();
         }
 
-        $image_data = file_get_contents($image_url);
+        list(
+            'imageData' => $imageData,
+            'mimeType' => $mimeType
+        ) = $this->readImageData($imageUrl);
 
-        if ($image_data === false) {
+        if (false === $imageData || false === $mimeType) {
+            //store empty values to prevent further attempts to load broken image
+            $this->writeCache($cacheKey, '', '');
             $this->sendNotFoundResponse();
         }
 
-        $image_info = getimagesize($image_url);
-        if ($image_info === false) {
-            $this->sendNotFoundResponse();
-        }
-
-        $mimeType = $image_info['mime'];
-        $this->cache->set($cacheKey . 'mimeType', $mimeType);
-        $this->cache->set($cacheKey, $image_data);
-
-        $this->sendImageResponse($mimeType, $image_data);
+        $this->writeCache($cacheKey, $mimeType, $imageData);
+        $this->sendImageResponse($mimeType, $imageData);
     }
 
-    private function sendNotFoundResponse()
+    private function sendNotFoundResponse(): void
     {
         header('HTTP/1.1 404 Not Found');
         exit;
     }
 
-    private function sendImageResponse($mimeType, $imageData)
+    private function sendImageResponse(string $mimeType, string $imageData): void
     {
         header('Content-Type: ' . $mimeType);
         echo $imageData;
         exit;
     }
 
-    public function buildCacheKey($bridgeClassName): string
+    private function buildCacheKey(string $bridgeClassName): string
     {
         return md5($bridgeClassName . 'icon');
+    }
+
+    private function cleanImageUrl(string $imageUrl): string
+    {
+        //negative look behind: replace duplicate slashes in path, but not in protocol part of uri
+        $imageUrl = preg_replace('~(?<!:)//~', '/', $imageUrl);
+        return str_replace(["\r", "\n"], '', $imageUrl);
+    }
+
+    private function writeCache(string $cacheKey, string $mimeType, string $imageData): void
+    {
+        $this->cache->set($cacheKey, ['imageData' => $imageData, 'mimeType' => $mimeType]);
+    }
+
+    private function readCache(string $cacheKey): array
+    {
+        return (array)$this->cache->get($cacheKey);
+    }
+
+    private function readImageData(string $imageUrl): array
+    {
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 10,
+            ],
+        ]);
+
+        $handle = @fopen($imageUrl, 'r', false, $context);
+
+        if ($handle === false) {
+            return ['imageData' => false, 'mimeType' => false];
+        }
+        $metaData = stream_get_meta_data($handle);
+        $headers = $metaData['wrapper_data'];
+
+        $contentType = false;
+
+        foreach ($headers as $header) {
+            if (stripos($header, 'Content-Type:') === 0) {
+                $contentType = trim(substr($header, 13)); // 13 is the length of "Content-Type:"
+                break;
+            }
+        }
+
+        $imageData = stream_get_contents($handle);
+
+        fclose($handle);
+
+        return ['imageData' => $imageData, 'mimeType' => $contentType];
     }
 }

--- a/actions/FeedIconAction.php
+++ b/actions/FeedIconAction.php
@@ -1,0 +1,73 @@
+<?php
+
+class FeedIconAction implements ActionInterface
+{
+    private CacheInterface $cache;
+    private BridgeFactory $bridgeFactory;
+
+    public function __construct()
+    {
+        $this->cache = RssBridge::getCache();
+        $this->bridgeFactory = new BridgeFactory();
+    }
+
+    public function execute(array $request)
+    {
+        $bridgeClassName = $request['bridgeClassName'] ?? null;
+
+        if (!$bridgeClassName) {
+            $this->sendNotFoundResponse();
+        }
+
+        $cacheKey = $this->buildCacheKey($bridgeClassName);
+
+        if ($cachedImageData = $this->cache->get($cacheKey)) {
+            $mimeType = $this->cache->get($cacheKey . 'mimeType');
+            if ($mimeType) {
+                $this->sendImageResponse($mimeType, $cachedImageData);
+            }
+        }
+
+        $bridge = $this->bridgeFactory->create($bridgeClassName);
+        $image_url = $bridge->getIcon();
+
+        if (!filter_var($image_url, FILTER_VALIDATE_URL)) {
+            $this->sendNotFoundResponse();
+        }
+
+        $image_data = file_get_contents($image_url);
+
+        if ($image_data === false) {
+            $this->sendNotFoundResponse();
+        }
+
+        $image_info = getimagesize($image_url);
+        if ($image_info === false) {
+            $this->sendNotFoundResponse();
+        }
+
+        $mimeType = $image_info['mime'];
+        $this->cache->set($cacheKey . 'mimeType', $mimeType);
+        $this->cache->set($cacheKey, $image_data);
+
+        $this->sendImageResponse($mimeType, $image_data);
+    }
+
+    private function sendNotFoundResponse()
+    {
+        header('HTTP/1.1 404 Not Found');
+        exit;
+    }
+
+    private function sendImageResponse($mimeType, $imageData)
+    {
+        header('Content-Type: ' . $mimeType);
+        echo $imageData;
+        exit;
+    }
+
+    public function buildCacheKey($bridgeClassName): string
+    {
+        return md5($bridgeClassName . 'icon');
+    }
+}

--- a/actions/FrontpageAction.php
+++ b/actions/FrontpageAction.php
@@ -23,11 +23,10 @@ final class FrontpageAction implements ActionInterface
 
         $body = '';
         foreach ($bridgeClassNames as $bridgeClassName) {
-            if ($bridgeFactory->isEnabled($bridgeClassName)) {
-                $body .= BridgeCard::displayBridgeCard($bridgeClassName, $formats);
-                $activeBridges++;
-            } elseif ($showInactive) {
-                $body .= BridgeCard::displayBridgeCard($bridgeClassName, $formats, false) . PHP_EOL;
+            $isEnabled = $bridgeFactory->isEnabled($bridgeClassName);
+            if ($isEnabled || $showInactive) {
+                $body .= BridgeCard::displayBridgeCard($bridgeClassName, $formats, $isEnabled) . PHP_EOL;
+                $activeBridges += (int)$isEnabled;
             }
         }
 

--- a/bridges/BlizzardNewsBridge.php
+++ b/bridges/BlizzardNewsBridge.php
@@ -57,4 +57,11 @@ class BlizzardNewsBridge extends XPathAbstract
         }
         return 'https://news.blizzard.com/' . $locale;
     }
+
+    public function getIcon()
+    {
+        return <<<icon
+https://blznews.akamaized.net/images/favicon-cb34a003c6f2f637ee8f4f7b406f3b9b120b918c04cabec7f03a760e708977ea9689a1c638f4396def8dce7b202cd007eae91946cc3c4a578aa8b5694226cfc6.ico
+icon;
+    }
 }

--- a/bridges/NiusBridge.php
+++ b/bridges/NiusBridge.php
@@ -23,6 +23,11 @@ class NiusBridge extends XPathAbstract
     const XPATH_EXPRESSION_ITEM_CATEGORIES = './/div[@class="subtitle"]/text()';
     const SETTING_FIX_ENCODING = false;
 
+    public function getIcon()
+    {
+        return 'https://www.nius.de/favicon.ico';
+    }
+
     protected function formatItemTitle($value)
     {
         return strip_tags($value);

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -20,7 +20,7 @@ final class BridgeCard
 
         $uri = $bridge->getURI();
         $name = $bridge->getName();
-        $icon = $_SERVER['PHP_SELF'] . '?action=FeedIcon&bridgeClassName=' . $bridgeClassName;
+        $icon = self::hasBrokenIcon($bridgeClassName) ? '' : $_SERVER['PHP_SELF'] . '?action=FeedIcon&bridgeClassName=' . $bridgeClassName;
         $description = $bridge->getDescription();
         $parameters = $bridge->getParameters();
         if (Configuration::getConfig('proxy', 'url') && Configuration::getConfig('proxy', 'by_bridge')) {
@@ -370,5 +370,15 @@ This bridge is not fetching its content through a secure connection</div>';
         . ($entry['defaultValue'] === 'checked' ? 'checked' : '')
         . ' />'
         . PHP_EOL;
+    }
+
+    private static function hasBrokenIcon(string $bridgeClassName): bool
+    {
+        $logger = RssBridge::getLogger();
+        $cacheFactory = new CacheFactory($logger);
+        $cache = $cacheFactory->create();
+        $cacheKey = md5($bridgeClassName . 'icon');
+        $cachedImage = (array)$cache->get($cacheKey);
+        return isset($cachedImage['imageData']) && '' === $cachedImage['imageData'] && isset($cachedImage['mimeType']) && '' === $cachedImage['mimeType'];
     }
 }

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -20,7 +20,7 @@ final class BridgeCard
 
         $uri = $bridge->getURI();
         $name = $bridge->getName();
-        $icon = $bridge->getIcon();
+        $icon = $_SERVER['PHP_SELF'] . '?action=FeedIcon&bridgeClassName=' . $bridgeClassName;
         $description = $bridge->getDescription();
         $parameters = $bridge->getParameters();
         if (Configuration::getConfig('proxy', 'url') && Configuration::getConfig('proxy', 'by_bridge')) {

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -47,7 +47,7 @@ final class BridgeCard
                     data-short-name="$shortName"
                 >
 
-                <h2><a href="{$uri}">{$name}</a></h2>
+                <h2><img src="{$icon}" onerror="this.style.display='none'" /><a href="{$uri}">{$name}</a></h2>
                 <p class="description">{$description}</p>
                 <input type="checkbox" class="showmore-box" id="showmore-{$bridgeClassName}" />
                 <label class="showmore" for="showmore-{$bridgeClassName}">Show more</label>

--- a/lib/Debug.php
+++ b/lib/Debug.php
@@ -8,9 +8,10 @@ class Debug
     public static function isEnabled(): bool
     {
         $ip = $_SERVER['REMOTE_ADDR'] ?? 'x.y.z.1';
+        $isIconRequest = isset($_REQUEST['action']) && 'FeedIcon' === $_REQUEST['action'];
         $enableDebugMode = Configuration::getConfig('system', 'enable_debug_mode');
         $debugModeWhitelist = Configuration::getConfig('system', 'debug_mode_whitelist') ?: [];
-        if ($enableDebugMode && ($debugModeWhitelist === [] || in_array($ip, $debugModeWhitelist))) {
+        if ($enableDebugMode && !$isIconRequest && ($debugModeWhitelist === [] || in_array($ip, $debugModeWhitelist))) {
             return true;
         }
         return false;

--- a/static/style.css
+++ b/static/style.css
@@ -182,6 +182,11 @@ section > h2 {
     font-weight: bold;
     text-align: center;
 }
+section > h2 img {
+    height: 1em;
+    margin-right: 10px;
+}
+
 section li {
     margin-left: 1em;
 }


### PR DESCRIPTION
This PR adds the display of the icon of each bridge on the front page of rss bridge. If the icon uri cannot be resolved, the icon will be hidden.
The code change in `FrontpageAction.php` is just a small refactoring and is optional.