### PR TITLE
[MixologyBridge] add null checks for author and timestamp elements

### DIFF
--- a/bridges/MixologyBridge.php
+++ b/bridges/MixologyBridge.php
@@ -56,14 +56,14 @@ class MixologyBridge extends BridgeAbstract
         $article = getSimpleHTMLDOMCached($item['uri']);
 
         $authorLink = $article->find('.beitrag-author a', 0);
-		if (!empty($authorLink)) {
-			$item['author'] = $authorLink->plaintext;
-		}
-        
-		$timeElement = $article->find('.beitrag-date time', 0);
-		if (!empty($timeElement)) {
-			$item['timestamp'] = strtotime($timeElement->datetime);
-		}
+        if (!empty($authorLink)) {
+            $item['author'] = $authorLink->plaintext;
+        }
+
+        $timeElement = $article->find('.beitrag-date time', 0);
+        if (!empty($timeElement)) {
+            $item['timestamp'] = strtotime($timeElement->datetime);
+        }
 
         $content = '';
 

--- a/bridges/MixologyBridge.php
+++ b/bridges/MixologyBridge.php
@@ -55,8 +55,15 @@ class MixologyBridge extends BridgeAbstract
     {
         $article = getSimpleHTMLDOMCached($item['uri']);
 
-        $item['author'] = $article->find('.beitrag-author a', 0)->plaintext;
-        $item['timestamp'] = strtotime($article->find('.beitrag-date time', 0)->datetime);
+        $authorLink = $article->find('.beitrag-author a', 0);
+		if (!empty($authorLink)) {
+			$item['author'] = $authorLink->plaintext;
+		}
+        
+		$timeElement = $article->find('.beitrag-date time', 0);
+		if (!empty($timeElement)) {
+			$item['timestamp'] = strtotime($timeElement->datetime);
+		}
 
         $content = '';
 


### PR DESCRIPTION
Fixes following error when author or timestamp is not set in article.

```
Details
Type: ErrorException
Code: 0
Message: Attempt to read property "plaintext" on null
File: bridges/MixologyBridge.php
Line: 58
```