### PR TITLE
Fix deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/bridges/ItakuBridge.php
+++ b/bridges/ItakuBridge.php
@@ -443,7 +443,7 @@ class ItakuBridge extends BridgeAbstract
         return $data['owner'];
     }
 
-    private function getPost($id, array $metadata = null)
+    private function getPost($id, ?array $metadata = null)
     {
         if (isset($metadata) && count($metadata['gallery_images']) < $metadata['num_images']) {
             $metadata = null; //force re-fetch of metadata
@@ -515,7 +515,7 @@ class ItakuBridge extends BridgeAbstract
         ];
     }
 
-    private function getCommission($id, array $metadata = null)
+    private function getCommission($id, ?array $metadata = null)
     {
         $url = self::URI . '/api/commissions/' . $id . '/?format=json';
         $uri = self::URI . '/commissions/' . $id;

--- a/caches/ArrayCache.php
+++ b/caches/ArrayCache.php
@@ -23,7 +23,7 @@ class ArrayCache implements CacheInterface
         return $default;
     }
 
-    public function set(string $key, $value, int $ttl = null): void
+    public function set(string $key, $value, ?int $ttl = null): void
     {
         $this->data[$key] = [
             'key'           => $key,

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -45,7 +45,7 @@ class FileCache implements CacheInterface
         return $default;
     }
 
-    public function set($key, $value, int $ttl = null): void
+    public function set($key, $value, ?int $ttl = null): void
     {
         $item = [
             'key'           => $key,

--- a/caches/NullCache.php
+++ b/caches/NullCache.php
@@ -9,7 +9,7 @@ class NullCache implements CacheInterface
         return $default;
     }
 
-    public function set(string $key, $value, int $ttl = null): void
+    public function set(string $key, $value, ?int $ttl = null): void
     {
     }
 

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -77,7 +77,7 @@ class SQLiteCache implements CacheInterface
         return $default;
     }
 
-    public function set(string $key, $value, int $ttl = null): void
+    public function set(string $key, $value, ?int $ttl = null): void
     {
         $cacheKey = $this->createCacheKey($key);
         $blob = serialize($value);

--- a/lib/CacheFactory.php
+++ b/lib/CacheFactory.php
@@ -12,7 +12,7 @@ class CacheFactory
         $this->logger = $logger;
     }
 
-    public function create(string $name = null): CacheInterface
+    public function create(?string $name = null): CacheInterface
     {
         $cacheNames = [];
         foreach (scandir(PATH_LIB_CACHES) as $file) {

--- a/lib/CacheInterface.php
+++ b/lib/CacheInterface.php
@@ -4,7 +4,7 @@ interface CacheInterface
 {
     public function get(string $key, $default = null);
 
-    public function set(string $key, $value, int $ttl = null): void;
+    public function set(string $key, $value, ?int $ttl = null): void;
 
     public function delete(string $key): void;
 

--- a/lib/http.php
+++ b/lib/http.php
@@ -227,7 +227,7 @@ final class Request
         return $this->get[$key] ?? $default;
     }
 
-    public function server(string $key, string $default = null): ?string
+    public function server(string $key, ?string $default = null): ?string
     {
         return $this->server[$key] ?? $default;
     }

--- a/lib/parsedown/Parsedown.php
+++ b/lib/parsedown/Parsedown.php
@@ -712,7 +712,7 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
@@ -850,7 +850,7 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {


### PR DESCRIPTION
This pull request fixes deprecation warnings, which are displayed on main page.

Steps to reproduce the behavior: `docker run --rm -v $PWD/rss-bridge:/app -p 3000:3000 php:8.4-cli php -S 0.0.0.0:3000 -t /app`

Expected behavior:  no errors

Screenshots:

<img width="1455" height="703" alt="image" src="https://github.com/user-attachments/assets/f9da7a58-1452-451e-a64d-94bf8942d943" />
