### PR TITLE
[NovayaGazetaEuropeBridge]: fix warnings

### DIFF
--- a/bridges/NovayaGazetaEuropeBridge.php
+++ b/bridges/NovayaGazetaEuropeBridge.php
@@ -41,6 +41,9 @@ class NovayaGazetaEuropeBridge extends BridgeAbstract
         $data = json_decode($json);
 
         foreach ($data->records as $record) {
+            if (!isset($record->blocks)) {
+                continue;
+            }
             foreach ($record->blocks as $block) {
                 if (!property_exists($block, 'date')) {
                     continue;


### PR DESCRIPTION
This MR introduces an additional check for the presence of the "blocks" property within JSON objects. 

JSON responses contain entries that lack "blocks" property. Without this property, attempting to iterate over these objects with foreach triggers warnings such as:
```log
NOTICE: PHP message: [2024-07-21 23:48:07] rssbridge.WARNING Undefined property: stdClass::$blocks at bridges/NovayaGazetaEuropeBridge.php line 49 
NOTICE: PHP message: [2024-07-21 23:48:07] rssbridge.WARNING foreach() argument must be of type array|object, null given at bridges/NovayaGazetaEuropeBridge.php line 49 
```
By adding this check, we prevent such warnings from cluttering the logs.
