### PR TITLE
[HeiseBridge] Remove "Videos by heise" ads

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -163,7 +163,7 @@ class HeiseBridge extends FeedExpander
         // remove unwanted stuff
         foreach (
             $article->find('figure.branding, figure.a-inline-image, a-ad, div.ho-text, a-img,
-            .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote, .notice-banner__text, .notice-banner__link') as $element
+            .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote, .notice-banner__text, .notice-banner__link, .ad, .ad--inread') as $element
         ) {
             $element->remove();
         }


### PR DESCRIPTION
This seems to be a new middle-of-content self-ad.
Seen on https://heise.de/-10519045

The code snippet in that case was:
```html
<div class="ad ad--inread">

  <div class="ad--inread-header">
    <p class="ad--inread-header__text">
      Videos by heise
    </p>

    <div class="ad--inread-header__more">
      <button class="ad--inread-header-menu-toggle" popovertarget="ad--inread-header-menu">
        mehr Videos
        <svg fill="none" height="24" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
          <path d="M8.625 12.0023C8.625 12.2094 8.45711 12.3773 8.25 12.3773C8.04289 12.3773 7.875 12.2094 7.875 12.0023C7.875 11.7952 8.04289 11.6273 8.25 11.6273C8.45711 11.6273 8.625 11.7952 8.625 12.0023ZM8.625 12.0023H8.25M12.375 12.0023C12.375 12.2094 12.2071 12.3773 12 12.3773C11.7929 12.3773 11.625 12.2094 11.625 12.0023C11.625 11.7952 11.7929 11.6273 12 11.6273C12.2071 11.6273 12.375 11.7952 12.375 12.0023ZM12.375 12.0023H12M16.125 12.0023C16.125 12.2094 15.9571 12.3773 15.75 12.3773C15.5429 12.3773 15.375 12.2094 15.375 12.0023C15.375 11.7952 15.5429 11.6273 15.75 11.6273C15.9571 11.6273 16.125 11.7952 16.125 12.0023ZM16.125 12.0023H15.75M21 12.0023C21 16.9729 16.9706 21.0023 12 21.0023C7.02944 21.0023 3 16.9729 3 12.0023C3 7.03176 7.02944 3.00232 12 3.00232C16.9706 3.00232 21 7.03176 21 12.0023Z" stroke="#777" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
        </svg>
      </button>

      <div class="ad--inread-header-menu" id="ad--inread-header-menu" popover>
        <ul class="a-u-mb-0">
          <li>
            <a class="ad--inread-header-menu-link" href="https://www.youtube.com/@ct3003" target="_blank">
              c&#39;t 3003
            </a>
          </li>
          <li>
            <a class="ad--inread-header-menu-link" href="https://www.youtube.com/heiseonline" target="_blank">
              heise &amp; ct
            </a>
          </li>
          <li>
            <a class="ad--inread-header-menu-link" href="https://peertube.heise.de/" target="_blank">
              Peertube
            </a>
          </li>
        </ul>
      </div>
    </div>
  </div>

  <figure class="video video--fullwidth">
    <a-video entry-id="25969" height="9" instant is-target-video-playlist style="aspect-ratio: 16 / 9" type="targetvideo" width="16"></a-video>
  </figure>
</div>
```

Hence filtering anything with the class `ad` or `ad--inread` gets rid of it.