### PR TITLE
refactor: rename functions

### DIFF
--- a/bridges/ARDAudiothekBridge.php
+++ b/bridges/ARDAudiothekBridge.php
@@ -71,7 +71,7 @@ class ARDAudiothekBridge extends BridgeAbstract
 
         $pathComponents = explode('/', $path);
         if (empty($pathComponents)) {
-            returnClientError('Path may not be empty');
+            throwClientException('Path may not be empty');
         }
         if (count($pathComponents) < 2) {
             $showID = $pathComponents[0];

--- a/bridges/ARDMediathekBridge.php
+++ b/bridges/ARDMediathekBridge.php
@@ -65,7 +65,7 @@ class ARDMediathekBridge extends BridgeAbstract
 
         $pathComponents = explode('/', $this->getInput('path'));
         if (empty($pathComponents)) {
-            returnClientError('Path may not be empty');
+            throwClientException('Path may not be empty');
         }
         if (count($pathComponents) < 2) {
             $showID = $pathComponents[0];

--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -57,7 +57,7 @@ class AllocineFRBridge extends BridgeAbstract
             if (array_key_exists($category, $categories)) {
                 return static::URI . $this->getLastSeasonURI($categories[$category]);
             } else {
-                returnClientError('Emission inconnue');
+                throwClientException('Emission inconnue');
             }
         }
 

--- a/bridges/AnidexBridge.php
+++ b/bridges/AnidexBridge.php
@@ -152,7 +152,7 @@ class AnidexBridge extends BridgeAbstract
             }
         }
         if (empty($results) && empty($this->getInput('q'))) {
-            returnServerError('No results from Anidex: ' . $search_url);
+            throwServerException('No results from Anidex: ' . $search_url);
         }
 
         //Process each item individually

--- a/bridges/AppleMusicBridge.php
+++ b/bridges/AppleMusicBridge.php
@@ -71,7 +71,7 @@ class AppleMusicBridge extends BridgeAbstract
         $result = $json->results;
 
         if (!is_array($result) || count($result) == 0) {
-            returnServerError('There is no artist with id "' . $this->getInput('artist') . '".');
+            throwServerException('There is no artist with id "' . $this->getInput('artist') . '".');
         }
 
         return $result;

--- a/bridges/AssociatedPressNewsBridge.php
+++ b/bridges/AssociatedPressNewsBridge.php
@@ -66,10 +66,10 @@ class AssociatedPressNewsBridge extends BridgeAbstract
     {
         switch ($this->getInput('topic')) {
             case 'Podcasts':
-                returnClientError('Podcasts topic feed is not supported');
+                throwClientException('Podcasts topic feed is not supported');
                 break;
             case 'PressReleases':
-                returnClientError('PressReleases topic feed is not supported');
+                throwClientException('PressReleases topic feed is not supported');
                 break;
             default:
                 $this->collectCardData();
@@ -110,7 +110,7 @@ class AssociatedPressNewsBridge extends BridgeAbstract
         $tagContents = json_decode($json, true);
 
         if (empty($tagContents['tagObjs'])) {
-            returnClientError('Topic not found: ' . $this->getInput('topic'));
+            throwClientException('Topic not found: ' . $this->getInput('topic'));
         }
 
         $this->feedName = $tagContents['tagObjs'][0]['name'];

--- a/bridges/BakaUpdatesMangaReleasesBridge.php
+++ b/bridges/BakaUpdatesMangaReleasesBridge.php
@@ -94,7 +94,7 @@ class BakaUpdatesMangaReleasesBridge extends BridgeAbstract
         // content is an unstructured pile of divs, ugly to parse
         $cols = $html->find('div#main_content div.row > div.text');
         if (!$cols) {
-            returnServerError('No releases');
+            throwServerException('No releases');
         }
 
         $rows = array_slice(

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -123,7 +123,7 @@ class BandcampBridge extends BridgeAbstract
                 $json = json_decode($content);
 
                 if ($json->ok !== true) {
-                    returnServerError('Invalid response');
+                    throwServerException('Invalid response');
                 }
 
                 foreach ($json->items as $entry) {
@@ -165,7 +165,7 @@ class BandcampBridge extends BridgeAbstract
 
                 $regex = '/band_id=(\d+)/';
                 if (preg_match($regex, $html, $matches) == false) {
-                    returnServerError('Unable to find band ID on: ' . $this->getURI());
+                    throwServerException('Unable to find band ID on: ' . $this->getURI());
                 }
                 $band_id = $matches[1];
 
@@ -196,7 +196,7 @@ class BandcampBridge extends BridgeAbstract
                     case 'By album':
                         $regex = '/album=(\d+)/';
                         if (preg_match($regex, $html, $matches) == false) {
-                            returnServerError('Unable to find album ID on: ' . $this->getURI());
+                            throwServerException('Unable to find album ID on: ' . $this->getURI());
                         }
                         $album_id = $matches[1];
 

--- a/bridges/BlueskyBridge.php
+++ b/bridges/BlueskyBridge.php
@@ -154,7 +154,7 @@ class BlueskyBridge extends BridgeAbstract
             //valid DID
             $did = $user_id;
         } else {
-            returnClientError('Invalid ATproto handle or DID provided.');
+            throwClientException('Invalid ATproto handle or DID provided.');
         }
 
         $filter = $this->getInput('feed_filter') ?: 'posts_and_author_threads';

--- a/bridges/BugzillaBridge.php
+++ b/bridges/BugzillaBridge.php
@@ -98,7 +98,7 @@ class BugzillaBridge extends BridgeAbstract
 
         // Array of comments is here
         if (!isset($json['bugs'][$this->bugid]['comments'])) {
-            returnClientError('Cannot find REST endpoint');
+            throwClientException('Cannot find REST endpoint');
         }
 
         foreach ($json['bugs'][$this->bugid]['comments'] as $comment) {
@@ -131,7 +131,7 @@ class BugzillaBridge extends BridgeAbstract
 
         // Array of changesets which contain an array of changes
         if (!isset($json['bugs']['0']['history'])) {
-            returnClientError('Cannot find REST endpoint');
+            throwClientException('Cannot find REST endpoint');
         }
 
         foreach ($json['bugs']['0']['history'] as $changeset) {

--- a/bridges/BundestagParteispendenBridge.php
+++ b/bridges/BundestagParteispendenBridge.php
@@ -30,7 +30,7 @@ URI;
 
         // Build the URL from the first anchor element. The list is sorted by year, descending, so the first element is the current year.
         $firstAnchor = $html->find('a', 0)
-            or returnServerError('Could not find the proper HTML element.');
+            or throwServerException('Could not find the proper HTML element.');
 
         $url = $firstAnchor->href;
 
@@ -38,7 +38,7 @@ URI;
         $html = getSimpleHTMLDOMCached($url, self::CACHE_TIMEOUT);
 
         $rows = $html->find('table.table > tbody > tr')
-            or returnServerError('Could not find the proper HTML elements.');
+            or throwServerException('Could not find the proper HTML elements.');
 
         foreach ($rows as $row) {
             $item = $this->generateItemFromRow($row);

--- a/bridges/CNETBridge.php
+++ b/bridges/CNETBridge.php
@@ -50,7 +50,7 @@ class CNETBridge extends SitemapBridge
         }
 
         if (empty($links)) {
-            returnClientError('Failed to retrieve article list');
+            throwClientException('Failed to retrieve article list');
         }
 
         foreach ($links as $article_uri) {

--- a/bridges/CVEDetailsBridge.php
+++ b/bridges/CVEDetailsBridge.php
@@ -87,7 +87,7 @@ class CVEDetailsBridge extends BridgeAbstract
 
         $vendor = $html->find('#contentdiv h1 > a', 0);
         if ($vendor == null) {
-            returnServerError('Invalid Vendor ID ' . $this->getInput('vendor_id') . ' or Product ID ' . $this->getInput('product_id'));
+            throwServerException('Invalid Vendor ID ' . $this->getInput('vendor_id') . ' or Product ID ' . $this->getInput('product_id'));
         }
         $this->vendor = $vendor->innertext;
 

--- a/bridges/CachetBridge.php
+++ b/bridges/CachetBridge.php
@@ -72,14 +72,14 @@ class CachetBridge extends BridgeAbstract
     {
         $ping = getContents(urljoin($this->getURI(), '/api/v1/ping'));
         if (!$this->validatePing($ping)) {
-            returnClientError('Provided URI is invalid!');
+            throwClientException('Provided URI is invalid!');
         }
 
         $url = urljoin($this->getURI(), '/api/v1/incidents?sort=id&order=desc');
         $incidents = getContents($url);
         $incidents = json_decode($incidents);
         if ($incidents === null) {
-            returnClientError('/api/v1/incidents returned no valid json');
+            throwClientException('/api/v1/incidents returned no valid json');
         }
 
         usort($incidents->data, function ($a, $b) {

--- a/bridges/CastorusBridge.php
+++ b/bridges/CastorusBridge.php
@@ -36,7 +36,7 @@ class CastorusBridge extends BridgeAbstract
         $title = $activity->find('a', 0);
 
         if (!$title) {
-            returnServerError('Cannot find title!');
+            throwServerException('Cannot find title!');
         }
 
         return trim($title->plaintext);
@@ -48,7 +48,7 @@ class CastorusBridge extends BridgeAbstract
         $url = $activity->find('a', 0);
 
         if (!$url) {
-            returnServerError('Cannot find url!');
+            throwServerException('Cannot find url!');
         }
 
         return self::URI . $url->href;
@@ -62,7 +62,7 @@ class CastorusBridge extends BridgeAbstract
         $nodes = $activity->find('*');
 
         if (!$nodes) {
-            returnServerError('Cannot find nodes!');
+            throwServerException('Cannot find nodes!');
         }
 
         foreach ($nodes as $node) {
@@ -78,7 +78,7 @@ class CastorusBridge extends BridgeAbstract
         $price = $activity->find('span', 1);
 
         if (!$price) {
-            returnServerError('Cannot find price!');
+            throwServerException('Cannot find price!');
         }
 
         return $price->innertext;
@@ -92,13 +92,13 @@ class CastorusBridge extends BridgeAbstract
         $html = getSimpleHTMLDOM(self::URI);
 
         if (!$html) {
-            returnServerError('Could not load data from ' . self::URI . '!');
+            throwServerException('Could not load data from ' . self::URI . '!');
         }
 
         $activities = $html->find('div#activite > li');
 
         if (!$activities) {
-            returnServerError('Failed to find activities!');
+            throwServerException('Failed to find activities!');
         }
 
         foreach ($activities as $activity) {

--- a/bridges/CeskaTelevizeBridge.php
+++ b/bridges/CeskaTelevizeBridge.php
@@ -24,7 +24,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
 
         $validUrl = '/^(https:\/\/www\.ceskatelevize\.cz\/porady\/\d+-[a-z0-9-]+\/)(bonus\/)?$/';
         if (!preg_match($validUrl, $url, $match)) {
-            returnServerError('Invalid url');
+            throwServerException('Invalid url');
         }
 
         $category = $match[4] ?? 'nove';
@@ -63,7 +63,7 @@ class CeskaTelevizeBridge extends BridgeAbstract
         } elseif (strpos($string, 'včera') !== false) {
             return strtotime('yesterday');
         } elseif (!preg_match('/(\d+).(\d+).((\d+))?/', $string, $match)) {
-            returnServerError('Could not get date from Česká televize string');
+            throwServerException('Could not get date from Česká televize string');
         }
 
         $date = sprintf('%04d-%02d-%02d', $match[3] ?? date('Y'), $match[2], $match[1]);

--- a/bridges/CssSelectorBridge.php
+++ b/bridges/CssSelectorBridge.php
@@ -217,7 +217,7 @@ class CssSelectorBridge extends BridgeAbstract
         $links = $page->find($url_selector);
 
         if (empty($links)) {
-            returnClientError('No results for URL selector');
+            throwClientException('No results for URL selector');
         }
 
         $link_to_item = [];
@@ -245,13 +245,13 @@ class CssSelectorBridge extends BridgeAbstract
         }
 
         if (empty($link_to_item)) {
-            returnClientError('The provided URL selector matches some elements, but they do not contain links.');
+            throwClientException('The provided URL selector matches some elements, but they do not contain links.');
         }
 
         $links = $this->filterUrlList(array_keys($link_to_item), $url_pattern, $limit);
 
         if (empty($links)) {
-            returnClientError('No results for URL pattern');
+            throwClientException('No results for URL pattern');
         }
 
         $items = [];
@@ -274,7 +274,7 @@ class CssSelectorBridge extends BridgeAbstract
     protected function expandEntryWithSelector($entry_url, $content_selector, $content_cleanup = null, $title_cleanup = null, $title_default = null)
     {
         if (empty($content_selector)) {
-            returnClientError('Please specify a content selector');
+            throwClientException('Please specify a content selector');
         }
 
         $entry_html = getSimpleHTMLDOMCached($entry_url);

--- a/bridges/CssSelectorComplexBridge.php
+++ b/bridges/CssSelectorComplexBridge.php
@@ -187,7 +187,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
         // Fetch the elements from the article pages.
         if ($use_article_pages) {
             if (empty($article_page_content_selector)) {
-                returnClientError('`Article selector` is required when `Load article page` is enabled');
+                throwClientException('`Article selector` is required when `Load article page` is enabled');
             }
 
             foreach (array_keys($entry_elements) as $uri) {
@@ -307,7 +307,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
 
         $entryElements = $page->find($entry_selector);
         if (empty($entryElements)) {
-            returnClientError('No entry elements for entry selector');
+            throwClientException('No entry elements for entry selector');
         }
 
         // Extract URIs with the associated entry element
@@ -327,7 +327,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
         }
 
         if (empty($links_with_elements)) {
-            returnClientError('The provided URL selector matches some elements, but they do not 
+            throwClientException('The provided URL selector matches some elements, but they do not 
                 contain links.');
         }
 
@@ -335,7 +335,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
         $filtered_urls = $this->filterUrlList(array_keys($links_with_elements), $url_pattern, $limit);
 
         if (empty($filtered_urls)) {
-            returnClientError('No results for URL pattern');
+            throwClientException('No results for URL pattern');
         }
 
         $items = [];
@@ -359,7 +359,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
         $article_content = $entry_html->find($content_selector, 0);
 
         if (is_null($article_content)) {
-            returnClientError('Could not get article content at URL: ' . $entry_url);
+            throwClientException('Could not get article content at URL: ' . $entry_url);
         }
 
         $article_content = defaultLinkTo($article_content, $entry_url);
@@ -370,7 +370,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
     {
         $date = date_parse_from_format($format, $timeStr);
         if ($date['error_count'] != 0) {
-            returnClientError('Error while parsing time string');
+            throwClientException('Error while parsing time string');
         }
 
         $timestamp = mktime(
@@ -383,7 +383,7 @@ class CssSelectorComplexBridge extends BridgeAbstract
         );
 
         if ($timestamp == false) {
-            returnClientError('Error while creating timestamp');
+            throwClientException('Error while creating timestamp');
         }
 
         return $timestamp;

--- a/bridges/DevToBridge.php
+++ b/bridges/DevToBridge.php
@@ -75,7 +75,7 @@ apple-icon-5c6fa9f2bce280428589c6195b7f1924206a53b782b371cfe2d02da932c8c173.png'
         $html = defaultLinkTo($html, static::URI);
 
         $articles = $html->find('div.crayons-story')
-            or returnServerError('Could not find articles!');
+            or throwServerException('Could not find articles!');
 
         foreach ($articles as $article) {
             $item = [];

--- a/bridges/Drive2ruBridge.php
+++ b/bridges/Drive2ruBridge.php
@@ -204,13 +204,13 @@ class Drive2ruBridge extends BridgeAbstract
                 break;
             case 'Бортжурналы (По модели или марке)':
                 if (!preg_match('/^https:\/\/www.drive2.ru\/experience/', $this->getInput('url'))) {
-                    returnServerError('Invalid url');
+                    throwServerException('Invalid url');
                 }
                 $this->getLogbooksContent($this->getInput('url'));
                 break;
             case 'Личные блоги':
                 if (!preg_match('/^[a-zA-Z0-9-]{3,16}$/', $this->getInput('username'))) {
-                    returnServerError('Invalid username');
+                    throwServerException('Invalid username');
                 }
                 $this->getUserContent('https://www.drive2.ru/users/' . $this->getInput('username'));
                 break;

--- a/bridges/ElektroARGOSBridge.php
+++ b/bridges/ElektroARGOSBridge.php
@@ -160,7 +160,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Check if page contains articles and split by class
         $articles = $html->find('.com-news-feature-prerex') or
-            returnServerError('No articles found! Layout might have changed!');
+            throwServerException('No articles found! Layout might have changed!');
 
         // Articles loop
         foreach ($articles as $article) {
@@ -189,7 +189,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Check if page contains articles and split by class
         $articles = $html->find('.com-news-common-prerex') or
-            returnServerError('No articles found! Layout might have changed!');
+            throwServerException('No articles found! Layout might have changed!');
 
         // Articles loop
         foreach ($articles as $article) {
@@ -225,7 +225,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Check if page contains articles and split by class
         $articles = $html->find('.com-news-common-prerex') or
-            returnServerError('No articles found! Layout might have changed!');
+            throwServerException('No articles found! Layout might have changed!');
 
         // Articles loop
         foreach ($articles as $article) {
@@ -273,7 +273,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Return URI of the article
         $element = $article->find('a', 0) or
-            returnServerError('Anchor not found!');
+            throwServerException('Anchor not found!');
 
         return $element->href;
     }
@@ -307,7 +307,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Check if date is set
         $element = $article->find('div.com-news-common-prerex__date', 0) or
-            returnServerError('Date not found!');
+            throwServerException('Date not found!');
 
         return $element->plaintext;
     }
@@ -322,7 +322,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Extract description
         $element = $article->find('ul.ws-product-information__piece-description', 0)->find('li', 0) or
-            returnServerError('Description not found!');
+            throwServerException('Description not found!');
 
         return $element->innertext;
     }
@@ -337,7 +337,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Extract description
         $element = $article->find('div.ws-product-price-validity', 0)->find('div', 0) or
-            returnServerError('Description not found!');
+            throwServerException('Description not found!');
 
         return $element->innertext;
     }
@@ -352,7 +352,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Extract description
         $element = $article->find('div.ws-product-price-validity', 0)->find('div', 1) or
-            returnServerError('Description not found!');
+            throwServerException('Description not found!');
 
         return $element->innertext;
     }
@@ -454,7 +454,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Extract title
         $element = $article->find('img', 0) or
-            returnServerError('Title not found!');
+            throwServerException('Title not found!');
 
         return $element->alt;
     }
@@ -469,7 +469,7 @@ class ElektroARGOSBridge extends BridgeAbstract
     {
         // Extract title
         $element = $article->find('div.com-news-common-prerex__right-box', 0)->find('h3', 0)
-            or returnServerError('Title not found!');
+            or throwServerException('Title not found!');
 
         return $element->plaintext;
     }

--- a/bridges/FB2Bridge.php
+++ b/bridges/FB2Bridge.php
@@ -85,13 +85,13 @@ class FB2Bridge extends BridgeAbstract
             $pageInfo = $this->getPageInfos($page, $cookies);
 
             if ($pageInfo['userId'] === null) {
-                returnClientError(
+                throwClientException(
                     <<<EOD
 Unable to get the page id. You should consider getting the ID by hand, then importing it into FB2Bridge
 EOD
                 );
             } elseif ($pageInfo['userId'] == -1) {
-                returnClientError(
+                throwClientException(
                     <<<EOD
 This page is not accessible without being logged in.
 EOD

--- a/bridges/FacebookBridge.php
+++ b/bridges/FacebookBridge.php
@@ -155,7 +155,7 @@ class FacebookBridge extends BridgeAbstract
                 break;
 
             default:
-                returnClientError('Unknown context: "' . $this->queriedContext . '"!');
+                throwClientException('Unknown context: "' . $this->queriedContext . '"!');
         }
 
         $limit = $this->getInput('limit') ?: -1;
@@ -184,7 +184,7 @@ class FacebookBridge extends BridgeAbstract
         $html = getSimpleHTMLDOM($touchURI, $header);
 
         if (!$this->isPublicGroup($html)) {
-            returnClientError('This group is not public! RSS-Bridge only supports public groups!');
+            throwClientException('This group is not public! RSS-Bridge only supports public groups!');
         }
 
         defaultLinkTo($html, substr(self::URI, 0, strlen(self::URI) - 1));
@@ -192,7 +192,7 @@ class FacebookBridge extends BridgeAbstract
         $this->groupName = $this->extractGroupName($html);
 
         $posts = $html->find('div.story_body_container')
-            or returnServerError('Failed finding posts!');
+            or throwServerException('Failed finding posts!');
 
         foreach ($posts as $post) {
             $item = [];
@@ -224,7 +224,7 @@ class FacebookBridge extends BridgeAbstract
 
             return explode('/', $urlparts['path'])[2];
         } elseif (strpos($group, '/') !== false) {
-            returnClientError('The group you provided is invalid: ' . $group);
+            throwClientException('The group you provided is invalid: ' . $group);
         } else {
             return $group;
         }
@@ -246,7 +246,7 @@ class FacebookBridge extends BridgeAbstract
             $provided_host !== $facebook_host
             && 'www.' . $provided_host !== $facebook_host
         ) {
-            returnClientError('The host you provided is invalid! Received "'
+            throwClientException('The host you provided is invalid! Received "'
                 . $provided_host
                 . '", expected "'
                 . $facebook_host
@@ -268,7 +268,7 @@ class FacebookBridge extends BridgeAbstract
     private function extractGroupName($html)
     {
         $ogtitle = $html->find('._de1', 0)
-            or returnServerError('Unable to find group title!');
+            or throwServerException('Unable to find group title!');
 
         return html_entity_decode($ogtitle->plaintext, ENT_QUOTES);
     }
@@ -276,7 +276,7 @@ class FacebookBridge extends BridgeAbstract
     private function extractGroupPostURI($post)
     {
         $elements = $post->find('a')
-            or returnServerError('Unable to find URI!');
+            or throwServerException('Unable to find URI!');
 
         foreach ($elements as $anchor) {
             // Find the one that is a permalink
@@ -292,7 +292,7 @@ class FacebookBridge extends BridgeAbstract
     private function extractGroupPostContent($post)
     {
         $content = $post->find('div._5rgt', 0)
-            or returnServerError('Unable to find user content!');
+            or throwServerException('Unable to find user content!');
 
         $context_text = $content->innertext;
         if ($content->next_sibling() !== null) {
@@ -304,7 +304,7 @@ class FacebookBridge extends BridgeAbstract
     private function extractGroupPostAuthor($post)
     {
         $element = $post->find('h3 a', 0)
-            or returnServerError('Unable to find author information!');
+            or throwServerException('Unable to find author information!');
 
         return $element->plaintext;
     }
@@ -334,7 +334,7 @@ class FacebookBridge extends BridgeAbstract
     private function extractGroupPostTitle($post)
     {
         $element = $post->find('h3', 0)
-            or returnServerError('Unable to find title!');
+            or throwServerException('Unable to find title!');
 
         if (strpos($element->plaintext, 'shared') === false) {
             $content = strip_tags($this->extractGroupPostContent($post));
@@ -370,14 +370,14 @@ class FacebookBridge extends BridgeAbstract
                 !array_key_exists('path', $urlparts)
                 || $urlparts['path'] === '/'
             ) {
-                returnClientError('The URL you provided doesn\'t contain the user name!');
+                throwClientException('The URL you provided doesn\'t contain the user name!');
             }
 
             return explode('/', $urlparts['path'])[1];
         } else {
             // First character cannot be a forward slash
             if (strpos($user, '/') === 0) {
-                returnClientError('Remove leading slash "/" from the username!');
+                throwClientException('Remove leading slash "/" from the username!');
             }
 
             return $user;
@@ -572,7 +572,7 @@ EOD;
         $loginForm = $html->find('._585r', 0);
 
         if ($loginForm != null) {
-            returnServerError('You must be logged in to view this page. This is not supported by RSS-Bridge.');
+            throwServerException('You must be logged in to view this page. This is not supported by RSS-Bridge.');
         }
 
         $mainColumn = $html->find('#pagelet_timeline_main_column');

--- a/bridges/FeedExpanderExampleBridge.php
+++ b/bridges/FeedExpanderExampleBridge.php
@@ -40,7 +40,7 @@ class FeedExpanderExampleBridge extends FeedExpander
                 parent::collectExpandableDatas('http://segfault.linuxmint.com/feed/atom/');
                 break;
             default:
-                returnClientError('Unknown version ' . $this->getInput('version') . '!');
+                throwClientException('Unknown version ' . $this->getInput('version') . '!');
         }
     }
 }

--- a/bridges/FlickrBridge.php
+++ b/bridges/FlickrBridge.php
@@ -112,7 +112,7 @@ class FlickrBridge extends BridgeAbstract
                 break;
 
             default:
-                returnClientError('Invalid context: ' . $this->queriedContext);
+                throwClientException('Invalid context: ' . $this->queriedContext);
         }
 
         $model_json = $this->extractJsonModel($html);

--- a/bridges/Formula1Bridge.php
+++ b/bridges/Formula1Bridge.php
@@ -42,7 +42,7 @@ class Formula1Bridge extends BridgeAbstract
             'locale: en'
         ]));
         if (property_exists($json, 'error')) {
-            returnServerError($json->message);
+            throwServerException($json->message);
         }
         $list = $json->items;
 

--- a/bridges/FunkBridge.php
+++ b/bridges/FunkBridge.php
@@ -40,7 +40,7 @@ class FunkBridge extends BridgeAbstract
                 }
                 break;
             default:
-                returnServerError('Unknown context!');
+                throwServerException('Unknown context!');
         }
     }
 

--- a/bridges/GitHubGistBridge.php
+++ b/bridges/GitHubGistBridge.php
@@ -56,7 +56,7 @@ class GitHubGistBridge extends BridgeAbstract
         $html = defaultLinkTo($html, $this->getURI());
 
         $fileinfo = $html->find('[class~="file-info"]', 0)
-            or returnServerError('Could not find file info!');
+            or throwServerException('Could not find file info!');
 
         $this->filename = $fileinfo->plaintext;
 
@@ -68,18 +68,18 @@ class GitHubGistBridge extends BridgeAbstract
 
         foreach ($comments as $comment) {
             $uri = $comment->find('a[href*=#gistcomment]', 0)
-                or returnServerError('Could not find comment anchor!');
+                or throwServerException('Could not find comment anchor!');
 
             $title = $comment->find('h3', 0);
 
             $datetime = $comment->find('[datetime]', 0)
-                or returnServerError('Could not find comment datetime!');
+                or throwServerException('Could not find comment datetime!');
 
             $author = $comment->find('a.author', 0)
-                or returnServerError('Could not find author name!');
+                or throwServerException('Could not find author name!');
 
             $message = $comment->find('[class~="comment-body"]', 0)
-                or returnServerError('Could not find comment body!');
+                or throwServerException('Could not find comment body!');
 
             $item = [];
 

--- a/bridges/GiteaBridge.php
+++ b/bridges/GiteaBridge.php
@@ -188,7 +188,7 @@ class GiteaBridge extends BridgeAbstract
     protected function collectReleasesData($html)
     {
         $releases = $html->find('#release-list > li')
-            or returnServerError('Unable to find releases');
+            or throwServerException('Unable to find releases');
 
         foreach ($releases as $release) {
             $this->items[] = [
@@ -203,7 +203,7 @@ class GiteaBridge extends BridgeAbstract
     protected function collectTagsData($html)
     {
         $tags = $html->find('table#tags-table > tbody > tr')
-            or returnServerError('Unable to find tags');
+            or throwServerException('Unable to find tags');
 
         foreach ($tags as $tag) {
             $this->items[] = [
@@ -216,7 +216,7 @@ class GiteaBridge extends BridgeAbstract
     protected function collectCommitsData($html)
     {
         $commits = $html->find('#commits-table tbody tr')
-            or returnServerError('Unable to find commits');
+            or throwServerException('Unable to find commits');
 
         foreach ($commits as $commit) {
             $this->items[] = [
@@ -232,7 +232,7 @@ class GiteaBridge extends BridgeAbstract
     protected function collectIssuesData($html)
     {
         $issues = $html->find('.issue.list li')
-            or returnServerError('Unable to find issues');
+            or throwServerException('Unable to find issues');
 
         foreach ($issues as $issue) {
             $uri = $issue->find('a', 0)->href;
@@ -259,7 +259,7 @@ class GiteaBridge extends BridgeAbstract
     protected function collectSingleIssueOrPrData($html)
     {
         $comments = $html->find('.comment')
-            or returnServerError('Unable to find comments');
+            or throwServerException('Unable to find comments');
 
         foreach ($comments as $comment) {
             if (
@@ -293,7 +293,7 @@ class GiteaBridge extends BridgeAbstract
     protected function collectPullRequestsData($html)
     {
         $issues = $html->find('.issue.list li')
-            or returnServerError('Unable to find pull requests');
+            or throwServerException('Unable to find pull requests');
 
         foreach ($issues as $issue) {
             $uri = $issue->find('a', 0)->href;

--- a/bridges/GlassdoorBridge.php
+++ b/bridges/GlassdoorBridge.php
@@ -98,7 +98,7 @@ class GlassdoorBridge extends BridgeAbstract
     private function collectBlogData($html, $limit)
     {
         $posts = $html->find('div.post')
-            or returnServerError('Unable to find blog posts!');
+            or throwServerException('Unable to find blog posts!');
 
         foreach ($posts as $post) {
             $item = [];
@@ -121,7 +121,7 @@ class GlassdoorBridge extends BridgeAbstract
     private function collectReviewData($html, $limit)
     {
         $reviews = $html->find('#ReviewsFeed li[id^="empReview]')
-            or returnServerError('Unable to find reviews!');
+            or throwServerException('Unable to find reviews!');
 
         foreach ($reviews as $review) {
             $item = [];
@@ -163,7 +163,7 @@ class GlassdoorBridge extends BridgeAbstract
                 FILTER_FLAG_PATH_REQUIRED
             )
         ) {
-            returnClientError('The specified URL is invalid!');
+            throwClientException('The specified URL is invalid!');
         }
 
         $uri = filter_var($uri, FILTER_SANITIZE_URL);
@@ -189,7 +189,7 @@ class GlassdoorBridge extends BridgeAbstract
         ];
 
         if (!in_array($parts[1], $allowed_strings)) {
-            returnClientError('Please specify a URL pointing to the companies review page!');
+            throwClientException('Please specify a URL pointing to the companies review page!');
         }
 
         return $uri;

--- a/bridges/GogsBridge.php
+++ b/bridges/GogsBridge.php
@@ -141,7 +141,7 @@ class GogsBridge extends BridgeAbstract
     protected function collectCommitsData($html)
     {
         $commits = $html->find('#commits-table tbody tr')
-            or returnServerError('Unable to find commits');
+            or throwServerException('Unable to find commits');
 
         foreach ($commits as $commit) {
             $this->items[] = [
@@ -157,7 +157,7 @@ class GogsBridge extends BridgeAbstract
     protected function collectIssuesData($html)
     {
         $issues = $html->find('.issue.list li')
-            or returnServerError('Unable to find issues');
+            or throwServerException('Unable to find issues');
 
         foreach ($issues as $issue) {
             $uri = $issue->find('a', 0)->href;
@@ -185,7 +185,7 @@ class GogsBridge extends BridgeAbstract
     protected function collectSingleIssueData($html)
     {
         $comments = $html->find('.comments .comment')
-            or returnServerError('Unable to find comments');
+            or throwServerException('Unable to find comments');
 
         foreach ($comments as $comment) {
             $this->items[] = [
@@ -203,7 +203,7 @@ class GogsBridge extends BridgeAbstract
     protected function collectReleasesData($html)
     {
         $releases = $html->find('#release-list li')
-            or returnServerError('Unable to find releases');
+            or throwServerException('Unable to find releases');
 
         foreach ($releases as $release) {
             $this->items[] = [

--- a/bridges/GoogleSearchBridge.php
+++ b/bridges/GoogleSearchBridge.php
@@ -26,7 +26,7 @@ class GoogleSearchBridge extends BridgeAbstract
         // todo: wrap this in try..catch because 429 too many requests happens a lot
         $dom = getSimpleHTMLDOM($this->getURI(), ['Accept-language: en-US']);
         if (!$dom) {
-            returnServerError('No results for this query.');
+            throwServerException('No results for this query.');
         }
         $result = $dom->find('div[id=res]', 0);
 

--- a/bridges/I4wifiBridge.php
+++ b/bridges/I4wifiBridge.php
@@ -126,7 +126,7 @@ class I4wifiBridge extends BridgeAbstract
     private function collectNews($html)
     {
         $articles = $html->find('.timeline-item.timeline-item-right')
-            or returnServerError('No articles found! Layout might have changed!');
+            or throwServerException('No articles found! Layout might have changed!');
 
         foreach ($articles as $article) {
             $item = [];
@@ -157,7 +157,7 @@ class I4wifiBridge extends BridgeAbstract
     {
         // Return URI of the article
         $element = $article->find('a', 0)
-            or returnServerError('Anchor not found!');
+            or throwServerException('Anchor not found!');
 
         return $element->href;
     }
@@ -172,7 +172,7 @@ class I4wifiBridge extends BridgeAbstract
     {
         // Check if date is set
         $element = $article->find('.timeline-item-info', 0)
-            or returnServerError('Date not found!');
+            or throwServerException('Date not found!');
 
         // Format date
         return $this->fixDate($element->plaintext);
@@ -188,7 +188,7 @@ class I4wifiBridge extends BridgeAbstract
     {
         // Extract description
         $element = $article->find('p', 0)
-            or returnServerError('Description not found!');
+            or throwServerException('Description not found!');
 
         return $element->innertext;
     }
@@ -203,7 +203,7 @@ class I4wifiBridge extends BridgeAbstract
     {
         // Extract title
         $element = $article->find('img', 0)
-            or returnServerError('Title not found!');
+            or throwServerException('Title not found!');
 
         return $element->alt;
     }

--- a/bridges/IPBBridge.php
+++ b/bridges/IPBBridge.php
@@ -44,7 +44,7 @@ class IPBBridge extends FeedExpander
         switch (parse_url($this->getInput('uri'), PHP_URL_PATH)) {
             case null:
             case '/index.php':
-                returnClientError('Provided URI is invalid!');
+                throwClientException('Provided URI is invalid!');
                 break;
             default:
                 break;
@@ -75,7 +75,7 @@ class IPBBridge extends FeedExpander
                 $this->collectForum($html);
                 break;
             default:
-                returnClientError('Unknown type!');
+                throwClientException('Unknown type!');
                 break;
         }
     }
@@ -106,7 +106,7 @@ class IPBBridge extends FeedExpander
                 $this->collectForumTable($html);
                 break;
             default:
-                returnClientError('Unknown forum format!');
+                throwClientException('Unknown forum format!');
                 break;
         }
     }
@@ -159,7 +159,7 @@ class IPBBridge extends FeedExpander
                 $this->collectTopicHistory($html, $limit, 'collectTopicDiv');
                 break;
             default:
-                returnClientError('Unknown topic format!');
+                throwClientException('Unknown topic format!');
                 break;
         }
     }
@@ -168,7 +168,7 @@ class IPBBridge extends FeedExpander
     {
         // Make sure the callback is valid!
         if (!method_exists($this, $callback)) {
-            returnServerError('Unknown function (\'' . $callback . '\')!');
+            throwServerException('Unknown function (\'' . $callback . '\')!');
         }
 
         $next = null; // Holds the URI of the next page

--- a/bridges/ImgsedBridge.php
+++ b/bridges/ImgsedBridge.php
@@ -258,7 +258,7 @@ HTML,
 
             // If no content type is selected, this bridge does nothing, so we return an error
             if (count($types) == 0) {
-                returnClientError('You must select at least one of the content type : Post, Stories or Tags !');
+                throwClientException('You must select at least one of the content type : Post, Stories or Tags !');
             }
             $typesText = $types[0] ?? '';
 

--- a/bridges/ItakuBridge.php
+++ b/bridges/ItakuBridge.php
@@ -689,7 +689,7 @@ class ItakuBridge extends BridgeAbstract
         if (is_array($item) || is_object($item)) {
             $this->items[] = $item;
         } else {
-            returnServerError("Incorrectly parsed item. Check the code!\nType: " . gettype($item) . "\nprint_r(item:)\n" . var_dump($item));
+            throwServerException("Incorrectly parsed item. Check the code!\nType: " . gettype($item) . "\nprint_r(item:)\n" . var_dump($item));
         }
     }
 }

--- a/bridges/ItchioBridge.php
+++ b/bridges/ItchioBridge.php
@@ -21,7 +21,7 @@ class ItchioBridge extends BridgeAbstract
         $html = getSimpleHTMLDOM($url);
         // if the page is password protected, abort
         if ($html->find('.game_password_page', 0) !== null) {
-            returnClientError('The requested page is password protected.');
+            throwClientException('The requested page is password protected.');
         }
         $title = $html->find('.game_title', 0)->innertext;
 

--- a/bridges/IvooxBridge.php
+++ b/bridges/IvooxBridge.php
@@ -110,7 +110,7 @@ class IvooxBridge extends BridgeAbstract
             $this->request = str_replace(' ', '-', $this->getInput('s'));
             $url_feed = self::URI . urlencode($this->request) . '_sb_f_1.html?o=uploaddate';
         } else {
-            returnClientError('Not valid mode at IvooxBridge');
+            throwClientException('Not valid mode at IvooxBridge');
         }
 
         $dom = getSimpleHTMLDOM($url_feed);

--- a/bridges/JustETFBridge.php
+++ b/bridges/JustETFBridge.php
@@ -167,7 +167,7 @@ class JustETFBridge extends BridgeAbstract
     private function collectNews($html)
     {
         $articles = $html->find('div.newsTopArticle')
-            or returnServerError('No articles found! Layout might have changed!');
+            or throwServerException('No articles found! Layout might have changed!');
 
         foreach ($articles as $article) {
             $item = [];
@@ -184,7 +184,7 @@ class JustETFBridge extends BridgeAbstract
                 $html = getSimpleHTMLDOMCached($uri);
 
                 $fullArticle = $html->find('div.article', 0)
-                    or returnServerError('No content found! Layout might have changed!');
+                    or throwServerException('No content found! Layout might have changed!');
 
                 defaultLinkTo($fullArticle, static::URI);
 
@@ -203,7 +203,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractNewsUri($article)
     {
         $element = $article->find('a', 0)
-            or returnServerError('Anchor not found!');
+            or throwServerException('Anchor not found!');
 
         return $element->href;
     }
@@ -211,7 +211,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractNewsDate($article)
     {
         $element = $article->find('div.subheadline', 0)
-            or returnServerError('Date not found!');
+            or throwServerException('Date not found!');
 
         $date = trim(explode('|', $element->plaintext)[0]);
 
@@ -221,7 +221,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractNewsDescription($article)
     {
         $element = $article->find('span.newsText', 0)
-            or returnServerError('Description not found!');
+            or throwServerException('Description not found!');
 
         $element->find('a', 0)->onclick = '';
 
@@ -231,7 +231,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractNewsTitle($article)
     {
         $element = $article->find('h3', 0)
-            or returnServerError('Title not found!');
+            or throwServerException('Title not found!');
 
         return $element->plaintext;
     }
@@ -239,7 +239,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractFullArticleContent($article)
     {
         $element = $article->find('div.article_body', 0)
-            or returnServerError('Article body not found!');
+            or throwServerException('Article body not found!');
 
         // Remove teaser image
         $element->find('img.teaser-img', 0)->outertext = '';
@@ -266,7 +266,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractFullArticleAuthor($article)
     {
         $element = $article->find('span[itemprop=name]', 0)
-            or returnServerError('Author not found!');
+            or throwServerException('Author not found!');
 
         return $element->plaintext;
     }
@@ -291,7 +291,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractProfileDate($html)
     {
         $element = $html->find('div.infobox div.vallabel', 0)
-            or returnServerError('Date not found!');
+            or throwServerException('Date not found!');
 
         $date = trim(explode("\r\n", $element->plaintext)[1]);
 
@@ -301,7 +301,7 @@ class JustETFBridge extends BridgeAbstract
     private function extractProfileTitle($html)
     {
         $element = $html->find('span.h1', 0)
-            or returnServerError('Title not found!');
+            or throwServerException('Title not found!');
 
         return $element->plaintext;
     }
@@ -314,12 +314,12 @@ class JustETFBridge extends BridgeAbstract
         // - Quote
 
         $strategy = $html->find('div.tab-container div.col-sm-6 p', 0)
-            or returnServerError('Investment Strategy not found!');
+            or throwServerException('Investment Strategy not found!');
 
         // Description requires a bit of cleanup due to lack of propper identification
 
         $description = $html->find('div.headline', 5)
-            or returnServerError('Description container not found!');
+            or throwServerException('Description container not found!');
 
         $description = $description->parent();
 
@@ -328,7 +328,7 @@ class JustETFBridge extends BridgeAbstract
         }
 
         $quote = $html->find('div.infobox div.val', 0)
-            or returnServerError('Quote not found!');
+            or throwServerException('Quote not found!');
 
         $quote_html = '<strong>Quote</strong><br><p>' . $quote . '</p>';
         $strategy_html = '';
@@ -350,7 +350,7 @@ class JustETFBridge extends BridgeAbstract
         // Use ISIN + WKN as author
         // Notice: "identfier" is not a typo [sic]!
         $element = $html->find('span.identfier', 0)
-            or returnServerError('Author not found!');
+            or throwServerException('Author not found!');
 
         return $element->plaintext;
     }

--- a/bridges/LaCentraleBridge.php
+++ b/bridges/LaCentraleBridge.php
@@ -420,7 +420,7 @@ class LaCentraleBridge extends BridgeAbstract
             !empty($this->getInput('distance'))
             && is_null($this->getInput('location'))
         ) {
-            returnClientError('You need a place ("CP ou département") to search arround.');
+            throwClientException('You need a place ("CP ou département") to search arround.');
         }
 
         $params = [

--- a/bridges/LeBonCoinBridge.php
+++ b/bridges/LeBonCoinBridge.php
@@ -339,14 +339,14 @@ class LeBonCoinBridge extends BridgeAbstract
             && !is_null($range_max)
             && $range_min > $range_max
         ) {
-            returnClientError('Min-' . $field . ' must be lower than max-' . $field . '.');
+            throwClientException('Min-' . $field . ' must be lower than max-' . $field . '.');
         }
 
         if (
             !is_null($range_min)
             && is_null($range_max)
         ) {
-            returnClientError('Max-' . $field . ' is needed when min-' . $field . ' is setted (range).');
+            throwClientException('Max-' . $field . ' is needed when min-' . $field . ' is setted (range).');
         }
 
         return [

--- a/bridges/LinuxBlogBridge.php
+++ b/bridges/LinuxBlogBridge.php
@@ -16,7 +16,7 @@ class LinuxBlogBridge extends BridgeAbstract
         $articles = $dom->find('ul.display-posts-listing li.listing-item');
 
         if (!$articles) {
-            returnServerError('Failed to retrieve articles');
+            throwServerException('Failed to retrieve articles');
         }
 
         foreach ($articles as $article) {

--- a/bridges/MallTvBridge.php
+++ b/bridges/MallTvBridge.php
@@ -29,7 +29,7 @@ class MallTvBridge extends BridgeAbstract
 
         $scriptLdJson = $html->find('script[type="application/ld+json"]', 0)->innertext;
         if (!preg_match('/[\'"]uploadDate[\'"]\s*:\s*[\'"](\d{4}-\d{2}-\d{2})[\'"]/', $scriptLdJson, $match)) {
-            returnServerError('Could not get date from MALL.TV detail page');
+            throwServerException('Could not get date from MALL.TV detail page');
         }
 
         return strtotime($match[1]);
@@ -40,7 +40,7 @@ class MallTvBridge extends BridgeAbstract
         $url = $this->getInput('url');
 
         if (!preg_match('/^https:\/\/www\.mall\.tv\/[a-z0-9-]+(\/[a-z0-9-]+)?\/?$/', $url)) {
-            returnServerError('Invalid url');
+            throwServerException('Invalid url');
         }
 
         $html = getSimpleHTMLDOM($url);

--- a/bridges/MangaDexBridge.php
+++ b/bridges/MangaDexBridge.php
@@ -108,7 +108,7 @@ class MangaDexBridge extends BridgeAbstract
         switch ($this->queriedContext) {
             case 'Title Chapters':
                 preg_match(self::TITLE_REGEX, $this->getInput('url'), $matches)
-                or returnClientError('Invalid URL Parameter');
+                or throwClientException('Invalid URL Parameter');
                 $this->feedURI = self::URI . 'title/' . $matches['uuid'];
                 $params['order[readableAt]'] = 'desc';
                 if (!$this->getInput('external')) {
@@ -129,7 +129,7 @@ class MangaDexBridge extends BridgeAbstract
                 $uri = self::API_ROOT . 'chapter';
                 break;
             default:
-                returnServerError('Unimplemented Context (getAPI)');
+                throwServerException('Unimplemented Context (getAPI)');
         }
 
         // Remove null keys
@@ -180,7 +180,7 @@ class MangaDexBridge extends BridgeAbstract
         if ($content['result'] == 'ok') {
             $content = $content['data'];
         } else {
-            returnServerError('Could not retrieve API results');
+            throwServerException('Could not retrieve API results');
         }
 
         switch ($this->queriedContext) {
@@ -191,7 +191,7 @@ class MangaDexBridge extends BridgeAbstract
                 $this->getChapters($content);
                 break;
             default:
-                returnServerError('Unimplemented Context (collectData)');
+                throwServerException('Unimplemented Context (collectData)');
         }
     }
 
@@ -257,7 +257,7 @@ class MangaDexBridge extends BridgeAbstract
                 $header = [ 'Content-Type: application/json' ];
                 $pages = json_decode(getContents($api_uri, $header), true);
                 if ($pages['result'] != 'ok') {
-                    returnServerError('Could not retrieve API results');
+                    throwServerException('Could not retrieve API results');
                 }
 
                 if ($this->getInput('images') == 'saver') {

--- a/bridges/MinecraftBridge.php
+++ b/bridges/MinecraftBridge.php
@@ -21,7 +21,7 @@ class MinecraftBridge extends BridgeAbstract
         $articles = json_decode($json);
 
         if ($articles === null) {
-            returnServerError('Failed to decode JSON content.');
+            throwServerException('Failed to decode JSON content.');
         }
 
         foreach ($articles->article_grid as $article) {

--- a/bridges/ModelKarteiBridge.php
+++ b/bridges/ModelKarteiBridge.php
@@ -22,7 +22,7 @@ class ModelKarteiBridge extends BridgeAbstract
     {
         $model_id = preg_replace('/[^0-9]/', '', $this->getInput('model_id'));
         if (empty($model_id)) {
-            returnServerError('Invalid model ID');
+            throwServerException('Invalid model ID');
         }
 
         $html = getSimpleHTMLDOM(self::URI . 'sedcards/model/' . $model_id . '/');
@@ -34,7 +34,7 @@ class ModelKarteiBridge extends BridgeAbstract
 
         $itemlist = $html->find('#photoList .photoPreview');
         if (!$itemlist) {
-            returnServerError('No gallery');
+            throwServerException('No gallery');
         }
 
         foreach ($itemlist as $idx => $element) {

--- a/bridges/MoinMoinBridge.php
+++ b/bridges/MoinMoinBridge.php
@@ -166,7 +166,7 @@ class MoinMoinBridge extends BridgeAbstract
     private function splitSections($html)
     {
         $content = $html->find('div#page', 0)->innertext
-            or returnServerError('Unable to find <div id="page"/>!');
+            or throwServerException('Unable to find <div id="page"/>!');
 
         $sections = [];
 

--- a/bridges/NasestrechaBridge.php
+++ b/bridges/NasestrechaBridge.php
@@ -127,7 +127,7 @@ class NasestrechaBridge extends BridgeAbstract
     {
         // Check if page contains articles
         $articles = $html->find('.post')
-            or returnServerError('No articles found! Layout might have changed!');
+            or throwServerException('No articles found! Layout might have changed!');
 
         foreach ($articles as $article) {
             $item = [];
@@ -153,7 +153,7 @@ class NasestrechaBridge extends BridgeAbstract
     {
         // Return URI of the article
         $element = $article->find('.thumbnail', 0)
-            or returnServerError('Anchor not found!');
+            or throwServerException('Anchor not found!');
 
         return $element->href;
     }
@@ -168,7 +168,7 @@ class NasestrechaBridge extends BridgeAbstract
     {
         // Check if date is set
         $element = $article->find('div.post__info', 0)->find('span', 0)
-            or returnServerError('Date not found!');
+            or throwServerException('Date not found!');
 
         $date = trim(explode('|', $element->plaintext)[0]);
 
@@ -186,7 +186,7 @@ class NasestrechaBridge extends BridgeAbstract
     {
         // Extract description
         $element = $article->find('p.post__text', 0)
-            or returnServerError('Description not found!');
+            or throwServerException('Description not found!');
 
         return $element->innertext;
     }
@@ -201,7 +201,7 @@ class NasestrechaBridge extends BridgeAbstract
     {
         // Extract title
         $element = $article->find('a.post__title', 0)
-            or returnServerError('Title not found!');
+            or throwServerException('Title not found!');
 
         return $element->plaintext;
     }

--- a/bridges/NationalGeographicBridge.php
+++ b/bridges/NationalGeographicBridge.php
@@ -75,7 +75,7 @@ class NationalGeographicBridge extends BridgeAbstract
             case self::TOPIC_LATEST_STORIES:
                 return $this->collectLatestStories();
             default:
-                returnServerError('Unknown topic: "' . $this->topicName . '"');
+                throwServerException('Unknown topic: "' . $this->topicName . '"');
         }
     }
 

--- a/bridges/OtrkeyFinderBridge.php
+++ b/bridges/OtrkeyFinderBridge.php
@@ -117,7 +117,7 @@ class OtrkeyFinderBridge extends BridgeAbstract
         // Do we need to check the running time?
         if ($minTime != 0 || $maxTime != 0) {
             if ($maxTime > 0 && $maxTime < $minTime) {
-                returnClientError('The minimum running time must be less than the maximum running time.');
+                throwClientException('The minimum running time must be less than the maximum running time.');
             }
 
             preg_match(self::FILENAME_REGEX, $file, $matches);

--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -25,7 +25,7 @@ class PatreonBridge extends BridgeAbstract
         if (preg_match($regex, $html->save(), $matches) > 0) {
             $campaign_id = $matches[1];
         } else {
-            returnServerError('Could not find campaign ID');
+            throwServerException('Could not find campaign ID');
         }
 
         $query = [

--- a/bridges/PepperBridgeAbstract.php
+++ b/bridges/PepperBridgeAbstract.php
@@ -109,7 +109,7 @@ class PepperBridgeAbstract extends BridgeAbstract
 
         // Show an error message if we can't find the thread ID in the URL sent by the user
         if ($threadSearch !== 1) {
-            returnClientError($this->i8n('thread-error'));
+            throwClientException($this->i8n('thread-error'));
         }
         $threadID = $matches[1];
 

--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -131,7 +131,7 @@ class PixivBridge extends BridgeAbstract
                     . '/profile/top';
                 break;
             default:
-                returnClientError('Invalid Context');
+                throwClientException('Invalid Context');
         }
         return $uri;
     }
@@ -279,7 +279,7 @@ class PixivBridge extends BridgeAbstract
             if (
                 !(strlen($proxy) > 0 && preg_match('/https?:\/\/.*/', $proxy))
             ) {
-                returnServerError('Invalid proxy_url value set. The proxy must include the HTTP/S at the beginning of the url.');
+                throwServerException('Invalid proxy_url value set. The proxy must include the HTTP/S at the beginning of the url.');
             }
         }
 

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -116,12 +116,12 @@ class RedditBridge extends BridgeAbstract
     {
         $forbiddenKey = 'reddit_forbidden';
         if ($this->cache->get($forbiddenKey)) {
-            throw new RateLimitException();
+            throwRateLimitException();
         }
 
         $rateLimitKey = 'reddit_rate_limit';
         if ($this->cache->get($rateLimitKey)) {
-            throw new RateLimitException();
+            throwRateLimitException();
         }
 
         try {
@@ -131,10 +131,10 @@ class RedditBridge extends BridgeAbstract
                 // 403 Forbidden
                 // This can possibly mean that reddit has permanently blocked this server's ip address
                 $this->cache->set($forbiddenKey, true, 60 * 61);
-                throw new RateLimitException();
+                throwRateLimitException();
             } elseif ($e->getCode() === 429) {
                 $this->cache->set($rateLimitKey, true, 60 * 61);
-                throw new RateLimitException();
+                throwRateLimitException();
             }
             throw $e;
         }

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -355,7 +355,7 @@ class ReutersBridge extends BridgeAbstract
                 return $base_url . 'articles-by-section-alias-or-id-v1?query=' . $json_query;
                 break;
         }
-        returnServerError('unsupported endpoint');
+        throwServerException('unsupported endpoint');
     }
 
     private function addStories($title, $content, $timestamp, $author, $url, $category)

--- a/bridges/RutubeBridge.php
+++ b/bridges/RutubeBridge.php
@@ -65,7 +65,7 @@ class RutubeBridge extends BridgeAbstract
     private function getJSONData($html)
     {
         $jsonDataRegex = '/window.reduxState = (.*);/';
-        preg_match($jsonDataRegex, $html, $matches) or returnServerError('Could not find reduxState');
+        preg_match($jsonDataRegex, $html, $matches) or throwServerException('Could not find reduxState');
         $map = [
             '\x26' => '&',
             '\x3c' => '<',

--- a/bridges/SIMARBridge.php
+++ b/bridges/SIMARBridge.php
@@ -20,7 +20,7 @@ class SIMARBridge extends BridgeAbstract
     {
         $html = getSimpleHTMLDOM($this->getURI());
         $e_home = $html->find('#home', 0)
-            or returnServerError('Invalid site structure');
+            or throwServerException('Invalid site structure');
 
         foreach ($e_home->find('span') as $element) {
             $item = [];
@@ -34,7 +34,7 @@ class SIMARBridge extends BridgeAbstract
 
         if ($this->getInput('interventions')) {
             $e_main1 = $html->find('#menu1', 0)
-                or returnServerError('Invalid site structure');
+                or throwServerException('Invalid site structure');
 
             foreach ($e_main1->find('a') as $element) {
                 $item = [];

--- a/bridges/SchweinfurtBuergerinformationenBridge.php
+++ b/bridges/SchweinfurtBuergerinformationenBridge.php
@@ -59,7 +59,7 @@ class SchweinfurtBuergerinformationenBridge extends BridgeAbstract
             if (preg_match('/artikel_id_(\d+)/', $article->id, $match)) {
                 $articleIDs[] = $match[1];
             } else {
-                returnServerError('Couldn\'t determine article ID from index page.');
+                throwServerException('Couldn\'t determine article ID from index page.');
             }
         }
 

--- a/bridges/ScribdBridge.php
+++ b/bridges/ScribdBridge.php
@@ -71,7 +71,7 @@ EOD;
     {
         if (!is_null($this->getInput('profile'))) {
             preg_match($this->profileUrlRegex, $this->getInput('profile'), $user)
-                or returnServerError('Could not extract user ID and name from given profile URL.');
+                or throwServerException('Could not extract user ID and name from given profile URL.');
 
             return self::URI . '/' . $user[1] . '/uploads';
         }

--- a/bridges/SensCritiqueBridge.php
+++ b/bridges/SensCritiqueBridge.php
@@ -67,7 +67,7 @@ class SensCritiqueBridge extends BridgeAbstract
     private function extractDataFromList($list)
     {
         if ($list === null) {
-            returnClientError('Cannot extract data from list');
+            throwClientException('Cannot extract data from list');
         }
 
         foreach ($list->find('div[data-testid="product-list-item"]') as $movie) {

--- a/bridges/SeznamZpravyBridge.php
+++ b/bridges/SeznamZpravyBridge.php
@@ -48,20 +48,20 @@ class SeznamZpravyBridge extends BridgeAbstract
 
                 $html = getSimpleHTMLDOMCached($url . $this->getInput('author'), $ONE_DAY);
                 $mainBreadcrumbs = $html->find($selectors['breadcrumbs'], 0)
-                or returnServerError('Could not get breadcrumbs for: ' . $this->getURI());
+                or throwServerException('Could not get breadcrumbs for: ' . $this->getURI());
 
                 $author = $mainBreadcrumbs->last_child()->plaintext
-                or returnServerError('Could not get author for: ' . $this->getURI());
+                or throwServerException('Could not get author for: ' . $this->getURI());
 
                 $this->feedName = $author . ' - Seznam Zprávy';
 
                 $articles = $html->find($selectors['articleList'])
-                or returnServerError('Could not find articles for: ' . $this->getURI());
+                or throwServerException('Could not find articles for: ' . $this->getURI());
 
                 foreach ($articles as $article) {
                     // Get article URL
                     $titleLink = $article->find($selectors['articleTitle'], 0)
-                    or returnServerError('Could not find title for: ' . $this->getURI());
+                    or throwServerException('Could not find title for: ' . $this->getURI());
                     $articleURL = $titleLink->href;
 
                     $articleContentHTML = getSimpleHTMLDOMCached($articleURL, $ONE_DAY);
@@ -71,9 +71,9 @@ class SeznamZpravyBridge extends BridgeAbstract
 
                     // Article text content
                     $contentElem = $articleContentHTML->find($selectors['articleContent'], 0)
-                    or returnServerError('Could not get article content for: ' . $articleURL);
+                    or throwServerException('Could not get article content for: ' . $articleURL);
                     $contentParagraphs = $contentElem->find($selectors['articleParagraphs'])
-                    or returnServerError('Could not find paragraphs for: ' . $articleURL);
+                    or throwServerException('Could not find paragraphs for: ' . $articleURL);
 
                     // If the article has an image, put that image at the start
                     $contentInitialValue = isset($articleImageElem) ? $articleImageElem->outertext : '';
@@ -83,7 +83,7 @@ class SeznamZpravyBridge extends BridgeAbstract
 
                     // Article categories
                     $breadcrumbsElem = $articleContentHTML->find($selectors['breadcrumbs'], 0)
-                        or returnServerError('Could not find breadcrumbs for: ' . $articleURL);
+                        or throwServerException('Could not find breadcrumbs for: ' . $articleURL);
                     $breadcrumbs = $breadcrumbsElem->children();
                     $numBreadcrumbs = count($breadcrumbs);
                     $categories = [];
@@ -96,7 +96,7 @@ class SeznamZpravyBridge extends BridgeAbstract
 
                     // Article date & time
                     $articleTimeElem = $article->find($selectors['articleTime'], 0)
-                    or returnServerError('Could not find article time for: ' . $articleURL);
+                    or throwServerException('Could not find article time for: ' . $articleURL);
                     $articleTime = $articleTimeElem->plaintext;
 
                     $articleDMElem = $article->find($selectors['articleDM'], 0);

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -41,7 +41,7 @@ class ShanaprojectBridge extends BridgeAbstract
         $html = $this->loadSeasonAnimeList();
 
         $animes = $html->find('div.header_display_box_info')
-            or returnServerError('Could not find anime headers!');
+            or throwServerException('Could not find anime headers!');
 
         $min_episodes = $this->getInput('min_episodes') ?: 0;
         $min_total_episodes = $this->getInput('min_total_episodes') ?: 0;
@@ -89,7 +89,7 @@ class ShanaprojectBridge extends BridgeAbstract
         $html = defaultLinkTo($html, self::URI . '/seasons');
 
         $season = $html->find('div.follows_menu > a', 1)
-            or returnServerError('Could not find \'Season Anime List\'!');
+            or throwServerException('Could not find \'Season Anime List\'!');
 
         $html = getSimpleHTMLDOM($season->href);
 
@@ -104,7 +104,7 @@ class ShanaprojectBridge extends BridgeAbstract
     private function extractAnimeTitle($anime)
     {
         $title = $anime->find('a', 0)
-            or returnServerError('Could not find anime title!');
+            or throwServerException('Could not find anime title!');
         return trim($title->innertext);
     }
 
@@ -112,7 +112,7 @@ class ShanaprojectBridge extends BridgeAbstract
     private function extractAnimeUri($anime)
     {
         $uri = $anime->find('a', 0)
-            or returnServerError('Could not find anime URI!');
+            or throwServerException('Could not find anime URI!');
         return $uri->href;
     }
 
@@ -144,7 +144,7 @@ class ShanaprojectBridge extends BridgeAbstract
     private function extractAnimeEpisodeInformation($anime)
     {
         $episode = $anime->find('div.header_info_episode', 0)
-            or returnServerError('Could not find anime episode information!');
+            or throwServerException('Could not find anime episode information!');
 
         $retVal = preg_replace('/\r|\n/', ' ', $episode->plaintext);
         $retVal = preg_replace('/\s+/', ' ', $retVal);
@@ -162,7 +162,7 @@ class ShanaprojectBridge extends BridgeAbstract
             return $matches[1];
         }
 
-        returnServerError('Could not extract background image!');
+        throwServerException('Could not extract background image!');
     }
 
     // Builds an URI to search for a specific anime (subber is left empty)

--- a/bridges/SitemapBridge.php
+++ b/bridges/SitemapBridge.php
@@ -85,7 +85,7 @@ class SitemapBridge extends CssSelectorBridge
         $links = $this->sitemapXmlToList($sitemap_xml, $url_pattern, empty($limit) ? 10 : $limit);
 
         if (empty($links) && empty($this->sitemapXmlToList($sitemap_xml))) {
-            returnClientError('Could not retrieve URLs with Timestamps from Sitemap: ' . $sitemap_url);
+            throwClientException('Could not retrieve URLs with Timestamps from Sitemap: ' . $sitemap_url);
         }
 
         foreach ($links as $link) {
@@ -117,7 +117,7 @@ class SitemapBridge extends CssSelectorBridge
                     $url = urljoin($url, '/sitemap.xml');
                     return $sitemap;
                 } else {
-                    returnClientError('Failed to locate Sitemap from /robots.txt or /sitemap.xml. Try setting it manually.');
+                    throwClientException('Failed to locate Sitemap from /robots.txt or /sitemap.xml. Try setting it manually.');
                 }
             }
             $url = $matches[1];

--- a/bridges/SkimfeedBridge.php
+++ b/bridges/SkimfeedBridge.php
@@ -562,7 +562,7 @@ class SkimfeedBridge extends BridgeAbstract
     private function extractFeed($html, $author)
     {
         $articles = $html->find('li')
-            or returnServerError('Could not find articles!');
+            or throwServerException('Could not find articles!');
 
         if (
             count($articles) === 1
@@ -575,7 +575,7 @@ class SkimfeedBridge extends BridgeAbstract
 
         foreach ($articles as $article) {
             $anchor = $article->find('a', 0)
-                or returnServerError('Could not find anchor!');
+                or throwServerException('Could not find anchor!');
 
             $item = [];
 
@@ -600,13 +600,13 @@ class SkimfeedBridge extends BridgeAbstract
     private function extractHotTopics($html)
     {
         $topics = $html->find('#popbox ul li')
-            or returnServerError('Could not find topics!');
+            or throwServerException('Could not find topics!');
 
         $limit = $this->getInput('limit') ?: -1;
 
         foreach ($topics as $topic) {
             $anchor = $topic->find('a', 0)
-                or returnServerError('Could not find anchor!');
+                or throwServerException('Could not find anchor!');
 
             $item = [];
 
@@ -624,11 +624,11 @@ class SkimfeedBridge extends BridgeAbstract
     private function extractCustomFeed($html)
     {
         $boxes = $html->find('#boxx .boxes')
-            or returnServerError('Could not find boxes!');
+            or throwServerException('Could not find boxes!');
 
         foreach ($boxes as $box) {
             $anchor = $box->find('span.boxtitles a', 0)
-                or returnServerError('Could not find box anchor!');
+                or throwServerException('Could not find box anchor!');
 
             $author = '<a href="' . $anchor->href . '">' . trim($anchor->plaintext) . '</a>';
             $uri    = $anchor->href;
@@ -667,11 +667,11 @@ class SkimfeedBridge extends BridgeAbstract
         $html = getSimpleHTMLDOMCached(static::URI);
 
         if (!$this->isCompatible($html)) {
-            returnServerError('Skimfeed version is not compatible!');
+            throwServerException('Skimfeed version is not compatible!');
         }
 
         $boxes = $html->find('#boxx .boxes')
-            or returnServerError('Could not find boxes!');
+            or throwServerException('Could not find boxes!');
 
         // begin of 'channel' list
         $message = <<<EOD
@@ -686,7 +686,7 @@ EOD;
 
         foreach ($boxes as $box) {
             $anchor = $box->find('span.boxtitles a', 0)
-                or returnServerError('Could not find box anchor!');
+                or throwServerException('Could not find box anchor!');
 
             $title  = trim($anchor->plaintext);
             $uri    = $anchor->href;
@@ -723,11 +723,11 @@ EOD;
         $html = getSimpleHTMLDOMCached(static::URI);
 
         if (!$this->isCompatible($html)) {
-            returnServerError('Skimfeed version is not compatible!');
+            throwServerException('Skimfeed version is not compatible!');
         }
 
         $channels = $html->find('#menubar a')
-            or returnServerError('Could not find channels!');
+            or throwServerException('Could not find channels!');
 
         // begin of 'tech_channel' list
         $message = <<<EOD
@@ -759,11 +759,11 @@ EOD;
             $channel_html = getSimpleHTMLDOMCached(static::URI . $uri);
 
             $boxes = $channel_html->find('#boxx .boxes')
-                or returnServerError('Could not find boxes!');
+                or throwServerException('Could not find boxes!');
 
             foreach ($boxes as $box) {
                 $anchor = $box->find('span.boxtitles a', 0)
-                    or returnServerError('Could not find box anchor!');
+                    or throwServerException('Could not find box anchor!');
 
                 $boxtitle   = trim($anchor->plaintext);
                 $boxuri     = $anchor->href;

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -48,7 +48,7 @@ class SoundCloudBridge extends BridgeAbstract
         $this->feedIcon = $res->avatar_url;
 
         $apiItems = $this->getUserItems($res->id, $this->getInput('t'))
-            or returnServerError('No results for ' . $this->getInput('t'));
+            or throwServerException('No results for ' . $this->getInput('t'));
 
         $hasTrackObject = ['all', 'reposts', 'likes'];
 
@@ -131,7 +131,7 @@ HTML;
 
         // Extract widget JS filenames from player page
         if (preg_match_all($this->widgetRegex, $playerHTML, $matches) == false) {
-            returnServerError('Unable to find widget JS URL.');
+            throwServerException('Unable to find widget JS URL.');
         }
 
         $clientID = '';
@@ -150,7 +150,7 @@ HTML;
         }
 
         if (empty($clientID)) {
-            returnServerError('Unable to find client ID.');
+            throwServerException('Unable to find client ID.');
         }
     }
 

--- a/bridges/SpotifyBridge.php
+++ b/bridges/SpotifyBridge.php
@@ -108,7 +108,7 @@ class SpotifyBridge extends BridgeAbstract
             if ($e->getCode() === 429) {
                 $retryAfter = $e->response->getHeader('Retry-After') ?? (60 * 5);
                 $this->cache->set($cacheKey, true, $retryAfter);
-                throw new RateLimitException(sprintf('Rate limited by spotify, try again in %s seconds', $retryAfter));
+                throwRateLimitException(sprintf('Rate limited by spotify, try again in %s seconds', $retryAfter));
             }
             throw $e;
         }

--- a/bridges/StockFilingsBridge.php
+++ b/bridges/StockFilingsBridge.php
@@ -80,7 +80,7 @@ class StockFilingsBridge extends FeedExpander
         if ($rssFeedUrl) {
             parent::collectExpandableDatas($rssFeedUrl);
         } else {
-            returnClientError('Could not find RSS Feed URL. Are you sure you used a valid CIK?');
+            throwClientException('Could not find RSS Feed URL. Are you sure you used a valid CIK?');
         }
     }
 }

--- a/bridges/StorytelBridge.php
+++ b/bridges/StorytelBridge.php
@@ -21,7 +21,7 @@ class StorytelBridge extends BridgeAbstract
         $url = $this->getInput('url');
 
         if (!preg_match('/^https:\/\/www\.storytel\.com/', $url)) {
-            returnServerError('Invalid URL: Only Storytel URLs are allowed.');
+            throwServerException('Invalid URL: Only Storytel URLs are allowed.');
         }
 
         $html = getSimpleHTMLDOM($url);

--- a/bridges/StravaBridge.php
+++ b/bridges/StravaBridge.php
@@ -30,7 +30,7 @@ class StravaBridge extends BridgeAbstract
 
         $dom = getSimpleHTMLDOM(self::URI . '/athletes/' . $athleteID);
         $scriptRegex = "/data-react-props='(.*?)'/";
-        preg_match($scriptRegex, $dom, $matches) or returnServerError('Could not find json');
+        preg_match($scriptRegex, $dom, $matches) or throwServerException('Could not find json');
         $jsonData = json_decode(html_entity_decode($matches[1]));
         $this->feedName = $jsonData->athlete->name . "'s Recent Activities";
         $this->iconURL = $jsonData->athlete->avatarUrl;

--- a/bridges/StreamCzBridge.php
+++ b/bridges/StreamCzBridge.php
@@ -24,7 +24,7 @@ class StreamCzBridge extends BridgeAbstract
 
         $validUrl = '/^(https:\/\/www.stream.cz\/[a-z0-9-]+)(\/[a-z0-9-]+-\d+)?$/';
         if (!preg_match($validUrl, $url, $match)) {
-            returnServerError('Invalid url');
+            throwServerException('Invalid url');
         }
 
         $fixedUrl = $match[1];
@@ -35,25 +35,25 @@ class StreamCzBridge extends BridgeAbstract
 
         $scriptElement = $html->find('body script', -1);
         if (null === $scriptElement) {
-            returnServerError('Could not find metadata element on the page');
+            throwServerException('Could not find metadata element on the page');
         }
         $json = extractFromDelimiters($scriptElement->innertext, 'data : ', 'logs : ');
         if (false === $json) {
-            returnServerError('Could not extract metadata from the page');
+            throwServerException('Could not extract metadata from the page');
         }
         $data = json_decode(trim($json, ",\t\n\r\0\x0B"), true);
         if (false === $data) {
-            returnServerError('Could not parse metadata on the page');
+            throwServerException('Could not parse metadata on the page');
         }
 
         $showData = $data['fetchable']['tag']['show']['data'];
         if (!is_array($showData)) {
-            returnServerError('Show not found in metadata');
+            throwServerException('Show not found in metadata');
         }
         $this->feedName = $showData['name'];
         $episodes = $showData['allEpisodesConnection']['edges'];
         if (!is_array($episodes)) {
-            returnServerError('Episodes not found in metadata');
+            throwServerException('Episodes not found in metadata');
         }
         foreach ($episodes as $episode) {
             if (!$episode['node']) {

--- a/bridges/ThePirateBayBridge.php
+++ b/bridges/ThePirateBayBridge.php
@@ -134,7 +134,7 @@ class ThePirateBayBridge extends BridgeAbstract
                 $query = sprintf('/q.php?q=user:%s', rawurlencode($keyword));
                 break;
             default:
-                returnClientError('Impossible');
+                throwClientException('Impossible');
         }
         $api = 'https://apibay.org';
         $json = getContents($api . $query);

--- a/bridges/TrelloBridge.php
+++ b/bridges/TrelloBridge.php
@@ -616,7 +616,7 @@ class TrelloBridge extends BridgeAbstract
                 $data = $this->queryAPI('cards/' . $this->getInput('c'), $apiParams);
                 break;
             default:
-                returnClientError('Invalid context');
+                throwClientException('Invalid context');
         }
 
         $this->feedName = $data->name;

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -289,19 +289,19 @@ EOD
                 $data = $api->fetchListTweets($query, $this->queriedContext);
                 break;
             default:
-                returnServerError('Invalid query context !');
+                throwServerException('Invalid query context !');
         }
 
         if (!$data) {
             switch ($this->queriedContext) {
                 case 'By keyword or hashtag':
-                    returnServerError('twitter: No results for this query.');
+                    throwServerException('twitter: No results for this query.');
                     // fall-through
                 case 'By username':
-                    returnServerError('Requested username can\'t be found.');
+                    throwServerException('Requested username can\'t be found.');
                     // fall-through
                 case 'By list':
-                    returnServerError('Requested username or list can\'t be found');
+                    throwServerException('Requested username or list can\'t be found');
             }
         }
 

--- a/bridges/TwitterV2Bridge.php
+++ b/bridges/TwitterV2Bridge.php
@@ -192,7 +192,7 @@ EOD
                 . $this->getInput('u'), $authHeaders, $params);
 
                 if (isset($user->errors)) {
-                    returnServerError('Requested username can\'t be found.');
+                    throwServerException('Requested username can\'t be found.');
                 }
 
                 // Set default params
@@ -258,7 +258,7 @@ EOD
                 break;
 
             default:
-                returnServerError('Invalid query context !');
+                throwServerException('Invalid query context !');
         }
 
         if (
@@ -267,13 +267,13 @@ EOD
         ) {
             switch ($this->queriedContext) {
                 case 'By keyword or hashtag':
-                    returnServerError('No results for this query.');
+                    throwServerException('No results for this query.');
                     // fall-through
                 case 'By username':
-                    returnServerError('Requested username cannnot be found.');
+                    throwServerException('Requested username cannnot be found.');
                     // fall-through
                 case 'By list ID':
-                    returnServerError('Requested list cannnot be found');
+                    throwServerException('Requested list cannnot be found');
                     // fall-through
             }
         }

--- a/bridges/UrlebirdBridge.php
+++ b/bridges/UrlebirdBridge.php
@@ -31,7 +31,7 @@ class UrlebirdBridge extends BridgeAbstract
                 $url = 'https://urlebird.com/hash/' . substr($this->getInput('query'), 1) . '/';
                 break;
             default:
-                returnServerError('Please, enter valid username or hashtag!');
+                throwServerException('Please, enter valid username or hashtag!');
                 break;
         }
 

--- a/bridges/UsenixBridge.php
+++ b/bridges/UsenixBridge.php
@@ -19,7 +19,7 @@ final class UsenixBridge extends BridgeAbstract
             $this->collectLoginOnlineItems();
             return;
         }
-        returnClientError('Illegal Context');
+        throwClientException('Illegal Context');
     }
 
     private function collectLoginOnlineItems(): void

--- a/bridges/VimeoBridge.php
+++ b/bridges/VimeoBridge.php
@@ -81,7 +81,7 @@ class VimeoBridge extends BridgeAbstract
         }
 
         if (is_null($json)) {
-            returnClientError('No results for this query!');
+            throwClientException('No results for this query!');
         }
 
         foreach ($json->api->initial_json->data as $element) {
@@ -103,7 +103,7 @@ class VimeoBridge extends BridgeAbstract
                     break;
 
                 default:
-                    returnServerError('Unknown type: ' . $element->type);
+                    throwServerException('Unknown type: ' . $element->type);
             }
         }
     }

--- a/bridges/Vk2Bridge.php
+++ b/bridges/Vk2Bridge.php
@@ -194,7 +194,7 @@ class Vk2Bridge extends BridgeAbstract
     public function collectData()
     {
         if ($this->cache->get($this->rateLimitCacheKey)) {
-            throw new RateLimitException();
+            throwRateLimitException();
         }
 
         $u = $this->getInput('u');
@@ -229,7 +229,7 @@ class Vk2Bridge extends BridgeAbstract
         }
 
         if (is_null($ownerId)) {
-            returnServerError('Could not detect owner id');
+            throwServerException('Could not detect owner id');
         }
 
         $r = $this->api('wall.get', [
@@ -304,7 +304,7 @@ class Vk2Bridge extends BridgeAbstract
     {
         $access_token = $this->getOption('access_token');
         if (!$access_token) {
-            returnServerError('You cannot run VK API methods without access_token');
+            throwServerException('You cannot run VK API methods without access_token');
         }
         $params['v'] = '5.131';
         $r = json_decode(
@@ -322,7 +322,7 @@ class Vk2Bridge extends BridgeAbstract
                 // if that limit is hit, VK returns error 29
                 $this->cache->set($this->rateLimitCacheKey, true, 60 * 30);
             }
-            returnServerError('API returned error: ' . $r['error']['error_msg'] . ' (' . $r['error']['error_code'] . ')');
+            throwServerException('API returned error: ' . $r['error']['error_msg'] . ' (' . $r['error']['error_code'] . ')');
         }
         return $r;
     }

--- a/bridges/VkBridge.php
+++ b/bridges/VkBridge.php
@@ -526,17 +526,17 @@ class VkBridge extends BridgeAbstract
             $uri = urljoin(self::URI, $headers['location'][0]);
 
             if (str_contains($uri, '/429.html')) {
-                throw new RateLimitException();
+                throwRateLimitException();
             }
 
             if (!preg_match('#^https?://vk.com/#', $uri)) {
-                returnServerError('Unexpected redirect location: ' . $uri);
+                throwServerException('Unexpected redirect location: ' . $uri);
             }
 
             $redirects++;
         }
 
-        returnServerError('Too many redirects, while retreving content from VK');
+        throwServerException('Too many redirects, while retreving content from VK');
     }
 
     protected function appendVideo($video_title, $video_link, $previewImg, &$content_suffix)

--- a/bridges/WebfailBridge.php
+++ b/bridges/WebfailBridge.php
@@ -61,7 +61,7 @@ class WebfailBridge extends BridgeAbstract
                 $this->extractArticle($html);
                 break;
             default:
-                returnClientError('Unknown type: ' . $type);
+                throwClientException('Unknown type: ' . $type);
         }
     }
 

--- a/bridges/WikipediaBridge.php
+++ b/bridges/WikipediaBridge.php
@@ -113,7 +113,7 @@ class WikipediaBridge extends BridgeAbstract
         $function = 'getContents' . ucfirst(strtolower($this->getInput('language')));
 
         if (!method_exists($this, $function)) {
-            returnServerError('A function to get the contents for your language is missing (\'' . $function . '\')!');
+            throwServerException('A function to get the contents for your language is missing (\'' . $function . '\')!');
         }
 
         /*
@@ -205,13 +205,13 @@ class WikipediaBridge extends BridgeAbstract
         $content_html = getSimpleHTMLDOMCached($uri);
 
         if (!$content_html) {
-            returnServerError('Could not load site: ' . $uri . '!');
+            throwServerException('Could not load site: ' . $uri . '!');
         }
 
         $content = $content_html->find('#mw-content-text', 0);
 
         if (!$content) {
-            returnServerError('Could not find content in page: ' . $uri . '!');
+            throwServerException('Could not find content in page: ' . $uri . '!');
         }
 
         // Let's remove a couple of things from the article

--- a/bridges/WiredBridge.php
+++ b/bridges/WiredBridge.php
@@ -32,7 +32,7 @@ class WiredBridge extends FeedExpander
     {
         $feed = $this->getInput('feed');
         if (empty($feed) || !ctype_alpha(str_replace('-', '', $feed))) {
-            returnClientError('Invalid feed, please check the "feed" parameter.');
+            throwClientException('Invalid feed, please check the "feed" parameter.');
         }
 
         $feed_url = $this->getURI() . 'feed/';

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -25,7 +25,7 @@ class WordPressBridge extends FeedExpander
         $limit = $this->getInput('limit') ?? 10;
         if ($this->getInput('url') && substr($this->getInput('url'), 0, strlen('http')) !== 'http') {
             // just in case someone find a way to access local files by playing with the url
-            returnClientError('The url parameter must either refer to http or https protocol.');
+            throwClientException('The url parameter must either refer to http or https protocol.');
         }
         try {
             $this->collectExpandableDatas($this->getURI() . '/feed/atom/', $limit);

--- a/bridges/XenForoBridge.php
+++ b/bridges/XenForoBridge.php
@@ -81,24 +81,24 @@ class XenForoBridge extends BridgeAbstract
         );
 
         if ($this->threadurl === false) {
-            returnClientError('The URL you provided is invalid!');
+            throwClientException('The URL you provided is invalid!');
         }
 
         $urlparts = parse_url($this->threadurl, PHP_URL_SCHEME);
 
         // Scheme must be "http" or "https"
         if (preg_match('/http[s]{0,1}/', parse_url($this->threadurl, PHP_URL_SCHEME)) == false) {
-            returnClientError('The URL you provided doesn\'t specify a valid scheme (http or https)!');
+            throwClientException('The URL you provided doesn\'t specify a valid scheme (http or https)!');
         }
 
         // Path cannot be root (../)
         if (parse_url($this->threadurl, PHP_URL_PATH) === '/') {
-            returnClientError('The URL you provided doesn\'t link to a valid thread (root path)!');
+            throwClientException('The URL you provided doesn\'t link to a valid thread (root path)!');
         }
 
         // XenForo adds a thread ID to the URL, like "...-thread.454934283". It must be present
         if (preg_match('/.+\.\d+[\/]{0,1}/', parse_URL($this->threadurl, PHP_URL_PATH)) == false) {
-            returnClientError('The URL you provided doesn\'t link to a valid thread (ID missing)!');
+            throwClientException('The URL you provided doesn\'t link to a valid thread (ID missing)!');
         }
 
         // We want to start at the first page in the thread. XenForo uses "../page-n" syntax
@@ -121,13 +121,13 @@ class XenForoBridge extends BridgeAbstract
         } elseif ($mainContent = $html->find('div[class~="p-body"]', 0)) {
             $this->version = self::XENFORO_VERSION_2;
         } else {
-            returnServerError('This forum is currently not supported!');
+            throwServerException('This forum is currently not supported!');
         }
 
         switch ($this->version) {
             case self::XENFORO_VERSION_1:
                 $titleBar = $mainContent->find('div.titleBar > h1', 0)
-                    or returnServerError('Error finding title bar!');
+                    or throwServerException('Error finding title bar!');
 
                 $this->title = $titleBar->plaintext;
 
@@ -139,7 +139,7 @@ class XenForoBridge extends BridgeAbstract
 
             case self::XENFORO_VERSION_2:
                 $titleBar = $mainContent->find('div[class~="p-title"] h1', 0)
-                    or returnServerError('Error finding title bar!');
+                    or throwServerException('Error finding title bar!');
 
                 $this->title = $titleBar->plaintext;
                 $this->extractThreadPostsV2($html, $this->threadurl);
@@ -166,7 +166,7 @@ class XenForoBridge extends BridgeAbstract
 
         // Posts are contained in an "ol"
         $messageList = $html->find('#messageList > li')
-            or returnServerError('Error finding message list!');
+            or throwServerException('Error finding message list!');
 
         foreach ($messageList as $post) {
             if (!isset($post->attr['id'])) { // Skip ads
@@ -252,7 +252,7 @@ class XenForoBridge extends BridgeAbstract
         $lang = $html->find('html', 0)->lang;
 
         $messageList = $html->find('div[class~="block-body"] article')
-            or returnServerError('Error finding message list!');
+            or throwServerException('Error finding message list!');
 
         foreach ($messageList as $post) {
             if (!isset($post->attr['id'])) { // Skip ads

--- a/bridges/YandexZenBridge.php
+++ b/bridges/YandexZenBridge.php
@@ -47,7 +47,7 @@ class YandexZenBridge extends BridgeAbstract
             $channelName = $matches['channelName'];
             $channelAPIURL = self::_BASE_API_URL_WITH_CHANNEL_NAME . $channelName;
         } else {
-            returnClientError(<<<EOT
+            throwClientException(<<<EOT
 Invalid channel URL provided.
 The channel\'s URL must be in one of these two forms:
 - https://dzen.ru/dream_faity_diy

--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -79,7 +79,7 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
         $this->feedName ??= '';
 
         if ($this->hasPostsTab($json) === false) {
-            returnServerError('Channel does not have a posts tab');
+            throwServerException('Channel does not have a posts tab');
         }
 
         $posts = $this->getPosts($json);
@@ -156,13 +156,13 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
     private function extractJson($html)
     {
         if (!preg_match($this->jsonRegex, $html, $parts)) {
-            returnServerError('Failed to extract data from page');
+            throwServerException('Failed to extract data from page');
         }
 
         $data = json_decode($parts[1]);
 
         if ($data === false) {
-            returnServerError('Failed to decode extracted data');
+            throwServerException('Failed to decode extracted data');
         }
 
         return $data;

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -75,14 +75,14 @@ class YoutubeBridge extends BridgeAbstract
     {
         $cacheKey = 'youtube_rate_limit';
         if ($this->cache->get($cacheKey)) {
-            throw new RateLimitException();
+            throwRateLimitException();
         }
         try {
             $this->collectDataInternal();
         } catch (HttpException $e) {
             if ($e->getCode() === 429) {
                 $this->cache->set($cacheKey, true, 60 * 16);
-                throw new RateLimitException();
+                throwRateLimitException();
             }
             throw $e;
         }
@@ -142,7 +142,7 @@ class YoutubeBridge extends BridgeAbstract
                     // $jsonData = $jsonData->itemSectionRenderer->contents[0]->gridRenderer->items;
                     $this->fetchItemsFromFromJsonData($jsonData);
                 } else {
-                    returnServerError('Unable to get data from YouTube');
+                    throwServerException('Unable to get data from YouTube');
                 }
             } else {
                 // Fetch the xml feed
@@ -192,7 +192,7 @@ class YoutubeBridge extends BridgeAbstract
             $this->feeduri = $url_listing;
             $this->feedName = 'Search: ' . $search;
         } else {
-            returnClientError("You must either specify either:\n - YouTube username (?u=...)\n - Channel id (?c=...)\n - Playlist id (?p=...)\n - Search (?s=...)");
+            throwClientException("You must either specify either:\n - YouTube username (?u=...)\n - Channel id (?c=...)\n - Playlist id (?p=...)\n - Search (?s=...)");
         }
     }
 
@@ -233,7 +233,7 @@ class YoutubeBridge extends BridgeAbstract
             }
         }
         if (!$videoSecondaryInfo) {
-            returnServerError('Could not find videoSecondaryInfoRenderer. Error at: ' . $videoId);
+            throwServerException('Could not find videoSecondaryInfoRenderer. Error at: ' . $videoId);
         }
 
         $description = $videoSecondaryInfo->attributedDescription->content ?? '';

--- a/bridges/ZonebourseBridge.php
+++ b/bridges/ZonebourseBridge.php
@@ -61,7 +61,7 @@ class ZonebourseBridge extends BridgeAbstract
         $articles = $dom->find('table#newsScreener tbody tr');
 
         if (!$articles) {
-            returnServerError('Failed to retrieve news content');
+            throwServerException('Failed to retrieve news content');
         }
 
         foreach ($articles as $article) {

--- a/docs/06_Helper_functions/index.md
+++ b/docs/06_Helper_functions/index.md
@@ -87,29 +87,32 @@ $html = getSimpleHTMLDOMCached('your URI', 86400); // Duration 24h
 
 [Defined in lib/contents.php](https://github.com/RSS-Bridge/rss-bridge/blob/master/lib/contents.php)
 
-# returnClientError
-The `returnClientError` function aborts execution of the current bridge
-and returns the given error message with error code **400**:
+# throwClientException($message = '')
+The `throwClientException` function aborts execution of the current bridge.
 
 ```PHP
-returnClientError('Your error message')
+throwClientException('Bad user input')
 ```
 
 Use this function when the user provided invalid parameter or a required parameter is missing.
 
 [Defined in lib/utils.php](https://github.com/RSS-Bridge/rss-bridge/blob/master/lib/utils.php)
 
-# returnServerError
-The `returnServerError` function aborts execution of the current bridge and returns the given error message with error code **500**:
+# throwServerException($message = '')
+The `throwServerException` function aborts execution of the current bridge.
 
 ```PHP
-returnServerError('Your error message')
+throwServerException('Received empty reply from thirdparty api')
 ```
 
 Use this function when a problem occurs that has nothing to do with the parameters provided by the user.
 (like: Host service gone missing, empty data received, etc...)
 
 [Defined in lib/utils.php](https://github.com/RSS-Bridge/rss-bridge/blob/master/lib/utils.php)
+
+# throwRateLimitException($message = '')
+
+Throws a `RateLimitException` which produces an HTTP 429 response.
 
 # defaultLinkTo
 Automatically replaces any relative URL in a given string or DOM object

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -242,12 +242,33 @@ function create_random_string(int $bytes = 16): string
     return bin2hex(openssl_random_pseudo_bytes($bytes));
 }
 
-function returnClientError($message)
+function throwClientException(string $message = '')
 {
     throw new \Exception($message, 400);
 }
 
-function returnServerError($message)
+function throwServerException(string $message = '')
 {
     throw new \Exception($message, 500);
+}
+
+function throwRateLimitException(string $message = '')
+{
+    throw new RateLimitException($message);
+}
+
+/**
+ * @deprecated Use throwClientException() instead
+ */
+function returnClientError(string $message = '')
+{
+    throw new \Exception($message);
+}
+
+/**
+ * @deprecated Use throwServerException() instead
+ */
+function returnServerError(string $message = '')
+{
+    throw new \Exception($message);
 }


### PR DESCRIPTION
I have decided to rename these because they were confusing and prone to error when used in conjunction with the logical or operator `or`.

`returnClientError` => `throwClientException`
`returnServerError` => `throwServerException`

New convenience function: `throwRateLimitException`

Old functions are kept, but deprecated.