### PR TITLE
specify system section for enabling bridges

### DIFF
--- a/docs/03_For_Hosts/05_Whitelisting.md
+++ b/docs/03_For_Hosts/05_Whitelisting.md
@@ -1,14 +1,18 @@
-Modify `config.ini.php` to limit available bridges.
+Modify `config.ini.php` to limit available bridges. Those changes should be applied in the `[system]` section.
 
 ## Enable all bridges
 
 ```
+[system]
+
 enabled_bridges[] = *
 ```
 
 ## Enable some bridges
 
 ```
+[system]
+
 enabled_bridges[] = TwitchBridge
 enabled_bridges[] = GettrBridge
 ```


### PR DESCRIPTION
Specifying that the `[system]` section should be used when enabling Bridges. It is currently not explicit in documentation except if you check the sample configuration file.