### PR TITLE
[PepperBridgeAbstract,DealabsBridge,HotUKDealsBridge,MydealsBridge] Fix search URL, No results handling fixed, Thread title and Message URL handling

### DIFF
--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -1913,7 +1913,6 @@ class DealabsBridge extends PepperBridgeAbstract
         'uri-merchant' => 'search/bons-plans?merchant-id=',
         'request-error' => 'Impossible de joindre Dealabs',
         'thread-error' => 'Impossible de déterminer l\'ID de la discussion. Vérifiez l\'URL que vous avez entré',
-        'no-results' => 'Aucun résultat',
         'currency' => '€',
         'price' => 'Prix',
         'shipping' => 'Livraison',

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -3277,7 +3277,6 @@ class HotUKDealsBridge extends PepperBridgeAbstract
         'uri-merchant' => 'search/deals?merchant-id=',
         'request-error' => 'Could not request HotUKDeals',
         'thread-error' => 'Unable to determine the thread ID. Check the URL you entered',
-        'no-results' => 'no results',
         'currency' => '£',
         'price' => 'Price',
         'shipping' => 'Shipping',

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -2024,7 +2024,6 @@ class MydealsBridge extends PepperBridgeAbstract
         'uri-merchant' => 'search/gutscheine?merchant-id=',
         'request-error' => 'Could not request mydeals',
         'thread-error' => 'Die ID der Diskussion kann nicht ermittelt werden. Überprüfen Sie die eingegebene URL',
-        'no-results' => 'keine Ergebnisse',
         'currency' => '€',
         'price' => 'Preis',
         'shipping' => 'Versand',

--- a/bridges/PepperBridgeAbstract.php
+++ b/bridges/PepperBridgeAbstract.php
@@ -55,8 +55,8 @@ class PepperBridgeAbstract extends BridgeAbstract
         );
 
         // If there is no results, we don't parse the content because it display some random deals
-        $noresult = $html->find('h3[class*=text--b]', 0);
-        if ($noresult != null && strpos($noresult->plaintext, $this->i8n('no-results')) !== false) {
+        $noresult = $html->find('section[class=subNav]', 0)->find('div[class*=page-center listLayout aGrid]', 0);
+        if ($noresult === null) {
             $this->items = [];
         } else {
             foreach ($list as $deal) {
@@ -174,13 +174,17 @@ HEREDOC;
             $item['uid'] = $comment->commentId;
             // Timestamp handling needs a new parsing function
             if ($onlyWithUrl == true) {
-                // Count Links and Quote Links
-                $content = str_get_html($item['content']);
-                $countLinks = count($content->find('a[href]'));
-                $countQuoteLinks = count($content->find('a[href][class=userHtml-quote-source]'));
-                // Only add element if there are Links ans more links tant Quote links
-                if ($countLinks > 0 && $countLinks > $countQuoteLinks) {
-                    $this->items[] = $item;
+                // Only parse the comment if it is not empry
+                if($item['content'] != '')
+                {
+                    // Count Links and Quote Links
+                    $content = str_get_html($item['content']);
+                    $countLinks = count($content->find('a[href]'));
+                    $countQuoteLinks = count($content->find('a[href][class=userHtml-quote-source]'));
+                    // Only add element if there are Links and more links tant Quote links
+                    if ($countLinks > 0 && $countLinks > $countQuoteLinks) {
+                        $this->items[] = $item;
+                    }
                 }
             } else {
                 $this->items[] = $item;
@@ -264,7 +268,7 @@ HEREDOC;
     private function getTalkTitle()
     {
         $html = getSimpleHTMLDOMCached($this->getInput('url'));
-        $title = $html->find('.thread-title', 0)->plaintext;
+        $title = $html->find('title', 0)->plaintext;
         return $title;
     }
 
@@ -472,7 +476,7 @@ HEREDOC;
         $priceFrom = $this->getInput('priceFrom');
         $priceTo = $this->getInput('priceTo');
         $url = $this->i8n('bridge-uri')
-            . 'search/advanced?q='
+            . 'search?q='
             . urlencode($q)
             . '&hide_expired=' . $hide_expired
             . '&hide_local=' . $hide_local

--- a/bridges/PepperBridgeAbstract.php
+++ b/bridges/PepperBridgeAbstract.php
@@ -175,8 +175,7 @@ HEREDOC;
             // Timestamp handling needs a new parsing function
             if ($onlyWithUrl == true) {
                 // Only parse the comment if it is not empry
-                if($item['content'] != '')
-                {
+                if ($item['content'] != '') {
                     // Count Links and Quote Links
                     $content = str_get_html($item['content']);
                     $countLinks = count($content->find('a[href]'));


### PR DESCRIPTION
Search URL has been updated according to the website.

If a search doesn't return any results, the HTML won't contain any
specific text now : the HTML structure is slightly different, so the
bridge has been updated.

The unnneded 'no-results' text is now removed from the specific bridges.

The board thread title has been removed from the content, so now we use
the page <title> element.

In case a board message is empty, there was an exception during the
filtering of message without URL.