### PR TITLE
Update RedditBridge.php

### DIFF
--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -189,7 +189,7 @@ class RedditBridge extends BridgeAbstract
                     // Comment
 
                     $item['content'] = htmlspecialchars_decode($data->body_html);
-                } elseif ($data->is_self) {
+                } elseif (isset($data->is_self)) {
                     // Text post
 
                     $item['content'] = htmlspecialchars_decode($data->selftext_html);


### PR DESCRIPTION
Sometimes (most at weekends, don't know why) I get this error:

`rssbridge.ERROR (shutdown) 8192: 
htmlspecialchars_decode(): Passing null to parameter #1 ($string) of type string is deprecated in bridges/RedditBridge.php`

to prevent this error I added an isset-check