### PR TITLE
fix(spotify): deprecation notice

### DIFF
--- a/bridges/SpotifyBridge.php
+++ b/bridges/SpotifyBridge.php
@@ -317,8 +317,10 @@ class SpotifyBridge extends BridgeAbstract
 
     private function getFirstEntry()
     {
-        $uris = explode(',', $this->getInput('spotifyuri'));
-        if (!is_null($this->getInput('spotifyuri')) && strpos($this->getInput('spotifyuri'), ',') === false) {
+        $spotifyUri = $this->getInput('spotifyuri');
+
+        if (!is_null($spotifyUri) && strpos($spotifyUri, ',') === false) {
+            $uris = explode(',', $spotifyUri);
             $firstUri = $uris[0];
             $type = explode(':', $firstUri)[1];
             $spotifyId = explode(':', $firstUri)[2];


### PR DESCRIPTION
8192: explode(): Passing null to parameter #2 ($string) of type string is deprecated in bridges/SpotifyBridge.php line 322