### PR TITLE
[EpicGamesFree] Fixes: url not set, other promos shown

### DIFF
--- a/bridges/EpicGamesFreeBridge.php
+++ b/bridges/EpicGamesFreeBridge.php
@@ -27,7 +27,7 @@ class EpicGamesFreeBridge extends BridgeAbstract
                 'Türkçe' => 'tr',
                 '简体中文' => 'zh-CN',
                 '繁體中文' => 'zh-Hant',
-             ],
+            ],
             'title' => 'Language for game information',
             'defaultValue' => 'en-US',
         ],
@@ -51,14 +51,19 @@ class EpicGamesFreeBridge extends BridgeAbstract
 
         $data = $json['data']['Catalog']['searchStore']['elements'];
         foreach ($data as $element) {
-            if (!isset($element['promotions']['promotionalOffers'][0])) {
+            $promo = $element['promotions']['promotionalOffers'][0]['promotionalOffers'][0] ?? false;
+            if (
+                !$promo ||
+                $promo['discountSetting']['discountType'] !== 'PERCENTAGE' ||
+                $promo['discountSetting']['discountPercentage'] !== 0
+            ) {
                 continue;
             }
             $item = [
                 'author' => $element['seller']['name'],
                 'content' => $element['description'],
                 'enclosures' => array_map(fn($item) => $item['url'], $element['keyImages']),
-                'timestamp' => strtotime($element['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['startDate']),
+                'timestamp' => strtotime($promo['startDate']),
                 'title' => $element['title'],
                 'uri' => parent::getURI() . $this->getInput('locale') . '/p/' . $element['productSlug'],
             ];

--- a/bridges/EpicGamesFreeBridge.php
+++ b/bridges/EpicGamesFreeBridge.php
@@ -60,7 +60,7 @@ class EpicGamesFreeBridge extends BridgeAbstract
                 'enclosures' => array_map(fn($item) => $item['url'], $element['keyImages']),
                 'timestamp' => strtotime($element['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['startDate']),
                 'title' => $element['title'],
-                'url' => parent::getURI() . $this->getInput('locale') . '/p/' . $element['urlSlug'],
+                'uri' => parent::getURI() . $this->getInput('locale') . '/p/' . $element['productSlug'],
             ];
             $this->items[] = $item;
         }


### PR DESCRIPTION
Fixes several bugs in EpicGamesFree:

* url was not set because of the typo (url instead of uri)
* url was generated incorrectly (used urlSlug instead of productSlug, urlSlug slug is used for future promotions that are titled "mystery game" before the reveal apparently)
* other promos were included

Other promos can be shown too but (1) the name suggests it's about free games (2) promos require a bit more complex processing, at least bundles need a different url generation. 