### PR TITLE
[ARDMediathekBridge] fixing API URL, start using show title (#4170)

### DIFF
--- a/bridges/ARDMediathekBridge.php
+++ b/bridges/ARDMediathekBridge.php
@@ -40,6 +40,11 @@ class ARDMediathekBridge extends BridgeAbstract
      * @const IMAGEWIDTHPLACEHOLDER
      */
     const IMAGEWIDTHPLACEHOLDER = '{width}';
+    /**
+     * Title of the current show
+     * @var string
+     */
+    private $title;
 
     const PARAMETERS = [
         [
@@ -72,7 +77,7 @@ class ARDMediathekBridge extends BridgeAbstract
             }
         }
 
-        $url = self::APIENDPOINT . $showID . '/?pageSize=' . self::PAGESIZE;
+        $url = self::APIENDPOINT . $showID . '?pageSize=' . self::PAGESIZE;
         $rawJSON = getContents($url);
         $processedJSON = json_decode($rawJSON);
 
@@ -93,6 +98,17 @@ class ARDMediathekBridge extends BridgeAbstract
             $this->items[] = $item;
         }
 
+        $this->title = $processedJSON->title;
+
         date_default_timezone_set($oldTz);
+    }
+
+    /** {@inheritdoc} */
+    public function getName()
+    {
+        if (!empty($this->title)) {
+            return $this->title;
+        }
+        return parent::getName();
     }
 }


### PR DESCRIPTION
The bridge stopped working after the API server stopped accepting a trailing slash after the ID in the URL. This is being fixed. Also, the show title in the JSON was ignored. This is being fixed as well