### PR TITLE
Update HeiseBridge.php

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -179,7 +179,7 @@ class HeiseBridge extends FeedExpander
             }
         }
 
-        $categories = $article->find('.article-footer__topics ul.topics li.topics__item');
+        $categories = $article->find('.article-footer__topics ul.topics li.topics__item a-topic a');
         foreach ($categories as $category) {
             $item['categories'][] = trim($category->plaintext);
         }


### PR DESCRIPTION
fix for broken article categories

heise changed the layout, so the categories weren't parsed correctly, 
e.g.: `Apple laden... Thema gefolgt Thema folgen Entfolgen` 
with the fix it's just `Apple` again