### PR TITLE
[CraigslistBridge] Updated selectors to match new structure

### DIFF
--- a/bridges/CraigslistBridge.php
+++ b/bridges/CraigslistBridge.php
@@ -6,33 +6,37 @@ class CraigslistBridge extends BridgeAbstract
     const URI = 'https://craigslist.org/';
     const DESCRIPTION = 'Returns craigslist search results';
 
-    const PARAMETERS = [ [
-        'region' => [
-            'name' => 'Region',
-            'title' => 'The subdomain before craigslist.org in the URL',
-            'exampleValue' => 'sfbay',
-            'required' => true
-        ],
-        'search' => [
-            'name' => 'Search Query',
-            'title' => 'Everything in the URL after /search/',
-            'exampleValue' => 'sya?query=laptop',
-            'required' => true
-        ],
-        'limit' => [
-            'name' => 'Number of Posts',
-            'type' => 'number',
-            'title' => 'The maximum number of posts is 120. Use 0 for unlimited posts.',
-            'defaultValue' => '25'
+    const PARAMETERS = [
+        [
+            'region' => [
+                'name' => 'Region',
+                'title' => 'The subdomain before craigslist.org in the URL',
+                'exampleValue' => 'sfbay',
+                'required' => true
+            ],
+            'search' => [
+                'name' => 'Search Query',
+                'title' => 'Everything in the URL after /search/',
+                'exampleValue' => 'sya?query=laptop',
+                'required' => true
+            ],
+            'limit' => [
+                'name' => 'Number of Posts',
+                'type' => 'number',
+                'title' => 'The maximum number of posts is 120. Use 0 for unlimited posts.',
+                'defaultValue' => '25'
+            ]
         ]
-    ]];
+    ];
 
     const TEST_DETECT_PARAMETERS = [
         'https://sfbay.craigslist.org/search/sya?query=laptop' => [
-            'region' => 'sfbay', 'search' => 'sya?query=laptop'
+            'region' => 'sfbay',
+            'search' => 'sya?query=laptop'
         ],
         'https://newyork.craigslist.org/search/sss?query=32gb+flash+drive&bundleDuplicates=1&max_price=20' => [
-            'region' => 'newyork', 'search' => 'sss?query=32gb+flash+drive&bundleDuplicates=1&max_price=20'
+            'region' => 'newyork',
+            'search' => 'sss?query=32gb+flash+drive&bundleDuplicates=1&max_price=20'
         ],
     ];
 
@@ -62,13 +66,7 @@ class CraigslistBridge extends BridgeAbstract
         $uri = $this->getURI();
         $html = getSimpleHTMLDOM($uri);
 
-        // Check if no results page is shown (nearby results)
-        if (($html->find('.displaycountShow', 0)->plaintext ?? '') == '0') {
-            return;
-        }
-
-        // Search for "more from nearby areas" banner in order to skip those results
-        $results = $html->find('.result-row, h4.nearby');
+        $results = $html->find('.cl-static-search-result');
 
         // Limit the number of posts
         if ($this->getInput('limit') > 0) {
@@ -76,37 +74,59 @@ class CraigslistBridge extends BridgeAbstract
         }
 
         foreach ($results as $post) {
-            // Skip "nearby results" banner and results
-            // This only appears when searchNearby is not specified
-            if ($post->tag == 'h4') {
-                break;
-            }
-
             $item = [];
 
-            $heading = $post->find('.result-heading a', 0);
-            $item['uri'] = $heading->href;
-            $item['title'] = $heading->plaintext;
-            $item['timestamp'] = $post->find('.result-date', 0)->datetime;
-            $item['uid'] = $heading->id;
+            $itemUri = $post->find('a', 0)->href;
 
-            $price = $post->find('.result-price', 0)->plaintext ?? '';
-            // Find the location (local and nearby results if searchNearby=1)
-            $nearby = $post->find('.result-hood, span.nearby', 0)->plaintext ?? '';
-            $item['content'] = sprintf('%s %s', $price, $nearby);
+            $item['uri'] = $itemUri;
+            $item['title'] = $post->getAttribute('title');
+            $item['uid'] = $itemUri;
 
-            $images = $post->find('.result-image[data-ids]', 0);
-            if (!is_null($images)) {
+            $price = $post->find('.price', 0)->plaintext ?? '';
+            $location = $post->find('.location', 0)->plaintext ?? '';
+            $item['content'] = sprintf('%s %s', $price, $location);
+
+            $images = $this->getImages($itemUri);
+            if (!empty($images)) {
                 $item['content'] .= '<br>';
-                foreach (explode(',', $images->getAttribute('data-ids')) as $image) {
-                    // Remove leading 3: from each image id
-                    $id = substr($image, 2);
-                    $image_uri = 'https://images.craigslist.org/' . $id . '_300x300.jpg';
-                    $item['content'] .= '<img src="' . $image_uri . '">';
-                    $item['enclosures'][] = $image_uri;
+                foreach ($images as $image) {
+                    $imageUri = $image->src;
+                    $item['content'] .= '<img src="' . $imageUri . '">';
+                    $item['enclosures'][] = $imageUri;
                 }
             }
             $this->items[] = $item;
         }
+    }
+
+    private function getImages($postUrl): array
+    {
+        $html = getSimpleHTMLDOM($postUrl);
+
+        // Try to extract imgList from the page's scripts
+        $imgList = [];
+        foreach ($html->find('script') as $script) {
+            if (preg_match('/var imgList = (\[.*?\]);/s', $script->innertext, $matches)) {
+                $json = $matches[1];
+                $imgList = json_decode($json, true);
+                break;
+            }
+        }
+
+        $images = [];
+        if (!empty($imgList)) {
+            foreach ($imgList as $img) {
+                if (isset($img['url'])) {
+                    $image = new stdClass();
+                    $image->src = $img['url'];
+                    $images[] = $image;
+                }
+            }
+        } else {
+            // Fallback to DOM search if imgList is not found
+            $images = $html->find('.swipe-wrap img') ?? [];
+        }
+
+        return $images;
     }
 }

--- a/bridges/CraigslistBridge.php
+++ b/bridges/CraigslistBridge.php
@@ -115,13 +115,13 @@ class CraigslistBridge extends BridgeAbstract
 
             if (isset($jsonData->itemListElement) && is_array($jsonData->itemListElement)) {
                 foreach ($jsonData->itemListElement as $item) {
-                    if (isset($item->item->image) && is_array($item->item->image)) {
+                    if (isset($item->item->image) && is_array($item->item->image) && isset($item->position)) {
                         $productImages = [];
                         foreach ($item->item->image as $imageUrl) {
                             $productImages[] = $imageUrl;
                         }
                         if (!empty($productImages)) {
-                            $images[] = $productImages;
+                            $images[$item->position] = $productImages;
                         }
                     }
                 }


### PR DESCRIPTION
This PR addresses https://github.com/RSS-Bridge/rss-bridge/issues/4678.

Craigslist has updated the HTML structure for search query responses, which required corresponding updates in the CraigslistBridge.

Changes:

- Updated CSS selectors to match the new HTML structure.
- Adjusted image handling — images are no longer included in the initial response and must now be fetched via a separate request.
- Removed the "Nearby" functionality, as it is no longer available in the current Craigslist response.