### PR TITLE
[YoutubePostsTabsBridge] Rename Community→Posts to fix broken bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Requires minimum PHP 7.4.
 * `TwitchBridge`: [Fetches videos from channel](https://rss-bridge.org/bridge01/#bridge-TwitchBridge)
 * `XPathBridge`: [Scrape out a feed using XPath expressions](https://rss-bridge.org/bridge01/#bridge-XPathBridge)
 * `YoutubeBridge`: [Fetches videos by username/channel/playlist/search](https://rss-bridge.org/bridge01/#bridge-YoutubeBridge)
-* `YouTubeCommunityTabBridge`: [Fetches posts from a channel's community tab](https://rss-bridge.org/bridge01/#bridge-YouTubeCommunityTabBridge)
+* `YouTubePostsTabBridge`: [Fetches posts from a channel's Posts tab](https://rss-bridge.org/bridge01/#bridge-YouTubePostsTabBridge)
 
 ## Tutorial
 

--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -2,9 +2,9 @@
 
 class YouTubeCommunityTabBridge extends BridgeAbstract
 {
-    const NAME = 'YouTube Community Tab Bridge';
+    const NAME = 'YouTube Posts Tab Bridge';
     const URI = 'https://www.youtube.com';
-    const DESCRIPTION = 'Returns posts from a channel\'s community tab';
+    const DESCRIPTION = 'Returns posts from a channel\'s posts tab';
     const MAINTAINER = 'VerifiedJoseph';
     const PARAMETERS = [
         'By channel ID' => [
@@ -31,7 +31,7 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
     private $feedName = '';
     private $itemTitle = '';
 
-    private $urlRegex = '/youtube\.com\/(channel|user|c)\/([\w]+)\/community/';
+    private $urlRegex = '/youtube\.com\/(channel|user|c)\/([\w]+)\/posts/';
     private $jsonRegex = '/var ytInitialData = ([^<]*);<\/script>/';
 
     public function detectParameters($url)
@@ -59,14 +59,14 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
     {
         if (is_null($this->getInput('username')) === false) {
             try {
-                $this->feedUrl = $this->buildCommunityUri($this->getInput('username'), 'c');
+                $this->feedUrl = $this->buildPostsUri($this->getInput('username'), 'c');
                 $html = getSimpleHTMLDOM($this->feedUrl);
             } catch (Exception $e) {
-                $this->feedUrl = $this->buildCommunityUri($this->getInput('username'), 'user');
+                $this->feedUrl = $this->buildPostsUri($this->getInput('username'), 'user');
                 $html = getSimpleHTMLDOM($this->feedUrl);
             }
         } else {
-            $this->feedUrl = $this->buildCommunityUri($this->getInput('channel'), 'channel');
+            $this->feedUrl = $this->buildPostsUri($this->getInput('channel'), 'channel');
             $html = getSimpleHTMLDOM($this->feedUrl);
         }
 
@@ -74,11 +74,11 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
 
         $this->feedName = $json->header->c4TabbedHeaderRenderer->title;
 
-        if ($this->hasCommunityTab($json) === false) {
-            returnServerError('Channel does not have a community tab');
+        if ($this->hasPostsTab($json) === false) {
+            returnServerError('Channel does not have a posts tab');
         }
 
-        $posts = $this->getCommunityPosts($json);
+        $posts = $this->getPosts($json);
         foreach ($posts as $key => $post) {
             $this->itemTitle = '';
 
@@ -132,18 +132,18 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
     public function getName()
     {
         if (!empty($this->feedName)) {
-            return $this->feedName . ' - YouTube Community Tab';
+            return $this->feedName . ' - YouTube Posts Tab';
         }
 
         return parent::getName();
     }
 
     /**
-     * Build Community URI
+     * Build Posts URI
      */
-    private function buildCommunityUri($value, $type)
+    private function buildPostsUri($value, $type)
     {
-        return self::URI . '/' . $type . '/' . $value . '/community';
+        return self::URI . '/' . $type . '/' . $value . '/posts';
     }
 
     /**
@@ -165,14 +165,14 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
     }
 
     /**
-     * Check if channel has a community tab
+     * Check if channel has a posts tab
      */
-    private function hasCommunityTab($json)
+    private function hasPostsTab($json)
     {
         foreach ($json->contents->twoColumnBrowseResultsRenderer->tabs as $tab) {
             if (
                 isset($tab->tabRenderer)
-                && str_ends_with($tab->tabRenderer->endpoint->commandMetadata->webCommandMetadata->url, 'community')
+                && str_ends_with($tab->tabRenderer->endpoint->commandMetadata->webCommandMetadata->url, 'posts')
             ) {
                 return true;
             }
@@ -182,14 +182,14 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
     }
 
     /**
-     * Get community tab posts
+     * Get posts from posts tab
      */
-    private function getCommunityPosts($json)
+    private function getPosts($json)
     {
         foreach ($json->contents->twoColumnBrowseResultsRenderer->tabs as $tab) {
             if (
                 isset($tab->tabRenderer)
-                && str_ends_with($tab->tabRenderer->endpoint->commandMetadata->webCommandMetadata->url, 'community')
+                && str_ends_with($tab->tabRenderer->endpoint->commandMetadata->webCommandMetadata->url, 'posts')
             ) {
                 return $tab->tabRenderer->content->sectionListRenderer->contents[0]->itemSectionRenderer->contents;
             }

--- a/bridges/YouTubePostsTabBridge.php
+++ b/bridges/YouTubePostsTabBridge.php
@@ -1,6 +1,6 @@
 <?php
 
-class YouTubeCommunityTabBridge extends BridgeAbstract
+class YouTubePostsTabBridge extends BridgeAbstract
 {
     const NAME = 'YouTube Posts Tab Bridge';
     const URI = 'https://www.youtube.com';

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -23,7 +23,7 @@
 ;enabled_bridges[] = Twitch
 ;enabled_bridges[] = XPathBridge
 ;enabled_bridges[] = Youtube
-;enabled_bridges[] = YouTubeCommunityTabBridge
+;enabled_bridges[] = YouTubePostsTabBridge
 enabled_bridges[] = *
 
 timezone = "UTC"


### PR DESCRIPTION
Fixes #4604 

From: https://support.google.com/youtube/thread/321825573?hl=en

> The Community tab is becoming the Posts tab: To make things clear, we’re giving the “Community” tab a new name: “Posts.” The tab will work just as it does today, just with a new name. Creators can still share updates and announcements via posts and viewers can engage by commenting on those posts like they always have! 