### PR TITLE
[DRKBlutspendeBridge] add offers to content & add caption to images

### DIFF
--- a/bridges/DRKBlutspendeBridge.php
+++ b/bridges/DRKBlutspendeBridge.php
@@ -37,6 +37,26 @@ class DRKBlutspendeBridge extends FeedExpander
         ]
     ];
 
+    const OFFER_LOW_PRIORITIES = [
+        'Imbiss nach der Blutspende',
+        'Registrierung als Stammzellspender',
+        'Typisierung möglich!',
+        'Allgemeine Informationen',
+        'Krankenkassen belohnen Blutspender',
+        'Wer benötigt eigentlich eine Blutspende?',
+        'Win-Win-Situation für die Gesundheit!',
+        'Terminreservierung',
+        'Du möchtest das erste Mal Blut spenden?',
+        'Spende-Check',
+        'Sie haben Fragen vor Ihrer Blutspende?'
+    ];
+
+    const IMAGE_PRIORITIES = [
+        'DRK',
+        'Imbiss',
+        'Obst',
+    ];
+
     public function collectData()
     {
         $limitItems = intval($this->getInput('limit_items'));
@@ -45,37 +65,116 @@ class DRKBlutspendeBridge extends FeedExpander
 
     protected function parseItem(array $item)
     {
-        $html = getSimpleHTMLDOM($item['uri']);
+        $html = getSimpleHTMLDOMCached($item['uri']);
 
         $detailsElement = $html->find('.details', 0);
 
-        $dateElement = $detailsElement->find('.datum', 0);
-        $dateLines = self::explodeLines($dateElement->plaintext);
-
-        $addressElement = $detailsElement->find('.adresse', 0);
-        $addressLines = self::explodeLines($addressElement->plaintext);
+        $dateLines = self::explodeLines($detailsElement->find('.datum', 0)->plaintext);
+        $addressLines = self::explodeLines($detailsElement->find('.adresse', 0)->plaintext);
 
         $infoElement = $detailsElement->find('.angebote > h4 + p', 0);
-        $info = $infoElement ? $infoElement->innertext : '';
+        $info = $infoElement ? trim($infoElement->plaintext) : '';
 
-        $imageElements = $detailsElement->find('.fotos img');
+        $offers = self::parseOffers($detailsElement->find('.angebote .item'));
 
-        $item['title'] = $dateLines[0] . ' ' . $dateLines[1] . ' ' . $addressLines[0] . ' - ' . $addressLines[1];
+        $images = self::parseImages($detailsElement->find('.fotos', 0));
+        usort($images, function ($imageA, $imageB): int {
+            list($titleA) = $imageA;
+            list($titleB) = $imageB;
+            $prioA = 0;
+            $prioB = 0;
+            foreach (self::IMAGE_PRIORITIES as $prioIndex => $prioTitleNeedle) {
+                if (stripos($titleA, $prioTitleNeedle) !== false) {
+                    $prioA = $prioIndex + 1;
+                }
+                if (stripos($titleB, $prioTitleNeedle) !== false) {
+                    $prioB = $prioIndex + 1;
+                }
+            }
+            return $prioA - $prioB;
+        });
 
-        $item['content'] = <<<HTML
-        <p><b>{$dateLines[0]} {$dateLines[1]}</b></p>
-        <p>{$addressElement->innertext}</p>
-        <p>{$info}</p>
+        $itemContent = <<<HTML
+        <div>
+            <p>
+                <b>{$dateLines[0]} {$dateLines[1]}</b><br>
+                {$addressLines[3]}
+            </p>
+            <p>
+                <b>{$addressLines[0]}</b><br>
+                {$addressLines[1]}<br>
+                {$addressLines[2]}
+            </p>
+        </div>
         HTML;
 
-        foreach ($imageElements as $imageElement) {
-            $src = $imageElement->getAttribute('src');
-            $item['content'] .= <<<HTML
-            <p><img src="{$src}"></p>
+        if ($info) {
+            $itemContent .= <<<HTML
+            <div>
+                <h3>Infos</h3>
+                <p>{$info}</p>
+            </div>
             HTML;
         }
 
+        $majorOffers = array_filter($offers, fn($title): bool => !in_array($title, self::OFFER_LOW_PRIORITIES), ARRAY_FILTER_USE_KEY);
+        foreach ($majorOffers as $offerTitle => list($offerText, $offerImages)) {
+            $itemContent .= <<<HTML
+            <div>
+                <h3>{$offerTitle}</h3>
+                <p>{$offerText}</p>
+            HTML;
+            foreach ($offerImages as list($imageTitle, $imageUrl)) {
+                $itemContent .= <<<HTML
+                <figure>
+                    <img src="{$imageUrl}">
+                    <figcaption>{$imageTitle}</figcaption>
+                </figure>
+                HTML;
+            }
+            $itemContent .= <<<HTML
+            </div>
+            HTML;
+        }
+
+        if (count($images) > 0) {
+            $itemContent .= <<<HTML
+            <div>
+                <h3>Fotos</h3>
+            HTML;
+            foreach ($images as list($imageTitle, $imageUrl)) {
+                $itemContent .= <<<HTML
+                <figure>
+                    <img src="{$imageUrl}">
+                    <figcaption>{$imageTitle}</figcaption>
+                </figure>
+                HTML;
+            }
+            $itemContent .= <<<HTML
+            </div>
+            HTML;
+        }
+
+        $minorOffers = array_filter($offers, fn($title): bool => in_array($title, self::OFFER_LOW_PRIORITIES), ARRAY_FILTER_USE_KEY);
+        foreach ($minorOffers as $offerTitle => list($offerText)) {
+            $itemContent .= <<<HTML
+            <div>
+                <h3>{$offerTitle}</h3>
+                <p>{$offerText}</p>
+            </div>
+            HTML;
+        }
+
+        $item['title'] = $dateLines[0] . ' ' . $dateLines[1] . ' ' . $addressLines[0] . ' - ' . $addressLines[1];
+        $item['content'] = $itemContent;
         $item['description'] = null;
+        $item['enclosures'] = array_map(
+            function ($image): string {
+                list($title, $url) = $image;
+                return $url . '#' . urlencode(str_replace(' ', '_', $title));
+            },
+            $images
+        );
 
         return $item;
     }
@@ -95,6 +194,67 @@ class DRKBlutspendeBridge extends FeedExpander
         $limitDays = intval($this->getInput('limit_days'));
         $dateTo = $limitDays > 0 ? date('Y-m-d', time() + (60 * 60 * 24 * $limitDays)) : '';
         return self::BASE_URI . '/blutspendetermine/termine.rss?date_to=' . $dateTo . '&radius=' . $radius . '&term=' . $term;
+    }
+
+    private function parseImages($parentElement): array
+    {
+        $images = [];
+
+        if ($parentElement) {
+            $elements = $parentElement->find('a[data-lightbox]');
+            foreach ($elements as $i => $element) {
+                $url = trim($element->getAttribute('href'));
+                if (!$url) {
+                    continue;
+                }
+
+                $title = trim($element->getAttribute('title'));
+                if (!$title) {
+                    $number = $i + 1;
+                    $title = "Foto {$number}";
+                }
+
+                $images[] = [$title, $url];
+            }
+        }
+
+        return $images;
+    }
+
+    private function parseOffers($offerElements): array
+    {
+        $offers = [];
+
+        foreach ($offerElements as $element) {
+            $title = self::getCleanPlainText($element->find(':is(h1,h2,h3,h4,h5,h6)', 0));
+            $text = trim(substr(self::getCleanPlainText($element), strlen($title)));
+            if (!$title || !$text) {
+                continue;
+            }
+
+            $linkElements = $element->find('a');
+            foreach ($linkElements as $linkElement) {
+                $linkText = trim($linkElement->plaintext);
+                $linkUrl = trim($linkElement->getAttribute('href'));
+                if (!$linkText || !$linkUrl) {
+                    continue;
+                }
+
+                $linkHtml = <<<HTML
+                <a href="{$linkUrl}" target="_blank">{$linkText}</a>
+                HTML;
+                $text = str_replace($linkText, $linkHtml, $text);
+            }
+
+            $offers[$title] = [$text, self::parseImages($element)];
+        }
+
+        return $offers;
+    }
+
+    private function getCleanPlainText($htmlElement): string
+    {
+        return $htmlElement ? trim(preg_replace('/\s+/', ' ', html_entity_decode($htmlElement->plaintext))) : '';
     }
 
     /**


### PR DESCRIPTION
This PR improves the content of the `DRKBlutspendeBridge`.

#### Changes
- Include offers/location details
  - Frequent/recurring offers receive a lower priority. They are added at the bottom and without images.
- Images now include their caption.
  - The caption is used to sort by relevance (food images have a lower priority, so the preview image in RSS readers shows the location and not the food).
- `getSimpleHTMLDOM` has been replaced by `getSimpleHTMLDOMCached`.
- `plaintext` is used for the main information.
- The time is now below the date instead of the address.
- The main images are added as `enclosures`.