### PR TITLE
[EconomistWorldInBriefBridge] Add cookie to options

### DIFF
--- a/bridges/EconomistWorldInBriefBridge.php
+++ b/bridges/EconomistWorldInBriefBridge.php
@@ -68,7 +68,9 @@ class EconomistWorldInBriefBridge extends BridgeAbstract
         };
         if ($this->getInput('agenda') == 1) {
             $articles = $html->find('._articles', 0);
-            $this->collectArticles($articles);
+            if ($articles != null) {
+                $this->collectArticles($articles);
+            }
         }
         if ($this->getInput('quote') == 1) {
             $quote = $html->find('._quote-container', 0);

--- a/bridges/EconomistWorldInBriefBridge.php
+++ b/bridges/EconomistWorldInBriefBridge.php
@@ -9,6 +9,12 @@ class EconomistWorldInBriefBridge extends BridgeAbstract
     const CACHE_TIMEOUT = 3600; // 1 hour
     const DESCRIPTION = 'Returns stories from the World in Brief section';
 
+    const CONFIGURATION = [
+        'cookie' => [
+            'required' => false,
+        ]
+    ];
+
     const PARAMETERS = [
         '' => [
             'splitGobbets' => [
@@ -41,7 +47,19 @@ class EconomistWorldInBriefBridge extends BridgeAbstract
 
     public function collectData()
     {
-        $html = getSimpleHTMLDOM(self::URI);
+        $headers = [];
+        if ($this->getOption('cookie')) {
+            $headers = [
+                'Authority: www.economist.com',
+                'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+                'Accept-language: en-US,en;q=0.9',
+                'Cache-control: max-age=0',
+                'Cookie: ' . $this->getOption('cookie'),
+                'Upgrade-insecure-requests: 1',
+                'User-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36'
+            ];
+        }
+        $html = getSimpleHTMLDOM(self::URI, $headers);
         $gobbets = $html->find('._gobbets', 0);
         if ($this->getInput('splitGobbets') == 1) {
             $this->splitGobbets($gobbets);

--- a/docs/10_Bridge_Specific/Economist.md
+++ b/docs/10_Bridge_Specific/Economist.md
@@ -1,0 +1,18 @@
+# EconomistWorldInBriefBridge
+
+In May 2024, The Economist finally fixed its paywall, and it started requiring authorization. Which means you can't use this bridge unless you have an active subscription.
+
+If you do, the way to use the bridge is to snitch a cookie:
+1. Log in to The Economist
+2. Open DevTools (Chrome DevTools or Firefox Developer Tools)
+2. Go to https://www.economist.com/the-world-in-brief
+3. In DevTools, go to the "Network" tab, there select the first request (`the-world-in-brief`) and copy the value of the `Cookie:` header from "Request Headers".
+
+The cookie lives three months.
+
+Once you've done this, add the cookie to your `config.ini.php`:
+
+```
+[EconomistWorldInBriefBridge]
+cookie = "<value>"
+```


### PR DESCRIPTION
It was good while it lasted, but in May this year, The Economist finally has implemented a proper paywall.

I tried to reverse-engineer their login system, but it's so ridiculously complicated so I gave up. So I had added an option to use a user-provided cookie, and it has worked for me ever since (I am a subscriber). The cookie lasts for three months, so I've had to update it once.

I don't know if this solution will be used by anyone, so I'll leave it to your discretion whether to merge this or to remove the bridge altogether.

If you do the former, I'll also update the main Economist bridge.