### PR TITLE
[prtester.py] Fix: Only select actual "option" elements of "select" elements

### DIFF
--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -87,7 +87,8 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                 selectionvalue = ''
                 listname = listing.get('name')
                 cleanlist = []
-                for option in listing.contents:
+                options = listing.find_all('option')
+                for option in options:
                     if 'optgroup' in option.name:
                         cleanlist.extend(option)
                     else:


### PR DESCRIPTION
This PR will fix the "TypeError: argument of type 'NoneType' is not iterable" error in `prtester.py` (first noticed in #3930).

The script iterates thought each child element and expects them to all be an `option` element. Since [#3924](https://github.com/RSS-Bridge/rss-bridge/pull/3924/files#diff-faa4e59a3e844638e3543617437b3bbc2f967003af16029d2bc7c2eaa7b3b885L248), every `option` now has an additional `\n` causing this error.

With this PR the script will only iterates thought actual `option` element.