### PR TITLE
[Rooster Teeth] Add Camp Camp channel

### DIFF
--- a/bridges/RoosterTeethBridge.php
+++ b/bridges/RoosterTeethBridge.php
@@ -17,6 +17,7 @@ class RoosterTeethBridge extends BridgeAbstract
                 'values' => [
                     'All channels' => 'all',
                     'Achievement Hunter' => 'achievement-hunter',
+                    'Camp Camp' => 'camp-camp',
                     'Cow Chop' => 'cow-chop',
                     'Death Battle' => 'death-battle',
                     'Friends of RT' => 'friends-of-rt',


### PR DESCRIPTION
Adding the Camp Camp Channel:
https://roosterteeth.com/channel/camp-camp

Example on my Bridge:
https://dhusch.de/rss-bridge/?action=display&bridge=RoosterTeethBridge&context=Options&channel=camp-camp&sort=desc&first=1&episodeImage=on&limit=100&format=Html