### PR TITLE
Fix: Ensure `$time` is set from `innertext` when `datetime` attribute is not found

### DIFF
--- a/bridges/CssSelectorComplexBridge.php
+++ b/bridges/CssSelectorComplexBridge.php
@@ -442,7 +442,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
         if (!is_null($time_selector) && $time_selector != '') {
             $time_element = $entry_html->find($time_selector, 0);
             $time = $time_element->getAttribute('datetime');
-            if (is_null($time)) {
+            if (empty($time)) {
                 $time = $time_element->innertext;
             }
 


### PR DESCRIPTION
This commit addresses a bug where the $time variable is not set from the innertext of the $time_element when the datetime attribute is not found. The previous implementation only checked if $time was null or an empty string, which did not cover all cases where the datetime attribute might be missing. By using the empty() function, we ensure that $time is correctly set from the innertext when the datetime attribute is not present.