### PR TITLE
Magikh42 steam app news use app name

### DIFF
--- a/bridges/SteamAppNewsBridge.php
+++ b/bridges/SteamAppNewsBridge.php
@@ -2,136 +2,136 @@
 
 class SteamAppNewsBridge extends BridgeAbstract
 {
-		const NAME = 'Steam App News';
-		const URI = 'https://www.steamcommunity.com';
-		const DESCRIPTION = 'Get the latest news for a game on Steam.';
-		const MAINTAINER = 'otakuf';
-		const CACHE_TIMEOUT = 3600; // 1h
+    const NAME = 'Steam App News';
+    const URI = 'https://www.steamcommunity.com';
+    const DESCRIPTION = 'Get the latest news for a game on Steam.';
+    const MAINTAINER = 'otakuf';
+    const CACHE_TIMEOUT = 3600; // 1h
 
-		const PARAMETERS = [ [
-				'appid' => [
-						'name' => 'App ID',
-						'title' => 'App ID (only digits). Find your App ID with steamdb.info',
-						'type' => 'number',
-						'exampleValue' => '730',
-						'required' => true
-				],
-				'maxlength' => [
-						'name' => 'Max Length',
-						'title' => 'Maximum length for the content to return, 0 for full content',
-						'type' => 'number',
-						'defaultValue' => 0
-				],
-				'count' => [
-						'name' => 'Count',
-						'title' => '# of posts to retrieve (default 20)',
-						'type' => 'number',
-						'defaultValue' => 20
-				],
-				'use_app_name' => [
-						'name' => 'Use App Name as Author ?',
-						'title' => 'Use the app name as author',
-						'type' => 'checkbox',
-						'defaultValue' => 20
-				]
-		]];
+    const PARAMETERS = [ [
+        'appid' => [
+            'name' => 'App ID',
+            'title' => 'App ID (only digits). Find your App ID with steamdb.info',
+            'type' => 'number',
+            'exampleValue' => '730',
+            'required' => true
+        ],
+        'maxlength' => [
+            'name' => 'Max Length',
+            'title' => 'Maximum length for the content to return, 0 for full content',
+            'type' => 'number',
+            'defaultValue' => 0
+        ],
+        'count' => [
+            'name' => 'Count',
+            'title' => '# of posts to retrieve (default 20)',
+            'type' => 'number',
+            'defaultValue' => 20
+        ],
+        'use_app_name' => [
+            'name' => 'Use App Name as Author ?',
+            'title' => 'Use the app name as author',
+            'type' => 'checkbox',
+            'defaultValue' => 20
+        ]
+    ]];
 
-		public function collectData()
-		{
-				$api = 'https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/';
-				// Example with params: https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=730&maxlength=0&count=20
-				$details_api = 'https://store.steampowered.com/api/appdetails?appids=';
-				// API used to get app name from its appid
+    public function collectData()
+    {
+        $api = 'https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/';
+        // Example with params: https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=730&maxlength=0&count=20
+        $details_api = 'https://store.steampowered.com/api/appdetails?appids=';
+        // API used to get app name from its appid
 
-				// More info at dev docs https://partner.steamgames.com/doc/webapi/ISteamNews
-				$url = $api . '?appid='
-						. $this->getInput('appid') . '&maxlength='
-						. $this->getInput('maxlength') . '&count='
-						. $this->getInput('count');
+        // More info at dev docs https://partner.steamgames.com/doc/webapi/ISteamNews
+        $url = $api . '?appid='
+            . $this->getInput('appid') . '&maxlength='
+            . $this->getInput('maxlength') . '&count='
+            . $this->getInput('count');
 
-				// Get the JSON content
-				$json = getContents($url);
-				$json_list = json_decode($json, true);
+        // Get the JSON content
+        $json = getContents($url);
+        $json_list = json_decode($json, true);
 
-				// Get the app name
-				$app_details_json = getContents($details_api . $this->getInput('appid'));
-				$app_details_decoded_json = json_decode($app_details_json, true);
-				$this->app_name = $app_details_decoded_json[$this->getInput('appid')]['data']['name'];
+        // Get the app name
+        $app_details_json = getContents($details_api . $this->getInput('appid'));
+        $app_details_decoded_json = json_decode($app_details_json, true);
+        $this->app_name = $app_details_decoded_json[$this->getInput('appid')]['data']['name'];
 
-				foreach ($json_list['appnews']['newsitems'] as $json_item) {
-						$this->items[] = $this->collectArticle($json_item);
-				}
-		}
+        foreach ($json_list['appnews']['newsitems'] as $json_item) {
+            $this->items[] = $this->collectArticle($json_item);
+        }
+    }
 
-		private function collectArticle($json_item)
-		{
-				$item = [];
-				$item['uri'] = preg_replace('[ ]', '%20', $json_item['url']);
-				$item['title'] = $json_item['title'];
-				$item['timestamp'] = $json_item['date'];
-				if ($this->getInput('use_app_name') == "yes") {
-						$item['author'] = $this->app_name;
-				} else {
-						$item['author'] = $json_item['author'];
-				}
+    private function collectArticle($json_item)
+    {
+        $item = [];
+        $item['uri'] = preg_replace('[ ]', '%20', $json_item['url']);
+        $item['title'] = $json_item['title'];
+        $item['timestamp'] = $json_item['date'];
+        if ($this->getInput('use_app_name') == "yes") {
+            $item['author'] = $this->app_name;
+        } else {
+            $item['author'] = $json_item['author'];
+        }
 
-				# Fix /n
-				if (str_contains($item['uri'], 'steam_community_announcements')) {
-						$item['content'] = $this->replaceBBcodes($json_item['contents']);
-				} else {
-						$item['content'] = $json_item['contents'];
-				}
-				$item['uid'] = $json_item['gid'];
-				return $item;
-		}
+        # Fix /n
+        if (str_contains($item['uri'], 'steam_community_announcements')) {
+            $item['content'] = $this->replaceBBcodes($json_item['contents']);
+        } else {
+            $item['content'] = $json_item['contents'];
+        }
+        $item['uid'] = $json_item['gid'];
+        return $item;
+    }
 
-		private function replaceBBcodes($text)
-		{
-				//$text = strip_tags($text);
-				$text = nl2br($text);
-				// BBcode array, all list available: https://steamcommunity.com/comment/ForumTopic/formattinghelp
-				$find = [
-						'~\[h1\](.*?)\[/h1\]~s',
-						'~\[h2\](.*?)\[/h2\]~s',
-						'~\[h3\](.*?)\[/h3\]~s',
-						'~\[list\](.*?)\[/list\]~s',
-						'~\[olist\](.*?)\[/olist\]~s',
-						'~\[\*\]~s',
-						'~\[b\](.*?)\[/b\]~s',
-						'~\[i\](.*?)\[/i\]~s',
-						'~\[u\](.*?)\[/u\]~s',
-						'~\[strike\](.*?)\[/strike\]~s',
-						'~\[spoiler\](.*?)\[/spoiler\]~s',
-						'~\[noparse\](.*?)\[/noparse\]~s',
-						'~\[hr\]~s',
-						'~\[quote\](.*?)\[/quote\]~s',
-						'~\[code\](.*?)\[/code\]~s',
-						'~\{STEAM_CLAN_IMAGE\}~s',
-						'~\[url=([^"><]*?)\](.*?)\[/url\]~s',
-						'~\[img\](https?://[^"><]*?\.(?:jpg|jpeg|gif|png|bmp))\[/img\]~s'
-				];
-				// HTML tags to replace BBcode
-				$replace = [
-						'<h1>$1</h1>',
-						'<h2>$1</h2>',
-						'<h3>$1</h3>',
-						'<ul>$1</ul>',
-						'<ol>$1</ol>',
-						'<li>',
-						'<b>$1</b>',
-						'<i>$1</i>',
-						'<u>$1</u>',
-						'<s>$1</s>',
-						'$1', // Just remove spoiler
-						'$1', // Just remove noparse
-						'<hr>',
-						'<blockquote>$1</blockquote>',
-						'<code>$1</code>',
-						'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/clans',
-						'<a href="$1">$2</a>',
-						'<img src="$1" alt="" />'
-				];
-				// Replacing the BBcodes with corresponding HTML tags
-				return preg_replace($find, $replace, $text);
-		}
+    private function replaceBBcodes($text)
+    {
+        //$text = strip_tags($text);
+        $text = nl2br($text);
+        // BBcode array, all list available: https://steamcommunity.com/comment/ForumTopic/formattinghelp
+        $find = [
+            '~\[h1\](.*?)\[/h1\]~s',
+            '~\[h2\](.*?)\[/h2\]~s',
+            '~\[h3\](.*?)\[/h3\]~s',
+            '~\[list\](.*?)\[/list\]~s',
+            '~\[olist\](.*?)\[/olist\]~s',
+            '~\[\*\]~s',
+            '~\[b\](.*?)\[/b\]~s',
+            '~\[i\](.*?)\[/i\]~s',
+            '~\[u\](.*?)\[/u\]~s',
+            '~\[strike\](.*?)\[/strike\]~s',
+            '~\[spoiler\](.*?)\[/spoiler\]~s',
+            '~\[noparse\](.*?)\[/noparse\]~s',
+            '~\[hr\]~s',
+            '~\[quote\](.*?)\[/quote\]~s',
+            '~\[code\](.*?)\[/code\]~s',
+            '~\{STEAM_CLAN_IMAGE\}~s',
+            '~\[url=([^"><]*?)\](.*?)\[/url\]~s',
+            '~\[img\](https?://[^"><]*?\.(?:jpg|jpeg|gif|png|bmp))\[/img\]~s'
+        ];
+        // HTML tags to replace BBcode
+        $replace = [
+            '<h1>$1</h1>',
+            '<h2>$1</h2>',
+            '<h3>$1</h3>',
+            '<ul>$1</ul>',
+            '<ol>$1</ol>',
+            '<li>',
+            '<b>$1</b>',
+            '<i>$1</i>',
+            '<u>$1</u>',
+            '<s>$1</s>',
+            '$1', // Just remove spoiler
+            '$1', // Just remove noparse
+            '<hr>',
+            '<blockquote>$1</blockquote>',
+            '<code>$1</code>',
+            'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/clans',
+            '<a href="$1">$2</a>',
+            '<img src="$1" alt="" />'
+        ];
+        // Replacing the BBcodes with corresponding HTML tags
+        return preg_replace($find, $replace, $text);
+    }
 }

--- a/bridges/SteamAppNewsBridge.php
+++ b/bridges/SteamAppNewsBridge.php
@@ -2,125 +2,136 @@
 
 class SteamAppNewsBridge extends BridgeAbstract
 {
-    const NAME = 'Steam App News';
-    const URI = 'https://www.steamcommunity.com';
-    const DESCRIPTION = 'Get the latest news for a game on Steam.';
-    const MAINTAINER = 'otakuf';
-    const CACHE_TIMEOUT = 3600; // 1h
+		const NAME = 'Steam App News';
+		const URI = 'https://www.steamcommunity.com';
+		const DESCRIPTION = 'Get the latest news for a game on Steam.';
+		const MAINTAINER = 'otakuf';
+		const CACHE_TIMEOUT = 3600; // 1h
 
-    const PARAMETERS = [ [
-        'appid' => [
-            'name' => 'App ID',
-            'title' => 'App ID (only digits). Find your App ID with steamdb.info',
-            'type' => 'number',
-            'exampleValue' => '730',
-            'required' => true
-        ],
-        'maxlength' => [
-            'name' => 'Max Length',
-            'title' => 'Maximum length for the content to return, 0 for full content',
-            'type' => 'number',
-            'defaultValue' => 0
-        ],
-        'count' => [
-            'name' => 'Count',
-            'title' => '# of posts to retrieve (default 20)',
-            'type' => 'number',
-            'defaultValue' => 20
-        ],
-        'tags' => [
-            'name' => 'Tag Filter',
-            'title' => 'Comma-separated list of tags to filter by',
-            'type' => 'text',
-            'exampleValue' => 'patchnotes'
-        ]
-    ]];
+		const PARAMETERS = [ [
+				'appid' => [
+						'name' => 'App ID',
+						'title' => 'App ID (only digits). Find your App ID with steamdb.info',
+						'type' => 'number',
+						'exampleValue' => '730',
+						'required' => true
+				],
+				'maxlength' => [
+						'name' => 'Max Length',
+						'title' => 'Maximum length for the content to return, 0 for full content',
+						'type' => 'number',
+						'defaultValue' => 0
+				],
+				'count' => [
+						'name' => 'Count',
+						'title' => '# of posts to retrieve (default 20)',
+						'type' => 'number',
+						'defaultValue' => 20
+				],
+				'use_app_name' => [
+						'name' => 'Use App Name as Author ?',
+						'title' => 'Use the app name as author',
+						'type' => 'checkbox',
+						'defaultValue' => 20
+				]
+		]];
 
-    public function collectData()
-    {
-        $apiTarget = 'https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/';
-        // Example with params: https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=730&maxlength=0&count=20
-        // More info at dev docs https://partner.steamgames.com/doc/webapi/ISteamNews
-        $url = $apiTarget
-            . '?appid=' . $this->getInput('appid')
-            . '&maxlength=' . $this->getInput('maxlength')
-            . '&count=' . $this->getInput('count')
-            . '&tags=' . $this->getInput('tags');
+		public function collectData()
+		{
+				$api = 'https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/';
+				// Example with params: https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=730&maxlength=0&count=20
+				$details_api = 'https://store.steampowered.com/api/appdetails?appids=';
+				// API used to get app name from its appid
 
-        // Get the JSON content
-        $json = getContents($url);
-        $json_list = json_decode($json, true);
+				// More info at dev docs https://partner.steamgames.com/doc/webapi/ISteamNews
+				$url = $api . '?appid='
+						. $this->getInput('appid') . '&maxlength='
+						. $this->getInput('maxlength') . '&count='
+						. $this->getInput('count');
 
-        foreach ($json_list['appnews']['newsitems'] as $json_item) {
-            $this->items[] = $this->collectArticle($json_item);
-        }
-    }
+				// Get the JSON content
+				$json = getContents($url);
+				$json_list = json_decode($json, true);
 
-    private function collectArticle($json_item)
-    {
-        $item = [];
-        $item['uri'] = preg_replace('[ ]', '%20', $json_item['url']);
-        $item['title'] = $json_item['title'];
-        $item['timestamp'] = $json_item['date'];
-        $item['author'] = $json_item['author'];
+				// Get the app name
+				$app_details_json = getContents($details_api . $this->getInput('appid'));
+				$app_details_decoded_json = json_decode($app_details_json, true);
+				$this->app_name = $app_details_decoded_json[$this->getInput('appid')]['data']['name'];
 
-        # Fix /n
-        if (str_contains($item['uri'], 'steam_community_announcements')) {
-            $item['content'] = $this->replaceBBcodes($json_item['contents']);
-        } else {
-            $item['content'] = $json_item['contents'];
-        }
-        $item['uid'] = $json_item['gid'];
-        return $item;
-    }
+				foreach ($json_list['appnews']['newsitems'] as $json_item) {
+						$this->items[] = $this->collectArticle($json_item);
+				}
+		}
 
-    private function replaceBBcodes($text)
-    {
-        //$text = strip_tags($text);
-        $text = nl2br($text);
-        // BBcode array, all list available: https://steamcommunity.com/comment/ForumTopic/formattinghelp
-        $find = [
-            '~\[h1\](.*?)\[/h1\]~s',
-            '~\[h2\](.*?)\[/h2\]~s',
-            '~\[h3\](.*?)\[/h3\]~s',
-            '~\[list\](.*?)\[/list\]~s',
-            '~\[olist\](.*?)\[/olist\]~s',
-            '~\[\*\]~s',
-            '~\[b\](.*?)\[/b\]~s',
-            '~\[i\](.*?)\[/i\]~s',
-            '~\[u\](.*?)\[/u\]~s',
-            '~\[strike\](.*?)\[/strike\]~s',
-            '~\[spoiler\](.*?)\[/spoiler\]~s',
-            '~\[noparse\](.*?)\[/noparse\]~s',
-            '~\[hr\]~s',
-            '~\[quote\](.*?)\[/quote\]~s',
-            '~\[code\](.*?)\[/code\]~s',
-            '~\{STEAM_CLAN_IMAGE\}~s',
-            '~\[url=([^"><]*?)\](.*?)\[/url\]~s',
-            '~\[img\](https?://[^"><]*?\.(?:jpg|jpeg|gif|png|bmp))\[/img\]~s'
-        ];
-        // HTML tags to replace BBcode
-        $replace = [
-            '<h1>$1</h1>',
-            '<h2>$1</h2>',
-            '<h3>$1</h3>',
-            '<ul>$1</ul>',
-            '<ol>$1</ol>',
-            '<li>',
-            '<b>$1</b>',
-            '<i>$1</i>',
-            '<u>$1</u>',
-            '<s>$1</s>',
-            '$1', // Just remove spoiler
-            '$1', // Just remove noparse
-            '<hr>',
-            '<blockquote>$1</blockquote>',
-            '<code>$1</code>',
-            'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/clans',
-            '<a href="$1">$2</a>',
-            '<img src="$1" alt="" />'
-        ];
-        // Replacing the BBcodes with corresponding HTML tags
-        return preg_replace($find, $replace, $text);
-    }
+		private function collectArticle($json_item)
+		{
+				$item = [];
+				$item['uri'] = preg_replace('[ ]', '%20', $json_item['url']);
+				$item['title'] = $json_item['title'];
+				$item['timestamp'] = $json_item['date'];
+				if ($this->getInput('use_app_name') == "yes") {
+						$item['author'] = $this->app_name;
+				} else {
+						$item['author'] = $json_item['author'];
+				}
+
+				# Fix /n
+				if (str_contains($item['uri'], 'steam_community_announcements')) {
+						$item['content'] = $this->replaceBBcodes($json_item['contents']);
+				} else {
+						$item['content'] = $json_item['contents'];
+				}
+				$item['uid'] = $json_item['gid'];
+				return $item;
+		}
+
+		private function replaceBBcodes($text)
+		{
+				//$text = strip_tags($text);
+				$text = nl2br($text);
+				// BBcode array, all list available: https://steamcommunity.com/comment/ForumTopic/formattinghelp
+				$find = [
+						'~\[h1\](.*?)\[/h1\]~s',
+						'~\[h2\](.*?)\[/h2\]~s',
+						'~\[h3\](.*?)\[/h3\]~s',
+						'~\[list\](.*?)\[/list\]~s',
+						'~\[olist\](.*?)\[/olist\]~s',
+						'~\[\*\]~s',
+						'~\[b\](.*?)\[/b\]~s',
+						'~\[i\](.*?)\[/i\]~s',
+						'~\[u\](.*?)\[/u\]~s',
+						'~\[strike\](.*?)\[/strike\]~s',
+						'~\[spoiler\](.*?)\[/spoiler\]~s',
+						'~\[noparse\](.*?)\[/noparse\]~s',
+						'~\[hr\]~s',
+						'~\[quote\](.*?)\[/quote\]~s',
+						'~\[code\](.*?)\[/code\]~s',
+						'~\{STEAM_CLAN_IMAGE\}~s',
+						'~\[url=([^"><]*?)\](.*?)\[/url\]~s',
+						'~\[img\](https?://[^"><]*?\.(?:jpg|jpeg|gif|png|bmp))\[/img\]~s'
+				];
+				// HTML tags to replace BBcode
+				$replace = [
+						'<h1>$1</h1>',
+						'<h2>$1</h2>',
+						'<h3>$1</h3>',
+						'<ul>$1</ul>',
+						'<ol>$1</ol>',
+						'<li>',
+						'<b>$1</b>',
+						'<i>$1</i>',
+						'<u>$1</u>',
+						'<s>$1</s>',
+						'$1', // Just remove spoiler
+						'$1', // Just remove noparse
+						'<hr>',
+						'<blockquote>$1</blockquote>',
+						'<code>$1</code>',
+						'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/clans',
+						'<a href="$1">$2</a>',
+						'<img src="$1" alt="" />'
+				];
+				// Replacing the BBcodes with corresponding HTML tags
+				return preg_replace($find, $replace, $text);
+		}
 }


### PR DESCRIPTION
Bridge: Steam App News

Hello, I added a checkbox to allow using the app name instead of author name, I think it's more practical for filtering by game in the user's preffered reader

I might have swapped commit messages and description but I don't know how to change that, sorry
If someone can set the messages to what I put in the description it would be nice, thank you