### PR TITLE
[SchweinfurtBuergerinformationenBridge] Don't include images with data URIs as enclosures

### DIFF
--- a/bridges/SchweinfurtBuergerinformationenBridge.php
+++ b/bridges/SchweinfurtBuergerinformationenBridge.php
@@ -107,9 +107,9 @@ class SchweinfurtBuergerinformationenBridge extends BridgeAbstract
             ];
 
         // Let's see if there are images in the content, and if yes, attach
-        // them as enclosures, but not images which are used for linking to an external site.
+        // them as enclosures, but not images which are used for linking to an external site and data URIs.
         foreach ($images as $image) {
-            if ($image->class != 'imgextlink') {
+            if ($image->class != 'imgextlink' && parse_url($image->src, PHP_URL_SCHEME) != 'data') {
                 $item['enclosures'][] = $image->src;
             }
         }


### PR DESCRIPTION
The website started using [data URIs](https://en.wikipedia.org/wiki/Data_URI_scheme) in images, which won't work here, so these cases are filtered out.

See also [setEnclosures() in FeedItem.php](https://github.com/RSS-Bridge/rss-bridge/blob/609eed1791598a798e7f94ac694d014605ec11ee/lib/FeedItem.php#L222-L229): URIs with a path are required.