### PR TITLE
[FindfeedAction.php] Use relative URL in Feed Link

### DIFF
--- a/actions/FindfeedAction.php
+++ b/actions/FindfeedAction.php
@@ -56,7 +56,7 @@ class FindfeedAction implements ActionInterface
             $bridgeParams['bridge'] = $bridgeClassName;
             $bridgeParams['format'] = $format;
             $content = [
-                'url' => get_home_page_url() . '?action=display&' . http_build_query($bridgeParams),
+                'url' => './?action=display&' . http_build_query($bridgeParams),
                 'bridgeParams' => $bridgeParams,
                 'bridgeData' => $bridgeData,
                 'bridgeMeta' => [


### PR DESCRIPTION
The FindFeed action used absolute URL. This breaks the usage of RSS Bridge behind a reverse proxy in a container.

Fixes #3801 for the Find Feed action