### PR TITLE
Update AppleMusicBridge HTML parsing

### DIFF
--- a/bridges/AppleMusicBridge.php
+++ b/bridges/AppleMusicBridge.php
@@ -66,7 +66,7 @@ class AppleMusicBridge extends BridgeAbstract
         }
 
         $url = 'https://itunes.apple.com/lookup?id=' . $this->getInput('artist') . '&entity=album&limit=' . $limit . '&sort=recent';
-        $html = getSimpleHTMLDOM($url);
+        $html = getContents($url);
         $json = json_decode($html);
         $result = $json->results;
 


### PR DESCRIPTION
Switch from getSimpleHTMLDOM() to getContents() to handle certain characters like '<' that break otherwise valid artist feeds, i.e. artistId 1736226642