### PR TITLE
[GolemBridge] Fix removal of affiliate images

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -132,7 +132,7 @@ class GolemBridge extends FeedExpander
         // delete known bad elements
         foreach (
             $article->find('div[id*="adtile"], #job-market, #seminars, iframe,
-			div.gbox_affiliate, div.toc') as $bad
+			.gbox_affiliate, div.toc') as $bad
         ) {
             $bad->remove();
         }


### PR DESCRIPTION
On https://www.golem.de/news/anlage-in-etfs-was-alternativen-zum-msci-world-bringen-2508-199041.html the affiliate box isn't properly filtered out.
The reason seems to be switching from a `div` to an `aside` element. HTML source fragment:
```html
<aside class="gbox_affiliate" data-nosnippet>
    <div class="gbox_attribution"></div>
    <div class="gbox_fx1">
<a href="https://www.financeads.net/tc.php?t=36731C67231788T" target="_blank" rel="nofollow" onclick="_gcpx.push(['ev','d','rklmbox/14387']); return true;"><img src="https://scr3.golem.de/screenshots/affiliate/14
387/9caaa476f979dcf7457395f39ac9ed9f.png" alt=""></a>
        <div class="gbox_fx2">
            <div class="gbox_title">Tagesgeld, Festgeld, ETFs, Aktien und mehr bei raisin</div>
            <div><a class="gbox_btn" data-cta="Jetzt Investmentm&ouml;glichkeiten bei raisin entdecken" href="https://www.financeads.net/tc.php?t=36731C67231788T" target="_blank" rel="nofollow" onclick="_gcpx.push(['ev','d','rklmbox/14387']); return true;"></a></div>
        </div>
    </div>
<!-- /gbox --></aside>
```