### PR TITLE
[PriviblurBridge] Add Priviblur (Tumblr frontend) bridge

### DIFF
--- a/bridges/PriviblurBridge.php
+++ b/bridges/PriviblurBridge.php
@@ -36,11 +36,13 @@ class PriviblurBridge extends BridgeAbstract
             $item['uid'] = $item['comments']; // tumblr url is canonical
             $item['uri'] = $element->find('.interaction-buttons > a', 0)->href;
 
-            $tags = html_entity_decode($element->find('.post-tags', 0)->plaintext);
-            $tags = explode('#', $tags);
-            $tags = array_map('trim', $tags);
-            array_shift($tags);
-            $item['categories'] = $tags;
+            if ($element->find('.post-tags', 0)) {
+                $tags = html_entity_decode($element->find('.post-tags', 0)->plaintext);
+                $tags = explode('#', $tags);
+                $tags = array_map('trim', $tags);
+                array_shift($tags);
+                $item['categories'] = $tags;
+            }
 
             $heading = $element->find('h1', 0);
             if ($heading) {

--- a/bridges/PriviblurBridge.php
+++ b/bridges/PriviblurBridge.php
@@ -1,0 +1,67 @@
+<?php
+
+class PriviblurBridge extends BridgeAbstract
+{
+    const NAME = 'Priviblur';
+    const MAINTAINER = 'phantop';
+    const URI = 'https://github.com/syeopite/priviblur';
+    const DESCRIPTION = 'Returns Tumblr posts from a Priviblur link';
+    const PARAMETERS = [
+        [
+            'url' => [
+                'name' => 'URL',
+                'exampleValue' => 'https://priviblur.fly.dev',
+                'required' => true,
+            ]
+        ]
+    ];
+
+    private $title;
+
+    public function collectData()
+    {
+        $url = $this->getURI();
+        $html = getSimpleHTMLDOM($url);
+        $html = defaultLinkTo($html, $url);
+        $this->title = $html->find('head title', 0)->innertext;
+
+        $elements = $html->find('.post');
+        foreach ($elements as $element) {
+            $item = [];
+            $item['author'] = $element->find('.primary-post-author .blog-name', 0)->innertext;
+            $item['comments'] = $element->find('.interaction-buttons > a', 1)->href;
+            $item['content'] = $element->find('.post-body', 0);
+            $item['timestamp'] = $element->find('.primary-post-author time', 0)->innertext;
+            $item['title'] = $item['author'] . ': ' . $item['timestamp'];
+            $item['uid'] = $item['comments']; // tumblr url is canonical
+            $item['uri'] = $element->find('.interaction-buttons > a', 0)->href;
+
+            $tags = html_entity_decode($element->find('.post-tags', 0)->plaintext);
+            $tags = explode('#', $tags);
+            $tags = array_map('trim', $tags);
+            array_shift($tags);
+            $item['categories'] = $tags;
+
+            $heading = $element->find('h1', 0);
+            if ($heading) {
+                $item['title'] = $heading->innertext;
+            }
+
+            $this->items[] = $item;
+        }
+    }
+
+    public function getName()
+    {
+        $name = parent::getName();
+        if (isset($this->title)) {
+            $name = $this->title;
+        }
+        return $name;
+    }
+
+    public function getURI()
+    {
+        return $this->getInput('url') ? $this->getInput('url') : parent::getURI();
+    }
+}


### PR DESCRIPTION
Adds a bridge for [Priviblur](https://github.com/syeopite/priviblur), as it provides plaintext versions of Tumblr posts. Useful as some Tumblr pages (e.g. page search, non-user tags, tags for users without a subdomain) do not have official RSS feeds and many require either Javascript or an API token (and substantial API usage) to access contents without the assistance of a frontend.