### PR TITLE
feat: Add handleYoutube function

### DIFF
--- a/bridges/AssociatedPressNewsBridge.php
+++ b/bridges/AssociatedPressNewsBridge.php
@@ -214,10 +214,7 @@ EOD;
                 }
 
                 if ($media['type'] === 'YouTube') {
-                    $div->outertext = <<<EOD
-	<iframe src="https://www.youtube.com/embed/{$media['externalId']}" width="560" height="315" referrerpolicy="strict-origin">
-	</iframe>
-EOD;
+                    $div->outertext = handleYoutube($media['externalId']);
                 }
             }
         }
@@ -249,10 +246,7 @@ EOD;
         $video = $storyContent['media'][0];
 
         if ($video['type'] === 'YouTube') {
-            $url = 'https://www.youtube.com/embed/' . $video['externalId'];
-            $html = <<<EOD
-<iframe width="560" height="315" src="{$url}" frameborder="0" allowfullscreen referrerpolicy="strict-origin"></iframe>
-EOD;
+            $html = handleYoutube($video['externalId']);
         } else {
             $html = <<<EOD
 <video controls poster="https://storage.googleapis.com/afs-prod/media/{$video['id']}/800.jpeg" preload="none">

--- a/bridges/Drive2ruBridge.php
+++ b/bridges/Drive2ruBridge.php
@@ -173,9 +173,7 @@ class Drive2ruBridge extends BridgeAbstract
             $node->outertext = '';
         }
         foreach ($content->find('iframe') as $node) {
-            preg_match('/embed\/(.*?)\?/', $node->src, $match);
-            $node->outertext = '<a href="https://www.youtube.com/watch?v=' . $match[1] .
-                '">https://www.youtube.com/watch?v=' . $match[1] . '</a>';
+            $node->outertext = handleYoutube($node->src);
         }
         return $content;
     }

--- a/bridges/EuronewsBridge.php
+++ b/bridges/EuronewsBridge.php
@@ -207,8 +207,7 @@ class EuronewsBridge extends BridgeAbstract
             $player_div = $html->find('.js-player-pfp', 0);
             if ($player_div) {
                 $video_id = $player_div->getAttribute('data-video-id');
-                $video_url = 'https://www.youtube.com/watch?v=' . $video_id;
-                $content .= '<a href="' . $video_url . '">' . $video_url . '</a>';
+                $content .= handleYoutube($video_id);
             }
         }
 

--- a/bridges/FallGuysBridge.php
+++ b/bridges/FallGuysBridge.php
@@ -94,22 +94,17 @@ class FallGuysBridge extends BridgeAbstract
                         if (count($mediaOptions) == count($mainContentOptions)) {
                             for ($i = 0; $i < count($mediaOptions); $i++) {
                                 if (property_exists($mediaOptions[$i], 'youtubeVideo')) {
-                                    $videoUrl = 'https://youtu.be/' . $mediaOptions[$i]->youtubeVideo->contentId;
+                                    $videoID = $mediaOptions[$i]->youtubeVideo->contentId;
+                                    $videoHtml = handleYoutube($videoID);
+
+                                    $content .= '<p>' . $videoHtml;
+
                                     $image = $mainContentOptions[$i]->image->src ?? '';
-
-                                    $content .= '<p>';
-
                                     if ($image != $headerImage) {
                                         $contentImages[] = $image;
 
-                                        $content .= <<<HTML
-                                        <a href="{$videoUrl}"><img src="{$image}"></a><br>
-                                        HTML;
+                                        $content .= '<img src="{$image}"><br>';
                                     }
-
-                                    $content .= <<<HTML
-                                    <i>(Video: <a href="{$videoUrl}">{$videoUrl}</a>)</i>
-                                    HTML;
 
                                     $content .= '</p>';
                                 }

--- a/bridges/GenshinImpactBridge.php
+++ b/bridges/GenshinImpactBridge.php
@@ -37,8 +37,7 @@ class GenshinImpactBridge extends BridgeAbstract
             if (preg_match($exp_youtube, $article_html, $matches)) {
                 // Replace the YouTube embed with a YouTube link
                 $yt_embed = $article_html->find('div[class="ttr-video-frame"]', 0);
-                $yt_link = sprintf('<a href="https://www.youtube.com/watch?v=%1$s">https://www.youtube.com/watch?v=%1$s</a>', $matches[1]);
-                $article_html = str_replace($yt_embed, $yt_link, $article_html);
+                $yt_embed->outertext = handleYoutube($yt_embed);
             }
             $item = [];
             $item['title'] = $json_item['sTitle'];

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -133,11 +133,7 @@ class GolemBridge extends FeedExpander
             if (array_key_exists($i, $embedSrcs)) {
                 $src = $embedSrcs[$i];
                 if (preg_match('/youtube(-nocookie)?\.com/', $src, $match)) {
-                    $placeholders[$i]->innertext = <<<EOT
-                    <iframe width="560" height="315" src="$src" title="YouTube video player" frameborder="0"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerpolicy="strict-origin" allowfullscreen></iframe>';
-                    EOT;
+                    $placeholders[$i]->innertext = handleYoutube($src);
                 }
             }
         }

--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -207,19 +207,13 @@ class HeiseBridge extends FeedExpander
         //fix for embbedded youtube-videos
         $oldlink = '';
         foreach ($article->find('div.video__yt-container') as &$ytvideo) {
-            if (preg_match('/www.youtube.*?\"/', $ytvideo->innertext, $link) && $link[0] != $oldlink) {
-                //save link to prevent duplicates
-                $oldlink = $link[0];
-                $ytiframe = <<<EOT
-                    <iframe width="560" height="315" src="https://$link[0] title="YouTube video player" frameborder="0"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerpolicy="strict-origin" allowfullscreen></iframe>
-                EOT;
-                //check if video is in header or article for correct possitioning
-                if (strpos($header->innertext, $link[0])) {
-                    $item['content'] .= $ytiframe;
+            $ytResult = handleYoutube($ytvideo->innertext);
+            if ($ytResult) {
+                //check if video is in header or article for correct positioning
+                if (strpos($header->innertext, $ytvideo)) {
+                    $item['content'] .= $ytResult;
                 } else {
-                    $ytvideo->innertext .= $ytiframe;
+                    $ytvideo->innertext .= $ytResult;
                     $reloadneeded = 1;
                 }
             }

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -280,8 +280,7 @@ class RedditBridge extends BridgeAbstract
                     }
                 } elseif (isset($data->media) && $data->media->type == 'youtube.com') {
                     // Youtube link
-                    $item['content'] = $this->createFigureLink($data->url, $data->media->oembed->thumbnail_url, 'YouTube');
-                    //$item['content'] = htmlspecialchars_decode($data->media->oembed->html);
+                    $item['content'] = handleYoutube($data->url);
                 } elseif (explode('.', $data->domain)[0] == 'self') {
                     // Crossposted text post
                     // TODO (optionally?) Fetch content of the original post.

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -535,18 +535,7 @@ class ReutersBridge extends BridgeAbstract
 EOD;
                             break;
                         case 'youtube':
-                            $url = "https://www.youtube.com/embed/$cid";
-                            $embed .= <<<EOD
-<‌iframe
-	width="560" 
-	height="315" 
-	src="{$url}"
-	frameborder="0" 
-	allowfullscreen
-	referrerpolicy="strict-origin"
->
-</iframe>
-EOD;
+                            $embed .= handleYoutube($cid);
                             break;
                     }
                     $description .= $embed;

--- a/bridges/SteamCommunityBridge.php
+++ b/bridges/SteamCommunityBridge.php
@@ -109,11 +109,10 @@ class SteamCommunityBridge extends BridgeAbstract
             $mediaURI = $media->getAttribute('src');
             $downloadURI = $mediaURI;
 
+            $content = '';
+
             if ($category == 'videos') {
-                preg_match('/.*\/embed\/(.*)\?/', $mediaURI, $result);
-                $youtubeID = $result[1];
-                $mediaURI = 'https://img.youtube.com/vi/' . $youtubeID . '/hqdefault.jpg';
-                $downloadURI = 'https://www.youtube.com/watch?v=' . $youtubeID;
+                $content = handleYoutube($mediaURI);
             }
 
             $desc = '';
@@ -133,8 +132,12 @@ class SteamCommunityBridge extends BridgeAbstract
                 $downloadURI = $htmlCard->find('a.downloadImage', 0)->href;
             }
 
-            $item['content'] = '<p><a href="' . $downloadURI . '"><img src="' . $mediaURI . '"/></a></p>';
-            $item['content'] .= '<p>' . $desc . '</p>';
+            if (empty($content)) {
+                $content = '<p><a href="' . $downloadURI . '"><img src="' . $mediaURI . '"/></a></p>';
+                $content .= '<p>' . $desc . '</p>';
+            }
+
+            $item['content'] = $content;
 
             $this->items[] = $item;
 

--- a/bridges/TheDriveBridge.php
+++ b/bridges/TheDriveBridge.php
@@ -35,7 +35,7 @@ class TheDriveBridge extends FeedExpander
             $videoID = $youtubeVideoDiv->getAttribute('data-video-id');
 
             //place <a> around the <div>
-            $youtubeVideoDiv->outertext = '<a href="https://www.youtube.com/watch?v=' . $videoID . '">' . $youtubeVideoDiv->outertext . '</a>';
+            $youtubeVideoDiv->outertext = handleYoutube($videoID);
         }
 
         $item['content'] = $html;

--- a/bridges/WebfailBridge.php
+++ b/bridges/WebfailBridge.php
@@ -127,11 +127,7 @@ class WebfailBridge extends BridgeAbstract
             } elseif (!is_null($article->find('div.wf-video', 0))) { // Video type
                 $videoId = $this->getVideoId($article->find('div.wf-play', 0)->onclick);
                 $item['uri'] = 'https://www.youtube.com/watch?v=' . $videoId;
-                $item['content'] = '<a href="'
-                . $item['uri']
-                . '"><img src="http://img.youtube.com/vi/'
-                . $videoId
-                . '/0.jpg"></a>';
+                $item['content'] = handleYoutube($videoId);
             } elseif (!is_null($article->find('video[id*=gif-]', 0))) { // Gif type
                 $item['uri'] = $this->getURI() . $article->find('a', 2)->href;
                 $item['content'] = '<video controls src="'

--- a/bridges/YorushikaBridge.php
+++ b/bridges/YorushikaBridge.php
@@ -107,13 +107,10 @@ class YorushikaBridge extends BridgeAbstract
             $art_html = getSimpleHTMLDOMCached($url)->find('.text.inview', 0);
             $art_html = defaultLinkTo($art_html, $this->getURI());
 
-            // Check if article contains a embed YouTube video
-            $exp_youtube = '/https:\/\/[w\.]+youtube\.com\/embed\/([\w]+)/m';
-            if (preg_match($exp_youtube, $art_html, $matches)) {
-                // Replace the YouTube embed with a YouTube link
-                $yt_embed = $art_html->find('iframe[src*="youtube.com"]', 0);
-                $yt_link = sprintf('<a href="https://www.youtube.com/watch?v=%1$s">https://www.youtube.com/watch?v=%1$s</a>', $matches[1]);
-                $art_html = str_replace($yt_embed, $yt_link, $art_html);
+            // Rewrite the YouTube embed with a YouTube link
+            $yt_embed = $art_html->find('iframe[src*="youtube.com"]', 0);
+            if ($yt_embed) {
+                $yt_embed->outertext = handleYoutube($yt_embed->outertext);
             }
 
 

--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -238,10 +238,7 @@ class YouTubeCommunityTabBridge extends BridgeAbstract
                     $this->itemTitle = $this->feedName . ' posted a video';
                 }
 
-                $content = <<<EOD
-<iframe width="100%" height="410" src="https://www.youtube.com/embed/{$attachments->videoRenderer->videoId}" 
-frameborder="0" allow="encrypted-media;" allowfullscreen referrerpolicy="strict-origin"></iframe>
-EOD;
+                $content = handleYoutube($attachments->videoRenderer->videoId);
             } elseif (isset($attachments->backstageImageRenderer)) {
                 // Image
                 if (empty($this->itemTitle)) {

--- a/bridges/YouTubeFeedExpanderBridge.php
+++ b/bridges/YouTubeFeedExpanderBridge.php
@@ -76,8 +76,7 @@ class YouTubeFeedExpanderBridge extends FeedExpander
         }
         $embed = $embedURI . 'embed/' . $id;
         if ($this->getInput('embed')) {
-            $iframe_fmt = '<iframe width="448" height="350" src="%s" title="%s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin" allowfullscreen></iframe>'; //phpcs:ignore
-            $iframe = sprintf($iframe_fmt, $embed, $item['title']) . '<br>';
+            $iframe = handleYoutube($id) . '<br>';
             $item['content'] = $iframe . $item['content'];
         }
         if ($this->getInput('embedurl')) {

--- a/config.default.ini.php
+++ b/config.default.ini.php
@@ -138,6 +138,18 @@ output = "feed"
 ; Defines how often an error must occur before it is reported to the user
 report_limit = 1
 
+[youtube]
+
+; Whether to use an iframe to directly embed YouTube videos in feeds.
+; If false, a clickable video thumbnail is used instead. This avoids sending a referrer to YouTube or only getting the error 153 if suppressing the referrer browser-wide.
+iframe = true
+
+; Use the youtube-nocookie.com domain instead of youtube.com for iframe embeds.
+; Only relevant if youtube.iframe is true.
+; See the following for a description:
+; https://support.google.com/youtube/answer/171780?hl=en#zippy=%2Cturn-on-privacy-enhanced-mode
+nocookie = false
+
 ; --- Cache specific configuration ---------------------------------------------
 
 [FileCache]

--- a/docs/06_Helper_functions/index.md
+++ b/docs/06_Helper_functions/index.md
@@ -355,3 +355,20 @@ foreach ($urls as $url) {
     $lastmod = $url['lastmod'];
 }
 ```
+
+# handleYoutube(string $html): string
+
+Use this function to throw a YouTube link, iframe tag or video ID and get a HTML snippet that returns a normalized iframe tag or clickable image thumbnail, depending on system configuration.
+
+```php
+$result = handleYoutube('naYc5X6EL_Y');
+
+$result = handleYoutube('https://www.youtube.com/watch?v=naYc5X6EL_Y');
+
+$result = handleYoutube('https://www.youtube.com/embed/naYc5X6EL_Y');
+
+$iframe = '<iframe width="560" height="315" src="https://www.youtube.com/embed/naYc5X6EL_Y?si=abcdefgh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>';
+$result = handleYoutube($iframe);
+```
+
+[Defined in lib/html.php](https://github.com/RSS-Bridge/rss-bridge/blob/master/lib/html.php)


### PR DESCRIPTION
This supersedes https://github.com/RSS-Bridge/rss-bridge/pull/4786.
It unifies the display of youtube videos (where explicitly handled by the bridges).

We might want to leave the `YouTubeFeedExpanderBridge` alone, as it handles this stuff already...