### PR TITLE
[GoComicsBridge] Cache comic page

### DIFF
--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -48,7 +48,7 @@ class GoComicsBridge extends BridgeAbstract
         }
 
         for ($i = 0; $i < $this->getInput('limit'); $i++) {
-            $html = getSimpleHTMLDOM($link);
+            $html = getSimpleHTMLDOMCached($link, 86400);
 
             $imagelink = $html->find('meta[property="og:image"]', 0)->content;
             $parts = explode('/', $link);


### PR DESCRIPTION
Caching the individual pages will reduce traffic to origin server and should speed up the response to the client significantly. Currently fetching each page can take a few seconds, if limit is 10+, this can case the RSS client and/or reverse proxy to timeout while the creating the response.