### PR TITLE
[FeedExpander] Add prepareXml() overridable function

### DIFF
--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -68,7 +68,7 @@ abstract class FeedExpander extends BridgeAbstract
         ];
         $xmlString = str_replace($problematicStrings, '', $xmlString);
 
-        // Remove extra content at the end of the document, if any.
+        // Remove extra content at the end of the document, if any (#4485)
         // First retrieve tag name of root node, which is the first node following <?xml prolog,
         // Then find the last matching </tag> in xml string and strip anything beyond that.
         if (preg_match('/(?:<\?xml[^>]*\?>[^<]*<)([^ "\'>]+)/i', $xmlString, $matches) === 1)

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -58,7 +58,7 @@ abstract class FeedExpander extends BridgeAbstract
     *
     * @return string
     */
-    protected function prepareXml($xmlString)
+    protected function prepareXml(string $xmlString): string
     {
         // Remove problematic escape sequences
         $problematicStrings = [

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -71,15 +71,12 @@ abstract class FeedExpander extends BridgeAbstract
         // Remove extra content at the end of the document, if any (#4485)
         // First retrieve tag name of root node, which is the first node following <?xml prolog,
         // Then find the last matching </tag> in xml string and strip anything beyond that.
-        if (preg_match('/(?:<\?xml[^>]*\?>[^<]*<)([^ "\'>]+)/i', $xmlString, $matches) === 1)
-        {
+        if (preg_match('/(?:<\?xml[^>]*\?>[^<]*<)([^ "\'>]+)/i', $xmlString, $matches) === 1) {
             $root_node_tag = $matches[1];
             $last_closing_occurrence = strripos($xmlString, '</' . $root_node_tag);
-            if ($last_closing_occurrence !== false)
-            {
+            if ($last_closing_occurrence !== false) {
                 $closing_node_end = strpos($xmlString, '>', $last_closing_occurrence);
-                if ($closing_node_end !== false)
-                {
+                if ($closing_node_end !== false) {
                     $xmlString = substr($xmlString, 0, $closing_node_end + 1);
                 }
             }

--- a/lib/FeedExpander.php
+++ b/lib/FeedExpander.php
@@ -66,23 +66,7 @@ abstract class FeedExpander extends BridgeAbstract
             '&raquo;',
             '&rsquo;',
         ];
-        $xmlString = str_replace($problematicStrings, '', $xmlString);
-
-        // Remove extra content at the end of the document, if any (#4485)
-        // First retrieve tag name of root node, which is the first node following <?xml prolog,
-        // Then find the last matching </tag> in xml string and strip anything beyond that.
-        if (preg_match('/(?:<\?xml[^>]*\?>[^<]*<)([^ "\'>]+)/i', $xmlString, $matches) === 1) {
-            $root_node_tag = $matches[1];
-            $last_closing_occurrence = strripos($xmlString, '</' . $root_node_tag);
-            if ($last_closing_occurrence !== false) {
-                $closing_node_end = strpos($xmlString, '>', $last_closing_occurrence);
-                if ($closing_node_end !== false) {
-                    $xmlString = substr($xmlString, 0, $closing_node_end + 1);
-                }
-            }
-        }
-
-        return $xmlString;
+        return str_replace($problematicStrings, '', $xmlString);
     }
 
     public function getURI()


### PR DESCRIPTION
**What this pull request does**

FeedExpander.php
* Introduce overridable `prepareXml($xmlString)` function and move existing cleanup code inside
* ~~Auto-remove trailing content after root xml node~~ (removed from PR, see discussion below)

**Use case: remove analytic tags inserted in XML feeds**

One of my bridge stopped working with the following error:
```
Type: Exception
Code: 0
Message: Unable to parse xml: Extra content at the end of the document
File: lib/FeedParser.php
Line: 26
Trace
#0 index.php(49): RssBridge->main()
#1 lib/RssBridge.php(57): DisplayAction->execute()
#2 actions/DisplayAction.php(71): DisplayAction->createResponse()
#3 actions/DisplayAction.php(106): CssSelectorFeedExpanderBridge->collectData()
#4 bridges/CssSelectorFeedExpanderBridge.php(61): FeedParser->parseFeed()
#5 lib/FeedParser.php(26)
```

Turns out the site's feed had an extra script tag from CloudFlare:

```xml
<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
	xmlns:content="http://purl.org/rss/1.0/modules/content/"
	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
	xmlns:dc="http://purl.org/dc/elements/1.1/"
	xmlns:atom="http://www.w3.org/2005/Atom"
	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
	>

<channel>
	<title>Numerama</title>
	<atom:link href="https://www.numerama.com/feed/" rel="self" type="application/rss+xml" />
	<link>https://www.numerama.com/</link>
	<description>Le média de référence sur la société numérique et l&#039;innovation technologique</description>
	<lastBuildDate>Thu, 20 Mar 2025 10:00:36 +0000</lastBuildDate>
<!-- [...] Feed content [...] -->
	</channel>
</rss>
<script defer src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ==" data-cf-beacon='{"rayId":"92345edefe2203f1","serverTiming":{"name":{"cfExtPri":true,"cfL4":true,"cfSpeedBrain":true,"cfCacheStatus":true}},"version":"2025.1.0","token":"8eedbc8e52114850a5577af1da359bcd"}' crossorigin="anonymous"></script>

```
~~This PR adds auto-cleaning to remove trailing data causing XML parsing to fail.~~
This PR allows overriding `prepareXml($xmlString)` from a bridge to clean XML before it gets parsed.

~~Seems like all my bridges still load fine on my instance after the change, and this fixed my broken feed. If you think this could break things, let me know and I'll move that code in a separate bridge on my instance.~~