### PR TITLE
[BlueskyBridge] prevent 408 request timeout by implementing cache

### DIFF
--- a/bridges/BlueskyBridge.php
+++ b/bridges/BlueskyBridge.php
@@ -173,7 +173,7 @@ class BlueskyBridge extends BridgeAbstract
             $item['author'] = $this->fallbackAuthor($post['post']['author'], 'display');
 
             $postAuthorDID = $post['post']['author']['did'];
-            $postAuthorHandle = $post['post']['author']['handle'] !== 'handle.invalid' ? '<i>@' . $post['post']['author']['handle'] . '</i> ' : '';
+            $postAuthorHandle = $post['post']['author']['handle'] !== 'handle.invalid' ? '<i>@' . $post['post']['author']['handle'] . '</i>' : '';
             $postDisplayName = $post['post']['author']['displayName'] ?? '';
             $postDisplayName = e($postDisplayName);
             $postUri = $item['uri'];
@@ -340,7 +340,7 @@ class BlueskyBridge extends BridgeAbstract
                 } else {
                     $replyPostRecord = $replyPost['record'];
                     $replyPostAuthorDID = $replyPost['author']['did'];
-                    $replyPostAuthorHandle = $replyPost['author']['handle'] !== 'handle.invalid' ? '<i>@' . $replyPost['author']['handle'] . '</i> ' : '';
+                    $replyPostAuthorHandle = $replyPost['author']['handle'] !== 'handle.invalid' ? '<i>@' . $replyPost['author']['handle'] . '</i>' : '';
                     $replyPostDisplayName = $replyPost['author']['displayName'] ?? '';
                     $replyPostDisplayName = e($replyPostDisplayName);
                     $replyPostUri = self::URI . '/profile/' . $this->fallbackAuthor($replyPost['author'], 'url') . '/post/' . explode('app.bsky.feed.post/', $replyPost['uri'])[1];
@@ -528,8 +528,9 @@ class BlueskyBridge extends BridgeAbstract
             $postType = isset($postRecord['reply']) ? 'reply' : 'post';
             $description .= "Replying to <b>$postDisplayName</b> $postAuthorHandle's <a href=\"$postUri\">$postType</a>:<br>";
         } else {
-            // aaa @aaa.com posted:
-            $description .= "<b>$postDisplayName</b> $postAuthorHandle <a href=\"$postUri\">posted</a>:<br>";
+            // aaa @aaa.com posted/replied:
+            $postType = isset($postRecord['reply']) ? 'replied' : 'posted';
+            $description .= "<b>$postDisplayName</b> $postAuthorHandle <a href=\"$postUri\">$postType</a>:<br>";
         }
         $description .= $this->textToDescription($postRecord);
         return $description;
@@ -555,9 +556,19 @@ class BlueskyBridge extends BridgeAbstract
         //use "Post by A, replying to B, quoting C" instead of post contents
         $title = '';
         if (isset($post['reason']) && str_contains($post['reason']['$type'], 'reasonRepost')) {
-            $title .= 'Repost by ' . $this->fallbackAuthor($post['reason']['by'], 'display') . ', post by ' . $this->fallbackAuthor($post['post']['author'], 'display');
+            $title .= 'Repost by ' . $this->fallbackAuthor($post['reason']['by'], 'display');
+            if (isset($post['reply'])) {
+                $title .= ', reply by ';
+            } else {
+                $title .= ', post by ';
+            }
+            $title .= $this->fallbackAuthor($post['post']['author'], 'display');
         } else {
-            $title .= 'Post by ' . $this->fallbackAuthor($post['post']['author'], 'display');
+            if (isset($post['reply'])) {
+                $title .= 'Reply by ' . $this->fallbackAuthor($post['post']['author'], 'display');
+            } else {
+                $title .= 'Post by ' . $this->fallbackAuthor($post['post']['author'], 'display');
+            }
         }
 
         if (isset($post['reply'])) {

--- a/bridges/BlueskyBridge.php
+++ b/bridges/BlueskyBridge.php
@@ -596,14 +596,20 @@ class BlueskyBridge extends BridgeAbstract
     private function resolveHandle($handle)
     {
         $uri = 'https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=' . urlencode($handle);
-        $response = json_decode(getContents($uri), true);
+        $response = $this->cache->get($uri) ?? json_decode(getContents($uri), true);
+        if (isset($response['did'])) {
+            $this->cache->set($uri, $response, 7 * 24 * 60 * 60);
+        }
         return $response['did'];
     }
 
     private function getProfile($did)
     {
         $uri = 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=' . urlencode($did);
-        $response = json_decode(getContents($uri), true);
+        $response = $this->cache->get($uri) ?? json_decode(getContents($uri), true);
+        if ($response['did'] === $did ?? false) {
+            $this->cache->set($uri, $response);
+        }
         return $response;
     }
 


### PR DESCRIPTION
PR implements a cache on the user handle to DID resolution for up to a week to prevent the resolution being performed each time the feed is generated. Could be permanent, but I don't like it sitting around in the cache permanently. Also added to user profiles (custom name, avatar and description) to the cache for up to the defaulted day.

In the future, I would like the bridge to resolve the user handle to its DID and redirect to itself with the DID as the `user_id` if a handle is provided (handles can be changed, DIDs cannot), and in turn automatically correct any currently subscribed feed urls that is using the user handle as the `user_id` parameter. This will require implementing a HTTP 301 redirect. Please see #4663 for a discussion on this.

Also added more semantics.