### PR TITLE
[NACSouthGermanyMediaLibraryBridge] Small fix for new website layout

### DIFF
--- a/bridges/NACSouthGermanyMediaLibraryBridge.php
+++ b/bridges/NACSouthGermanyMediaLibraryBridge.php
@@ -85,12 +85,12 @@ class NACSouthGermanyMediaLibraryBridge extends BridgeAbstract
 
         foreach ($page->find('div.flex-columns.entry') as $parent) {
             # Find title
-            $title = $parent->find('h2', 0)->plaintext;
+            $title = trim($parent->find('h2')[0]->innertext);
 
             # Find content
-            $contentBlock = $parent->find('ul', 0);
+            $contentBlock = $parent->find('div')[2];
             $content = '';
-            foreach ($contentBlock->find('li') as $li) {
+            foreach ($contentBlock->find('li,p') as $li) {
                 $content .= '<p>' . $li->plaintext . '</p>';
             }
 


### PR DESCRIPTION
The website that this bridge adapts recently had a small layout change that broke the `NACSouthGermanyMediaLibraryBridge`. This PR fixes this bridge.

Additionally, I fixed the titles of the RSS elements such that they do not have the unnecessary suffix "Download" anymore.
