### PR TITLE
Two fixes to DeutscheWelle

### DIFF
--- a/bridges/DeutscheWelleBridge.php
+++ b/bridges/DeutscheWelleBridge.php
@@ -112,6 +112,13 @@ class DeutscheWelleBridge extends FeedExpander
             $img->height = null;
         }
 
+        // remove bad img src's added by defaultLinkTo() above
+        // these images should have src="" and will then use
+        // the srcset attribute to load the best image for the displayed size
+        foreach ($article->find('figure > picture > img') as $img) {
+            $img->src = '';
+        }
+
         // replace lazy-loaded images
         foreach ($article->find('figure.placeholder-image') as $figure) {
             $img = $figure->find('img', 0);

--- a/bridges/DeutscheWelleBridge.php
+++ b/bridges/DeutscheWelleBridge.php
@@ -73,12 +73,12 @@ class DeutscheWelleBridge extends FeedExpander
 
     protected function parseItem(array $item)
     {
-        $parsedUrl = parse_url($item['uri']);
-        unset($parsedUrl['query']);
-        $url = $this->unparseUrl($parsedUrl);
+        $parsedUri = parse_url($item['uri']);
+        unset($parsedUri['query']);
+        $item['uri'] = $this->unparseUrl($parsedUri);
 
-        $page = getSimpleHTMLDOM($url);
-        $page = defaultLinkTo($page, $url);
+        $page = getSimpleHTMLDOM($item['uri']);
+        $page = defaultLinkTo($page, $item['uri']);
 
         $article = $page->find('article', 0);
 


### PR DESCRIPTION
This fixes two bugs from my original DeutscheWelle implementation.

1. Although I removed the tracking query string from later uses of the URI, I neglected to reset `$item['uri']`, so the tracking string remained in the main link to the item. This has been fixed.
2. The main "hero" images in the articles were not loading. This is because my call to `defaultLinkTo()` reset their `src`'s to the URI of the article instead of leaving them empty as is required for how DW structures these images. I have added code to reset the `src`'s after the call to `defaultLinkTo()`.