### PR TITLE
[GolemBridge] Fix multiple YouTube embeds

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -116,11 +116,12 @@ class GolemBridge extends FeedExpander
         $article = $page->find('article', 0);
 
         //built youtube iframes
-        foreach ($article->find('.go-embed-container') as &$embedcontent) {
+        $placeholders = $article->find('.go-embed-container');
+        foreach (range(0, count($placeholders) - 1) as $i) {
             foreach ($page->find('script') as $ytscript) {
-                if (preg_match('/(www.youtube.com.*?)\"/', $ytscript->innertext, $link)) {
-                    $link = 'https://' . str_replace('\\', '', $link[1]);
-                    $embedcontent->innertext .= <<<EOT
+                if (preg_match_all('/(www.youtube.com.*?)\"/', $ytscript->innertext, $link)) {
+                    $link = 'https://' . str_replace('\\', '', $link[1][$i]);
+                    $placeholders[$i]->innertext .= <<<EOT
                         <iframe width="560" height="315" src="$link" title="YouTube video player" frameborder="0"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                         referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>';


### PR DESCRIPTION
The following test article revealed that the previous code always takes the first youtube link on all YouTube embed spaces: https://www.golem.de/news/free-to-play-kostenlos-skaten-ballern-und-klicken-2510-201000.html

This command changes it to opportunistically select the i-th youtube embed link for the i-th placeholder. This might fail and produce wrong orderings, but should be better than the previous code. The above test article is at least completely correct.