### PR TITLE
Update python dependency for prtester

### DIFF
--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.13'
           cache: 'pip'
       - name: Install requirements
         run: |


### PR DESCRIPTION
This is necessary for glob.glob() with the root_dir argument