### PR TITLE
[BukowskisBridge] Fix data-lot-id not matching auction id so use link as uid instead

### DIFF
--- a/bridges/BukowskisBridge.php
+++ b/bridges/BukowskisBridge.php
@@ -206,7 +206,7 @@ class BukowskisBridge extends BridgeAbstract
             $this->items[] = [
                 'title' => $title,
                 'uri' => $baseUrl . $relative_url,
-                'uid' => $lot->getAttribute('data-lot-id'),
+                'uid' => $relative_url,
                 'content' => count($images) > 0 ? "<img src='$images[0]'/><br/>$title" : $title,
                 'enclosures' => array_slice($images, 1),
             ];


### PR DESCRIPTION
For some reason the lot ids that Bukowskis use is not the same as the id used for the auction object so I switched the uid to use the relative url instead which is the same between refreshes, so you don't get duplicate entries in the feed.

![image](https://github.com/user-attachments/assets/ab0a3f4e-f531-4b34-b06d-8ea5975ce4a4)
