### PR TITLE
[IdealoBridge] Fix

### DIFF
--- a/bridges/IdealoBridge.php
+++ b/bridges/IdealoBridge.php
@@ -152,7 +152,11 @@ class IdealoBridge extends BridgeAbstract
             $PriceNew = $FirstButton->find('strong', 0)->plaintext;
             // Save current price
             $this->saveCacheValue($KeyNEW, $PriceNew);
+        } else if ($FirstButton === null) {
+            // In case there is no actual New Price delete the previous value in the cache
+             $this->cache->delete($this->getShortName() . '_' . $KeyNEW);
         }
+
 
         // Second Button contains the used product price
         $SecondButton = $html->find('.oopStage-conditionButton-wrapper-text', 1);
@@ -160,6 +164,9 @@ class IdealoBridge extends BridgeAbstract
             $PriceUsed = $SecondButton->find('strong', 0)->plaintext;
             // Save current price
             $this->saveCacheValue($KeyUSED, $PriceUsed);
+        } else if ($SecondButton === null) {
+            // In case there is no actual Used Price delete the previous value in the cache
+             $this->cache->delete($this->getShortName() . '_' . $KeyUSED);
         }
 
         // Only continue if a price has changed


### PR DESCRIPTION
When a product was available before as used product in the past, and now it's not available used anymore, a price update article was generated on every feed loading, because the old used price was still stored in the cache, and therefore different as "no price".

The issue was also present in the cas of a New product price that becomes unavailable.

Now, when either there is no New or Used price available, the previous price is delete from the cache.