### PR TITLE
[TheFarSideBridge] Remove hotlink protection bypass

### DIFF
--- a/bridges/TheFarSideBridge.php
+++ b/bridges/TheFarSideBridge.php
@@ -26,21 +26,16 @@ class TheFarSideBridge extends BridgeAbstract
             $image = $card->find('img', 0);
             $imageUrl = $image->attr['data-src'];
 
-            // Images are downloaded to bypass the hotlink protection.
-            $image = getContents($imageUrl, ['Referer: ' . self::URI]);
-
-            // Encode image as base64
-            $imageBase64 = base64_encode($image);
-
             $caption = '';
 
             if ($card->find('figcaption', 0)) {
                 $caption = $card->find('figcaption', 0)->innertext;
             }
 
+            $item['enclosures'][] = $imageUrl;
             $item['content'] .= <<<EOD
 <figure>
-	<img title="{$caption}" src="data:image/jpeg;base64,{$imageBase64}"/>
+	<img title="{$caption}" src="{$imageUrl}"/>
 	<figcaption>{$caption}</figcaption>
 </figure>
 <br/>


### PR DESCRIPTION
Removes hotlink protection bypass as it is no longer needed and breaks Telegram's feed reader. Addresses #4481 