### PR TITLE
CI: Use a SSH deploy key for PR HTML previews

### DIFF
--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -19,10 +19,10 @@ jobs:
           wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
           bridgeamount=$(cat $PR.patch | grep "\bbridges/[A-Za-z0-9]*Bridge\.php\b" | sed "s=.*\bbridges/\([A-Za-z0-9]*\)Bridge\.php\b.*=\1=g" | sort | uniq | wc -l);
           echo "BRIDGES=$bridgeamount" >> "$GITHUB_OUTPUT"
-      - name: "Check upload token secret RSSTESTER_ACTION is set"
+      - name: "Check upload token secret RSSTESTER_SSH_KEY is set"
         id: check_upload
         run: |
-          echo "WITH_UPLOAD=$([ -n "${{ secrets.RSSTESTER_ACTION }}" ] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
+          echo "WITH_UPLOAD=$([ -n "${{ secrets.RSSTESTER_SSH_KEY }}" ] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
   test-pr:
     name: Generate HTML
     runs-on: ubuntu-latest
@@ -103,7 +103,7 @@ jobs:
         with:
           repository: "${{ github.repository_owner }}/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}"
           ref: 'main'
-          token:  ${{ secrets.RSSTESTER_ACTION }}
+          ssh-key:  ${{ secrets.RSSTESTER_SSH_KEY }}
       - name: Setup git config
         run: |
           git config --global user.name "GitHub Actions"


### PR DESCRIPTION
The main advantage is the non-expiry, while personal access tokens expire after a maximum of 1 year. The coarse-grained permissions are no problem here, as the deploy key is bound to the separate rss-bridge-tests repo which has no other data or secrets.

This is the easiest/fastest method to avoid the fallout of an expired key after a year. Closes https://github.com/RSS-Bridge/rss-bridge/issues/4770 for good.

@Bockiii Can you add such a deploy key? I haven't tested the change, but replaced all occurrences of `RSSTESTER_ACTION`. Also, actions/checkout says it makes the ssh key available to further commands, just like the token.

More info on deploy keys: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys