### PR TITLE
fix: dont acquire exclusive locks

### DIFF
--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -53,7 +53,7 @@ class FileCache implements CacheInterface
             'value'         => $value,
         ];
         $cacheFile = $this->createCacheFile($key);
-        $bytes = file_put_contents($cacheFile, serialize($item), LOCK_EX);
+        $bytes = file_put_contents($cacheFile, serialize($item));
         // todo: Consider tightening the permissions of the created file. It usually allow others to read, depending on umask
         if ($bytes === false) {
             // Consider just logging the error here

--- a/lib/logger.php
+++ b/lib/logger.php
@@ -136,7 +136,7 @@ final class StreamHandler
             $record['message'],
             $context
         );
-        $bytes = file_put_contents($this->stream, $text, FILE_APPEND | LOCK_EX);
+        $bytes = file_put_contents($this->stream, $text, FILE_APPEND);
     }
 }
 


### PR DESCRIPTION
Due to bugs in logging/error-handling there sometimes are deadlocks.
Let's just drop ex locks for now.