### PR TITLE
[CeskaTelevizeBridge] Adjusted getting article timestamp

### DIFF
--- a/bridges/CeskaTelevizeBridge.php
+++ b/bridges/CeskaTelevizeBridge.php
@@ -41,11 +41,15 @@ class CeskaTelevizeBridge extends BridgeAbstract
         foreach ($html->find('#episodeListSection a[data-testid=card]') as $element) {
             $itemContent = $element->find('p[class^=content-]', 0);
             $itemDate = $element->find('div[class^=playTime-] span, [data-testid=episode-item-broadcast] span', 0);
+
+            // Remove special characters and whitespace
+            $cleanDate =  preg_replace('/[^0-9.]/', '', $itemDate->plaintext);
+
             $item = [
                 'title'     => $this->fixChars($element->find('h3', 0)->plaintext),
                 'uri'       => self::URI . $element->getAttribute('href'),
                 'content'   => '<img src="' . $element->find('img', 0)->getAttribute('srcset') . '" /><br />' . $this->fixChars($itemContent->plaintext),
-                'timestamp' => $this->getUploadTimeFromString($itemDate->plaintext),
+                'timestamp' => $this->getUploadTimeFromString($cleanDate),
             ];
 
             $this->items[] = $item;
@@ -58,7 +62,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
             return strtotime('today');
         } elseif (strpos($string, 'včera') !== false) {
             return strtotime('yesterday');
-        } elseif (!preg_match('/(\d+).\s(\d+).(\s(\d+))?/', $string, $match)) {
+        } elseif (!preg_match('/(\d+).(\d+).((\d+))?/', $string, $match)) {
             returnServerError('Could not get date from Česká televize string');
         }
 

--- a/bridges/CeskaTelevizeBridge.php
+++ b/bridges/CeskaTelevizeBridge.php
@@ -43,7 +43,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
             $itemDate = $element->find('div[class^=playTime-] span, [data-testid=episode-item-broadcast] span', 0);
 
             // Remove special characters and whitespace
-            $cleanDate =  preg_replace('/[^0-9.]/', '', $itemDate->plaintext);
+            $cleanDate = preg_replace('/[^0-9.]/', '', $itemDate->plaintext);
 
             $item = [
                 'title'     => $this->fixChars($element->find('h3', 0)->plaintext),


### PR DESCRIPTION
PR addressing the issue https://github.com/RSS-Bridge/rss-bridge/issues/4482

Special characters on the website of Ceska Televize in article date prevent it from being parsed correctly by the bridge.
More background: https://github.com/RSS-Bridge/rss-bridge/issues/4482#issuecomment-2744886087

Changes:

- Clean up the article date before attempting to parse it - remove all characters except of numbers and `.` character.
- Updated the article date regex to reflect above changes