### PR TITLE
[YouTubeFeedExpanderBridge] More reliable channel icons

### DIFF
--- a/bridges/YouTubeFeedExpanderBridge.php
+++ b/bridges/YouTubeFeedExpanderBridge.php
@@ -38,12 +38,7 @@ class YouTubeFeedExpanderBridge extends FeedExpander
     {
         if ($this->getInput('channel') != null) {
             $html = getSimpleHTMLDOMCached($this->getURI());
-            $scriptRegex = '/var ytInitialData = (.*?);<\/script>/';
-            $result = preg_match($scriptRegex, $html, $matches);
-            if (isset($matches[1])) {
-                $json = json_decode($matches[1]);
-                return $json->metadata->channelMetadataRenderer->avatar->thumbnails[0]->url;
-            }
+            return $html->find('[itemprop="thumbnailUrl"]', 0)->href;
         }
         return parent::getIcon();
     }


### PR DESCRIPTION
Some channels under the old implementation would not receive icons. This fixes that with a different way that appears more reliable.