### PR TITLE
Send origin referrer for YouTube embeds

### DIFF
--- a/bridges/AnisearchBridge.php
+++ b/bridges/AnisearchBridge.php
@@ -72,7 +72,7 @@ class AnisearchBridge extends BridgeAbstract
                     $ytlink = <<<EOT
                         <br /><iframe width="560" height="315" src="$trailer" title="YouTube video player"
                         frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                        referrerpolicy="strict-origin" allowfullscreen></iframe>
                     EOT;
                 }
             }

--- a/bridges/AssociatedPressNewsBridge.php
+++ b/bridges/AssociatedPressNewsBridge.php
@@ -215,7 +215,7 @@ EOD;
 
                 if ($media['type'] === 'YouTube') {
                     $div->outertext = <<<EOD
-	<iframe src="https://www.youtube.com/embed/{$media['externalId']}" width="560" height="315">
+	<iframe src="https://www.youtube.com/embed/{$media['externalId']}" width="560" height="315" referrerpolicy="strict-origin">
 	</iframe>
 EOD;
                 }
@@ -251,7 +251,7 @@ EOD;
         if ($video['type'] === 'YouTube') {
             $url = 'https://www.youtube.com/embed/' . $video['externalId'];
             $html = <<<EOD
-<iframe width="560" height="315" src="{$url}" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="{$url}" frameborder="0" allowfullscreen referrerpolicy="strict-origin"></iframe>
 EOD;
         } else {
             $html = <<<EOD

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -136,7 +136,7 @@ class GolemBridge extends FeedExpander
                     $placeholders[$i]->innertext = <<<EOT
                     <iframe width="560" height="315" src="$src" title="YouTube video player" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>';
+                    referrerpolicy="strict-origin" allowfullscreen></iframe>';
                     EOT;
                 }
             }

--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -213,7 +213,7 @@ class HeiseBridge extends FeedExpander
                 $ytiframe = <<<EOT
                     <iframe width="560" height="315" src="https://$link[0] title="YouTube video player" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                    referrerpolicy="strict-origin" allowfullscreen></iframe>
                 EOT;
                 //check if video is in header or article for correct possitioning
                 if (strpos($header->innertext, $link[0])) {

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -543,6 +543,7 @@ EOD;
 	src="{$url}"
 	frameborder="0" 
 	allowfullscreen
+	referrerpolicy="strict-origin"
 >
 </iframe>
 EOD;

--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -240,7 +240,7 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
 
                 $content = <<<EOD
 <iframe width="100%" height="410" src="https://www.youtube.com/embed/{$attachments->videoRenderer->videoId}" 
-frameborder="0" allow="encrypted-media;" allowfullscreen></iframe>
+frameborder="0" allow="encrypted-media;" allowfullscreen referrerpolicy="strict-origin"></iframe>
 EOD;
             } elseif (isset($attachments->backstageImageRenderer)) {
                 // Image

--- a/bridges/YouTubeFeedExpanderBridge.php
+++ b/bridges/YouTubeFeedExpanderBridge.php
@@ -76,7 +76,7 @@ class YouTubeFeedExpanderBridge extends FeedExpander
         }
         $embed = $embedURI . 'embed/' . $id;
         if ($this->getInput('embed')) {
-            $iframe_fmt = '<iframe width="448" height="350" src="%s" title="%s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>'; //phpcs:ignore
+            $iframe_fmt = '<iframe width="448" height="350" src="%s" title="%s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin" allowfullscreen></iframe>'; //phpcs:ignore
             $iframe = sprintf($iframe_fmt, $embed, $item['title']) . '<br>';
             $item['content'] = $iframe . $item['content'];
         }


### PR DESCRIPTION
Unfortunately, YouTube blocks embedded views in iframes that don't send a referrer. To fix them as-is, we explicitly provide the origin.
Using `strict-origin` over `strict-origin-when-cross-origin` is the more private setting, avoiding sending unintended full-path referrers to the original origin.

A future implementation might offer a config option to either offer a YouTube video as iframe, requiring to send referrers towards Google, or provide just a link (with thumbnail), which requires no referrer, iframe or JavaScript.

https://support.google.com/youtube/answer/171780#zippy=%2Cprovide-an-http-referrer-header-to-enable-video-playback https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity