### PR TITLE
fix: Enclosure uses wrong image URL

### DIFF
--- a/bridges/MinecraftBridge.php
+++ b/bridges/MinecraftBridge.php
@@ -51,7 +51,7 @@ class MinecraftBridge extends BridgeAbstract
                 'uri' => self::URI . $article->article_url,
                 'content' => $article->default_tile->sub_header,
                 'categories' => [$article->primary_category],
-                'enclosures' => isset($article->image) ? [$article->image] : [],
+                'enclosures' => [self::URI . $article->default_tile->image->imageURL],
             ];
         }
     }


### PR DESCRIPTION
I mistakenly implemented the image enclosure incorrectly, which caused it to use the wrong image URL. This PR should correct that. Also there is no need to check for the existence of the image since every article has one.