### PR TITLE
[GolemBridge] Add h2 elements from article content

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -132,7 +132,7 @@ class GolemBridge extends FeedExpander
             $img->src = $img->getAttribute('data-src-full');
         }
 
-        foreach ($content->find('p, h1, h3, img[src*="."]') as $element) {
+        foreach ($content->find('p, h1, h2, h3, img[src*="."]') as $element) {
             $item .= $element;
         }
 


### PR DESCRIPTION
Else some headers are just missing.
Example article with previously missing movie names: https://www.golem.de/news/science-fiction-die-zehn-besten-filme-aus-den-spannenden-70ern-2312-179557.html