### PR TITLE
CI: Switch to ARM runners, update to Ubuntu 24.04

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   bake:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v5
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   phpcs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         php-versions: ['7.4']
@@ -24,7 +24,7 @@ jobs:
       - run: phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
 
   phpcompatibility:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         php-versions: ['7.4']
@@ -38,7 +38,7 @@ jobs:
       - run: ~/.composer/vendor/bin/phpcs . --standard=phpcompatibility.xml --warning-severity=0 --extensions=php -p
 
   executable_php_files_check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
       - run: |

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -122,7 +122,7 @@ jobs:
     name: Upload to GitHub Pages repository
     runs-on: ubuntu-latest
     needs: test-pr
-    if: needs.checks.outputs.WITH_UPLOAD == 'true'
+    if: needs.test-pr.outputs.COMMENT_LENGTH > 130 && needs.checks.outputs.WITH_UPLOAD == 'true'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   checks:
     name: Check if bridges were changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     outputs:
       BRIDGES: ${{ steps.check_bridges.outputs.BRIDGES }}
       WITH_UPLOAD: ${{ steps.check_upload.outputs.WITH_UPLOAD }}
@@ -29,7 +29,7 @@ jobs:
 
   test-pr:
     name: Generate HTML files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: checks
     if: needs.checks.outputs.BRIDGES > 0
     outputs:
@@ -91,7 +91,7 @@ jobs:
 
   comment-pr:
     name: Create or update PR comment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: test-pr
     if: needs.test-pr.outputs.COMMENT_LENGTH > 130
     permissions:
@@ -120,7 +120,7 @@ jobs:
 
   upload-test-results:
     name: Upload to GitHub Pages repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: test-pr
     if: needs.test-pr.outputs.COMMENT_LENGTH > 130 && needs.checks.outputs.WITH_UPLOAD == 'true'
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   phpunit8:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']


### PR DESCRIPTION
- Fix issue in invalid whitelist.txt entries (see https://github.com/RSS-Bridge/rss-bridge/pull/4792#issuecomment-3478187416)
- Switch to ARM runners to improve performance
- Upgrades all runners from Ubuntu 22.04 to 24.04 (this seems to work with PHP 7.4 without problems)

We can see the container building is faster. The PR HTML generator is not really ran in this PR, as no changes in bridges are made, but it should also be faster, as most of the time is spent building the container image for the PR.