### PR TITLE
fix(FeedParser): dont emit content module

### DIFF
--- a/lib/FeedItem.php
+++ b/lib/FeedItem.php
@@ -197,9 +197,6 @@ class FeedItem
             || $content instanceof simple_html_dom_node
         ) {
             $content = (string) $content;
-        } elseif (is_array($content)) {
-            // Assuming this is the rss2.0 content module
-            $content = $content['encoded'] ?? '';
         }
 
         if (is_string($content)) {

--- a/lib/FeedParser.php
+++ b/lib/FeedParser.php
@@ -168,8 +168,13 @@ final class FeedParser
             $media = $feedItem->children($namespaces['media']);
         }
 
+        if (isset($namespaces['content'])) {
+            $content = $feedItem->children($namespaces['content']);
+            $item['content'] = (string) $content;
+        }
+
         foreach ($namespaces as $namespaceName => $namespaceUrl) {
-            if (in_array($namespaceName, ['', 'media'])) {
+            if (in_array($namespaceName, ['', 'content', 'media'])) {
                 continue;
             }
             $item[$namespaceName] = $this->parseModule($feedItem, $namespaceName, $namespaceUrl);


### PR DESCRIPTION
it makes more sense for feed parser to only emit the content value.

also fixes some bugs where client code didnt check whether the result is a string or array.