### PR TITLE
Update GolemBridge.php

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -82,11 +82,6 @@ class GolemBridge extends FeedExpander
             // URI without RSS feed reference
             $item['uri'] = $articlePage->find('head meta[name="twitter:url"]', 0)->content;
 
-            $author = $articlePage->find('article header .authors .authors__name', 0);
-            if ($author) {
-                $item['author'] = $author->plaintext;
-            }
-
             $categories = $articlePage->find('ul.tags__list li');
             foreach ($categories as $category) {
                 $trimmedcategories[] = trim(html_entity_decode($category->plaintext));


### PR DESCRIPTION
Deleted the code which adds the author to the feed, because the author is already in the original feed, so it is not needed.

With the code included, authors sometimes are written like this, which breaks some rss-reader and they can't parse the rss anymore:
```
      <name>Tobias K&amp;ouml;ltzsch/dpa</name>
```
With the code deleted, they are written correctly:
```
      <name>Tobias Költzsch/dpa</name>
```