### PR TITLE
[NACSouthGermanyMediaLibraryBridge] Fix bridge for new website layout

### DIFF
--- a/bridges/NACSouthGermanyMediaLibraryBridge.php
+++ b/bridges/NACSouthGermanyMediaLibraryBridge.php
@@ -31,7 +31,7 @@ class NACSouthGermanyMediaLibraryBridge extends BridgeAbstract
 
     public function getIcon()
     {
-        return 'https://www.nak-stuttgart.de/static/themes/nak_sued/images/nak-logo.png';
+        return 'https://nak-sued.de/static/themes/sued/images/logo.png';
     }
 
     private static function parseTimestamp($title)
@@ -66,9 +66,12 @@ class NACSouthGermanyMediaLibraryBridge extends BridgeAbstract
     private static function collectDataForBayern2($parent, $item)
     {
         # Find link
-        $playerDom = getSimpleHTMLDOMCached(self::BASE_URI . $parent->find('a', 0)->href);
-        $sourceURI = $playerDom->find('source', 0)->src;
-        $item['enclosures'] = [self::BASE_URI . $sourceURI];
+        $relativeURICode = $parent->find('a', 0)->onclick;
+        if (preg_match('/window\.open\(\'([^\']*)\'/', $relativeURICode, $matches)) {
+            $playerDom = getSimpleHTMLDOMCached(self::BASE_URI . $matches[1]);
+            $sourceURI = $playerDom->find('source', 0)->src;
+            $item['enclosures'] = [self::BASE_URI . $sourceURI];
+        }
 
         # Add time to timestamp
         $item['timestamp'] .= ' 06:45';
@@ -78,14 +81,14 @@ class NACSouthGermanyMediaLibraryBridge extends BridgeAbstract
 
     private function collectDataInList($pageURI, $customizeItemCall)
     {
-        $page = getSimpleHTMLDOM(self::BASE_URI . $pageURI);
+        $page = getSimpleHTMLDOM($pageURI);
 
-        foreach ($page->find('div.grids') as $parent) {
+        foreach ($page->find('div.flex-columns.entry') as $parent) {
             # Find title
             $title = $parent->find('h2', 0)->plaintext;
 
             # Find content
-            $contentBlock = $parent->find('ul.contentlist', 0);
+            $contentBlock = $parent->find('ul', 0);
             $content = '';
             foreach ($contentBlock->find('li') as $li) {
                 $content .= '<p>' . $li->plaintext . '</p>';
@@ -103,7 +106,7 @@ class NACSouthGermanyMediaLibraryBridge extends BridgeAbstract
     private function collectDataFromAllPages($rootURI, $customizeItemCall)
     {
         $rootPage = getSimpleHTMLDOM($rootURI);
-        $pages = $rootPage->find('div#tabmenu', 0);
+        $pages = $rootPage->find('div.flex-columns.inner_filter', 0);
         foreach ($pages->find('a') as $page) {
             self::collectDataInList($page->href, [$this, $customizeItemCall]);
         }


### PR DESCRIPTION
The website that this bridge adapts recently went through a layout change, breaking the `NACSouthGermanyMediaLibraryBridge`. This PR updates this bridge to work with the new layout.

Additionally, I swapped out the feed icon URL to get a better quality icon.