### PR TITLE
[CubariProxyBridge] Replace MangaSee with WeebCentral

### DIFF
--- a/bridges/CubariProxyBridge.php
+++ b/bridges/CubariProxyBridge.php
@@ -15,7 +15,7 @@ class CubariProxyBridge extends BridgeAbstract
                 'MangAventure' => 'mangadventure',
                 'MangaDex' => 'mangadex',
                 'MangaKatana' => 'mangakatana',
-                'MangaSee' => 'mangasee',
+                'WeebCentral' => 'weebcentral',
             ]
         ],
         'series' => [


### PR DESCRIPTION
Seems to be the same content source, but renamed.