### PR TITLE
[prtester] Rework test storage

### DIFF
--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -40,7 +40,7 @@ def main(instances: Iterable[Instance], with_upload: bool, with_reduced_upload: 
 
 def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, with_reduced_upload: bool) -> Iterable:
     instance_suffix = ''
-    prid = os.environ.get("PR")
+    prid = os.environ.get["PR"]
     tester_url = f'https://bockiii.github.io/prs/{prid}/'
     if instance.name:
         instance_suffix = f' ({instance.name})'
@@ -146,7 +146,7 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                     filename = f'{os.getcwd()}/{instance.name}_{form_number}.html'
                     with open(file=filename, mode='wb') as file:
                         file.write(page_text)
-            table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}/{filename}) | {status} |')
+            table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}/{instance.name}_{form_number}.html) | {status} |')
             form_number += 1
     return table_rows
 

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -4,7 +4,6 @@ import re
 from bs4 import BeautifulSoup
 from datetime import datetime
 from typing import Iterable
-#import os.path
 import os
 import urllib
 
@@ -41,7 +40,7 @@ def main(instances: Iterable[Instance], with_upload: bool, with_reduced_upload: 
 def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, with_reduced_upload: bool) -> Iterable:
     instance_suffix = ''
     prid = os.getenv("PR")
-    tester_url = f'https://bockiii.github.io/prs/{prid}'
+    tester_url = f'https://rss-bridge.github.io/rss-bridge-tests/prs/{prid}'
     if instance.name:
         instance_suffix = f' ({instance.name})'
     table_rows = []

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -142,7 +142,7 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                     status = '✔️'
                 if with_upload and (not with_reduced_upload or not status_is_ok):
                     filename = f'{os.getcwd()}/{instance.name}_{form_number}.html'
-                    with open(file=filename, mode='w+', encoding='utf-8') as file:
+                    with open(file=filename, mode='wb', encoding='utf-8') as file:
                         file.write(page_text)
             table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}) | {status} |')
             form_number += 1

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -41,7 +41,7 @@ def main(instances: Iterable[Instance], with_upload: bool, with_reduced_upload: 
 def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, with_reduced_upload: bool) -> Iterable:
     instance_suffix = ''
     prid = os.getenv("PR")
-    tester_url = f'https://bockiii.github.io/prs/{prid}/'
+    tester_url = f'https://bockiii.github.io/prs/{prid}'
     if instance.name:
         instance_suffix = f' ({instance.name})'
     table_rows = []

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -40,7 +40,7 @@ def main(instances: Iterable[Instance], with_upload: bool, with_reduced_upload: 
 
 def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, with_reduced_upload: bool) -> Iterable:
     instance_suffix = ''
-    prid = os.environ.get["PR"]
+    prid = os.getenv("PR")
     tester_url = f'https://bockiii.github.io/prs/{prid}/'
     if instance.name:
         instance_suffix = f' ({instance.name})'

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -141,7 +141,7 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                 if status_is_ok:
                     status = '✔️'
                 if with_upload and (not with_reduced_upload or not status_is_ok):
-                    filename = os.getcwd() + '/' + {instance.name} + '_' + {form_number} + '.html'
+                    filename = {instance.name} + '_' + {form_number} + '.html'
                     with open(file=filename, mode='w+', encoding='utf-8') as file:
                         file.write(page_text)
             table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}) | {status} |')

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -141,7 +141,7 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                 if status_is_ok:
                     status = '✔️'
                 if with_upload and (not with_reduced_upload or not status_is_ok):
-                    filename = {instance.name} + '_' + {form_number} + '.html'
+                    filename = f'{os.getcwd()}/{instance.name}_{form_number}.html'
                     with open(file=filename, mode='w+', encoding='utf-8') as file:
                         file.write(page_text)
             table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}) | {status} |')

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -4,7 +4,8 @@ import re
 from bs4 import BeautifulSoup
 from datetime import datetime
 from typing import Iterable
-import os.path
+#import os.path
+import os
 import urllib
 
 # This script is specifically written to be used in automation for https://github.com/RSS-Bridge/rss-bridge
@@ -39,7 +40,8 @@ def main(instances: Iterable[Instance], with_upload: bool, with_reduced_upload: 
 
 def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, with_reduced_upload: bool) -> Iterable:
     instance_suffix = ''
-    tester_url = 'https://bockiii.github.io/prs/'
+    prid = os.environ.get("PR")
+    tester_url = f'https://bockiii.github.io/prs/{prid}/'
     if instance.name:
         instance_suffix = f' ({instance.name})'
     table_rows = []
@@ -144,7 +146,7 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                     filename = f'{os.getcwd()}/{instance.name}_{form_number}.html'
                     with open(file=filename, mode='wb') as file:
                         file.write(page_text)
-            table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}) | {status} |')
+            table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}/{filename}) | {status} |')
             form_number += 1
     return table_rows
 

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -142,7 +142,7 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                     status = '✔️'
                 if with_upload and (not with_reduced_upload or not status_is_ok):
                     filename = f'{os.getcwd()}/{instance.name}_{form_number}.html'
-                    with open(file=filename, mode='wb', encoding='utf-8') as file:
+                    with open(file=filename, mode='wb') as file:
                         file.write(page_text)
             table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}) | {status} |')
             form_number += 1

--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -39,6 +39,7 @@ def main(instances: Iterable[Instance], with_upload: bool, with_reduced_upload: 
 
 def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, with_reduced_upload: bool) -> Iterable:
     instance_suffix = ''
+    tester_url = 'https://bockiii.github.io/prs/'
     if instance.name:
         instance_suffix = f' ({instance.name})'
     table_rows = []
@@ -140,10 +141,10 @@ def testBridges(instance: Instance, bridge_cards: Iterable, with_upload: bool, w
                 if status_is_ok:
                     status = '✔️'
                 if with_upload and (not with_reduced_upload or not status_is_ok):
-                    termpad = requests.post(url="https://termpad.com/", data=page_text)
-                    termpad_url = termpad.text.strip()
-                    termpad_url = termpad_url.replace('termpad.com/','termpad.com/raw/')
-            table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({termpad_url}) | {status} |')
+                    filename = os.getcwd() + '/' + {instance.name} + '_' + {form_number} + '.html'
+                    with open(file=filename, mode='w+', encoding='utf-8') as file:
+                        file.write(page_text)
+            table_rows.append(f'| {bridge_name} | [{form_number} {context_name}{instance_suffix}]({tester_url}) | {status} |')
             form_number += 1
     return table_rows
 

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -51,6 +51,12 @@ jobs:
           body="${body//$'\n'/'%0A'}";
           body="${body//$'\r'/'%0D'}";
           echo "bodylength=${#body}" >> $GITHUB_OUTPUT
+      - name: Upload generated template
+        uses: actions/upload-artifact@v4
+        id: upload-generated-template
+        with:
+          name: tests
+          path: '*.html'
       - name: Find Comment
         if: ${{ steps.testrun.outputs.bodylength > 130 }}
         uses: peter-evans/find-comment@v2
@@ -67,3 +73,37 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-file: comment.txt
           edit-mode: replace
+  upload_tests:
+    name: Upload tests
+    runs-on: ubuntu-latest
+    needs: test-pr
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'Bockiii/bockiii.github.io'
+          ref: 'main'
+          token:  ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Setup git config
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "<>"
+  
+      - name: Download generated template
+        uses: actions/download-artifact@v4
+        with:
+          name: tests
+
+      - name: Move tests
+        run: |
+          cd prs
+          mkdir ${{github.event.number}}
+          cd ${{github.event.number}}
+          cp $GITHUB_WORKSPACE/*.html .
+          
+      - name: Commit and push generated template
+        run: |
+          export COMMIT_MESSAGE="Added tests for PR ${{github.event.number}}"
+          git add .
+          git commit -m "$COMMIT_MESSAGE"
+          git push

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -86,7 +86,6 @@ jobs:
   
       - name: Setup git config
         run: |
-          git config --unset-all http.https://github.com/.extraheader
           git config --global user.name "GitHub Actions"
           git config --global user.email "<>"
   

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -19,7 +19,7 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Check out rss-bridge
         run: |
-          export PR=${{github.event.number}};
+          PR=${{github.event.number}};
           wget -O requirements.txt https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester-requirements.txt;
           wget https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester.py;
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
@@ -51,6 +51,8 @@ jobs:
           body="${body//$'\n'/'%0A'}";
           body="${body//$'\r'/'%0D'}";
           echo "bodylength=${#body}" >> $GITHUB_OUTPUT
+        env:
+          PR: ${{ github.event.number }}
       - name: Upload generated tests
         uses: actions/upload-artifact@v4
         id: upload-generated-tests

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -13,7 +13,7 @@ jobs:
     # Needs additional permissions https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989
     steps:
       - name: Check out self
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Move tests
         run: |
           cd prs
-          mkdir ${{github.event.number}}
+          mkdir -p ${{github.event.number}}
           cd ${{github.event.number}}
-          mv $GITHUB_WORKSPACE/*.html .
+          mv -f $GITHUB_WORKSPACE/*.html .
           
       - name: Commit and push generated template
         run: |

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -33,7 +33,7 @@ jobs:
           docker build -t prbuild .;
           docker run -d -v $GITHUB_WORKSPACE/whitelist.txt:/app/whitelist.txt -v $GITHUB_WORKSPACE/DEBUG:/app/DEBUG -p 3001:80 prbuild
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.7'
           cache: 'pip'
@@ -59,7 +59,7 @@ jobs:
           path: '*.html'
       - name: Find Comment
         if: ${{ steps.testrun.outputs.bodylength > 130 }}
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -67,7 +67,7 @@ jobs:
           body-includes: Pull request artifacts
       - name: Create or update comment
         if: ${{ steps.testrun.outputs.bodylength > 130 }}
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -86,9 +86,9 @@ jobs:
   
       - name: Setup git config
         run: |
+          git config --unset-all http.https://github.com/.extraheader
           git config --global user.name "GitHub Actions"
           git config --global user.email "<>"
-          git config --unset-all http.https://github.com/.extraheader
   
       - name: Download generated template
         uses: actions/download-artifact@v4

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -51,9 +51,9 @@ jobs:
           body="${body//$'\n'/'%0A'}";
           body="${body//$'\r'/'%0D'}";
           echo "bodylength=${#body}" >> $GITHUB_OUTPUT
-      - name: Upload generated template
+      - name: Upload generated tests
         uses: actions/upload-artifact@v4
-        id: upload-generated-template
+        id: upload-generated-tests
         with:
           name: tests
           path: '*.html'

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           repository: 'Bockiii/bockiii.github.io'
           ref: 'main'
-          token:  ${{ secrets.GITHUB_TOKEN }}
+          token:  ${{ secrets.RSSTESTER_ACTION }}
   
       - name: Setup git config
         run: |

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'Bockiii/bockiii.github.io'
+          repository: 'RSS-Bridge/rss-bridge-tests'
           ref: 'main'
           token:  ${{ secrets.RSSTESTER_ACTION }}
   
@@ -91,7 +91,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "<>"
   
-      - name: Download generated template
+      - name: Download tests
         uses: actions/download-artifact@v4
         with:
           name: tests
@@ -103,7 +103,7 @@ jobs:
           cd ${{github.event.number}}
           mv -f $GITHUB_WORKSPACE/*.html .
           
-      - name: Commit and push generated template
+      - name: Commit and push generated tests
         run: |
           export COMMIT_MESSAGE="Added tests for PR ${{github.event.number}}"
           git add .

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "<>"
+          git config --unset-all http.https://github.com/.extraheader
   
       - name: Download generated template
         uses: actions/download-artifact@v4
@@ -99,7 +100,7 @@ jobs:
           cd prs
           mkdir ${{github.event.number}}
           cd ${{github.event.number}}
-          cp $GITHUB_WORKSPACE/*.html .
+          mv $GITHUB_WORKSPACE/*.html .
           
       - name: Commit and push generated template
         run: |

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -67,7 +67,7 @@ jobs:
           body-includes: Pull request artifacts
       - name: Create or update comment
         if: ${{ steps.testrun.outputs.bodylength > 130 }}
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -19,7 +19,7 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Check out rss-bridge
         run: |
-          PR=${{github.event.number}};
+          export PR=${{github.event.number}};
           wget -O requirements.txt https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester-requirements.txt;
           wget https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester.py;
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;


### PR DESCRIPTION
This PR adapts the workflow and the prtester.py

The prtester.py will save the generated html files to the workflow executor instead of uploading it to the defunct termpad instance.

See #4269 

The workflow adaption will upload those generated html files to a second repo, https://github.com/RSS-Bridge/rss-bridge-tests

The workflow will create a PR numbered folder in the /prs/ folder and store and update the files there in case a PR update is done.

The Workflow works in my personal repo setup:
- Workflow example: https://github.com/Bockiii/rss-bridge/actions/runs/11326514420
- Generated file example: https://bockiii.github.io/prs/32/pr_1.html

To Do:
- An organizational secret needs to be created with an API key that has access to all (or at least both) current org-repos. It needs to either be created as "RSSTESTER_ACTION" or that line in the workflow template needs to be adapted. I'm not an owner of the org, and thus, cannot create that secret.
- I will create a new workflow that will clean up old pr files as soon as the PR is either closed or merged, but thats a second PR.