### PR TITLE
Load a config file from environment variable

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,8 +12,12 @@ if ($errors) {
 }
 
 $customConfig = [];
-if (file_exists(__DIR__ . '/config.ini.php')) {
-    $customConfig = parse_ini_file(__DIR__ . '/config.ini.php', true, INI_SCANNER_TYPED);
+$customConfigPath = __DIR__ . '/config.ini.php';
+if (getenv('RSSBRIDGE_CONFIG') !== false) {
+    $customConfigPath = getenv('RSSBRIDGE_CONFIG');
+}
+if (file_exists($customConfigPath)) {
+    $customConfig = parse_ini_file($customConfigPath, true, INI_SCANNER_TYPED);
 }
 Configuration::loadConfiguration($customConfig, getenv());
 


### PR DESCRIPTION
The environment variable RSSBRIDGE_CONFIG, if set, is used as file path instead of the default config.ini.php in the document root. This allows having a read-only document root and still setting custom configuration options. In particular, this helps NixOS which patched the code previously (ref https://github.com/NixOS/nixpkgs/blob/23.11/pkgs/servers/web-apps/rss-bridge/paths.patch ).

An alternative would be setting the config options as environment variables. But coercing arrays in comma-separated lists and escaping special symbols can easily lead to errors. Using an ini file is easier for NixOS (see https://github.com/NixOS/nixpkgs/pull/223148 if you're interested).