### PR TITLE
fix nn.de description and paywall filter

### DIFF
--- a/bridges/NurembergerNachrichtenBridge.php
+++ b/bridges/NurembergerNachrichtenBridge.php
@@ -6,7 +6,7 @@ class NurembergerNachrichtenBridge extends BridgeAbstract
     const NAME = 'Nürnberger Nachrichten';
     const CACHE_TIMEOUT = 3600;
     const URI = 'https://www.nn.de';
-    const DESCRIPTION = 'Bridge for Bavarian regional news site nordbayern.de';
+    const DESCRIPTION = 'Bridge for NurembergerNachrichten news site nn.de';
     const PARAMETERS = [ [
         'region' => [
             'name' => 'region',
@@ -66,7 +66,7 @@ class NurembergerNachrichtenBridge extends BridgeAbstract
             // exclude nn+ articles if desired
             if (
                 $this->getInput('hideNNPlus') &&
-                str_contains($articleContent->find('article[id=article]', 0)->find('header', 0), 'icon-nnplus')
+                $articleContent->find('div[class=paywall]')
             ) {
                 continue;
             }


### PR DESCRIPTION
This pr does two things:
1. Fix the description of the bridge.
2. Fix the paywall filter. The nn.de website has changed so the filter had to be updated.