### PR TITLE
[RutubeBridge] Use publication time instead of creation time

### DIFF
--- a/bridges/RutubeBridge.php
+++ b/bridges/RutubeBridge.php
@@ -132,7 +132,7 @@ class RutubeBridge extends BridgeAbstract
                     $video->description . ' '
                 )
             );
-            $item['timestamp'] = $video->created_ts;
+            $item['timestamp'] = $video->publication_ts;
             $item['author'] = $video->author->name;
             $item['content'] = $content;
 


### PR DESCRIPTION
Publication time is shown in video page itself, so it is more essential