### PR TITLE
[GolemBridge] Add code elements

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -152,7 +152,7 @@ class GolemBridge extends FeedExpander
             $img->src = $img->getAttribute('data-src-full');
         }
 
-        foreach ($content->find('p, h1, h2, h3, img[src*="."], iframe, video') as $element) {
+        foreach ($content->find('p, h1, h2, h3, pre, img[src*="."], iframe, video') as $element) {
             $item .= $element;
         }
 


### PR DESCRIPTION
The extractor missed `<pre>` elements for code snippets. For example the code line in
https://www.golem.de/news/falsch-deklarierte-hdds-betrug-bei-festplatten-bleibt-ein-problem-2505-196675.html