### PR TITLE
[KemonoBridge] Convert to new Kemono api to fix KemonoBridge

### DIFF
--- a/bridges/KemonoBridge.php
+++ b/bridges/KemonoBridge.php
@@ -4,7 +4,7 @@ class KemonoBridge extends BridgeAbstract
 {
     const NAME = 'Kemono';
     const MAINTAINER = 'phantop';
-    const URI = 'https://kemono.su/';
+    const URI = 'https://kemono.cr/';
     const DESCRIPTION = 'Returns posts from Kemono.';
     const PARAMETERS = [[
         'service' => [
@@ -38,48 +38,56 @@ class KemonoBridge extends BridgeAbstract
     {
         $api = parent::getURI() . 'api/v1/';
         $url = $api . $this->getInput('service') . '/user/' . $this->getInput('user');
+        $headers = [
+            "Accept: text/css"
+        ];
 
-        $api_response = getContents($url . '/profile');
+        $api_response = getContents($url . '/profile', $headers);
         $profile = Json::decode($api_response);
         $this->title = ucfirst($profile['name']);
+
+        $url .= '/posts';
 
         if ($this->getInput('q')) {
             $url .= '?q=' . urlencode($this->getInput('q'));
         }
-        $api_response = getContents($url);
-        $json = Json::decode($api_response);
 
-
-        foreach ($json as $element) {
+        // First, get the list of post IDs
+        $api_response = getContents($url, $headers);
+        $posts_list = Json::decode($api_response);
+        
+        // Then fetch detailed information for each post
+        foreach ($posts_list as $post_summary) {
+            $post_id = $post_summary['id'];
+            $post_url = $api . $this->getInput('service') . '/user/' . $this->getInput('user') . '/post/' . $post_id;
+            
+            $post_response = getContents($post_url, $headers);
+            $post_data = Json::decode($post_response);
+            $post = $post_data['post'];
+            
             $item = [];
             $item['author'] = $this->title;
-            $item['content'] = $element['content'];
-            $item['timestamp'] = strtotime($element['published']);
-            $item['title'] = $element['title'];
-            $item['uid'] = $element['id'];
+            $item['content'] = $post['content'] ?? '';
+            $item['timestamp'] = strtotime($post['published']);
+            $item['title'] = $post['title'];
+            $item['uid'] = $post['id'];
             $item['uri'] = $this->getURI() . '/post/' . $item['uid'];
 
-            if ($element['tags']) {
-                $tags = $element['tags'];
-                if (is_array($tags)) {
-                    $item['categories'] = $tags;
-                } else {
-                    $tags = preg_replace('/^{/', '', $tags);
-                    $tags = preg_replace('/}$/', '', $tags);
-                    $tags = preg_replace('/"/', '', $tags);
-                    $item['categories'] = explode(',', $tags);
-                }
+            if (isset($post['tags']) && is_array($post['tags']) && !empty($post['tags'])) {
+                $item['categories'] = $post['tags'];
             }
 
             $item['enclosures'] = [];
-            if (array_key_exists('url', $element['embed'])) {
-                $item['enclosures'][] = $element['embed']['url'];
+            if (isset($post['embed']) && is_array($post['embed']) && array_key_exists('url', $post['embed'])) {
+                $item['enclosures'][] = $post['embed']['url'];
             }
-            if (array_key_exists('path', $element['file'])) {
-                $element['attachments'][] = $element['file'];
+            if (isset($post['file']) && is_array($post['file']) && array_key_exists('path', $post['file'])) {
+                $item['enclosures'][] = parent::getURI() . $post['file']['path'];
             }
-            foreach ($element['attachments'] as $file) {
-                $item['enclosures'][] = parent::getURI() . $file['path'];
+            if (isset($post['attachments']) && is_array($post['attachments'])) {
+                foreach ($post['attachments'] as $file) {
+                    $item['enclosures'][] = parent::getURI() . $file['path'];
+                }
             }
 
             $this->items[] = $item;

--- a/bridges/KemonoBridge.php
+++ b/bridges/KemonoBridge.php
@@ -29,6 +29,12 @@ class KemonoBridge extends BridgeAbstract
             'name' => 'Search query',
             'exampleValue' => 'classic',
             'required' => false,
+        ],
+        'limit' => [
+            'name' => 'Number of posts',
+            'type' => 'number',
+            'exampleValue' => '15',
+            'required' => false,
         ]
     ]];
 
@@ -55,6 +61,12 @@ class KemonoBridge extends BridgeAbstract
         // First, get the list of post IDs
         $api_response = getContents($url, $headers);
         $posts_list = Json::decode($api_response);
+        
+        // Limit the number of posts to fetch (if specified)
+        $limit = $this->getInput('limit');
+        if (!empty($limit)) {
+            $posts_list = array_slice($posts_list, 0, intval($limit));
+        }
         
         // Then fetch detailed information for each post
         foreach ($posts_list as $post_summary) {


### PR DESCRIPTION
- Changes tld to `.cr` from `.su`
- Fixes post logic to work with [new API](https://kemono.cr/documentation/api)
- Switches content-type to `text/css` due to issues on their end. 

Note: Previously, we were able to hit the API to get all of the posts & content from a few requests. Due to the API change, the new content is cutoff in a 'substring' object like:
```
  {
    "id": "$ID",
    "user": "$USER",
    "service": "$SERVICE",
    "title": "$TITLE",
    "substring": "$CONTENT:50", <--- Cut content down to the first 50 characters
    "published": "DATE",
    "attachments": [
      {
        "name": "image.jpg",
        "path": "/image.jpg"
      },
    ]
  },
```

As a result, we now have to hit the `/posts` api, get each post's ID, then do a request to `/api/v1/$SERVICE/user/$USER_ID/post/$POST_ID` - Which results in substantially slower population & substantially more requests. 

Should resolve the issues in https://github.com/RSS-Bridge/rss-bridge/issues/4671