### PR TITLE
[BundestagParteispendenBridge] Fix cURL Error

### DIFF
--- a/bridges/BundestagParteispendenBridge.php
+++ b/bridges/BundestagParteispendenBridge.php
@@ -32,7 +32,7 @@ URI;
         $firstAnchor = $html->find('a', 0)
             or returnServerError('Could not find the proper HTML element.');
 
-        $url = 'https://www.bundestag.de' . $firstAnchor->href;
+        $url = $firstAnchor->href;
 
         // Get the actual page with the soft money donations
         $html = getSimpleHTMLDOMCached($url, self::CACHE_TIMEOUT);


### PR DESCRIPTION
Fixed cURL Error. Beginning of URL not needed anymore, causing a duplicate in the string.

ErrorMessage: cURL error Could not resolve host: [www.bundestag.dehttps](http://www.bundestag.dehttps/): 6 (https://curl.haxx.se/libcurl/c/libcurl-errors.html) for [https://www.bundestag.dehttps://www.bundestag.de/parlament/praesidium/parteienfinanzierung/fundstellen50000/2025/2025-inhalt-1032412](https://www.bundestag.dehttps//www.bundestag.de/parlament/praesidium/parteienfinanzierung/fundstellen50000/2025/2025-inhalt-1032412)