### PR TITLE
Update GolemBridge.php

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -113,6 +113,15 @@ class GolemBridge extends FeedExpander
         ) {
             $bad->remove();
         }
+
+       //delete data-src from all images, which otherwise breaks the feed for some readers
+       foreach (
+            $article->find('img') as $img
+        ) {
+            $img->removeAttribute('data-src');
+            $img->removeAttribute('data-src-full');
+        }
+
         // reload html, as remove() is buggy
         $article = str_get_html($article->outertext);
 

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -114,8 +114,8 @@ class GolemBridge extends FeedExpander
             $bad->remove();
         }
 
-       //delete data-src from all images, which otherwise breaks the feed for some readers
-       foreach (
+        //delete data-src from all images, which otherwise breaks the feed for some readers
+        foreach (
             $article->find('img') as $img
         ) {
             $img->removeAttribute('data-src');


### PR DESCRIPTION
delete data-src and data-src-full from all images, which otherwise breaks the feed (at least for some readers)

At the moment the feed is broken if an image contains the attribute `data-src` or `data-src-full`, 
I checked with some feed-validators:
`content should not contain data-src attribute`
`content should not contain data-src-full attribute `

All the images still have a src-attribute so they are still displayed, even without `data-src`.

I already tested it and without the attributes, the feed is working again.