### PR TITLE
devcontainer: Fixed Dev Containers setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,21 @@
 FROM rssbridge/rss-bridge:latest
 
-RUN  apt-get update && \
-    apt-get install --yes --no-install-recommends \
-      git && \
-    pecl install xdebug && \
-    pear install PHP_CodeSniffer && \
-    docker-php-ext-enable xdebug
+COPY --chmod=755 post-create-command.sh /usr/local/bin/post-create-command
+
+ADD https://raw.githubusercontent.com/docker-library/php/master/docker-php-ext-enable /usr/local/bin/docker-php-ext-enable
+RUN chmod u+x /usr/local/bin/docker-php-ext-enable
+
+ADD https://getcomposer.org/installer /usr/local/bin/composer-installer.php
+RUN chmod u+x /usr/local/bin/composer-installer.php
+RUN php /usr/local/bin/composer-installer.php --check && \
+    php /usr/local/bin/composer-installer.php --filename=composer --install-dir=/usr/local/bin
+
+RUN apt-get update && \
+    apt-get install -y \
+      git \
+      php-dev \
+      make \
+      unzip
+
+RUN pecl install xdebug && \
+    PHP_INI_DIR=/etc/php/8.2/fpm docker-php-ext-enable xdebug

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,9 @@
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
-				"php.validate.executablePath": "/usr/local/bin/php",
-				"phpSniffer.executablesFolder": "/usr/local/bin/",
-				"phpcs.executablePath": "/usr/local/bin/phpcs",
+				"php.validate.executablePath": "/usr/bin/php",
+				"phpSniffer.executablesFolder": "/root/.config/composer/vendor/bin",
+				"phpcs.executablePath": "/root/.config/composer/vendor/bin/phpcs",
 				"phpcs.lintOnType": false
 			},
 
@@ -22,6 +22,9 @@
 			]
 		}
 	},
+	"remoteEnv": {
+		"PATH": "${containerEnv:PATH}:/root/.config/composer/vendor/bin",
+	},
 	"forwardPorts": [3100, 9000, 9003],
-	"postCreateCommand": "cp .devcontainer/nginx.conf /etc/nginx/conf.d/default.conf && cp .devcontainer/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini && mkdir .vscode && cp .devcontainer/launch.json .vscode && echo '*' > whitelist.txt && chmod a+x \"$(pwd)\" && rm -rf /var/www/html && ln -s \"$(pwd)\" /var/www/html && nginx && php-fpm -D"
+	"postCreateCommand": "/usr/local/bin/post-create-command"
 }

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -9,7 +9,8 @@
             "type": "php",
             "request": "launch",
             "port": 9003,
-            "auto": true
+            "auto": true,
+            "log": true
         },
         {
             "name": "Launch currently open script",

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -1,0 +1,27 @@
+#/bin/sh
+
+cp .devcontainer/nginx.conf /etc/nginx/conf.d/default.conf
+cp .devcontainer/xdebug.ini /etc/php/8.2/fpm/conf.d/xdebug.ini
+
+#  This should download some dev-dependencies, like phpunit and the PHP code sniffers
+composer global require "phpunit/phpunit:^9"
+composer global require "squizlabs/php_codesniffer:^3.6"
+composer global require "phpcompatibility/php-compatibility:^9.3"
+
+#  We need to this manually for running the PHPCompatibility ruleset
+phpcs --config-set installed_paths /root/.config/composer/vendor/phpcompatibility/php-compatibility
+
+mkdir -p .vscode
+cp .devcontainer/launch.json .vscode
+
+echo '*' > whitelist.txt 
+
+chmod a+x $(pwd)
+rm -rf /var/www/html 
+ln -s $(pwd) /var/www/html 
+
+# Solves possible issue of cache directory not being accessible
+chown www-data:www-data -R $(pwd)/cache 
+
+nginx
+php-fpm8.2 -D


### PR DESCRIPTION
The current setup for Dev Containers was not working, with multiple different errors. So, in order to restore its functionality (and allow for things like linting and debugging), the following changes were made:

- The Dockerfile was severely alterered. Now, the `docker-php-ext-enable` binary is installed before its usage, it points to the correct PHP binary, and we install Composer for for loading dev-dependencies later-on;

- Moved the "postCreateCommand" section (defined on the `devcontainer.json` file) into its own script file (for a more readable experience);

- On the post-creation script, moved the `xdebug.ini` to the correct directory (alongside the PHP-FPM bin), installed PHPUnit, PHPCodesniffer (and the 'PHP Compatibility' sniffer) with Composer on a global location, and changed owner of the `cache` directory;

- Changed VSCode-specific customization setting in order to point to the update some binary paths. Also made sure globally-installed composer packages binaries are accessible via PATH.

Closes #4223