### PR TITLE
[TikTokBridge] Use oEmbed for video metadata

### DIFF
--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -42,16 +42,20 @@ class TikTokBridge extends BridgeAbstract
             $parsedUrl = parse_url($href);
             $url = $parsedUrl['scheme'] . '://' . $parsedUrl['host'] . '/' . ltrim($parsedUrl['path'], '/');
 
-            $image = $video->find('video', 0)->poster;
-            $views = $video->find('div[data-e2e=common-Video-Count]', 0)->plaintext;
+            $videoEmbedResponse = getContents('https://tiktok.com/oembed?url=' . $url);
+            $videoEmbedData = json_decode($videoEmbedResponse);
+
+            $title = $videoEmbedData->title;
+            $image = $videoEmbedData->thumbnail_url;
 
             $enclosures = [$image, $authorProfilePicture];
 
             $item['uri'] = $url;
-            $item['title'] = 'Video';
-            $item['author'] = '@' . $author;
+            $item['title'] = $title;
+            $item['author'] = '@' . $videoEmbedData->author_unique_id;
             $item['enclosures'] = $enclosures;
             $item['content'] = <<<EOD
+<p>$title</p>
 <a href="{$url}"><img src="{$image}"/></a>
 <p>{$views} views<p><br/>
 EOD;

--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -42,7 +42,7 @@ class TikTokBridge extends BridgeAbstract
             $parsedUrl = parse_url($href);
             $url = $parsedUrl['scheme'] . '://' . $parsedUrl['host'] . '/' . ltrim($parsedUrl['path'], '/');
 
-            $videoEmbedResponse = getContents('https://tiktok.com/oembed?url=' . $url);
+            $videoEmbedResponse = getContents('https://www.tiktok.com/oembed?url=' . $url);
             $videoEmbedData = json_decode($videoEmbedResponse);
 
             $title = $videoEmbedData->title;

--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -47,6 +47,7 @@ class TikTokBridge extends BridgeAbstract
 
             $title = $videoEmbedData->title;
             $image = $videoEmbedData->thumbnail_url;
+            $views = $video->find('div[data-e2e=common-Video-Count]', 0)->plaintext;
 
             $enclosures = [$image, $authorProfilePicture];
 


### PR DESCRIPTION
Fetches oEmbed-formatted metadata for videos through the TikTok API to provide post titles, thumbnails, and authors. I'm not caching JSON responses so it has the potential to be a bit slow in theory, but in my testing this doesn't appear to cause any noticeable performance issues (I'm not super familiar with PHP so I'm not entirely sure how to add this if it is needed).