### PR TITLE
fix bulletpoints for nordbayern

### DIFF
--- a/bridges/NordbayernBridge.php
+++ b/bridges/NordbayernBridge.php
@@ -92,6 +92,8 @@ class NordbayernBridge extends BridgeAbstract
                 $content .= self::getUseFullContent($element);
             } elseif ($element->tag === 'picture') {
                 $content .= self::getValidImage($element);
+            } elseif ($element->tag === 'ul') {
+                $content .= $element;
             }
         }
         return $content;


### PR DESCRIPTION
`ul` and `il` tags could not be handled by the Nordbayern bridge. This was just fixed.