### PR TITLE
[IdealoBridge] Fix for cURL Error

### DIFF
--- a/bridges/IdealoBridge.php
+++ b/bridges/IdealoBridge.php
@@ -41,6 +41,7 @@ class IdealoBridge extends BridgeAbstract
         'Accept-Language: fr-FR,fr;q=0.8,en-US;q=0.5,en;q=0.3'
     ];
     private $options = [
+        CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
         CURLOPT_TRANSFER_ENCODING => 1,
         CURLOPT_ACCEPT_ENCODING => 'gzip, deflate, br'
     ];


### PR DESCRIPTION
Some Feeds gave no update anymore. There was a cURL Error:

Type: HttpException
Code: 0
Message: cURL error HTTP/2 stream 3 was not closed cleanly: PROTOCOL_ERROR (err 1): 92 (https://curl.haxx.se/libcurl/c/libcurl-errors.html) 

Works again when forcing HTTP/1.1 via CURLOPT