### PR TITLE
[TldrTechBridge] Rename Webdev and add new channels

### DIFF
--- a/bridges/TldrTechBridge.php
+++ b/bridges/TldrTechBridge.php
@@ -22,7 +22,7 @@ class TldrTechBridge extends BridgeAbstract
                 'type' => 'list',
                 'values' => [
                     'Tech' => 'tech',
-                    'Web Dev' => 'webdev',
+                    'Dev' => 'dev',
                     'AI' => 'ai',
                     'Information Security' => 'infosec',
                     'Product Management' => 'product',
@@ -31,6 +31,10 @@ class TldrTechBridge extends BridgeAbstract
                     'Design' => 'design',
                     'Marketing' => 'marketing',
                     'Founders' => 'founders',
+                    'Fintech' => 'fintech',
+                    'Data' => 'data',
+                    'IT' => 'it',
+                    'Hardware' => 'hardware',
                 ],
                 'defaultValue' => 'tech'
             ]


### PR DESCRIPTION
TLDR has renamed the 'Webdev' channel to 'Dev' and Webdev has stopped working in the bridge. This PR makes the applicable change.

They have also added new channels for 'Fintech' and 'Data' and 'Coming Soon' channels for 'IT' and 'Hardware' which are missing from the bridge. This PR adds options for all of these new channels.