### PR TITLE
[GoComicsBridge] Add Chrome user agent and lowered defaults

### DIFF
--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class GoComicsBridge extends BridgeAbstract
 {
     const MAINTAINER = 'TReKiE';
@@ -24,14 +26,17 @@ class GoComicsBridge extends BridgeAbstract
             'name' => 'Limit',
             'type' => 'number',
             'title' => 'The number of recent comics to get',
-            'defaultValue' => 5
+            'defaultValue' => 2
         ]
     ]];
 
     public function collectData()
     {
         $link = $this->getURI();
-        $landingpage = getSimpleHTMLDOM($link);
+        $header = [
+            'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36'
+        ];
+        $landingpage = getSimpleHTMLDOM($link, $header);
         $element = $landingpage->find('div[data-post-url]', 0);
         if ($element) {
             $link = $element->getAttribute('data-post-url');
@@ -48,7 +53,7 @@ class GoComicsBridge extends BridgeAbstract
         }
 
         for ($i = 0; $i < $this->getInput('limit'); $i++) {
-            $html = getSimpleHTMLDOMCached($link, 86400);
+            $html = getSimpleHTMLDOMCached($link, 86400, $header);
 
             $imagelink = $html->find('meta[property="og:image"]', 0)->content;
             $parts = explode('/', $link);


### PR DESCRIPTION
GoComics has added bunny.net's Bunny Shield to their site which can block traffic.  Added a Chrome user agent to be more friendly, which avoids being blocked.  Also, lowered the default comic retrieval to 2 to avoid more traffic than needed.

Approach originally proposed by @rsd76.  Fixes #4751.