### PR TITLE
[RedditBridge] Added time interval and filter for min comment count

### DIFF
--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -38,7 +38,8 @@ class RedditBridge extends BridgeAbstract
                     'Hot' => 'hot',
                     'Relevance' => 'relevance',
                     'New' => 'new',
-                    'Top' => 'top'
+                    'Top' => 'top',
+                    'Comments' => 'comments'
                 ],
                 'defaultValue' => 'Hot'
             ],

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -192,13 +192,11 @@ class RedditBridge extends BridgeAbstract
                     if ($data->num_comments < $min_comments || $data->score < $min_score) {
                         continue;
                     }
-                }
-                else if ($min_score >= 0) {
+                } elseif ($min_score >= 0) {
                     if ($data->score < $min_score) {
                         continue;
                     }
-                }
-                else if ($min_comments >= 0) {
+                } elseif ($min_comments >= 0) {
                     if ($data->num_comments < $min_comments) {
                         continue;
                     }

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -39,7 +39,7 @@ class RedditBridge extends BridgeAbstract
                     'Relevance' => 'relevance',
                     'New' => 'new',
                     'Top' => 'top',
-                    'Comments' => 'comments'
+                    'Comments' => 'comments',
                 ],
                 'defaultValue' => 'Hot'
             ],

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -20,7 +20,15 @@ class RedditBridge extends BridgeAbstract
                 'required' => false,
                 'type' => 'number',
                 'exampleValue' => 100,
-                'title' => 'Filter out posts with lower score'
+                'title' => 'Filter out posts with lower score. Set to -1 to disable. If both score and comments are set, an OR is applied.',
+            ],
+            'min_comments' => [
+                'name' => 'Minimal number of comments',
+                'required' => false,
+                'type' => 'number',
+                'exampleValue' => 100,
+                'title' => 'Filter out posts with lower number of comments. Set to -1 to disable. If both score and comments are set, an OR is applied.',
+                'defaultValue' => -1
             ],
             'd' => [
                 'name' => 'Sort By',
@@ -33,6 +41,20 @@ class RedditBridge extends BridgeAbstract
                     'Top' => 'top'
                 ],
                 'defaultValue' => 'Hot'
+            ],
+            't' => [
+                'name' => 'Time',
+                'type' => 'list',
+                'title' => 'Sort by new, hot, top or relevancy',
+                'values' => [
+                    'All' => 'all',
+                    'Year' => 'year',
+                    'Month' => 'month',
+                    'Week' => 'week',
+                    'Day' => 'day',
+                    'Hour' => 'hour',
+                ],
+                'defaultValue' => 'week'
             ],
             'search' => [
                 'name' => 'Keyword search',
@@ -126,6 +148,7 @@ class RedditBridge extends BridgeAbstract
             $frontend = 'https://old.reddit.com';
         }
         $section = $this->getInput('d');
+        $time = $this->getInput('t');
 
         switch ($this->queriedContext) {
             case 'single':
@@ -147,7 +170,7 @@ class RedditBridge extends BridgeAbstract
         foreach ($subreddits as $subreddit) {
             $version = 'v0.0.2';
             $useragent = "rss-bridge $version (https://github.com/RSS-Bridge/rss-bridge)";
-            $url = self::createUrl($search, $flareInput, $subreddit, $user, $section, $this->queriedContext);
+            $url = self::createUrl($search, $flareInput, $subreddit, $user, $section, $time, $this->queriedContext);
 
             $response = getContents($url, ['User-Agent: ' . $useragent], [], true);
 
@@ -162,8 +185,22 @@ class RedditBridge extends BridgeAbstract
 
                 $data = $post->data;
 
-                if ($data->score < $this->getInput('score')) {
-                    continue;
+                $min_score = $this->getInput('score');
+                $min_comments = $this->getInput('min_comments');
+                if ($min_score >= 0 && $min_comments >= 0) {
+                    if ($data->num_comments < $min_comments || $data->score < $min_score) {
+                        continue;
+                    }
+                }
+                else if ($min_score >= 0) {
+                    if ($data->score < $min_score) {
+                        continue;
+                    }
+                }
+                else if ($min_comments >= 0) {
+                    if ($data->num_comments < $min_comments) {
+                        continue;
+                    }
                 }
 
                 $item = [];
@@ -264,7 +301,7 @@ class RedditBridge extends BridgeAbstract
         });
     }
 
-    public static function createUrl($search, $flareInput, $subreddit, bool $user, $section, $queriedContext): string
+    public static function createUrl($search, $flareInput, $subreddit, bool $user, $section, $time, $queriedContext): string
     {
         if ($search === '') {
             $keywords = '';
@@ -286,6 +323,7 @@ class RedditBridge extends BridgeAbstract
             'q' => $keywords . $flair . ($user ? 'author:' : 'subreddit:') . $name,
             'sort' => $section,
             'include_over_18' => 'on',
+            't' => $time
         ];
         return 'https://old.reddit.com/search.json?' . http_build_query($query);
     }

--- a/tests/RedditBridgeTest.php
+++ b/tests/RedditBridgeTest.php
@@ -11,23 +11,23 @@ class RedditBridgeTest extends TestCase
         $sut = new RedditBridge(new NullCache(), new NullLogger());
 
         // https://old.reddit.com/search.json?q=cats dogs hen subreddit:php&sort=hot&include_over_18=on
-        $expected = 'https://old.reddit.com/search.json?q=cats+dogs+hen+subreddit%3Aphp&sort=hot&include_over_18=on';
-        $actual = RedditBridge::createUrl('cats,dogs hen', '', 'php', false, 'hot', 'single');
+        $expected = 'https://old.reddit.com/search.json?q=cats+dogs+hen+subreddit%3Aphp&sort=hot&include_over_18=on&t=all';
+        $actual = RedditBridge::createUrl('cats,dogs hen', '', 'php', false, 'hot', 'all', 'single');
         $this->assertSame($expected, $actual);
 
         // https://old.reddit.com/search.json?q=author:RavenousRandy&sort=hot&include_over_18=on
-        $expected = 'https://old.reddit.com/search.json?q=author%3ARavenousRandy&sort=hot&include_over_18=on';
-        $actual = RedditBridge::createUrl('', '', 'RavenousRandy', true, 'hot', 'user');
+        $expected = 'https://old.reddit.com/search.json?q=author%3ARavenousRandy&sort=hot&include_over_18=on&t=week';
+        $actual = RedditBridge::createUrl('', '', 'RavenousRandy', true, 'hot', 'week', 'user');
         $this->assertSame($expected, $actual);
 
         // https://old.reddit.com/search.json?q=cats dogs hen flair:"Proxy" subreddit:php&sort=hot&include_over_18=on
-        $expected = 'https://old.reddit.com/search.json?q=cats+dogs+hen+flair%3A%22Proxy%22+subreddit%3Aphp&sort=hot&include_over_18=on';
-        $actual = RedditBridge::createUrl('cats,dogs hen', 'Proxy', 'php', false, 'hot', 'single');
+        $expected = 'https://old.reddit.com/search.json?q=cats+dogs+hen+flair%3A%22Proxy%22+subreddit%3Aphp&sort=hot&include_over_18=on&t=month';
+        $actual = RedditBridge::createUrl('cats,dogs hen', 'Proxy', 'php', false, 'hot', 'month', 'single');
         $this->assertSame($expected, $actual);
 
         // https://old.reddit.com/search.json?q=cats dogs hen flair:"Proxy Linux Server" subreddit:php&sort=hot&include_over_18=on
-        $expected = 'https://old.reddit.com/search.json?q=cats+dogs+hen+flair%3A%22Proxy+Linux+Server%22+subreddit%3Aphp&sort=hot&include_over_18=on';
-        $actual = RedditBridge::createUrl('cats,dogs hen', 'Proxy,Linux Server', 'php', false, 'hot', 'single');
+        $expected = 'https://old.reddit.com/search.json?q=cats+dogs+hen+flair%3A%22Proxy+Linux+Server%22+subreddit%3Aphp&sort=hot&include_over_18=on&t=day';
+        $actual = RedditBridge::createUrl('cats,dogs hen', 'Proxy,Linux Server', 'php', false, 'hot', 'day', 'single');
         $this->assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
When using the 'top' sorting order for reddit, most times you want to limit to a time interval (e.g. top in the last month). In the [search UI](https://old.reddit.com/search/?q=subreddit%3Alinux&sort=comments&t=week&include_over_18=on), there is a time interval filter that will end up as a query parameter `t=interval` .

Also, added filtering and sorting by comment count.