### PR TITLE
feat: logger config

### DIFF
--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -31,6 +31,10 @@ timezone = "UTC"
 ; Display a system message to users.
 ;message = "Hello world"
 
+; Where to store logs and at which level (debug, info, warning, error)
+;log_file_path = "/tmp/rss-bridge.log"
+;log_file_level = "info"
+
 ; Whether to enable debug mode.
 enable_debug_mode = false
 

--- a/lib/dependencies.php
+++ b/lib/dependencies.php
@@ -52,8 +52,12 @@ $container['logger'] = function () {
     } else {
         $logger->addHandler(new ErrorLogHandler(Logger::INFO));
     }
-    // Uncomment this for info logging to fs
-    // $logger->addHandler(new StreamHandler('/tmp/rss-bridge.txt', Logger::INFO));
+    $path  = Configuration::getConfig('system', 'log_file_path');
+    $level = Configuration::getConfig('system', 'log_file_level');
+    if ($path && $level) {
+        $level = array_flip(Logger::LEVEL_NAMES)[strtoupper($level)];
+        $logger->addHandler(new StreamHandler($path, $level));
+    }
 
     // Uncomment this for debug logging to fs
     // $logger->addHandler(new StreamHandler('/tmp/rss-bridge-debug.txt', Logger::DEBUG));


### PR DESCRIPTION
here in which i suggest two new config options to tweak log file path and level

```ini
; Where to store logs and at which level (debug, info, warning, error)
;log_file_path = "/tmp/rss-bridge.log"
;log_file_level = "info"
```

disabled by default

im looking for better names or perhaps a separate `logger` section in ini file?

@Mynacol @Bockiii 