### PR TITLE
[RumbleBridge] Facelift, Validation, & Livestreams

### DIFF
--- a/bridges/RumbleBridge.php
+++ b/bridges/RumbleBridge.php
@@ -77,8 +77,9 @@ class RumbleBridge extends BridgeAbstract
 
     public function getName()
     {
-        return $this->getInput('account')
-            ? ('Rumble.com - ' . $this->getInput('account'))
-            : self::NAME;
+        if ($this->getInput('account')) {
+            return 'Rumble.com - ' . $this->getInput('account');
+        }
+        return self::NAME;
     }
 }

--- a/bridges/RumbleBridge.php
+++ b/bridges/RumbleBridge.php
@@ -2,10 +2,10 @@
 
 class RumbleBridge extends BridgeAbstract
 {
-    const NAME = 'rumble.com bridge';
-    const URI = 'https://rumble.com';
-    const DESCRIPTION = 'Fetches the latest channel/user videos';
-    const MAINTAINER = 'dvikan';
+    const NAME = 'Rumble.com Bridge';
+    const URI = 'https://rumble.com/';
+    const DESCRIPTION = 'Fetches the latest channel/user videos and livestreams.';
+    const MAINTAINER = 'dvikan, NotsoanoNimus';
     const CACHE_TIMEOUT = 60 * 60; // 1h
     const PARAMETERS = [
         [
@@ -13,15 +13,20 @@ class RumbleBridge extends BridgeAbstract
                 'name' => 'Account',
                 'type' => 'text',
                 'required' => true,
+                'title' => 'Name of the target account to create into a feed.',
                 'defaultValue' => 'bjornandreasbullhansen',
             ],
             'type' => [
+                'name' => 'Account Type',
                 'type' => 'list',
-                'name' => 'Type',
+                'required' => true,
+                'title' => 'The type of profile to create a feed from.',
                 'values' => [
-                    'Channel' => 'channel',
-                    'User' => 'user',
-                ]
+                    'Channel (All)' => 'channel',
+                    'Channel Videos' => 'channel-videos',
+                    'Channel Livestreams' => 'channel-livestream',
+                    'User (All)' => 'user',
+                ],
             ],
         ]
     ];
@@ -30,12 +35,28 @@ class RumbleBridge extends BridgeAbstract
     {
         $account = $this->getInput('account');
         $type = $this->getInput('type');
+        $url = self::getURI();
 
-        if ($type === 'channel') {
-            $url = "https://rumble.com/c/$account";
+        if (!preg_match('#^[\w\-_.@]+$#', $account) || strlen($account) > 64) {
+            throw new \Exception('Invalid target account.');
         }
-        if ($type === 'user') {
-            $url = "https://rumble.com/user/$account";
+
+        switch ($type) {
+            case 'user':
+                $url .= "user/$account";
+                break;
+            case 'channel':
+                $url .= "c/$account";
+                break;
+            case 'channel-videos':
+                $url .= "c/$account/videos";
+                break;
+            case 'channel-livestream':
+                $url .= "c/$account/livestreams";
+                break;
+            default:
+                // Shouldn't ever happen.
+                throw new \Exception('Invalid media type.');
         }
 
         $dom = getSimpleHTMLDOM($url);
@@ -57,6 +78,8 @@ class RumbleBridge extends BridgeAbstract
 
     public function getName()
     {
-        return 'Rumble.com ' . $this->getInput('account');
+        return $this->getInput('account')
+            ? ('Rumble.com - ' . $this->getInput('account'))
+            : self::NAME;
     }
 }

--- a/bridges/RumbleBridge.php
+++ b/bridges/RumbleBridge.php
@@ -19,7 +19,6 @@ class RumbleBridge extends BridgeAbstract
             'type' => [
                 'name' => 'Account Type',
                 'type' => 'list',
-                'required' => true,
                 'title' => 'The type of profile to create a feed from.',
                 'values' => [
                     'Channel (All)' => 'channel',


### PR DESCRIPTION
Cleaned up some of the components of the Rumble Bridge.
- [x] Added a distinction between All, Videos, & Live tabs on target channel pages. The 'user' option will always just show the All page in the created feed.
- [x] Added validation of the input parameters. Not that this was a serious risk, but it's nice to be explicit.
- [x] Fixed the `NAME` property displaying properly based on whether a specific account is being viewed or just the bridge card is showing.
- [x] More accessibility (if that's even really necessary).
- [x] Various punctuation fixes.

This change addresses Issue #4155.


Bridge card now:
![image](https://github.com/user-attachments/assets/6a27023b-3e88-425e-9e54-8f919beba902)

Feed results look the same as they did before:
![image](https://github.com/user-attachments/assets/550a634e-47fb-40ed-9195-16f3e6e301bf)
