### PR TITLE
New bridge: FilterMore

### DIFF
--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -86,6 +86,7 @@ class FilterMoreBridge extends FeedExpander
             ],
             'defaultValue' => 'asc',
         ],
+        'limit' => self::LIMIT,
 
         ]];
 
@@ -158,6 +159,7 @@ class FilterMoreBridge extends FeedExpander
     public function collectExpandableDatas($url, $maxItems = -1)
     {
         parent::collectExpandableDatas($url, $maxItems);
+        $limit = (int)($this->getInput('limit') ?: 10);
         if ($this->getInput('sort_by') === 'random') {
             shuffle($this->items);
         } elseif ($this->getInput('sort_by') !== 'none') {
@@ -170,6 +172,9 @@ class FilterMoreBridge extends FeedExpander
         }
         if ($this->getInput('sort_dir') === 'desc') {
             $this->items = array_reverse($this->items);
+        }
+        if ($limit > 0) {
+            $this->items = array_slice($this->items, 0, $limit);
         }
     }
 

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -1,0 +1,157 @@
+<?php
+
+class FilterMoreBridge extends FeedExpander {
+
+	const MAINTAINER = 'boyska';
+	const NAME = 'FilterMore';
+	const CACHE_TIMEOUT = 2;
+	const DESCRIPTION = 'Filters a feed of your choice';
+	const URI = 'https://git.lattuta.net/boyska/rss-bridge';
+
+	const PARAMETERS = array(array(
+		'url' => array(
+			'name' => 'Feed URL',
+			'required' => true,
+		),
+		'conj_type' => array(
+			'name' => 'Conjunction type type',
+			'type' => 'list',
+			'required' => false,
+			'values' => array(
+				'All conditions must be met' => 'and',
+				'Any condition must be met' => 'or',
+			),
+			'defaultValue' => 'permit',
+		),
+
+		'title_re' => array(
+			'name' => 'Filter item title (regular expression, see php.net/pcre_match for details)',
+			'required' => false,
+            'exampleValue' => '/breaking\ news/i',
+		),
+		'body_re' => array(
+			'name' => 'Filter body (regular expression)',
+			'required' => false,
+		),
+		'author_re' => array(
+			'name' => 'Filter author (regular expression)',
+			'required' => false,
+            'exampleValue' => '/(technology|politics)/i',
+		),
+		'newer_than' => array(
+			'name' => 'Filter date: ok if newer than the value (see php.net/strtotime for details)',
+			'required' => false,
+            'exampleValue' => '-14 days',
+		),
+		'older_than' => array(
+			'name' => 'Filter date: ok if older than the value (see php.net/strtotime for details)',
+			'required' => false,
+            'exampleValue' => '-1 hour',
+		),
+
+		'invert_filter' => array(
+			'name' => 'Invert filter result',
+			'type' => 'checkbox',
+			'required' => false,
+			'defaultValue' => false,
+		),
+	));
+
+	protected function parseItem($newItem){
+		$item = parent::parseItem($newItem);
+
+        $filters = ['filterByTitle', 'filterByBody', 'filterByAuthor', 'filterByDateNewer', 'filterByDateOlder'];
+        $results = [];
+
+        foreach($filters as $filter) {
+            $filter_res = $this->$filter($item);
+            if($filter_res === null) continue;
+            $results[] = $filter_res;
+        }
+        if(count($results) === 0) {
+            return $item;
+        }
+        if($this->getConjType() === 'and') {
+            $result = !in_array(false, $results);
+        } else { // or
+            $result = in_array(true, $results);
+        }
+        if($this->getInvertResult()) {
+            $result = !$result;
+        }
+        if($result)
+            return $item;
+        else
+            return null;
+	}
+
+    private function cmp($a, $b) {
+        if($a > $b) return 1;
+        if($a < $b) return -1;
+        return 0;
+    }
+	private function filterByFieldRegexp($field, $re){
+        if($re === "") return null;
+        if(preg_match($re, $field)) {
+            return true;
+        }
+        return false;
+	}
+	protected function filterByTitle($item){
+		$re = $this->getInput('title_re');
+        return $this->filterByFieldRegexp($item['title'], $re);
+	}
+	protected function filterByBody($item){
+		$re = $this->getInput('body_re');
+        return $this->filterByFieldRegexp($item['content'], $re);
+	}
+	protected function filterByAuthor($item){
+		$re = $this->getInput('author_re');
+        return $this->filterByFieldRegexp($item['author'], $re);
+	}
+	private function filterByDate($item, $input, $expected){
+		$val = $this->getInput($input);
+        if($val === "") return null;
+        $ts = strtotime($val);
+        if($ts === false) {
+            throw new Exception("Invalid time specification: " . $val);
+        }
+        $cmp =  $this->cmp($item['timestamp'], $ts); // 1 if newer, -1 if older
+        return $cmp === $expected;
+	}
+	protected function filterByDateNewer($item){
+        return $this->filterByDate($item, 'newer_than', 1);
+	}
+	protected function filterByDateOlder($item){
+        return $this->filterByDate($item, 'older_than', -1);
+	}
+
+	protected function getConjType(){
+		return $this->getInput('conj_type');
+	}
+	protected function getInvertResult(){
+		return $this->getInput('invert_filter');
+	}
+
+	public function getURI(){
+		$url = $this->getInput('url');
+
+		if(empty($url)) {
+			$url = parent::getURI();
+		}
+		return $url;
+	}
+
+	public function collectData(){
+		if($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http') {
+			// just in case someone find a way to access local files by playing with the url
+			returnClientError('The url parameter must either refer to http or https protocol.');
+		}
+		try{
+			$this->collectExpandableDatas($this->getURI());
+		} catch (HttpException $e) {
+			$this->collectExpandableDatas($this->getURI());
+		}
+	}
+}
+

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -49,6 +49,13 @@ class FilterMoreBridge extends FeedExpander {
             'exampleValue' => '-1 hour',
 		),
 
+		'has_media' => array(
+			'name' => 'Has at least 1 media inside',
+			'type' => 'checkbox',
+			'required' => false,
+			'defaultValue' => false,
+		),
+
 		'invert_filter' => array(
 			'name' => 'Invert filter result',
 			'type' => 'checkbox',
@@ -80,7 +87,7 @@ class FilterMoreBridge extends FeedExpander {
             }
         }
 
-        $filters = ['filterByTitle', 'filterByBody', 'filterByAuthor', 'filterByDateNewer', 'filterByDateOlder'];
+        $filters = ['filterByTitle', 'filterByBody', 'filterByAuthor', 'filterByDateNewer', 'filterByDateOlder', 'filterByMedia'];
         $results = [];
 
         foreach($filters as $filter) {
@@ -151,6 +158,11 @@ class FilterMoreBridge extends FeedExpander {
 	protected function filterByDateOlder($item){
         return $this->filterByDate($item, 'older_than', -1);
 	}
+    protected function filterByMedia($item) {
+        if(!$this->getInput('has_media')) return null;
+        if(count($item['enclosures']) > 0) return true;
+        return false;
+    }
 
 	protected function getConjType(){
 		return $this->getInput('conj_type');

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -92,9 +92,8 @@ class FilterMoreBridge extends FeedExpander
 
         ]];
 
-    protected function parseItem($newItem)
+    protected function parseItem($item)
     {
-        $item = parent::parseItem($newItem);
         $item['enclosures'] = [];
         if (isset($newItem->enclosure)) {
             foreach ($newItem->enclosure as $encl) {

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -184,7 +184,7 @@ class FilterMoreBridge extends FeedExpander
     }
     private function filterByFieldRegexp($field, $re)
     {
-        if ($re === '') {
+        if ($re === '' || $re === null) {
             return null;
         } elseif (preg_match($re, $field)) {
             return true;
@@ -209,7 +209,7 @@ class FilterMoreBridge extends FeedExpander
     private function filterByDate($item, $input, $expected)
     {
         $val = $this->getInput($input);
-        if ($val === '') {
+        if ($val === '' || $val === null) {
             return null;
         }
         $ts = strtotime($val);

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -10,59 +10,59 @@ class FilterMoreBridge extends FeedExpander
 
     const PARAMETERS = [
         [
-        'url' => array(
+        'url' => [
             'name' => 'Feed URL',
             'required' => true,
-        ),
-        'conj_type' => array(
+        ],
+        'conj_type' => [
             'name' => 'Conjunction type type',
             'type' => 'list',
             'required' => false,
-            'values' => array(
+            'values' => [
                 'All conditions must be met' => 'and',
                 'Any condition must be met' => 'or',
-            ),
+            ],
             'defaultValue' => 'permit',
-        ),
+        ],
 
-        'title_re' => array(
+        'title_re' => [
             'name' => 'Filter item title (regular expression, see php.net/pcre_match for details)',
             'required' => false,
             'exampleValue' => '/breaking\ news/i',
-        ),
-        'body_re' => array(
+        ],
+        'body_re' => [
             'name' => 'Filter body (regular expression)',
             'required' => false,
-        ),
-        'author_re' => array(
+        ],
+        'author_re' => [
             'name' => 'Filter author (regular expression)',
             'required' => false,
             'exampleValue' => '/(technology|politics)/i',
-        ),
-        'newer_than' => array(
+        ],
+        'newer_than' => [
             'name' => 'Filter date: ok if newer than the value (see php.net/strtotime for details)',
             'required' => false,
             'exampleValue' => '-14 days',
-        ),
-        'older_than' => array(
+        ],
+        'older_than' => [
             'name' => 'Filter date: ok if older than the value (see php.net/strtotime for details)',
             'required' => false,
             'exampleValue' => '-1 hour',
-        ),
+        ],
 
-        'has_media' => array(
+        'has_media' => [
             'name' => 'Has at least 1 media inside',
             'type' => 'checkbox',
             'required' => false,
             'defaultValue' => false,
-        ),
+        ],
 
-        'invert_filter' => array(
+        'invert_filter' => [
             'name' => 'Invert filter result',
             'type' => 'checkbox',
             'required' => false,
             'defaultValue' => false,
-        ),
+        ],
 
         'sort_by' => [
             'name' => 'Sort by',
@@ -87,7 +87,7 @@ class FilterMoreBridge extends FeedExpander
             'defaultValue' => 'asc',
         ],
 
-    ]];
+        ]];
 
     protected function parseItem($newItem)
     {
@@ -158,30 +158,35 @@ class FilterMoreBridge extends FeedExpander
     public function collectExpandableDatas($url, $maxItems = -1)
     {
         parent::collectExpandableDatas($url, $maxItems);
-        if($this->getInput('sort_by') === 'random') {
+        if ($this->getInput('sort_by') === 'random') {
             shuffle($this->items);
-        } elseif($this->getInput('sort_by') !== 'none') {
-            usort($this->items, function($itemA, $itemB) {
+        } elseif ($this->getInput('sort_by') !== 'none') {
+            usort($this->items, function ($itemA, $itemB) {
                 $valA = $this->sortItemKey($itemA);
                 $valB = $this->sortItemKey($itemB);
                 $cmp = strcmp($valA, $valB);
                 return $cmp;
             });
         }
-        if($this->getInput('sort_dir') === 'desc')
+        if ($this->getInput('sort_dir') === 'desc') {
             $this->items = array_reverse($this->items);
+        }
     }
 
     private function cmp($a, $b)
     {
-        if($a > $b) return 1;
-        if($a < $b) return -1;
+        if ($a > $b) {
+            return 1;
+        } elseif ($a < $b) {
+            return -1;
+        }
         return 0;
     }
     private function filterByFieldRegexp($field, $re)
     {
-        if($re === "") return null;
-        if(preg_match($re, $field)) {
+        if ($re === '') {
+            return null;
+        } elseif (preg_match($re, $field)) {
             return true;
         }
         return false;
@@ -204,12 +209,14 @@ class FilterMoreBridge extends FeedExpander
     private function filterByDate($item, $input, $expected)
     {
         $val = $this->getInput($input);
-        if($val === "") return null;
-        $ts = strtotime($val);
-        if($ts === false) {
-            throw new Exception("Invalid time specification: " . $val);
+        if ($val === '') {
+            return null;
         }
-        $cmp =  $this->cmp($item['timestamp'], $ts); // 1 if newer, -1 if older
+        $ts = strtotime($val);
+        if ($ts === false) {
+            throw new Exception('Invalid time specification: ' . $val);
+        }
+        $cmp = $this->cmp($item['timestamp'], $ts); // 1 if newer, -1 if older
         return $cmp === $expected;
     }
     protected function filterByDateNewer($item)
@@ -222,8 +229,11 @@ class FilterMoreBridge extends FeedExpander
     }
     protected function filterByMedia($item)
     {
-        if(!$this->getInput('has_media')) return null;
-        if(count($item['enclosures']) > 0) return true;
+        if (!$this->getInput('has_media')) {
+            return null;
+        } elseif (count($item['enclosures']) > 0) {
+            return true;
+        }
         return false;
     }
 
@@ -248,8 +258,7 @@ class FilterMoreBridge extends FeedExpander
 
     public function collectData()
     {
-        if ($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http')
-        {
+        if ($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http') {
             // just in case someone find a way to access local files by playing with the url
             returnClientError('The url parameter must either refer to http or https protocol.');
         }

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -74,7 +74,7 @@ class FilterMoreBridge extends FeedExpander
                 'Title' => 'title',
                 'Random' => 'random',
             ],
-            'defaultValue' => 'date',
+            'defaultValue' => 'timestamp',
         ],
         'sort_dir' => [
             'name' => 'Sort direction',

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -92,6 +92,19 @@ class FilterMoreBridge extends FeedExpander
 
         ]];
 
+    public function collectData()
+    {
+        if ($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http') {
+            // just in case someone find a way to access local files by playing with the url
+            returnClientError('The url parameter must either refer to http or https protocol.');
+        }
+        try {
+            $this->collectExpandableDatas($this->getURI());
+        } catch (HttpException $e) {
+            $this->collectExpandableDatas($this->getURI());
+        }
+    }
+
     protected function parseItem($item)
     {
         $item['enclosures'] = [];
@@ -151,12 +164,6 @@ class FilterMoreBridge extends FeedExpander
         }
     }
 
-    protected function sortItemKey($item)
-    {
-        $sort_by = $this->getInput('sort_by');
-        $key = $item[$sort_by];
-        return $key;
-    }
     public function collectExpandableDatas($url, $maxItems = -1)
     {
         parent::collectExpandableDatas($url, $maxItems);
@@ -178,6 +185,14 @@ class FilterMoreBridge extends FeedExpander
             $this->items = array_slice($this->items, 0, $limit);
         }
     }
+
+    protected function sortItemKey($item)
+    {
+        $sort_by = $this->getInput('sort_by');
+        $key = $item[$sort_by];
+        return $key;
+    }
+
 
     private function cmp($a, $b)
     {
@@ -260,19 +275,6 @@ class FilterMoreBridge extends FeedExpander
             $url = parent::getURI();
         }
         return $url;
-    }
-
-    public function collectData()
-    {
-        if ($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http') {
-            // just in case someone find a way to access local files by playing with the url
-            returnClientError('The url parameter must either refer to http or https protocol.');
-        }
-        try {
-            $this->collectExpandableDatas($this->getURI());
-        } catch (HttpException $e) {
-            $this->collectExpandableDatas($this->getURI());
-        }
     }
 }
 

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -1,68 +1,68 @@
 <?php
 
-class FilterMoreBridge extends FeedExpander {
-
-	const MAINTAINER = 'boyska';
-	const NAME = 'FilterMore';
-	const CACHE_TIMEOUT = 2;
-	const DESCRIPTION = 'Filters a feed of your choice';
-	const URI = 'https://git.lattuta.net/boyska/rss-bridge';
+class FilterMoreBridge extends FeedExpander
+{
+    const MAINTAINER = 'boyska';
+    const NAME = 'FilterMore';
+    const CACHE_TIMEOUT = 2;
+    const DESCRIPTION = 'Filters a feed of your choice';
+    const URI = 'https://git.lattuta.net/boyska/rss-bridge';
 
     const PARAMETERS = [
         [
-		'url' => array(
-			'name' => 'Feed URL',
-			'required' => true,
-		),
-		'conj_type' => array(
-			'name' => 'Conjunction type type',
-			'type' => 'list',
-			'required' => false,
-			'values' => array(
-				'All conditions must be met' => 'and',
-				'Any condition must be met' => 'or',
-			),
-			'defaultValue' => 'permit',
-		),
+        'url' => array(
+            'name' => 'Feed URL',
+            'required' => true,
+        ),
+        'conj_type' => array(
+            'name' => 'Conjunction type type',
+            'type' => 'list',
+            'required' => false,
+            'values' => array(
+                'All conditions must be met' => 'and',
+                'Any condition must be met' => 'or',
+            ),
+            'defaultValue' => 'permit',
+        ),
 
-		'title_re' => array(
-			'name' => 'Filter item title (regular expression, see php.net/pcre_match for details)',
-			'required' => false,
+        'title_re' => array(
+            'name' => 'Filter item title (regular expression, see php.net/pcre_match for details)',
+            'required' => false,
             'exampleValue' => '/breaking\ news/i',
-		),
-		'body_re' => array(
-			'name' => 'Filter body (regular expression)',
-			'required' => false,
-		),
-		'author_re' => array(
-			'name' => 'Filter author (regular expression)',
-			'required' => false,
+        ),
+        'body_re' => array(
+            'name' => 'Filter body (regular expression)',
+            'required' => false,
+        ),
+        'author_re' => array(
+            'name' => 'Filter author (regular expression)',
+            'required' => false,
             'exampleValue' => '/(technology|politics)/i',
-		),
-		'newer_than' => array(
-			'name' => 'Filter date: ok if newer than the value (see php.net/strtotime for details)',
-			'required' => false,
+        ),
+        'newer_than' => array(
+            'name' => 'Filter date: ok if newer than the value (see php.net/strtotime for details)',
+            'required' => false,
             'exampleValue' => '-14 days',
-		),
-		'older_than' => array(
-			'name' => 'Filter date: ok if older than the value (see php.net/strtotime for details)',
-			'required' => false,
+        ),
+        'older_than' => array(
+            'name' => 'Filter date: ok if older than the value (see php.net/strtotime for details)',
+            'required' => false,
             'exampleValue' => '-1 hour',
-		),
+        ),
 
-		'has_media' => array(
-			'name' => 'Has at least 1 media inside',
-			'type' => 'checkbox',
-			'required' => false,
-			'defaultValue' => false,
-		),
+        'has_media' => array(
+            'name' => 'Has at least 1 media inside',
+            'type' => 'checkbox',
+            'required' => false,
+            'defaultValue' => false,
+        ),
 
-		'invert_filter' => array(
-			'name' => 'Invert filter result',
-			'type' => 'checkbox',
-			'required' => false,
-			'defaultValue' => false,
-		),
+        'invert_filter' => array(
+            'name' => 'Invert filter result',
+            'type' => 'checkbox',
+            'required' => false,
+            'defaultValue' => false,
+        ),
 
         'sort_by' => [
             'name' => 'Sort by',
@@ -87,24 +87,27 @@ class FilterMoreBridge extends FeedExpander {
             'defaultValue' => 'asc',
         ],
 
-	]];
+    ]];
 
-	protected function parseItem($newItem){
-		$item = parent::parseItem($newItem);
+    protected function parseItem($newItem)
+    {
+        $item = parent::parseItem($newItem);
         $item['enclosures'] = [];
-        if(isset($newItem->enclosure)) {
-            foreach($newItem->enclosure as $encl) {
+        if (isset($newItem->enclosure)) {
+            foreach ($newItem->enclosure as $encl) {
                 $serialized = [];
-                foreach($encl->attributes() as $key => $value) {
+                foreach ($encl->attributes() as $key => $value) {
                     $serialized[$key] = (string)$value;
                 }
-                $serialized["length"] = intval($serialized["length"]);
+                $serialized['length'] = intval($serialized['length']);
                 $item['enclosures'][] = $serialized;
             }
         }
-        if(isset($newItem->link)) {
-            foreach($newItem->link as $el) {
-                if(((string)$el['rel']) !== 'enclosure') continue;
+        if (isset($newItem->link)) {
+            foreach ($newItem->link as $el) {
+                if (((string)$el['rel']) !== 'enclosure') {
+                    continue;
+                }
                 $serialized = [];
                 $serialized['url'] = (string)$el['href'];
 
@@ -115,40 +118,45 @@ class FilterMoreBridge extends FeedExpander {
         $filters = ['filterByTitle', 'filterByBody', 'filterByAuthor', 'filterByDateNewer', 'filterByDateOlder', 'filterByMedia'];
         $results = [];
 
-        foreach($filters as $filter) {
+        foreach ($filters as $filter) {
             $filter_res = $this->$filter($item);
-            if($filter_res === null) continue;
+            if ($filter_res === null) {
+                continue;
+            }
             $results[] = $filter_res;
         }
 
         $old_enclosures = $item['enclosures'];
         $item['enclosures'] = [];
-        foreach($old_enclosures as $e) {
+        foreach ($old_enclosures as $e) {
             $item['enclosures'][] = $e['url'];
         }
-        if(count($results) === 0) {
+        if (count($results) === 0) {
             return $item;
         }
-        if($this->getConjType() === 'and') {
+        if ($this->getConjType() === 'and') {
             $result = !in_array(false, $results);
         } else { // or
             $result = in_array(true, $results);
         }
-        if($this->getInvertResult()) {
+        if ($this->getInvertResult()) {
             $result = !$result;
         }
-        if($result)
+        if ($result) {
             return $item;
-        else
+        } else {
             return null;
-	}
+        }
+    }
 
-    protected function sortItemKey($item) {
+    protected function sortItemKey($item)
+    {
         $sort_by = $this->getInput('sort_by');
         $key = $item[$sort_by];
         return $key;
     }
-    public function collectExpandableDatas($url, $maxItems = -1){
+    public function collectExpandableDatas($url, $maxItems = -1)
+    {
         parent::collectExpandableDatas($url, $maxItems);
         if($this->getInput('sort_by') === 'random') {
             shuffle($this->items);
@@ -164,32 +172,38 @@ class FilterMoreBridge extends FeedExpander {
             $this->items = array_reverse($this->items);
     }
 
-    private function cmp($a, $b) {
+    private function cmp($a, $b)
+    {
         if($a > $b) return 1;
         if($a < $b) return -1;
         return 0;
     }
-	private function filterByFieldRegexp($field, $re){
+    private function filterByFieldRegexp($field, $re)
+    {
         if($re === "") return null;
         if(preg_match($re, $field)) {
             return true;
         }
         return false;
-	}
-	protected function filterByTitle($item){
-		$re = $this->getInput('title_re');
+    }
+    protected function filterByTitle($item)
+    {
+        $re = $this->getInput('title_re');
         return $this->filterByFieldRegexp($item['title'], $re);
-	}
-	protected function filterByBody($item){
-		$re = $this->getInput('body_re');
+    }
+    protected function filterByBody($item)
+    {
+        $re = $this->getInput('body_re');
         return $this->filterByFieldRegexp($item['content'], $re);
-	}
-	protected function filterByAuthor($item){
-		$re = $this->getInput('author_re');
+    }
+    protected function filterByAuthor($item)
+    {
+        $re = $this->getInput('author_re');
         return $this->filterByFieldRegexp($item['author'], $re);
-	}
-	private function filterByDate($item, $input, $expected){
-		$val = $this->getInput($input);
+    }
+    private function filterByDate($item, $input, $expected)
+    {
+        $val = $this->getInput($input);
         if($val === "") return null;
         $ts = strtotime($val);
         if($ts === false) {
@@ -197,45 +211,53 @@ class FilterMoreBridge extends FeedExpander {
         }
         $cmp =  $this->cmp($item['timestamp'], $ts); // 1 if newer, -1 if older
         return $cmp === $expected;
-	}
-	protected function filterByDateNewer($item){
+    }
+    protected function filterByDateNewer($item)
+    {
         return $this->filterByDate($item, 'newer_than', 1);
-	}
-	protected function filterByDateOlder($item){
+    }
+    protected function filterByDateOlder($item)
+    {
         return $this->filterByDate($item, 'older_than', -1);
-	}
-    protected function filterByMedia($item) {
+    }
+    protected function filterByMedia($item)
+    {
         if(!$this->getInput('has_media')) return null;
         if(count($item['enclosures']) > 0) return true;
         return false;
     }
 
-	protected function getConjType(){
-		return $this->getInput('conj_type');
-	}
-	protected function getInvertResult(){
-		return $this->getInput('invert_filter');
-	}
+    protected function getConjType()
+    {
+        return $this->getInput('conj_type');
+    }
+    protected function getInvertResult()
+    {
+        return $this->getInput('invert_filter');
+    }
 
-	public function getURI(){
-		$url = $this->getInput('url');
+    public function getURI()
+    {
+        $url = $this->getInput('url');
 
-		if(empty($url)) {
-			$url = parent::getURI();
-		}
-		return $url;
-	}
+        if (empty($url)) {
+            $url = parent::getURI();
+        }
+        return $url;
+    }
 
-	public function collectData(){
-		if($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http') {
-			// just in case someone find a way to access local files by playing with the url
-			returnClientError('The url parameter must either refer to http or https protocol.');
-		}
-		try{
-			$this->collectExpandableDatas($this->getURI());
-		} catch (HttpException $e) {
-			$this->collectExpandableDatas($this->getURI());
-		}
-	}
+    public function collectData()
+    {
+        if ($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http')
+        {
+            // just in case someone find a way to access local files by playing with the url
+            returnClientError('The url parameter must either refer to http or https protocol.');
+        }
+        try {
+            $this->collectExpandableDatas($this->getURI());
+        } catch (HttpException $e) {
+            $this->collectExpandableDatas($this->getURI());
+        }
+    }
 }
 

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -13,6 +13,7 @@ class FilterMoreBridge extends FeedExpander
         'url' => [
             'name' => 'Feed URL',
             'required' => true,
+            'exampleValue' => 'https://example.com/feed/',
         ],
         'conj_type' => [
             'name' => 'Conjunction type type',
@@ -33,6 +34,7 @@ class FilterMoreBridge extends FeedExpander
         'body_re' => [
             'name' => 'Filter body (regular expression)',
             'required' => false,
+            'exampleValue' => '/(technology|politics)/i',
         ],
         'author_re' => [
             'name' => 'Filter author (regular expression)',

--- a/bridges/FilterMoreBridge.php
+++ b/bridges/FilterMoreBridge.php
@@ -8,7 +8,8 @@ class FilterMoreBridge extends FeedExpander {
 	const DESCRIPTION = 'Filters a feed of your choice';
 	const URI = 'https://git.lattuta.net/boyska/rss-bridge';
 
-	const PARAMETERS = array(array(
+    const PARAMETERS = [
+        [
 		'url' => array(
 			'name' => 'Feed URL',
 			'required' => true,
@@ -62,7 +63,31 @@ class FilterMoreBridge extends FeedExpander {
 			'required' => false,
 			'defaultValue' => false,
 		),
-	));
+
+        'sort_by' => [
+            'name' => 'Sort by',
+            'type' => 'list',
+            'required' => true,
+            'values' => [
+                "Don't sort" => 'none',
+                'Date' => 'timestamp',
+                'Title' => 'title',
+                'Random' => 'random',
+            ],
+            'defaultValue' => 'date',
+        ],
+        'sort_dir' => [
+            'name' => 'Sort direction',
+            'type' => 'list',
+            'required' => true,
+            'values' => [
+                'Ascending' => 'asc',
+                'Descending' => 'desc',
+            ],
+            'defaultValue' => 'asc',
+        ],
+
+	]];
 
 	protected function parseItem($newItem){
 		$item = parent::parseItem($newItem);
@@ -117,6 +142,27 @@ class FilterMoreBridge extends FeedExpander {
         else
             return null;
 	}
+
+    protected function sortItemKey($item) {
+        $sort_by = $this->getInput('sort_by');
+        $key = $item[$sort_by];
+        return $key;
+    }
+    public function collectExpandableDatas($url, $maxItems = -1){
+        parent::collectExpandableDatas($url, $maxItems);
+        if($this->getInput('sort_by') === 'random') {
+            shuffle($this->items);
+        } elseif($this->getInput('sort_by') !== 'none') {
+            usort($this->items, function($itemA, $itemB) {
+                $valA = $this->sortItemKey($itemA);
+                $valB = $this->sortItemKey($itemB);
+                $cmp = strcmp($valA, $valB);
+                return $cmp;
+            });
+        }
+        if($this->getInput('sort_dir') === 'desc')
+            $this->items = array_reverse($this->items);
+    }
 
     private function cmp($a, $b) {
         if($a > $b) return 1;


### PR DESCRIPTION
this bridge allows the user to have a filtered version of a feed.

it is quite advanced: offers regexp filtering, sorting, limiting...

I used it when I wanted to follow a websites including events. They had no way to filter based on city, but they were specifying that in the title, so I could use this bridge to get what I wanted.

The `has_media` field is particularly useful for podcasts: sometimes I want to just play the first audio in a feed. With this, I can :
 - filter `has_media`
 -  `limit=1`
which gives me exactly what I wanted.