### PR TITLE
[AppleMusicBridge] fix linting error

### DIFF
--- a/bridges/AppleMusicBridge.php
+++ b/bridges/AppleMusicBridge.php
@@ -43,7 +43,10 @@ class AppleMusicBridge extends BridgeAbstract
                     'enclosures' => $artworkUrl500,
                     'author' => $item->artistName,
                     'content' => "<figure>
-    <img srcset=\"$item->artworkUrl60 60w, $item->artworkUrl100 100w, $artworkUrl500 500w, $artworkUrl2000 2000w\" sizes=\"100%\" src=\"$artworkUrl2000\" alt=\"Cover of $escapedCollectionName\" style=\"display: block; margin: 0 auto;\" />
+    <img srcset=\"$item->artworkUrl60 60w, $item->artworkUrl100 100w, $artworkUrl500 500w, $artworkUrl2000 2000w\"
+         sizes=\"100%\" src=\"$artworkUrl2000\"
+         alt=\"Cover of $escapedCollectionName\"
+         style=\"display: block; margin: 0 auto;\" />
     <figcaption>
         from <a href=\"$artist->artistLinkUrl\">$item->artistName</a><br />$copyright
     </figcaption>


### PR DESCRIPTION
Fix errors that causes automatic checks of other PRs to fail.

Output from https://github.com/RSS-Bridge/rss-bridge/actions/runs/11415696578/job/31766035758?pr=4307

====================================================

```
FILE: /home/runner/work/rss-bridge/rss-bridge/bridges/AppleMusicBridge.php 
-------------------------------------------------------------------------------- 
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 46 | ERROR | Line exceeds maximum limit of 180 characters; contains 238
    |       | characters
--------------------------------------------------------------------------------
```