### PR TITLE
[PR Testing] fix wrong pr check fail when refactoring code

### DIFF
--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -122,5 +122,5 @@ jobs:
         run: |
           export COMMIT_MESSAGE="Added tests for PR ${{github.event.number}}"
           git add .
-          git commit -m "$COMMIT_MESSAGE"
+          git commit -m "$COMMIT_MESSAGE" || exit 0
           git push


### PR DESCRIPTION
This PR fixes the pr check `PR Testing` wrongfully failing when the author commits code-only changes (when the bridge html output has not changed).

Example scenario when this happens:
- Create a PR
- The `PR Testing` check succeeds, generates the html preview and pushes it into https://github.com/RSS-Bridge/rss-bridge-tests
- A linter check fails e.g. a double white-space in a code line
- The PR author fixes the linting errors e.g. removes a single white-space
- The linter check succeeds 
- The `PR Testing` check fails
  - `PR Testing` generates the exact same html preview, because the code change was irrelevant the the output. Because the html preview is the same, the git command `git commit -m "$COMMIT_MESSAGE"` fails with `nothing to commit, working tree clean` and the check gets marked as failed, even though the PR is actually fine
  - (if you would create a new PR with the same branch it would be marked as successful)

Same happens if you fix a typo in a variable name or any other code-only change.

If you look at the `PR Testing` [action runs and filter by failure](https://github.com/RSS-Bridge/rss-bridge/actions/workflows/prhtmlgenerator.yml?query=is%3Afailure), around 50% failed because of `nothing to commit, working tree clean`, e.g.
- https://github.com/RSS-Bridge/rss-bridge/actions/runs/16418489279/job/46390421272
- https://github.com/RSS-Bridge/rss-bridge/actions/runs/16202571793/job/45745083484
- https://github.com/RSS-Bridge/rss-bridge/actions/runs/15414567717/job/43374310641
- https://github.com/RSS-Bridge/rss-bridge/actions/runs/16694754803/job/47257290739

It gets fixed by this PR by cancelling the `Commit and push generated tests` step with `exit 0` when `git commit` fails.