### PR TITLE
test: fix deprecation error

### DIFF
--- a/bridges/KemonoBridge.php
+++ b/bridges/KemonoBridge.php
@@ -42,7 +42,8 @@ class KemonoBridge extends BridgeAbstract
 
     private function isCoomer()
     {
-        return str_contains($this->getInput('service'), 'fans');
+        $haystack = $this->getInput('service') ?? '';
+        return str_contains($haystack, 'fans');
     }
 
     private function baseURI()
@@ -112,7 +113,10 @@ class KemonoBridge extends BridgeAbstract
 
     public function getURI()
     {
-        $uri = $this->baseURI() . $this->getInput('service') . '/user/' . $this->getInput('user');
+        $service = $this->getInput('service');
+        $user = $this->getInput('user');
+
+        $uri = $this->baseURI() . $service . '/user/' . $user;
         return $uri;
     }
 }


### PR DESCRIPTION
PHP Deprecated:  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/rss-bridge/bridges/KemonoBridge.php on line 46