### PR TITLE
[IdealoBridge] Fix Feed items & Feed title customisation

### DIFF
--- a/bridges/IdealoBridge.php
+++ b/bridges/IdealoBridge.php
@@ -40,6 +40,47 @@ class IdealoBridge extends BridgeAbstract
         return 'https://cdn.idealo.com/storage/ids-assets/ico/favicon.ico';
     }
 
+    /**
+     * Returns the RSS Feed title when a RSS feed is rendered
+     * @return string the RSS feed Title
+     */
+    private function getFeedTitle()
+    {
+        $cacheDuration = 604800;
+        $link = $this->getInput('Link');
+        $keyTITLE = $link . 'TITLE';
+        $product = $this->loadCacheValue($keyTITLE, $cacheDuration);
+
+        // The cache does not contain the title of the bridge, we must get it and save it in the cache
+        if ($product === null) {
+            $header = [
+                'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.1 Safari/605.1.15'
+            ];
+            $html = getSimpleHTMLDOM($link, $header);
+            $product = $html->find('.oopStage-title', 0)->find('span', 0)->plaintext;
+            $this->saveCacheValue($keyTITLE, $product);
+        }
+
+        $MaxPriceUsed = $this->getInput('MaxPriceUsed');
+        $MaxPriceNew = $this->getInput('MaxPriceNew');
+        $titleParts = [];
+
+        $titleParts[] = $product;
+
+        // Add Max Prices to the title
+        if ($MaxPriceUsed !== null) {
+            $titleParts[] = 'Max Price Used : ' . $MaxPriceUsed . '€';
+        }
+        if ($MaxPriceNew !== null) {
+            $titleParts[] = 'Max Price New : ' . $MaxPriceNew . '€';
+        }
+
+        $title = implode(' ', $titleParts);
+
+
+        return $title . ' - ' . $this::NAME;
+    }
+
     public function collectData()
     {
         // Needs header with user-agent to function properly.
@@ -69,12 +110,16 @@ class IdealoBridge extends BridgeAbstract
         $FirstButton = $html->find('.oopStage-conditionButton-wrapper-text', 0);
         if ($FirstButton) {
             $PriceNew = $FirstButton->find('strong', 0)->plaintext;
+            // Save current price
+            $this->saveCacheValue($KeyNEW, $PriceNew);
         }
 
         // Second Button is used
         $SecondButton = $html->find('.oopStage-conditionButton-wrapper-text', 1);
         if ($SecondButton) {
             $PriceUsed = $SecondButton->find('strong', 0)->plaintext;
+            // Save current price
+            $this->saveCacheValue($KeyUSED, $PriceUsed);
         }
 
         // Only continue if a price has changed
@@ -83,16 +128,16 @@ class IdealoBridge extends BridgeAbstract
             $image = $html->find('.datasheet-cover-image', 0)->src;
 
             // Generate Content
-            if ($PriceNew > 1) {
+            if (isset($PriceNew) && $PriceNew > 1) {
                 $content = "<p><b>Price New:</b><br>$PriceNew</p>";
                 $content .= "<p><b>Price New before:</b><br>$OldPriceNew</p>";
             }
 
             if ($this->getInput('MaxPriceNew') != '') {
-                $content .= sprintf('<p><b>Max Price Used:</b><br>%s,00 €</p>', $this->getInput('MaxPriceNew'));
+                $content .= sprintf('<p><b>Max Price New:</b><br>%s,00 €</p>', $this->getInput('MaxPriceNew'));
             }
 
-            if ($PriceUsed > 1) {
+            if (isset($PriceUsed) && $PriceUsed > 1) {
                 $content .= "<p><b>Price Used:</b><br>$PriceUsed</p>";
                 $content .= "<p><b>Price Used before:</b><br>$OldPriceUsed</p>";
             }
@@ -110,8 +155,8 @@ class IdealoBridge extends BridgeAbstract
 
             // Currently under Max new price
             if ($this->getInput('MaxPriceNew') != '') {
-                if ($PriceNew < $this->getInput('MaxPriceNew')) {
-                    $title = sprintf($Pricealarm, 'Used', $PriceNew, $Productname, $now);
+                if (isset($PriceNew) && $PriceNew < $this->getInput('MaxPriceNew')) {
+                    $title = sprintf($Pricealarm, 'New', $PriceNew, $Productname, $now);
                     $item = [
                         'title'     => $title,
                         'uri'       => $link,
@@ -124,7 +169,7 @@ class IdealoBridge extends BridgeAbstract
 
             // Currently under Max used price
             if ($this->getInput('MaxPriceUsed') != '') {
-                if ($PriceUsed < $this->getInput('MaxPriceUsed')) {
+                if (isset($PriceUsed) && $PriceUsed < $this->getInput('MaxPriceUsed')) {
                     $title = sprintf($Pricealarm, 'Used', $PriceUsed, $Productname, $now);
                     $item = [
                         'title'     => $title,
@@ -143,23 +188,23 @@ class IdealoBridge extends BridgeAbstract
                     (!$this->getInput('ExcludeNew') && $PriceNew != $OldPriceNew ) ||
                     (!$this->getInput('ExcludeUsed') && $PriceUsed != $OldPriceUsed )
                 ) {
-                    $title .= 'Priceupdate! ';
+                    $title = 'Priceupdate! ';
 
                     if (!$this->getInput('ExcludeNew')) {
-                        if ($PriceNew < $OldPriceNew) {
+                        if (isset($PriceNew) &&  $PriceNew < $OldPriceNew) {
                             $title .= 'NEW:&#11015 '; // Arrow Down Emoji
                         }
-                        if ($PriceNew > $OldPriceNew) {
+                        if (isset($PriceNew) && $PriceNew > $OldPriceNew) {
                             $title .= 'NEW:&#11014 '; // Arrow Up Emoji
                         }
                     }
 
 
                     if (!$this->getInput('ExcludeUsed')) {
-                        if ($PriceUsed < $OldPriceUsed) {
+                        if (isset($PriceUsed) && $PriceUsed < $OldPriceUsed) {
                             $title .= 'USED:&#11015 '; // Arrow Down Emoji
                         }
-                        if ($PriceUsed > $OldPriceUsed) {
+                        if (isset($PriceUsed) && $PriceUsed > $OldPriceUsed) {
                             $title .= 'USED:&#11014 '; // Arrow Up Emoji
                         }
                     }
@@ -177,9 +222,19 @@ class IdealoBridge extends BridgeAbstract
                 }
             }
         }
+    }
 
-        // Save current price
-        $this->saveCacheValue($KeyNEW, $PriceNew);
-        $this->saveCacheValue($KeyUSED, $PriceUsed);
+    /**
+     * Returns the RSS Feed title according to the parameters
+     * @return string the RSS feed Tile
+     */
+    public function getName()
+    {
+        switch ($this->queriedContext) {
+            case '0':
+                return $this->getFeedTitle();
+            default:
+                return parent::getName();
+        }
     }
 }


### PR DESCRIPTION
- Feed items with new price tracking had "Max Price Used" instead of "Max Price New"
- Feed Title is now customised with the product name and the Price limits
- Fixed logic for saving prices in cache
- remove undefined variable notices