### PR TITLE
[HeiseBridge] removes language-info-text, add archive.is link for people without subscription

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -138,7 +138,7 @@ class HeiseBridge extends FeedExpander
         }
         // abort on heise+ articles
         if ($sessioncookie == '' && str_starts_with($item['title'], 'heise+ |')) {
-            $item['uri'] = 'https://archive.is/'.$item['uri'];
+            $item['uri'] = 'https://archive.is/' . $item['uri'];
             return $item;
         }
 

--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -138,6 +138,7 @@ class HeiseBridge extends FeedExpander
         }
         // abort on heise+ articles
         if ($sessioncookie == '' && str_starts_with($item['title'], 'heise+ |')) {
+            $item['uri'] = 'https://archive.is/'.$item['uri'];
             return $item;
         }
 
@@ -162,7 +163,7 @@ class HeiseBridge extends FeedExpander
         // remove unwanted stuff
         foreach (
             $article->find('figure.branding, figure.a-inline-image, a-ad, div.ho-text, a-img,
-            .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote') as $element
+            .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote, .notice-banner__text, .notice-banner__link') as $element
         ) {
             $element->remove();
         }


### PR DESCRIPTION
- removes text "this article is also available in $language"
- for people without a heise+ subscription or session key, the article-link will be replaced with the archive.is equivalent, so then can at least read it there