### PR TITLE
[MangaReaderBridge] Change feed title to manga name

### DIFF
--- a/bridges/MangaReaderBridge.php
+++ b/bridges/MangaReaderBridge.php
@@ -29,13 +29,13 @@ class MangaReaderBridge extends BridgeAbstract
     protected $feedName = '';
 
 
-    public function getName(){
+    public function getName()
+    {
         if (empty($this->feedName)) {
             return parent::getName();
-        }
-        else {
+        } else {
             return $this->feedName;
-	}
+        }
     }
 
     public function collectData()

--- a/bridges/MangaReaderBridge.php
+++ b/bridges/MangaReaderBridge.php
@@ -26,11 +26,26 @@ class MangaReaderBridge extends BridgeAbstract
         ]
     ];
 
+    protected $feedName = '';
+
+
+    public function getName(){
+        if (empty($this->feedName)) {
+            return parent::getName();
+        }
+        else {
+            return $this->feedName;
+	}
+    }
+
     public function collectData()
     {
         $url = $this->getInput('url');
         $lang = $this->getInput('lang');
         $dom = getSimpleHTMLDOM($url);
+        $aniDetail = $dom->getElementById('ani_detail');
+        $this->feedName = html_entity_decode($aniDetail->find('h2', 0)->plaintext);
+
         $chapters = $dom->getElementById($lang . '-chapters');
 
         foreach ($chapters->getElementsByTagName('li') as $chapter) {


### PR DESCRIPTION
Before this change, all generated feeds would have the same generic `MangaReader Bridge` title.

This PR makes the name of the generated feed the same as the manga name.