### PR TITLE
[ZeitBridge] Remove content from original feed

### DIFF
--- a/bridges/ZeitBridge.php
+++ b/bridges/ZeitBridge.php
@@ -117,6 +117,14 @@ class ZeitBridge extends FeedExpander
             }, $authors));
         }
 
+        $item['content'] = '';
+
+        // summary
+        $summary = $article->find('.summary');
+        if ($summary) {
+            $item['content'] .= implode('', $summary);
+        }
+
         // header image
         $headerimg = $article->find('*[data-ct-row="headerimage"]', 0) ?? $article->find('.article-header', 0) ?? $article->find('header', 0);
         if ($headerimg) {


### PR DESCRIPTION
The original feed contains a small version of the header image and the summary or a literal "None". The header image is already added, but the original content was kept. This removes the original content and adds the summary if it exists.