### PR TITLE
[HeiseBridge] Remove additional ad banners

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -160,7 +160,10 @@ class HeiseBridge extends FeedExpander
         $article = defaultLinkTo($article, $item['uri']);
 
         // remove unwanted stuff
-        foreach ($article->find('figure.branding, a-ad, div.ho-text, a-img, .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote') as $element) {
+        foreach (
+            $article->find('figure.branding, figure.a-inline-image, a-ad, div.ho-text, a-img,
+            .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote') as $element
+        ) {
             $element->remove();
         }
         // reload html, as remove() is buggy


### PR DESCRIPTION
For example
https://www.heise.de/meinung/Kommentar-Microsofts-Sicherheitspraxis-wird-zur-Gefahr-und-das-BSI-schweigt-9686629.html has two inline banners for a heise offering, not directly related to the article. Removing all "inline" figures, which seems to catch all inline unwanted elements, while avoiding removing useful figures/images.