### PR TITLE
[actions] prhtmlgenerator and other workflow improvements

### DIFF
--- a/.github/prtester.py
+++ b/.github/prtester.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
     parser.add_argument('--artifacts-directory', default=os.getcwd())
     parser.add_argument('--artifacts-base-url', default='')
     parser.add_argument('--title', default='Pull request artifacts')
-    parser.add_argument('--output-file', default=os.getcwd() + '/comment.txt')
+    parser.add_argument('--output-file', default=os.getcwd() + '/comment.md')
     args = parser.parse_args()
     instances = []
     if args.instances:

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - '20*'
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   DOCKERHUB_SLUG: rssbridge/rss-bridge
   GHCR_SLUG: ghcr.io/rss-bridge/rss-bridge
@@ -15,11 +19,9 @@ jobs:
   bake:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -  
-        name: Docker meta
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
@@ -31,28 +33,23 @@ jobs:
             type=sha
             type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/20') }}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/20') }}
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      -
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/bake-action@v5
+      - name: Build and push
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,11 +5,14 @@ on:
     paths:
     - 'docs/**'
 
+permissions:
+  contents: write
+
 jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Setup PHP

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   phpcs:
     runs-on: ubuntu-22.04
@@ -13,7 +16,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
@@ -26,7 +29,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
@@ -37,7 +40,7 @@ jobs:
   executable_php_files_check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: |
           if find -name "*.php" -executable -type f -print -exec false {} +
           then

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Check if bridges were changed
@@ -23,83 +26,105 @@ jobs:
         id: check_upload
         run: |
           echo "WITH_UPLOAD=$([ -n "${{ secrets.RSSTESTER_SSH_KEY }}" ] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
+
   test-pr:
-    name: Generate HTML
+    name: Generate HTML files
     runs-on: ubuntu-latest
     needs: checks
     if: needs.checks.outputs.BRIDGES > 0
-    env:
-      PYTHONUNBUFFERED: 1
-    # Needs additional permissions https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989
+    outputs:
+      COMMENT_LENGTH: ${{ steps.run-tests.outputs.bodylength }}
     steps:
-      - name: Check out self
-        uses: actions/checkout@v4
+      - name: Checkout - PR
+        uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - name: Check out rss-bridge
+      - name: Build docker image - PR
+        run: docker build -t rss-bridge-pr .
+      - name: Clear workspace
+        run: rm -r *
+      - name: Checkout - Current
+        uses: actions/checkout@v5
+      - name: Build docker image - Current
+        run: docker build -t rss-bridge-current .
+      - name: Create configuration files
         run: |
-          PR=${{ github.event.number || 'none' }};
-          wget -O requirements.txt https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester-requirements.txt;
-          wget https://raw.githubusercontent.com/$GITHUB_REPOSITORY/${{ github.event.pull_request.base.ref }}/.github/prtester.py;
-          wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
           touch DEBUG;
-          cat $PR.patch | grep "\bbridges/[A-Za-z0-9]*Bridge\.php\b" | sed "s=.*\bbridges/\([A-Za-z0-9]*\)Bridge\.php\b.*=\1=g" | sort | uniq > whitelist.txt
-      - name: Start Docker - Current
-        run: |
-          docker run -d -v $GITHUB_WORKSPACE/whitelist.txt:/app/whitelist.txt -v $GITHUB_WORKSPACE/DEBUG:/app/DEBUG -p 3000:80 ghcr.io/rss-bridge/rss-bridge:latest
-      - name: Start Docker - PR
-        run: |
-          docker build -t prbuild .;
-          docker run -d -v $GITHUB_WORKSPACE/whitelist.txt:/app/whitelist.txt -v $GITHUB_WORKSPACE/DEBUG:/app/DEBUG -p 3001:80 prbuild
+          PR=${{ github.event.number || 'none' }};
+          wget https://patch-diff.githubusercontent.com/raw/$GITHUB_REPOSITORY/pull/$PR.patch;
+          cat $PR.patch | grep "\bbridges/[A-Za-z0-9]*Bridge\.php\b" | sed "s=.*\bbridges/\([A-Za-z0-9]*\)Bridge\.php\b.*=\1=g" | sort | uniq > whitelist.txt;
+          echo "whitelist.txt:";
+          cat whitelist.txt
+      - name: Run docker container - Current
+        run: docker run -v $GITHUB_WORKSPACE/whitelist.txt:/app/whitelist.txt -v $GITHUB_WORKSPACE/DEBUG:/app/DEBUG --detach --pull never -p 3000:80 rss-bridge-current
+      - name: Run docker container - PR
+        run: docker run -v $GITHUB_WORKSPACE/whitelist.txt:/app/whitelist.txt -v $GITHUB_WORKSPACE/DEBUG:/app/DEBUG --detach --pull never -p 3001:80 rss-bridge-pr
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip'
+          cache-dependency-path: '**/*requirements*.txt'
       - name: Install requirements
-        run: |
-          cd $GITHUB_WORKSPACE
-          pip install -r requirements.txt
+        run: pip install -r ./.github/prtester-requirements.txt
       - name: Run bridge tests
-        id: testrun
+        id: run-tests
+        env:
+          PYTHONUNBUFFERED: 1
         run: |
-          mkdir results;
-          python prtester.py --artifacts-base-url "https://${{ github.repository_owner }}.github.io/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}/prs/${{ github.event.number || 'none' }}";
-          body="$(cat comment.txt)";
+          python ./.github/prtester.py --artifacts-base-url "https://${{ github.repository_owner }}.github.io/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}/prs/${{ github.event.number || 'none' }}";
+          body="$(cat comment.md)";
           body="${body//'%'/'%25'}";
           body="${body//$'\n'/'%0A'}";
           body="${body//$'\r'/'%0D'}";
           echo "bodylength=${#body}" >> $GITHUB_OUTPUT
-      - name: Upload generated tests
-        uses: actions/upload-artifact@v4
-        id: upload-generated-tests
+      - name: Upload test results
+        if: steps.run-tests.outputs.bodylength > 130
+        uses: actions/upload-artifact@v5
         with:
-          name: tests
-          path: '*.html'
+          name: test-results
+          path: |
+            comment.md
+            *.html
+          if-no-files-found: error
+
+  comment-pr:
+    name: Create or update PR comment
+    runs-on: ubuntu-latest
+    needs: test-pr
+    if: needs.test-pr.outputs.COMMENT_LENGTH > 130
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download test results
+        uses: actions/download-artifact@v5
+        with:
+          name: test-results
+      - name: Add comment to job summary
+        run: cat comment.md >> $GITHUB_STEP_SUMMARY
       - name: Find Comment
-        if: ${{ steps.testrun.outputs.bodylength > 130 }}
-        uses: peter-evans/find-comment@v3
-        id: fc
+        uses: peter-evans/find-comment@v4
+        id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Pull request artifacts
       - name: Create or update comment
-        if: ${{ steps.testrun.outputs.bodylength > 130 }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body-file: comment.txt
+          body-file: comment.md
           edit-mode: replace
-  upload_tests:
-    name: Upload tests
+
+  upload-test-results:
+    name: Upload to GitHub Pages repository
     runs-on: ubuntu-latest
-    needs: test-pr
+    needs: comment-pr
     if: needs.checks.outputs.WITH_UPLOAD == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: "${{ github.repository_owner }}/${{ vars.ARTIFACTS_REPO || 'rss-bridge-tests' }}"
           ref: 'main'
@@ -108,20 +133,21 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "<>"
-      - name: Download tests
-        uses: actions/download-artifact@v4
+      - name: Download test results
+        uses: actions/download-artifact@v5
         with:
-          name: tests
-      - name: Move tests
+          name: test-results
+      - name: Move test results
         run: |
           DIRECTORY="$GITHUB_WORKSPACE/prs/${{ github.event.number || 'none' }}"
           rm -rf $DIRECTORY
           mkdir -p $DIRECTORY
           cd $DIRECTORY
+          mv -f $GITHUB_WORKSPACE/comment.md ./README.md
           mv -f $GITHUB_WORKSPACE/*.html .
-      - name: Commit and push generated tests
+      - name: Commit and push test results
         run: |
-          export COMMIT_MESSAGE="Added tests for PR ${{ github.event.number || 'none' }}"
+          export COMMIT_MESSAGE="Test results for PR ${{ github.event.number || 'none' }}"
           git add .
           git commit -m "$COMMIT_MESSAGE" || exit 0
           git push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   phpunit8:
     runs-on: ubuntu-22.04
@@ -13,7 +16,7 @@ jobs:
       matrix:
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}


### PR DESCRIPTION
This PR makes some improvements to all GitHub workflow files:
- Update all actions to the latest version.
- Explicitly use the `permissions` section to reduce them to whats actually needed. By default the `$GITHUB_TOKEN` has too much unneeded read and write permissions.
  - All possible permissions
    ```
    permissions:
        actions: read|write|none
        checks: read|write|none
        contents: read|write|none
        deployments: read|write|none
        id-token: read|write|none
        issues: read|write|none
        discussions: read|write|none
        packages: read|write|none
        pages: read|write|none
        pull-requests: read|write|none
        repository-projects: read|write|none
        security-events: read|write|none
        statuses: read|write|none
    ``` 
  - I have not tested the `permissions` change on `dockerbuild.yml` and `documentation.yml`, because I would need login credentials or other configuration for that, but I am confident that it works
- `prhtmlgenerator.yml` workflow
  - Moved the create/update comment step from `test-pr` into its own job `comment-pr`. This allows to reduce the `permissions` down to only `contents: read` for job `test-pr` and only `pull-requests: write` for job `comment-pr`. This makes it much safer to checkout the untrusted code from forks, because before the untrusted code had to many unneeded read and write permissions. Only `contents: read` is enough for building the docker image from the untrusted code.
  - Rearranged the steps of job `test-pr` to keep the use of untrusted code as short as possible to reduce the attack surface to only `docker build`
  - Instead of downloading `prtester.py` and `prtester-requirements.txt`, checkout the code of the target branch (`master`) and use the files from there
  - Instead of using the prebuild docker image `ghcr.io/rss-bridge/rss-bridge:latest`, which might not represent the current state of the target branch (`master`) e.g. race conditions, checkout the code of the target branch (`master`) and build the docker image from it
  - Output the content of `whitelist.txt` to be able to better debug false positives
  - The `comment.txt` (now `comment.md`) gets added to https://github.com/RSS-Bridge/rss-bridge-tests as `prs/PRID/README.md` (example: https://github.com/User123698745/rss-bridge-artifacts/tree/main/prs/1) and piped into `$GITHUB_STEP_SUMMARY` so that you can also access the result on the job overview (example: https://github.com/User123698745/sandbox-upstream/actions/runs/18949114622)

It was a bit annoying to test the changes to `prhtmlgenerator.yml` because of `pull_request_target` (but we need that to be able to comment on PRs of forks) only the target branch (`master`) workflow code gets used. I created https://github.com/User123698745/sandbox-upstream as a copy of this repo to test it. You can see all the test runs here https://github.com/User123698745/sandbox-upstream/actions/workflows/prhtmlgenerator.yml. If you want to also test the changes to `prhtmlgenerator.yml` you can fork that repo and create a PR