### PR TITLE
Add JSON extraction embedded in HTML script element

### DIFF
--- a/formats/BarejsonFormat.php
+++ b/formats/BarejsonFormat.php
@@ -1,0 +1,17 @@
+<?php
+
+class BarejsonFormat extends FormatAbstract
+{
+    const MIME_TYPE = 'application/json';
+
+    public function stringify()
+    {
+        if (count($this->getItems()) != 1) {
+            throw new Exception('Unable to identify the target');
+        }
+        $item = $this->getItems()[0];
+        $content = $item->getContent() ?? '';
+        $content = mb_convert_encoding($content, $this->getCharset(), 'UTF-8');
+        return $content;
+    }
+}


### PR DESCRIPTION
I want to extract JSON embedded in HTML script elements for processing by JSON dotpath.
So I have added a format that outputs only bare content.
`Barejson` is a term I coined because pure format names could not explain the behavior..
So if you have a better idea, I would like to adopt it.

This format can output only one item, so if more and less than one is found, an error will occur.

This is triggered by the following discussion:
https://github.com/FreshRSS/FreshRSS/discussions/6406