### PR TITLE
[EdfColorDay Bridge] add new bridge

### DIFF
--- a/bridges/EdfColorDayBridge.php
+++ b/bridges/EdfColorDayBridge.php
@@ -19,7 +19,7 @@ class EdfColorDayBridge extends BridgeAbstract
             ]
         ]
     ];
-    const CACHE_TIMEOUT = 0; //7200; // 2h
+    const CACHE_TIMEOUT = 7200; // 2h
 
     /**
      * @param simple_html_dom $html

--- a/bridges/EdfColorDayBridge.php
+++ b/bridges/EdfColorDayBridge.php
@@ -1,0 +1,116 @@
+<?php
+
+class EdfColorDayBridge extends BridgeAbstract
+{
+    const NAME = 'EDF tempo color';
+    // pull info from this site for now because EDF do not provide correct opendata
+    const URI = 'https://www.services-rte.com/cms/open_data/v1/tempo';
+    const DESCRIPTION = 'Get EDF color of today and tomorrow of tempo contract';
+    const MAINTAINER = 'floviolleau';
+    const PARAMETERS = [
+        [
+            'contract' => [
+                'name' => 'Choisir un contrat',
+                'type' => 'list',
+                // we can add later more option prices like EJP
+                'values' => [
+                    'Tempo' => 'tempo'
+                ],
+            ]
+        ]
+    ];
+    const CACHE_TIMEOUT = 7200; // 2h
+
+    /**
+     * @param simple_html_dom $html
+     * @param string $contractUri
+     * @return void
+     */
+    private function tempo(string $json): void
+    {
+        $jsonDecoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        $values = [
+            $this->formatFrenchDate('now') => date('Y-m-d'),
+            'Demain ' . $this->formatFrenchDate('tomorrow') => date('Y-m-d', strtotime('+1 day'))
+        ];
+
+        foreach ($values as $key => $value) {
+            $i++;
+            $item = [];
+
+            $text = $key . ' : ' . $this->getDisplayableColor($jsonDecoded['values'][$value]);
+            $item['uri'] = self::URI . $contractUri;
+            $item['title'] = $text;
+            $item['author'] = self::MAINTAINER;
+            $item['content'] = $text;
+            $item['uid'] = hash('sha256', $item['title']);
+
+            $this->items[] = $item;
+        }
+    }
+
+    private function formatFrenchDate(string $datetime): string
+    {
+        // Set the locale to French
+        setlocale(LC_TIME, 'fr_FR.UTF-8');
+
+        // Create a DateTime object for the desired date
+        $now = new DateTime($datetime);
+
+        // Format the date
+        return strftime('%A %d %B %Y', $now->getTimestamp());
+    }
+
+    private function getDisplayableColor(string $color): string
+    {
+        $displayableColor = null;
+        switch($color) {
+            case 'BLUE':
+                $displayableColor = '🟦 TEMPO_BLEU';
+                break;
+            case 'WHITE':
+                $displayableColor = '⬜ TEMPO_BLANC';
+                break;
+            case 'RED':
+                $displayableColor = '🟥 TEMPO_ROUGE';
+                break;
+            default:
+                $displayableColor = '⬛ NON_DEFINI';
+                break;
+        }
+
+        return $displayableColor;
+    }
+
+    private function getTempoYear(): string
+    {
+        $month = date('n'); // Current month as a number (1-12)
+        $year = date('Y');  // Current year
+    
+        // Assuming the tempo year starts in September
+        if ($month >= 9) {
+            return $year . '-' . ($year + 1); // e.g., 2024-2025
+        }
+
+        return ($year - 1) . '-' . $year; // e.g., 2023-2024
+    }
+
+    public function collectData()
+    {
+        $contract = $this->getKey('contract');
+
+        $header = [
+            'Content-type: application/json',
+        ];
+        $opts = [
+            CURLOPT_HTTPGET => 1,
+        ];
+
+        $json = getContents(self::URI . '?season=' . $this->getTempoYear(), $header, $opts);
+
+        if ($contract === 'Tempo') {
+            $this->tempo($json);
+        }
+    }
+}

--- a/bridges/EdfColorDayBridge.php
+++ b/bridges/EdfColorDayBridge.php
@@ -65,7 +65,7 @@ class EdfColorDayBridge extends BridgeAbstract
     private function getDisplayableColor(string $color): string
     {
         $displayableColor = null;
-        switch($color) {
+        switch ($color) {
             case 'BLUE':
                 $displayableColor = '🟦 TEMPO_BLEU';
                 break;
@@ -87,7 +87,7 @@ class EdfColorDayBridge extends BridgeAbstract
     {
         $month = date('n'); // Current month as a number (1-12)
         $year = date('Y');  // Current year
-    
+
         // Assuming the tempo year starts in September
         if ($month >= 9) {
             return $year . '-' . ($year + 1); // e.g., 2024-2025

--- a/bridges/EdfColorDayBridge.php
+++ b/bridges/EdfColorDayBridge.php
@@ -36,7 +36,6 @@ class EdfColorDayBridge extends BridgeAbstract
         ];
 
         foreach ($values as $key => $value) {
-            $i++;
             $item = [];
 
             $text = $key . ' : ' . $this->getDisplayableColor($jsonDecoded['values'][$value]);

--- a/bridges/EdfColorDayBridge.php
+++ b/bridges/EdfColorDayBridge.php
@@ -22,8 +22,7 @@ class EdfColorDayBridge extends BridgeAbstract
     const CACHE_TIMEOUT = 7200; // 2h
 
     /**
-     * @param simple_html_dom $html
-     * @param string $contractUri
+     * @param string $json
      * @return void
      */
     private function tempo(string $json): void
@@ -39,7 +38,7 @@ class EdfColorDayBridge extends BridgeAbstract
             $item = [];
 
             $text = $key . ' : ' . $this->getDisplayableColor($jsonDecoded['values'][$value]);
-            $item['uri'] = self::URI . $contractUri;
+            $item['uri'] = self::URI . '?season=' . $this->getTempoYear();
             $item['title'] = $text;
             $item['author'] = self::MAINTAINER;
             $item['content'] = $text;

--- a/bridges/EdfColorDayBridge.php
+++ b/bridges/EdfColorDayBridge.php
@@ -19,7 +19,7 @@ class EdfColorDayBridge extends BridgeAbstract
             ]
         ]
     ];
-    const CACHE_TIMEOUT = 7200; // 2h
+    const CACHE_TIMEOUT = 0; //7200; // 2h
 
     /**
      * @param simple_html_dom $html
@@ -28,7 +28,7 @@ class EdfColorDayBridge extends BridgeAbstract
      */
     private function tempo(string $json): void
     {
-        $jsonDecoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $jsonDecoded = Json::decode($json);
 
         $values = [
             $this->formatFrenchDate('now') => date('Y-m-d'),
@@ -52,17 +52,25 @@ class EdfColorDayBridge extends BridgeAbstract
 
     private function formatFrenchDate(string $datetime): string
     {
-        // Set the locale to French
-        setlocale(LC_TIME, 'fr_FR.UTF-8');
+        // Set the locale and date format
+        $locale = 'fr_FR';
+        $formatter = new IntlDateFormatter(
+            $locale,
+            IntlDateFormatter::FULL, // Full date format
+            IntlDateFormatter::NONE,  // No time
+            null,                     // Default timezone
+            IntlDateFormatter::GREGORIAN, // Gregorian calendar
+            'EEEE dd MMMM yyyy'      // Custom pattern
+        );
 
         // Create a DateTime object for the desired date
         $now = new DateTime($datetime);
 
         // Format the date
-        return strftime('%A %d %B %Y', $now->getTimestamp());
+        return $formatter->format($now);
     }
 
-    private function getDisplayableColor(string $color): string
+    private function getDisplayableColor(?string $color): string
     {
         $displayableColor = null;
         switch ($color) {
@@ -101,7 +109,7 @@ class EdfColorDayBridge extends BridgeAbstract
         $contract = $this->getKey('contract');
 
         $header = [
-            'Content-type: application/json',
+            'Accept: application/json',
         ];
         $opts = [
             CURLOPT_HTTPGET => 1,

--- a/bridges/EdfColorDayBridge.php
+++ b/bridges/EdfColorDayBridge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class EdfColorDayBridge extends BridgeAbstract
 {
     const NAME = 'EDF tempo color';
@@ -22,7 +24,8 @@ class EdfColorDayBridge extends BridgeAbstract
     const CACHE_TIMEOUT = 7200; // 2h
 
     /**
-     * @param string $json
+     * @param simple_html_dom $html
+     * @param string $contractUri
      * @return void
      */
     private function tempo(string $json): void
@@ -38,7 +41,7 @@ class EdfColorDayBridge extends BridgeAbstract
             $item = [];
 
             $text = $key . ' : ' . $this->getDisplayableColor($jsonDecoded['values'][$value]);
-            $item['uri'] = self::URI . '?season=' . $this->getTempoYear();
+            $item['uri'] = self::URI . $contractUri;
             $item['title'] = $text;
             $item['author'] = self::MAINTAINER;
             $item['content'] = $text;


### PR DESCRIPTION
Hi,

I'm adding a new bridge to be able to get the color of the current day and the next day.

Info are based on RTE data: https://www.services-rte.com/fr/visualisez-les-donnees-publiees-par-rte/calendrier-des-offres-de-fourniture-de-type-tempo.html

Screenshot:

![image](https://github.com/user-attachments/assets/394e0eb7-10e7-41e1-b6e9-38a2cdf8207e)
