### PR TITLE
User can go back to the form

### DIFF
--- a/formats/FormFormat.php
+++ b/formats/FormFormat.php
@@ -1,0 +1,52 @@
+<?php
+
+class FormFormat extends FormatAbstract
+{
+    const MIME_TYPE = 'text/html';
+
+    public function stringify()
+    {
+        // This query string is url encoded
+        $queryString = $_SERVER['QUERY_STRING'];
+
+        $feedArray = $this->getFeed();
+        $formatFactory = new FormatFactory();
+        $formats = [];
+
+        // Create all formats (except HTML)
+        $formatNames = $formatFactory->getFormatNames();
+        foreach ($formatNames as $formatName) {
+            if ($formatName === 'Form') {
+                continue;
+            }
+            // The format url is relative, but should be absolute in order to help feed readers.
+            $formatUrl = '?' . str_ireplace('format=Form', 'format=' . $formatName, $queryString);
+            $formatObject = $formatFactory->create($formatName);
+            $formats[] = [
+                'url'       => $formatUrl,
+                'name'      => $formatName,
+                'type'      => $formatObject->getMimeType(),
+            ];
+        }
+
+
+        $donationUri = null;
+        if (Configuration::getConfig('admin', 'donations') && $feedArray['donationUri']) {
+            $donationUri = $feedArray['donationUri'];
+        }
+
+        $request = Request::fromGlobals();
+        $bridgeName = $_GET['bridge'];
+        $card = (new BridgeCard())->render($bridgeName, $request, true);
+        return render(__DIR__ . '/../templates/form-format.html.php', [
+            'bridgeForm' => $card,
+
+            'charset'       => $this->getCharset(),
+            'title'         => $feedArray['name'],
+            'formats'       => $formats,
+            'uri'           => $feedArray['uri'],
+            'items'         => [],
+            'donation_uri'  => $donationUri,
+        ]);
+    }
+}

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -6,8 +6,7 @@ final class BridgeCard
         string $bridgeClassName,
         Request $request,
         bool $setValuesFromQuery = false
-    ): string
-    {
+    ): string {
         $bridgeFactory = new BridgeFactory();
 
         $bridge = $bridgeFactory->create($bridgeClassName);

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -177,7 +177,7 @@ final class BridgeCard
         return $form . '</form>' . PHP_EOL;
     }
 
-    public static function getTextInput(array $entry, string $id, string $name, ?Request $request): string
+    public static function getTextInput(array $entry, string $id, string $name, ?Request $request = null): string
     {
         if ($request === null) {
             $defaultValue = filter_var($entry['defaultValue'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
@@ -190,7 +190,7 @@ final class BridgeCard
         return sprintf('<input %s id="%s" type="text" value="%s" placeholder="%s" name="%s" />', $attributes, $id, $defaultValue, $exampleValue, $name);
     }
 
-    public static function getNumberInput(array $entry, string $id, string $name, ?Request $request): string
+    public static function getNumberInput(array $entry, string $id, string $name, ?Request $request = null): string
     {
         if ($request === null) {
             $defaultValue = filter_var($entry['defaultValue'], FILTER_SANITIZE_NUMBER_INT);
@@ -203,7 +203,7 @@ final class BridgeCard
         return sprintf('<input %s id="%s" type="number" value="%s" placeholder="%s" name="%s" />' . "\n", $attributes, $id, $defaultValue, $exampleValue, $name);
     }
 
-    public static function getListInput(array $entry, string $id, string $name, ?Request $request): string
+    public static function getListInput(array $entry, string $id, string $name, ?Request $request = null): string
     {
         $required = $entry['required'] ?? null;
         if ($required) {
@@ -212,7 +212,7 @@ final class BridgeCard
         }
 
         if ($request === null) {
-            $defaultValue = $entry['defaultValue'];
+            $defaultValue = $entry['defaultValue'] ?? null;
         } else {
             $defaultValue = $request->get($name);
         }
@@ -251,7 +251,7 @@ final class BridgeCard
     }
 
 
-    public static function getCheckboxInput(array $entry, string $id, string $name, ?Request $request): string
+    public static function getCheckboxInput(array $entry, string $id, string $name, ?Request $request = null): string
     {
         $required = $entry['required'] ?? null;
         if ($required) {

--- a/templates/form-format.html.php
+++ b/templates/form-format.html.php
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="<?= $charset ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/ >
+    <meta name="description" content="RSS-Bridge" />
+    <title><?= e($title) ?></title>
+    <link href="static/style.css?2023-03-24" rel="stylesheet">
+    <link rel="icon" type="image/png" href="static/favicon.png">
+
+    <?php foreach ($formats as $format): ?>
+
+        <link
+            href="<?= e($format['url']) ?>"
+            title="<?= e($format['name']) ?>"
+            rel="alternate"
+            type="<?= e($format['type']) ?>"
+        >
+	<?php endforeach; ?>
+
+    <meta name="robots" content="noindex, follow">
+</head>
+
+<body>
+
+    <div class="container">
+
+        <h1 class="pagetitle">
+            <a href="<?= e($uri) ?>" target="_blank"><?= e($title) ?></a>
+        </h1>
+
+        <div class="buttons">
+            <a href="./#bridge-<?= $_GET['bridge'] ?>">
+                <button class="backbutton">← back to rss-bridge</button>
+            </a>
+
+            <?php foreach ($formats as $format): ?>
+                <a href="<?= e($format['url']) ?>">
+                    <button class="rss-feed">
+                        <?= e($format['name']) ?>
+                    </button>
+                </a>
+            <?php endforeach; ?>
+
+            <?php if ($donation_uri): ?>
+                <a href="<?= e($donation_uri) ?>">
+                    <button class="rss-feed">
+                        Donate to maintainer
+                    </button>
+                </a>
+            <?php endif; ?>
+        </div>
+
+        <?php foreach ($items as $item): ?>
+            <section class="feeditem">
+                <h2>
+                    <a
+                        class="itemtitle"
+                        href="<?= e($item['url']) ?>"
+                    ><?= strip_tags($item['title']) ?></a>
+                </h2>
+
+                <?php if ($item['timestamp']): ?>
+                    <time datetime="<?= date('Y-m-d H:i:s', $item['timestamp']) ?>">
+                        <?= date('Y-m-d H:i:s', $item['timestamp']) ?>
+                    </time>
+                    <p></p>
+                <?php endif; ?>
+
+                <?php if ($item['author']): ?>
+                    <p class="author">by: <?= e($item['author']) ?></p>
+                <?php endif; ?>
+
+                <!-- Intentionally not escaping for html context -->
+                <?= break_annoying_html_tags($item['content']) ?>
+
+                <?php if ($item['enclosures']): ?>
+                    <div class="attachments">
+                        <p>Attachments:</p>
+                        <?php foreach ($item['enclosures'] as $enclosure): ?>
+                            <li class="enclosure">
+                                <a href="<?= e($enclosure) ?>" rel="noopener noreferrer nofollow">
+                                    <?= e(substr($enclosure, strrpos($enclosure, '/') + 1)) ?>
+                                </a>
+                            </li>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <?php if ($item['categories']): ?>
+                    <div class="categories">
+                        <p>Categories:</p>
+                        <?php foreach ($item['categories'] as $category): ?>
+                            <li class="category"><?= e($category) ?></li>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+            </section>
+        <?php endforeach; ?>
+
+    <?= raw($bridgeForm) ?>
+
+    </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    document.getElementsByClassName('showmore-box')[0].checked = true;
+});
+</script>
+
+ </body>
+</html>
+


### PR DESCRIPTION
I tried to solve #4017. The easiest way I could find was to just add a new format.

That's the UX:
 - user has somehow got a link for a bridge. They might have just created it, or got the link from a friend. Say: http://localhost:8484/?action=display&bridge=FilterBridge&url=https%3A%2F%2Fanchor.fm%2Fs%2Fea123456%2Fpodcast%2Frss&filter=a&filter_type=permit&target_author=on&target_title=on&length_limit=54&format=Html
 - the format list includes a "Form" button. Click on it!
 - it now shows a form: <img src="https://github.com/RSS-Bridge/rss-bridge/assets/14236/9eab3af4-282e-4930-b349-4e637c52e308" width="200px" />

As for the implementation, i wanted to avoid repeating the code to generate the form, so I extended `BridgeCard` a fair bit, so that it now allows parameters to be set from the request. This required changing the prototype of many methods!