### PR TITLE
Docker fix default fastcgi.logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV CURL_IMPERSONATE ff91esr
 
 COPY ./config/nginx.conf /etc/nginx/sites-available/default
 COPY ./config/php-fpm.conf /etc/php/8.2/fpm/pool.d/rss-bridge.conf
-COPY ./config/php.ini /etc/php/8.2/fpm/conf.d/90-rss-bridge.conf
+COPY ./config/php.ini /etc/php/8.2/fpm/conf.d/90-rss-bridge.ini
 
 COPY --chown=www-data:www-data ./ /app/
 

--- a/config/php.ini
+++ b/config/php.ini
@@ -1,4 +1,4 @@
 ; Inspired by https://github.com/docker-library/php/blob/master/8.2/bookworm/fpm/Dockerfile
 
-; https://github.com/docker-library/php/issues/878#issuecomment-938595965'
+; https://github.com/docker-library/php/issues/878#issuecomment-938595965
 fastcgi.logging = Off


### PR DESCRIPTION
Mistake from https://github.com/RSS-Bridge/rss-bridge/pull/3500
Wrong file extension: should have been `.ini` and not `.conf` otherwise it has no effect.
See https://github.com/docker-library/php/pull/1360 and https://github.com/docker-library/php/issues/878#issuecomment-938595965