### PR TITLE
feat: add WKYT bridge

### DIFF
--- a/bridges/WKYTNewsBridge.php
+++ b/bridges/WKYTNewsBridge.php
@@ -1,0 +1,27 @@
+<?php
+
+class WKYTNewsBridge extends BridgeAbstract
+{
+    const NAME = 'WKYT Lexington News';
+    const URI = 'https://www.wkyt.com/news/';
+    const DESCRIPTION = 'Returns the recent articles published on WKYT News (Lexington KY)';
+    const MAINTAINER = 'mattconnell';
+
+    public function collectData()
+    {
+        $html = getSimpleHTMLDOM(self::URI);
+        $html = defaultLinkTo($html, self::URI);
+
+        $articles = $html->find('.card-body');
+
+        foreach ($articles as $article) {
+            $item = [];
+            $url = $article->find('.headline a', 0);
+            $item['uri'] = $url->href;
+            $item['title'] = trim($url->plaintext);
+            $item['author'] = $article->find('.author', 0)->plaintext;
+            $item['content'] = $article->find('.deck', 0)->plaintext;
+            $this->items[] = $item;
+        }
+    }
+}


### PR DESCRIPTION
Bridge for the WKYT Lexington News site

I noticed that WKYT and WYMT had very similar news interfaces, and I was correct in guessing that I could just copy and paste this bridge with some different metadata and it would work.  It occurs to me that a lot of the CBS news affiliate stations, probably most of the Gray Media affiliated sites, will be able to be handled in a very similar if not exactly the same way.  In fact I just checked, after typing this, and WSAZ works exactly the same way.

**Question**: is it worthwhile trying to flesh out an abstract class for these?  Is this something better discussed in an issue?  Am I retracing someone else's steps already?