### PR TITLE
[HeiseBridge] Remove lost+found icon

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -166,6 +166,11 @@ class HeiseBridge extends FeedExpander
         ) {
             $element->remove();
         }
+        foreach ($article->find('img') as $element) {
+            if (str_contains($element->alt, 'l+f')) {
+                $element->remove();
+            }
+        }
         // reload html, as remove() is buggy
         $article = str_get_html($article->outertext);
 


### PR DESCRIPTION
Remove the icon visible in l+f articles, e.g.
https://www.heise.de/news/l-f-DISGOMOJI-die-Linux-Malware-die-auf-Emojis-steht-9765024.html

Using a css selector in the form img[alt*="l+f"] was tried, but is not supported by the used library.