### PR TITLE
fix(OLX): deprecation notice

### DIFF
--- a/bridges/OLXBridge.php
+++ b/bridges/OLXBridge.php
@@ -56,7 +56,13 @@ EOF;
 
     public function getName()
     {
-        $paths = explode('/', parse_url($this->getInput('url'), PHP_URL_PATH));
+        $url = $this->getInput('url');
+        if (!$url) {
+            return parent::getName();
+        }
+
+        $parsedUrl = Url::fromString($url);
+        $paths = explode('/', $parsedUrl->getPath());
 
         $query = array_reduce($paths, function ($q, $p) {
             if (preg_match('/^q-(.+)$/i', $p, $matches)) {


### PR DESCRIPTION
fixes:

8192: parse_url(): Passing null to parameter #1 ($url) of type string is deprecated in bridges/OLXBridge.php line 59