### PR TITLE
[PepperBridgeAbstract, DealabsBridge, HotUKDealsBridge, MydealsBridge] Fix the Deal source link

### DIFF
--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1910,6 +1910,7 @@ class DealabsBridge extends PepperBridgeAbstract
         'context-talk' => 'Surveillance Discussion',
         'uri-group' => 'groupe/',
         'uri-deal' => 'bons-plans/',
+        'uri-merchant' => 'search/bons-plans?merchant-id=',
         'request-error' => 'Impossible de joindre Dealabs',
         'thread-error' => 'Impossible de déterminer l\'ID de la discussion. Vérifiez l\'URL que vous avez entré',
         'no-results' => 'Il n&#039;y a rien à afficher pour le moment :(',

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -3274,6 +3274,7 @@ class HotUKDealsBridge extends PepperBridgeAbstract
         'context-talk' => 'Discussion Monitoring',
         'uri-group' => 'tag/',
         'uri-deal' => 'deals/',
+        'uri-merchant' => 'search/deals?merchant-id=',
         'request-error' => 'Could not request HotUKDeals',
         'thread-error' => 'Unable to determine the thread ID. Check the URL you entered',
         'no-results' => 'Ooops, looks like we could',

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -2021,6 +2021,7 @@ class MydealsBridge extends PepperBridgeAbstract
         'context-talk' => 'Überwachung Diskussion',
         'uri-group' => 'gruppe/',
         'uri-deal' => 'deals/',
+        'uri-merchant' => 'search/gutscheine?merchant-id=',
         'request-error' => 'Could not request mydeals',
         'thread-error' => 'Die ID der Diskussion kann nicht ermittelt werden. Überprüfen Sie die eingegebene URL',
         'no-results' => 'Ups, wir konnten nichts',


### PR DESCRIPTION
The HTML does not contain the link to the "Deal source" anymore, now only an deal HTML attribute does contain the information about the Deal Source.

The JSON data is now extracted for each Deal, and used to get the Temperature and Deal Source.