### PR TITLE
[AO3Bridge] Fix bad heading selector

### DIFF
--- a/bridges/AO3Bridge.php
+++ b/bridges/AO3Bridge.php
@@ -77,7 +77,7 @@ class AO3Bridge extends BridgeAbstract
         $html = defaultLinkTo($html, self::URI);
 
         // Get list title. Will include page range + count in some cases
-        $heading = ($html->find('#main > h2', 0));
+        $heading = ($html->find('#main h2', 0));
         if ($heading->find('a.tag')) {
             $heading = $heading->find('a.tag', 0);
         }


### PR DESCRIPTION
Fixes pages like [this](https://rss-bridge.org/bridge01/?action=display&bridge=AO3Bridge&context=List&url=https%3A%2F%2Farchiveofourown.org%2Fusers%2FDraconicHex%2Fpseuds%2FDraconicHex&format=Html). Working version can be seen deployed [here](https://rssb.fly.dev/?action=display&bridge=AO3Bridge&context=List&url=https%3A%2F%2Farchiveofourown.org%2Fusers%2FDraconicHex%2Fpseuds%2FDraconicHex&format=Html)