### PR TITLE
Include all bridges in tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -47,8 +47,6 @@ phpcs.xml                               export-ignore
 phpcompatibility.xml                    export-ignore
 tests/                                  export-ignore
 cache/.gitkeep                          export-ignore
-bridges/DemoBridge.php                  export-ignore
-bridges/FeedExpanderExampleBridge.php   export-ignore
 
 ## Composer
 #


### PR DESCRIPTION
Currently, two "demo" and "example" bridges are excluded from GitHub's autogenerated tarballs. As I argued, those files can still be helpful for integration tests, as they are run in NixOS and don't need internet access or depend on the availability of external services [1].

Additionally, the official docker image builds from the checkout so it includes those bridges when users use containers or a git checkout compared to tarballs. This commit therefore unifies the list of available bridges between deployment methods.
Either we include those bridges in the tarball (preferred) or we exclude them from docker images as well.

[1] https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/web-apps/rss-bridge.nix#L20