### PR TITLE
[KleinanzeigenBridge] random improvements and fixes

### DIFF
--- a/bridges/KleinanzeigenBridge.php
+++ b/bridges/KleinanzeigenBridge.php
@@ -50,6 +50,13 @@ class KleinanzeigenBridge extends BridgeAbstract
                 'type' => 'number',
                 'title' => 'how many pages to fetch',
                 'defaultValue' => 2,
+            ],
+            'buyNowEnabled' => [
+                'name' => 'buyItNow',
+                'required' => false,
+                'type' => 'checkbox',
+                'title' => 'whether Buy It Now is offered',
+                'defaultValue' => 'unchecked',
             ]
         ],
         'By profile' => [
@@ -115,7 +122,8 @@ class KleinanzeigenBridge extends BridgeAbstract
                     'categoryId' => $categoryId,
                     'pageNum' => $page,
                     'maxPrice' => $this->getInput('maxprice'),
-                    'minPrice' => $this->getInput('minprice')
+                    'minPrice' => $this->getInput('minprice'),
+                    'buyNowEnabled' => $this->getInput('buyNowEnabled'),
                 ]);
 
                 $html = getSimpleHTMLDOM($searchUrl);


### PR DESCRIPTION
Previous MR #4820 introduced a bug where the URI wasn't getting expanded. This is because it is obtained from a non-standard data-uri attribute which defaultLinkTo() doesn't support.

On top of that:
- sanitize the HTML in Content
- use a longer Description found in JSON
- fix timestamp processing, including for relative Today and Yesterday strings
- move media to enclousures
- be explicit about elements chosen to augument the description
- simplify the image URL processing