### PR TITLE
[GolemBridge] Add tables to content

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -152,7 +152,7 @@ class GolemBridge extends FeedExpander
             $img->src = $img->getAttribute('data-src-full');
         }
 
-        foreach ($content->find('p, h1, h2, h3, pre, img[src*="."], iframe, video') as $element) {
+        foreach ($content->find('p, h1, h2, h3, pre, img[src*="."], div[class*="golem_tablediv"], iframe, video') as $element) {
             $item .= $element;
         }
 


### PR DESCRIPTION
For example the following article has such tables that should be included:
https://www.golem.de/news/immobilien-mieten-oder-kaufen-warum-es-dabei-nicht-nur-ums-geld-geht-2507-197406.html