### PR TITLE
fix(http): http headers missing

### DIFF
--- a/lib/http.php
+++ b/lib/http.php
@@ -66,7 +66,7 @@ final class CurlHttpClient implements HttpClient
     {
         $ch = curl_init($url);
 
-        $defaults = [
+        $defaultConfig = [
             'useragent' => null,
             'timeout' => 5,
             'headers' => [],
@@ -78,25 +78,28 @@ final class CurlHttpClient implements HttpClient
             'max_redirections' => 5,
         ];
 
-        // if curl-impersonate is not detected, use some basic defaults
-        if (curl_version()['ssl_version'] != 'BoringSSL') {
-            // Snagged from https://github.com/lwthiker/curl-impersonate/blob/main/firefox/curl_ff102
-            $defaults['headers'] = [
-                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-                'Accept-Language' => 'en-US,en;q=0.5',
-                'Upgrade-Insecure-Requests' => '1',
-                'Sec-Fetch-Dest' => 'document',
-                'Sec-Fetch-Mode' => 'navigate',
-                'Sec-Fetch-Site' => 'none',
-                'Sec-Fetch-User' => '?1',
-                'TE' => 'trailers',
-            ];
-            $defaults['useragent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0';
+        // Snagged from https://github.com/lwthiker/curl-impersonate/blob/main/firefox/curl_ff102
+        $defaultHeaders = [
+            'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+            'Accept-Language' => 'en-US,en;q=0.5',
+            'Upgrade-Insecure-Requests' => '1',
+            'Sec-Fetch-Dest' => 'document',
+            'Sec-Fetch-Mode' => 'navigate',
+            'Sec-Fetch-Site' => 'none',
+            'Sec-Fetch-User' => '?1',
+            'TE' => 'trailers',
+        ];
 
+        if (curl_version()['ssl_version'] == 'BoringSSL') {
+            $config = array_merge($defaultConfig, $config);
+        } else {
+            $defaultConfig['useragent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0';
             curl_setopt($ch, CURLOPT_HEADER, false);
+            $headers = array_merge($defaultHeaders, $config['headers']);
+            $config = array_merge($defaultConfig, $config);
+            $config['headers'] = $headers;
         }
-
-        $config = array_merge($defaults, $config);
+        unset($headers);
 
         $httpHeaders = [];
         foreach ($config['headers'] as $name => $value) {


### PR DESCRIPTION
The default http headers were missing when not using curl-impersonate (non-Docker I guess?)

Happens if a non-empty list of http headers is provided in client code:

```php
$url = 'http://127.0.0.1:8080/AAA';
$client = new CurlHttpClient();
$config = [
    'headers'       => [
        'cookie' => 'admin=yes',
    ],
];
$xmlString = $client->request($url, $config);
```
fix #4757

@wrobelda 