### PR TITLE
[prtester] improve prtester.py and prhtmlgenerator.yml for running in forks

### DIFF
--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check number of bridges
         id: check_bridges
         run: |
-          PR=${{github.event.number}};
+          PR=${{ github.event.number || 'none' }};
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
           bridgeamount=$(cat $PR.patch | grep "\bbridges/[A-Za-z0-9]*Bridge\.php\b" | sed "s=.*\bbridges/\([A-Za-z0-9]*\)Bridge\.php\b.*=\1=g" | sort | uniq | wc -l);
           echo "BRIDGES=$bridgeamount" >> "$GITHUB_OUTPUT"
@@ -39,7 +39,7 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Check out rss-bridge
         run: |
-          PR=${{github.event.number}};
+          PR=${{ github.event.number || 'none' }};
           wget -O requirements.txt https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester-requirements.txt;
           wget https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester.py;
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
@@ -65,7 +65,7 @@ jobs:
         id: testrun
         run: |
           mkdir results;
-          python prtester.py --artifacts-base-url "https://${{ github.repository_owner }}.github.io/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}/prs/${{ github.event.number }}";
+          python prtester.py --artifacts-base-url "https://${{ github.repository_owner }}.github.io/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}/prs/${{ github.event.number || 'none' }}";
           body="$(cat comment.txt)";
           body="${body//'%'/'%25'}";
           body="${body//$'\n'/'%0A'}";
@@ -114,14 +114,14 @@ jobs:
           name: tests
       - name: Move tests
         run: |
-          DIRECTORY="$GITHUB_WORKSPACE/prs/${{ github.event.number }}"
+          DIRECTORY="$GITHUB_WORKSPACE/prs/${{ github.event.number || 'none' }}"
           rm -rf $DIRECTORY
           mkdir -p $DIRECTORY
           cd $DIRECTORY
           mv -f $GITHUB_WORKSPACE/*.html .
       - name: Commit and push generated tests
         run: |
-          export COMMIT_MESSAGE="Added tests for PR ${{github.event.number}}"
+          export COMMIT_MESSAGE="Added tests for PR ${{ github.event.number || 'none' }}"
           git add .
           git commit -m "$COMMIT_MESSAGE" || exit 0
           git push

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -5,24 +5,29 @@ on:
     branches: [ master ]
 
 jobs:
-  check-bridges:
+  checks:
     name: Check if bridges were changed
     runs-on: ubuntu-latest
     outputs:
-      BRIDGES: ${{ steps.check1.outputs.BRIDGES }}
+      BRIDGES: ${{ steps.check_bridges.outputs.BRIDGES }}
+      WITH_UPLOAD: ${{ steps.check_upload.outputs.WITH_UPLOAD }}
     steps:
       - name: Check number of bridges
-        id: check1
+        id: check_bridges
         run: |
           PR=${{github.event.number}};
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
           bridgeamount=$(cat $PR.patch | grep "\bbridges/[A-Za-z0-9]*Bridge\.php\b" | sed "s=.*\bbridges/\([A-Za-z0-9]*\)Bridge\.php\b.*=\1=g" | sort | uniq | wc -l);
           echo "BRIDGES=$bridgeamount" >> "$GITHUB_OUTPUT"
+      - name: "Check upload token secret RSSTESTER_ACTION is set"
+        id: check_upload
+        run: |
+          echo "WITH_UPLOAD=$([ -n "${{ secrets.RSSTESTER_ACTION }}" ] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
   test-pr:
     name: Generate HTML
     runs-on: ubuntu-latest
-    needs: check-bridges
-    if: needs.check-bridges.outputs.BRIDGES > 0
+    needs: checks
+    if: needs.checks.outputs.BRIDGES > 0
     env:
       PYTHONUNBUFFERED: 1
     # Needs additional permissions https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989
@@ -60,14 +65,12 @@ jobs:
         id: testrun
         run: |
           mkdir results;
-          python prtester.py;
+          python prtester.py --artifacts-base-url "https://${{ github.repository_owner }}.github.io/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}/prs/${{ github.event.number }}";
           body="$(cat comment.txt)";
           body="${body//'%'/'%25'}";
           body="${body//$'\n'/'%0A'}";
           body="${body//$'\r'/'%0D'}";
           echo "bodylength=${#body}" >> $GITHUB_OUTPUT
-        env:
-          PR: ${{ github.event.number }}
       - name: Upload generated tests
         uses: actions/upload-artifact@v4
         id: upload-generated-tests
@@ -94,30 +97,28 @@ jobs:
     name: Upload tests
     runs-on: ubuntu-latest
     needs: test-pr
+    if: needs.checks.outputs.WITH_UPLOAD == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'RSS-Bridge/rss-bridge-tests'
+          repository: "${{ github.repository_owner }}/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}"
           ref: 'main'
           token:  ${{ secrets.RSSTESTER_ACTION }}
-  
       - name: Setup git config
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "<>"
-  
       - name: Download tests
         uses: actions/download-artifact@v4
         with:
           name: tests
-
       - name: Move tests
         run: |
-          cd prs
-          mkdir -p ${{github.event.number}}
-          cd ${{github.event.number}}
+          DIRECTORY="$GITHUB_WORKSPACE/prs/${{ github.event.number }}"
+          rm -rf $DIRECTORY
+          mkdir -p $DIRECTORY
+          cd $DIRECTORY
           mv -f $GITHUB_WORKSPACE/*.html .
-          
       - name: Commit and push generated tests
         run: |
           export COMMIT_MESSAGE="Added tests for PR ${{github.event.number}}"


### PR DESCRIPTION
This PR will improve `prtester.py` and `prhtmlgenerator.yml` for running in forks. It makes the hard-coded repo name and base url to the new `rss-bridge-tests` repo dynamic/configurable (by using the repo owners name and an optional `ARTIFACTS_REPO` variable). The `Upload tests` job will be skipped when the secret `RSSTESTER_ACTION` is missing (which will always be the case for forks, by default) instead of always failing. Additional small fixes to the `Upload tests` job: It failed when the `prs` directory did not exist yet and it failed when there was no change to the html files.