### PR TITLE
[HeiseBridge] Avoid double header image on some posts

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -179,7 +179,7 @@ class HeiseBridge extends FeedExpander
         // remove unwanted stuff
         foreach (
             $article->find('figure.branding, figure.a-inline-image, a-ad, div.ho-text, a-img,
-            .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote, .notice-banner__text, .notice-banner__link, .ad, .ad--inread') as $element
+            .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote, .opt-in__bg-image, .notice-banner__text, .notice-banner__link, .ad, .ad--inread') as $element
         ) {
             $element->remove();
         }


### PR DESCRIPTION
This removes the duplicate image on some articles. From the class name and found pages, this affects posts that require an opt-in, most notably podcast posts.

Example post: https://www.heise.de/hintergrund/Auslegungssache-143-Drei-Urteile-viele-Fragezeichen-10661743.html