### PR TITLE
[HeiseBridge] Remove notice of embedded content

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -178,7 +178,7 @@ class HeiseBridge extends FeedExpander
 
         // remove unwanted stuff
         foreach (
-            $article->find('figure.branding, figure.a-inline-image, a-ad, div.ho-text, a-img,
+            $article->find('figure.branding, figure.a-inline-image, a-ad, div.ho-text, a-img, .opt-in__title,
             .a-toc__list, a-collapse, .opt-in__description, .opt-in__footnote, .opt-in__bg-image, .notice-banner__text, .notice-banner__link, .ad, .ad--inread') as $element
         ) {
             $element->remove();


### PR DESCRIPTION
The content itself is included (if it's below `noscript iframe`). The notice is unnecessary clutter that is also not displayed in the JS variant of the Heise website.

Test site: https://www.heise.de/news/Satelliteninternet-Schon-ein-bis-zwei-Abstuerze-von-Starlink-Satelliten-pro-Tag-10726535.html?seite=all