### PR TITLE
[GolemBridge] Remove multi-page page headers

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -116,9 +116,6 @@ class GolemBridge extends FeedExpander
         // reload html, as remove() is buggy
         $article = str_get_html($article->outertext);
 
-        if ($pageHeader = $article->find('header.paged-cluster-header h1', 0)) {
-            $item .= $pageHeader;
-        }
 
         $header = $article->find('header', 0);
         foreach ($header->find('p, figure') as $element) {


### PR DESCRIPTION
On multi-page articles like [1], all the pages after the first one have a page header that we add in the article content. When we tack the pages together again, we don't need those extra page headers.

[1] https://www.golem.de/news/science-fiction-die-zehn-besten-filme-aus-den-spannenden-70ern-2312-179557.html