### PR TITLE
[prtester] fix prtester no longer supporting multiple bridges

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -4,3 +4,4 @@
 # Generated files
 comment*.md
 comment*.txt
+*.html


### PR DESCRIPTION
This PR will fix `prtester.py` no longer supporting multiple bridges being changed (after https://github.com/RSS-Bridge/rss-bridge/pull/4292 by @Bockiii), because the names of the generated html files are not unique enough.

**Example**
Reddit and XPath bridges get changed, because of refactoring.

Current filenames would be:
- current_1.html => XPath 1 overrides Reddit 1
- current_2.html => XPath 2 overrides Reddit 2
- current_3.html => Reddit 3
- pr_1.html => XPath 1 overrides Reddit 1
- pr_2.html => XPath 2 overrides Reddit 2
- pr_3.html => Reddit 3

New filenames will be:
- Reddit_1_current.html
- Reddit_1_pr.html
- Reddit_2_current.html
- Reddit_2_pr.html
- Reddit_3_current.html
- Reddit_3_pr.html
- XPath_1_current.html
- XPath_1_pr.html
- XPath_2_current.html
- XPath_2_pr.html

**Additional changes**
- delete all `*.html` files at the start (improves local debugging for devs)
- git ignore the generated `*.html` files in the `.github` directory
- use `about:blank` again when no html artifact is generated (`if error_messages` is `true` or `if with_upload and (not with_reduced_upload or not status_is_ok):` is `false`)
- fix `SyntaxWarning: invalid escape sequence` by add `r` in front of regex strings