### PR TITLE
[nginx.conf]: Set 'server_tokens off'; won't leak nginx version

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -6,6 +6,8 @@ server {
     error_log /var/log/nginx/error.log;
     index index.php;
 
+    server_tokens off; # Hide nginx version
+
     location ~ /(\.|vendor|tests) {
         deny all;
         return 403; # Forbidden


### PR DESCRIPTION
When deploying RSS-Bridge via Docker Compose, encountering a 404 error will expose the nginx version:

<img width="688" height="137" alt="Image" src="https://github.com/user-attachments/assets/543fb38a-0479-44e9-8655-e20488901b75" />

From a security point of view, this is bad practice. While everything is containerized, limiting the amount of information available to visitors reduces exposure and possible attack surfaces.

In this PR, I set `server_tokens off;` inside `config/nginx.conf`. This directive will hide the nginx version when encounter a 404 error.