### PR TITLE
[DailymotionBridge] Fetch playlist title from API

### DIFF
--- a/bridges/DailymotionBridge.php
+++ b/bridges/DailymotionBridge.php
@@ -129,8 +129,9 @@ class DailymotionBridge extends BridgeAbstract
 
     private function getPlaylistTitle($id)
     {
-        $html = getSimpleHTMLDOM(self::URI . 'playlist/' . $id);
-        return $html->find('meta[property=og:title]', 0)->getAttribute('content');
+        $apiJson = getContents($this->apiUrl . '/playlist/' . $this->getInput('p'));
+        $apiData = json_decode($apiJson, true);
+        return $apiData['name'];
     }
 
     private function getApiUrl()


### PR DESCRIPTION
Fetches playlist title from API instead of the web page, as the page doesn't always return the required HTML element.