### PR TITLE
[IdealoBridge] Fix price comparison and some PHP Notice

### DIFF
--- a/bridges/IdealoBridge.php
+++ b/bridges/IdealoBridge.php
@@ -81,6 +81,21 @@ class IdealoBridge extends BridgeAbstract
         return $title . ' - ' . $this::NAME;
     }
 
+    /**
+     * Returns the Price as float
+     * @return float rhe price converted in float
+     */
+    private function convertPriceToFloat($price)
+    {
+        // Every price is stored / displayed as "xxx,xx €", but PHP can't convert it as float
+
+        // Convert comma as dot
+        $price = str_replace(',', '.', $price);
+        // Remove the '€' char
+        $price = str_replace('€', '', $price);
+        // Convert to float
+        return floatval($price);
+    }
 
     /**
      * Returns the Price Trend emoji
@@ -88,8 +103,10 @@ class IdealoBridge extends BridgeAbstract
      */
     private function getPriceTrend($NewPrice, $OldPrice)
     {
-        // In case there is no old PRice, then show no trend
-        if ($OldPrice === null) {
+        $NewPrice = $this->convertPriceToFloat($NewPrice);
+        $OldPrice = $this->convertPriceToFloat($OldPrice);
+        // In case there is no old Price, then show no trend
+        if ($OldPrice === null || $OldPrice == 0) {
             $trend = '';
         } else if ($NewPrice > $OldPrice) {
             $trend = '&#x2197;';
@@ -125,7 +142,7 @@ class IdealoBridge extends BridgeAbstract
         $OldPriceNew = $this->loadCacheValue($KeyNEW);
         $OldPriceUsed = $this->loadCacheValue($KeyUSED);
 
-        // First button is new. Found at oopStage-conditionButton-wrapper-text class (.)
+        // First button contains the new price. Found at oopStage-conditionButton-wrapper-text class (.)
         $FirstButton = $html->find('.oopStage-conditionButton-wrapper-text', 0);
         if ($FirstButton) {
             $PriceNew = $FirstButton->find('strong', 0)->plaintext;
@@ -133,7 +150,7 @@ class IdealoBridge extends BridgeAbstract
             $this->saveCacheValue($KeyNEW, $PriceNew);
         }
 
-        // Second Button is used
+        // Second Button contains the used product price
         $SecondButton = $html->find('.oopStage-conditionButton-wrapper-text', 1);
         if ($SecondButton) {
             $PriceUsed = $SecondButton->find('strong', 0)->plaintext;
@@ -149,7 +166,7 @@ class IdealoBridge extends BridgeAbstract
             $content = '';
 
             // Generate Content
-            if (isset($PriceNew) && $PriceNew > 1) {
+            if (isset($PriceNew) && $this->convertPriceToFloat($PriceNew) > 0) {
                 $content .= sprintf('<p><b>Price New:</b><br>%s %s</p>', $PriceNew, $this->getPriceTrend($PriceNew, $OldPriceNew));
                 $content .= "<p><b>Price New before:</b><br>$OldPriceNew</p>";
             }
@@ -158,7 +175,7 @@ class IdealoBridge extends BridgeAbstract
                 $content .= sprintf('<p><b>Max Price New:</b><br>%s,00 €</p>', $this->getInput('MaxPriceNew'));
             }
 
-            if (isset($PriceUsed) && $PriceUsed > 1) {
+            if (isset($PriceUsed) && $this->convertPriceToFloat($PriceUsed) > 0) {
                 $content .= sprintf('<p><b>Price Used:</b><br>%s %s</p>', $PriceUsed, $this->getPriceTrend($PriceUsed, $OldPriceUsed));
                 $content .= "<p><b>Price Used before:</b><br>$OldPriceUsed</p>";
             }
@@ -176,7 +193,7 @@ class IdealoBridge extends BridgeAbstract
 
             // Currently under Max new price
             if ($this->getInput('MaxPriceNew') != '') {
-                if (isset($PriceNew) && $PriceNew < $this->getInput('MaxPriceNew')) {
+                if (isset($PriceNew) && $this->convertPriceToFloat($PriceNew) < $this->getInput('MaxPriceNew')) {
                     $title = sprintf($Pricealarm, 'New', $PriceNew, $Productname, $now);
                     $item = [
                         'title'     => $title,
@@ -190,7 +207,7 @@ class IdealoBridge extends BridgeAbstract
 
             // Currently under Max used price
             if ($this->getInput('MaxPriceUsed') != '') {
-                if (isset($PriceUsed) && $PriceUsed < $this->getInput('MaxPriceUsed')) {
+                if (isset($PriceUsed) && $this->convertPriceToFloat($PriceUsed) < $this->getInput('MaxPriceUsed')) {
                     $title = sprintf($Pricealarm, 'Used', $PriceUsed, $Productname, $now);
                     $item = [
                         'title'     => $title,
@@ -202,7 +219,7 @@ class IdealoBridge extends BridgeAbstract
                 }
             }
 
-            // General Priceupdate
+            // General Priceupdate Without any Max Price for new and Used product
             if ($this->getInput('MaxPriceUsed') == '' && $this->getInput('MaxPriceNew') == '') {
                 // check if a relevant pricechange happened
                 if (
@@ -211,11 +228,11 @@ class IdealoBridge extends BridgeAbstract
                 ) {
                     $title = 'Priceupdate! ';
 
-                    if (!$this->getInput('ExcludeNew')) {
+                    if (!$this->getInput('ExcludeNew') && isset($PriceNew)) {
                         $title .= 'NEW' . $this->getPriceTrend($PriceNew, $OldPriceNew) . ' ';
                     }
 
-                    if (!$this->getInput('ExcludeUsed')) {
+                    if (!$this->getInput('ExcludeUsed') && isset($PriceUsed)) {
                         $title .= 'USED' . $this->getPriceTrend($PriceUsed, $OldPriceUsed) . ' ';
                     }
                     $title .= $Productname;

--- a/bridges/IdealoBridge.php
+++ b/bridges/IdealoBridge.php
@@ -89,12 +89,16 @@ class IdealoBridge extends BridgeAbstract
     {
         // Every price is stored / displayed as "xxx,xx €", but PHP can't convert it as float
 
-        // Convert comma as dot
-        $price = str_replace(',', '.', $price);
-        // Remove the '€' char
-        $price = str_replace('€', '', $price);
-        // Convert to float
-        return floatval($price);
+        if ($price !== null) {
+            // Convert comma as dot
+            $price = str_replace(',', '.', $price);
+            // Remove the '€' char
+            $price = str_replace('€', '', $price);
+            // Convert to float
+            return floatval($price);
+        } else {
+            return $price;
+        }
     }
 
     /**


### PR DESCRIPTION
- The prices were compared as string and the comparison was wrong in some case : now the price are converted to float before the comparison, so the logic works really.

- Don't show a new or used product price if it does not exist : this prevents a PHP Notice to be thrown