### PR TITLE
RumbleBridge - new selector needed on user/channel page

### DIFF
--- a/bridges/RumbleBridge.php
+++ b/bridges/RumbleBridge.php
@@ -39,7 +39,7 @@ class RumbleBridge extends BridgeAbstract
         }
 
         $dom = getSimpleHTMLDOM($url);
-        foreach ($dom->find('li.video-listing-entry') as $video) {
+        foreach ($dom->find('ol.thumbnail__grid div.thumbnail__grid--item') as $video) {
             $datetime = $video->find('time', 0)->getAttribute('datetime');
 
             $this->items[] = [


### PR DESCRIPTION
`$dom->find('li.video-listing-entry')` wasn't working for me when I tried it. (I'm a new user, today.)

Changed it to `$dom->find('ol.thumbnail__grid div.thumbnail__grid--item')` and that seems to do the trick.