### PR TITLE
[EpicGamesFreeBridge] productSlug can be null; also add a universal future-proof-ish fallback

### DIFF
--- a/bridges/EpicGamesFreeBridge.php
+++ b/bridges/EpicGamesFreeBridge.php
@@ -59,13 +59,20 @@ class EpicGamesFreeBridge extends BridgeAbstract
             ) {
                 continue;
             }
+            $slug = $element['productSlug'] ?? $element['catalogNs']['mappings'][0]['pageSlug'] ?? null;
+            if ($slug !== null) {
+                $uri = parent::getURI() . $this->getInput('locale') . '/p/' . $slug;
+            } else {
+                // slug not found, show the root promos page
+                $uri = parent::getURI() . $this->getInput('locale') . '/free-games';
+            }
             $item = [
                 'author' => $element['seller']['name'],
                 'content' => $element['description'],
                 'enclosures' => array_map(fn($item) => $item['url'], $element['keyImages']),
                 'timestamp' => strtotime($promo['startDate']),
                 'title' => $element['title'],
-                'uri' => parent::getURI() . $this->getInput('locale') . '/p/' . $element['productSlug'],
+                'uri' => $uri,
             ];
             $this->items[] = $item;
         }

--- a/bridges/EpicGamesFreeBridge.php
+++ b/bridges/EpicGamesFreeBridge.php
@@ -59,7 +59,7 @@ class EpicGamesFreeBridge extends BridgeAbstract
             ) {
                 continue;
             }
-            $slug = $element['productSlug'] ?? $element['catalogNs']['mappings'][0]['pageSlug'] ?? null;
+            $slug = $element['catalogNs']['mappings'][0]['pageSlug'] ?? null;
             if ($slug !== null) {
                 $uri = parent::getURI() . $this->getInput('locale') . '/p/' . $slug;
             } else {


### PR DESCRIPTION
productSlug can be null sometimes, so:

* Try to find a slug from catalogNs mappings
* Fall back to just linking to /free-games in case anything else changes in future