### PR TITLE
[EBayBridge] Repair & Augment the eBay Feed

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -144,6 +144,7 @@
 * [Niehztog](https://github.com/Niehztog)
 * [NikNikYkt](https://github.com/NikNikYkt)
 * [Nono-m0le](https://github.com/Nono-m0le)
+* [NotsoanoNimus](https://github.com/NotsoanoNimus)
 * [obsiwitch](https://github.com/obsiwitch)
 * [Ololbu](https://github.com/Ololbu)
 * [ORelio](https://github.com/ORelio)

--- a/bridges/EBayBridge.php
+++ b/bridges/EBayBridge.php
@@ -88,14 +88,17 @@ class EBayBridge extends BridgeAbstract
                 $item['uid'] = $matches[1];
             }
 
-            $priceDom = $listing->find('.s-item__details > .s-item__detail > .s-item__price', 0);
-            $price = $priceDom->plaintext ?? 'N/A';
+            $price = $listing->find('.s-item__price', 0)->plaintext ?? 'N/A';
 
-            $shippingFree = $listing->find('.s-item__details > .s-item__detail > .s-item__freeXDays', 0)->plaintext ?? '';
-            $localDelivery = $listing->find('.s-item__details > .s-item__detail > .s-item__localDelivery', 0)->plaintext ?? '';
-            $logisticsCost = $listing->find('.s-item__details > .s-item__detail > .s-item__logisticsCost', 0)->plaintext ?? '';
+            $additionalPrice = $listing->find('.s-item__additional-price', 0)->plaintext ?? '';
+            $discount = $listing->find('.s-item__discount', 0)->plaintext ?? '';
+            $discountLine = ($additionalPrice || $discount) ? "($additionalPrice; $discount)" : "";
 
-            $location = $listing->find('.s-item__details > .s-item__detail > .s-item__location', 0)->plaintext ?? '';
+            $shippingFree = $listing->find('.s-item__freeXDays', 0)->plaintext ?? '';
+            $localDelivery = $listing->find('.s-item__localDelivery', 0)->plaintext ?? '';
+            $logisticsCost = $listing->find('.s-item__logisticsCost', 0)->plaintext ?? '';
+
+            $location = $listing->find('.s-item__location', 0)->plaintext ?? '';
 
             $sellerInfo = $listing->find('.s-item__seller-info-text', 0)->plaintext ?? '';
 
@@ -108,7 +111,8 @@ class EBayBridge extends BridgeAbstract
 
             $item['content'] = <<<CONTENT
 <p>$sellerInfo $location</p>
-<p><span style="font-weight:bold">$price</span> $shippingFree $localDelivery $logisticsCost<span></span></p>
+<p><strong>$price</strong>&nbsp;<em>$discountLine</em>
+    <br /><small>$shippingFree $localDelivery $logisticsCost</small></p>
 <p>$subtitle</p>
 CONTENT;
             $this->items[] = $item;

--- a/bridges/EBayBridge.php
+++ b/bridges/EBayBridge.php
@@ -92,7 +92,9 @@ class EBayBridge extends BridgeAbstract
 
             $additionalPrice = $listing->find('.s-item__additional-price', 0)->plaintext ?? '';
             $discount = $listing->find('.s-item__discount', 0)->plaintext ?? '';
-            $discountLine = ($additionalPrice || $discount) ? "($additionalPrice; $discount)" : "";
+            $discountLine = ($additionalPrice || $discount)
+                ? ('(' . trim($additionalPrice ?? '') . '; ' . trim($discount ?? '') . ')')
+                : '';
 
             $shippingFree = $listing->find('.s-item__freeXDays', 0)->plaintext ?? '';
             $localDelivery = $listing->find('.s-item__localDelivery', 0)->plaintext ?? '';

--- a/bridges/EBayBridge.php
+++ b/bridges/EBayBridge.php
@@ -94,7 +94,7 @@ class EBayBridge extends BridgeAbstract
             // It appears there may be more than a single 'subtitle' subclass in the listing. Collate them.
             $subtitles = $listing->find('.s-item__subtitle');
             if (is_array($subtitles)) {
-                $subtitle = trim(implode(' ', array_map(function ($s) { return $s->plaintext; }, $subtitles)));
+                $subtitle = trim(implode(' ', array_column($subtitles, 'plaintext')));
             } else {
                 $subtitle = trim($subtitles->plaintext ?? '');
             }

--- a/bridges/EBayBridge.php
+++ b/bridges/EBayBridge.php
@@ -13,7 +13,13 @@ class EBayBridge extends BridgeAbstract
             'pattern' => '^(https:\/\/)?(www\.)?(befr\.|benl\.)?ebay\.(com|com\.au|at|be|ca|ch|cn|es|fr|de|com\.hk|ie|it|com\.my|nl|ph|pl|com\.sg|co\.uk)\/.*$',
             'exampleValue' => 'https://www.ebay.com/sch/i.html?_nkw=atom+rss',
             'required' => true,
-        ]
+        ],
+        'includesSearchLink' => [
+            'name' => 'Include Original Search Link',
+            'title' => 'Whether or not each feed item should include the original search query link to eBay which was used to find the given listing.',
+            'type' => 'checkbox',
+            'defaultValue' => false,
+        ],
     ]];
 
     public function getURI()
@@ -151,6 +157,11 @@ class EBayBridge extends BridgeAbstract
                 $item['enclosures'] = [$imageUrl];
             }
 
+            // Include the original search link, if specified.
+            if ($this->getInput('includesSearchLink')) {
+                $searchLink = '<p><small><a target="_blank" href="' . $this->getURI() . '">View Search</a></small></p>';
+            }
+
             // Build the final item's content to display and add the item onto the list.
             $item['content'] = <<<CONTENT
 <p>$sellerInfo $location</p>
@@ -158,7 +169,7 @@ class EBayBridge extends BridgeAbstract
     $discountLine
     <br /><small>$shippingFree $localDelivery $logisticsCost</small></p>
 <p>{$subtitle}</p>
-<p><small><a target="_blank" href="{$this->getURI()}">View Search</a></small></p>
+$searchLink
 CONTENT;
 
             $this->items[] = $item;

--- a/bridges/EBayBridge.php
+++ b/bridges/EBayBridge.php
@@ -10,7 +10,7 @@ class EBayBridge extends BridgeAbstract
         'url' => [
             'name' => 'Search URL',
             'title' => 'Copy the URL from your browser\'s address bar after searching for your items and paste it here',
-            'pattern' => '^(https:\/\/)?(www\.)?(befr\.|benl\.)?ebay\.(com|com\.au|at|be|ca|ch|cn|es|fr|de|com\.hk|ie|it|com\.my|nl|ph|pl|com\.sg|co\.uk).*$',
+            'pattern' => '^(https:\/\/)?(www\.)?(befr\.|benl\.)?ebay\.(com|com\.au|at|be|ca|ch|cn|es|fr|de|com\.hk|ie|it|com\.my|nl|ph|pl|com\.sg|co\.uk)\/.*$',
             'exampleValue' => 'https://www.ebay.com/sch/i.html?_nkw=atom+rss',
             'required' => true,
         ]

--- a/bridges/EBayBridge.php
+++ b/bridges/EBayBridge.php
@@ -159,7 +159,7 @@ class EBayBridge extends BridgeAbstract
 
             // Include the original search link, if specified.
             if ($this->getInput('includesSearchLink')) {
-                $searchLink = '<p><small><a target="_blank" href="' . $this->getURI() . '">View Search</a></small></p>';
+                $searchLink = '<p><small><a target="_blank" href="' . e($this->getURI()) . '">View Search</a></small></p>';
             }
 
             // Build the final item's content to display and add the item onto the list.

--- a/bridges/EBayBridge.php
+++ b/bridges/EBayBridge.php
@@ -100,7 +100,10 @@ class EBayBridge extends BridgeAbstract
             }
 
             // Get the listing's link and uid.
-            $item['uri'] = $listing->find('.s-item__link', 0)?->href ?? null;
+            $itemUri = $listing->find('.s-item__link', 0);
+            if ($itemUri) {
+                $item['uri'] = $itemUri->href;
+            }
             if (preg_match('/.*\/itm\/(\d+).*/i', $item['uri'], $matches)) {
                 $item['uid'] = $matches[1];
             }


### PR DESCRIPTION
The eBay feed was in need of some repair according to issue #4147. At the same time, it was given a bit of a facelift.
- [x] Added more information to the feed's content (listing type, Or-Best-Offer, auction details, price cuts/discounts, and a link to view the original search that captured the listing).
- [x] Styled the feed's content just a little more, but not too much (a little goes a long way).
- [x] Added an ability to disable the 'View Search' original search link in a feed.
- [x] Most target sub-classes only appear once per listing. So I removed the hierarchical query selectors that had previously broken. For example, `.s-item__details > .s-item__detail > .s-item__freeXDays` became just `.s-item__freeXDays`.
- [x] Refactored the `EBayBridge` code to make it more readable and maintainable.
- [x] Added myself as a project contributor and an additional maintainer of the eBay bridge.

This PR also resolves issue #4147.

Screenshot of the new feed content:
![image](https://github.com/user-attachments/assets/e1b6b1d8-e7ca-4e2a-b49d-d707c0e4f59f)

Additional screenshot showing the `discountLine` details for a listing:
![image](https://github.com/user-attachments/assets/d4ec32ae-a6e0-48d3-bc61-32aac929b764)

Feel free to squash these changes into a single commit, of course. If there are any questions, please let me know.