### PR TITLE
[FDroidRepoBridge] Simplify json retrieval

### DIFF
--- a/bridges/FDroidRepoBridge.php
+++ b/bridges/FDroidRepoBridge.php
@@ -62,36 +62,11 @@ class FDroidRepoBridge extends BridgeAbstract
         }
     }
 
-    /**
-     * This method fetches data from arbitrary url and writes to os temp file.
-     * I don't think there's any security problem here but might be DOS problems.
-     */
     private function fetchData()
     {
         $url = $this->getURI();
-
-        $zipFile = getContents($url . '/index-v1.jar');
-        // On linux this creates a temp file in /tmp/
-        $temporaryFile = tempnam(sys_get_temp_dir(), 'rssbridge_');
-        file_put_contents($temporaryFile, $zipFile);
-
-        $archive = new \ZipArchive();
-        if ($archive->open($temporaryFile) !== true) {
-            unlink($temporaryFile);
-            throw new \Exception('Failed to extract archive');
-        }
-
-        $fp = $archive->getStream('index-v1.json');
-        if (!$fp) {
-            unlink($temporaryFile);
-            throw new \Exception('Failed to get file pointer');
-        }
-
-        $json = stream_get_contents($fp);
-        fclose($fp);
+        $json = getContents($url . '/index-v1.json');
         $data = Json::decode($json);
-        $archive->close();
-        unlink($temporaryFile);
         return $data;
     }
 

--- a/bridges/FDroidRepoBridge.php
+++ b/bridges/FDroidRepoBridge.php
@@ -45,10 +45,6 @@ class FDroidRepoBridge extends BridgeAbstract
 
     public function collectData()
     {
-        if (!extension_loaded('zip')) {
-            throw new \Exception('FDroidRepoBridge requires the php-zip extension');
-        }
-
         $this->repo = $this->fetchData();
         switch ($this->queriedContext) {
             case 'Latest Updates':


### PR DESCRIPTION
I looked into avoiding the writing-to-file and then reading-from-file altogether. Using a special file path that leaves the data in memory probably wouldn't work. But I'm unsure why we use the `index-v1.jar` file altogether. The main F-Droid repo [lists](https://f-droid.org/en/docs/All_our_APIs/#the-repo-index) not only `index-v1.jar` (which only makes sense if we were to use the contained signature, which we don't), but also `index-v1.json` and `index-v2.json`. These json files can be fetched with `getContents`, optionally cached, and directly fed into `Json::decode` without using a temporary file. The HTTP transfer encoding can compress the file to a similar degree the jar (=zip) can. That's exactly what this commit uses.

Now the question is whether all the F-Droid repositories out there have this file. I went through the whole [list of known repositories](https://forum.f-droid.org/t/known-repositories/721) and only one repo misses the `index-v1.json` file: [Bromite](https://fdroid.bromite.org/fdroid/repo/index-v1.json). Under these circumstances we can depend on the availability of the `index-v1.json` file.

Closes #4062