### PR TITLE
[GolemBridge] Handle YouTube embed errors

### DIFF
--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -120,13 +120,15 @@ class GolemBridge extends FeedExpander
         foreach (range(0, count($placeholders) - 1) as $i) {
             foreach ($page->find('script') as $ytscript) {
                 if (preg_match_all('/(www.youtube.com.*?)\"/', $ytscript->innertext, $link)) {
-                    $link = 'https://' . str_replace('\\', '', $link[1][$i]);
-                    $placeholders[$i]->innertext .= <<<EOT
-                        <iframe width="560" height="315" src="$link" title="YouTube video player" frameborder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>';
-                    EOT;
-                    break;
+                    if (array_key_exists($i, $link[1]) && array_key_exists($i, $placeholders)) {
+                        $link = 'https://' . str_replace('\\', '', $link[1][$i]);
+                        $placeholders[$i]->innertext .= <<<EOT
+                            <iframe width="560" height="315" src="$link" title="YouTube video player" frameborder="0"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>';
+                        EOT;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Catch invalid array indexes in articles that have embeds from YouTube and other sites. The embed location in the following test article is not correct, but at least no error is thrown.

Test article: https://www.golem.de/news/stornierung-sam-altman-bekommt-anzahlung-fuer-tesla-roadster-nicht-zurueck-2511-201749.html