### PR TITLE
Extract JWT token dynamically from Apple App Store JS bundle

### DIFF
--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -114,48 +114,26 @@ class AppleAppStoreBridge extends BridgeAbstract
         return getSimpleHTMLDOM($url);
     }
 
-    private function getJWTToken()
+    private function getAppData()
     {
-        // $html = $this->getHtml();
-        // $meta = $html->find('meta[name="web-experience-app/config/environment"]', 0);
+        // Spoof a call to get the HTML first to mimic browser behavior
+        $url = $this->makeHtmlUrl();
+        $content = getContents($url);
 
-        // if (!$meta || !isset($meta->content)) {
-        //     throw new \Exception('JWT token not found in page content');
-        // }
-
-        // $decoded_content = urldecode($meta->content);
-        // $this->debugLog('Found meta tag content');
-
-        // try {
-        //     $decoded_json = Json::decode($decoded_content);
-        // } catch (\Exception $e) {
-        //     throw new \Exception(sprintf('Failed to parse JSON from meta tag: %s', $e->getMessage()));
-        // }
-
-        // if (!isset($decoded_json['MEDIA_API']['token'])) {
-        //     throw new \Exception('Token field not found in JSON structure');
-        // }
-
-        // $token = $decoded_json['MEDIA_API']['token'];
-        // $this->debugLog('Successfully extracted JWT token');
-        
         // The above method stopped working, using a hardcoded token for now, "exp": 1769466135 (~Jan 26 2026)
         // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BDdsLoyyey.js
         $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxMzUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
-        return $token;
-    }
-
-    private function getAppData()
-    {
-        $token = $this->getJWTToken();
 
         $url = $this->makeJsonUrl();
         $this->debugLog(sprintf('Fetching data from API: %s', $url));
 
         $headers = [
+            'accept: */*',
             'Authorization: Bearer ' . $token,
+            'cache-control: no-cache',
             'Origin: https://apps.apple.com',
-            'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Referer: https://apps.apple.com/',
+            'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36w',
         ];
 
         $content = getContents($url, $headers);

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -116,18 +116,33 @@ class AppleAppStoreBridge extends BridgeAbstract
 
     private function getAppData()
     {
-        // Spoof a call to get the HTML first to mimic browser behavior
+        // Fetch the HTML page to find the JS bundle URL
         $url = $this->makeHtmlUrl();
+        $this->debugLog(sprintf('Fetching HTML page for token extraction: %s', $url));
         $content = getContents($url);
 
-        // The above method stopped working, using a hardcoded token for now, "exp": 1769466135 (~Jan 26 2026)
-        // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BMeKnrDH8T.js
+        // Extract the JS bundle path, e.g. /assets/index~BMeKnrDH8T.js
+        $matches = [];
+        if (!preg_match('#<script type="module" crossorigin src="(/assets/index~[^"]+\.js)"></script>#', $content, $matches)) {
+            throw new \Exception('Failed to locate JS bundle tag for token extraction');
+        }
 
-        // phpcs:disable Generic.Strings.UnnecessaryStringConcat.Found
-        $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.'
-            . 'eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyOTkwMTA3LCJleHAiOjE3NzAyNDc3MDcsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.'
-            . 'IrZxlIHsZBiBLZPw1UZYkyqwbPDPmzcj8U57M3w252i3A4TRzASKx2aGAoXJ0WtuNihmyyopREeVqpJlpjq0fw';
-        // phpcs:enable Generic.Strings.UnnecessaryStringConcat.Found
+        $jsPath = $matches[1];
+        $jsUrl = 'https://apps.apple.com' . $jsPath;
+        $this->debugLog(sprintf('Fetching JS bundle for token extraction: %s', $jsUrl));
+
+        // Fetch the JS bundle where the JWT is embedded
+        $jsContent = getContents($jsUrl);
+
+        // Find the JWT inside a const assignment, e.g.
+        // const SOME_NAME = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.XXXX.YYYY";
+        $tokenMatches = [];
+        if (!preg_match('#const\s+[A-Za-z0-9_$]+\s*=\s*"(eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ\.[^"\\]+)"#', $jsContent, $tokenMatches)) {
+            throw new \Exception('Failed to extract JWT token from JS bundle');
+        }
+
+        $token = $tokenMatches[1];
+        $this->debugLog('Successfully extracted JWT token from JS bundle');
 
         $url = $this->makeJsonUrl();
         $this->debugLog(sprintf('Fetching data from API: %s', $url));

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -128,8 +128,13 @@ class AppleAppStoreBridge extends BridgeAbstract
 
         // Find the JWT inside a const assignment, e.g.
         // const SOME_NAME = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.XXXX.YYYY";
+        // Match a const assignment that looks like a JWT
         $tokenMatches = [];
-        if (!preg_match('#const\s+[A-Za-z0-9_$]+\s*=\s*"(eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ\.[^"\\]+)"#', $jsContent, $tokenMatches)) {
+        if (!preg_match(
+            '#const\s+[A-Za-z0-9_$]+\s*=\s*"([A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+)"#',
+            $jsContent,
+            $tokenMatches
+        )) {
             throw new \Exception('Failed to extract JWT token from JS bundle');
         }
 

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -122,11 +122,12 @@ class AppleAppStoreBridge extends BridgeAbstract
 
         // The above method stopped working, using a hardcoded token for now, "exp": 1769466135 (~Jan 26 2026)
         // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BDdsLoyyey.js
-        
-        // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
+
+        // phpcs:disable Generic.Strings.UnnecessaryStringConcat.Found
         $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.'
             . 'eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxMzUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.'
             . 'WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
+        // phpcs:enable Generic.Strings.UnnecessaryStringConcat.Found
 
         $url = $this->makeJsonUrl();
         $this->debugLog(sprintf('Fetching data from API: %s', $url));

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -122,8 +122,11 @@ class AppleAppStoreBridge extends BridgeAbstract
 
         // The above method stopped working, using a hardcoded token for now, "exp": 1769466135 (~Jan 26 2026)
         // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BDdsLoyyey.js
-        $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxM'
-            . 'zUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
+        
+        // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
+        $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.'
+            . 'eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxMzUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.'
+            . 'WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
 
         $url = $this->makeJsonUrl();
         $this->debugLog(sprintf('Fetching data from API: %s', $url));

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -116,28 +116,32 @@ class AppleAppStoreBridge extends BridgeAbstract
 
     private function getJWTToken()
     {
-        $html = $this->getHtml();
-        $meta = $html->find('meta[name="web-experience-app/config/environment"]', 0);
+        // $html = $this->getHtml();
+        // $meta = $html->find('meta[name="web-experience-app/config/environment"]', 0);
 
-        if (!$meta || !isset($meta->content)) {
-            throw new \Exception('JWT token not found in page content');
-        }
+        // if (!$meta || !isset($meta->content)) {
+        //     throw new \Exception('JWT token not found in page content');
+        // }
 
-        $decoded_content = urldecode($meta->content);
-        $this->debugLog('Found meta tag content');
+        // $decoded_content = urldecode($meta->content);
+        // $this->debugLog('Found meta tag content');
 
-        try {
-            $decoded_json = Json::decode($decoded_content);
-        } catch (\Exception $e) {
-            throw new \Exception(sprintf('Failed to parse JSON from meta tag: %s', $e->getMessage()));
-        }
+        // try {
+        //     $decoded_json = Json::decode($decoded_content);
+        // } catch (\Exception $e) {
+        //     throw new \Exception(sprintf('Failed to parse JSON from meta tag: %s', $e->getMessage()));
+        // }
 
-        if (!isset($decoded_json['MEDIA_API']['token'])) {
-            throw new \Exception('Token field not found in JSON structure');
-        }
+        // if (!isset($decoded_json['MEDIA_API']['token'])) {
+        //     throw new \Exception('Token field not found in JSON structure');
+        // }
 
-        $token = $decoded_json['MEDIA_API']['token'];
-        $this->debugLog('Successfully extracted JWT token');
+        // $token = $decoded_json['MEDIA_API']['token'];
+        // $this->debugLog('Successfully extracted JWT token');
+        
+        // The above method stopped working, using a hardcoded token for now, "exp": 1769466135 (~Jan 26 2026)
+        // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BDdsLoyyey.js
+        $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxMzUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
         return $token;
     }
 

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -2,7 +2,7 @@
 
 class AppleAppStoreBridge extends BridgeAbstract
 {
-    const MAINTAINER = 'captn3m0';
+    const MAINTAINER = 'NohamR';
     const NAME = 'Apple App Store';
     const URI = 'https://apps.apple.com/';
     const CACHE_TIMEOUT = 3600; // 1h
@@ -27,7 +27,7 @@ class AppleAppStoreBridge extends BridgeAbstract
                 'Web'   => 'web',
                 'Apple TV'  => 'appletv',
             ],
-            'defaultValue'  => 'iphone',
+            'defaultValue'  => 'mac',
         ],
         'country'   => [
             'name'  => 'Store Country',
@@ -104,14 +104,6 @@ class AppleAppStoreBridge extends BridgeAbstract
         if ($this->getInput('debug')) {
             $this->logger->info(sprintf('[AppleAppStoreBridge] %s', $message));
         }
-    }
-
-    private function getHtml()
-    {
-        $url = $this->makeHtmlUrl();
-        $this->debugLog(sprintf('Fetching HTML from: %s', $url));
-
-        return getSimpleHTMLDOM($url);
     }
 
     private function getAppData()

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -131,14 +131,11 @@ class AppleAppStoreBridge extends BridgeAbstract
         // Match a const assignment that looks like a JWT
         // eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6 decodes to '{"alg":"ES256","typ":"JWT","kid"'
         $tokenMatches = [];
-        if (!preg_match(
-            '~const\s+\w+\s*=\s*[\'"](eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)[\'"]~',
-            $jsContent,
-            $tokenMatches
-        )) {
+        // phpcs:disable Generic.Files.LineLength
+        if (!preg_match('~const\s+\w+\s*=\s*[\'\"](eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)[\'\"]~', $jsContent, $tokenMatches)) {
             throw new \Exception('Failed to extract JWT token from JS bundle');
         }
-
+        // phpcs:enable Generic.Files.LineLength
         $token = $tokenMatches[1];
         $this->debugLog('Successfully extracted JWT token from JS bundle: ' . $token);
 

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -127,11 +127,12 @@ class AppleAppStoreBridge extends BridgeAbstract
         $jsContent = getContents($jsUrl);
 
         // Find the JWT inside a const assignment, e.g.
-        // const SOME_NAME = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.XXXX.YYYY";
+        // const SOME_NAME = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6.XXXX.YYYY";
         // Match a const assignment that looks like a JWT
+        // eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6 decodes to '{"alg":"ES256","typ":"JWT","kid"'
         $tokenMatches = [];
         if (!preg_match(
-            '#const\s+[A-Za-z0-9_$]+\s*=\s*"([A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+)"#',
+            '~const\s+\w+\s*=\s*[\'"](eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)[\'"]~',
             $jsContent,
             $tokenMatches
         )) {
@@ -139,7 +140,7 @@ class AppleAppStoreBridge extends BridgeAbstract
         }
 
         $token = $tokenMatches[1];
-        $this->debugLog('Successfully extracted JWT token from JS bundle');
+        $this->debugLog('Successfully extracted JWT token from JS bundle: ' . $token);
 
         $url = $this->makeJsonUrl();
         $this->debugLog(sprintf('Fetching data from API: %s', $url));

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -121,12 +121,12 @@ class AppleAppStoreBridge extends BridgeAbstract
         $content = getContents($url);
 
         // The above method stopped working, using a hardcoded token for now, "exp": 1769466135 (~Jan 26 2026)
-        // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BDdsLoyyey.js
+        // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BMeKnrDH8T.js
 
         // phpcs:disable Generic.Strings.UnnecessaryStringConcat.Found
         $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.'
-            . 'eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxMzUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.'
-            . 'WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
+            . 'eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyOTkwMTA3LCJleHAiOjE3NzAyNDc3MDcsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.'
+            . 'IrZxlIHsZBiBLZPw1UZYkyqwbPDPmzcj8U57M3w252i3A4TRzASKx2aGAoXJ0WtuNihmyyopREeVqpJlpjq0fw';
         // phpcs:enable Generic.Strings.UnnecessaryStringConcat.Found
 
         $url = $this->makeJsonUrl();

--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -122,7 +122,8 @@ class AppleAppStoreBridge extends BridgeAbstract
 
         // The above method stopped working, using a hardcoded token for now, "exp": 1769466135 (~Jan 26 2026)
         // This token is hardcoded in Apple's own JavaScript source code: https://apps.apple.com/assets/index~BDdsLoyyey.js
-        $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxMzUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
+        $token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlU4UlRZVjVaRFMifQ.eyJpc3MiOiI3TktaMlZQNDhaIiwiaWF0IjoxNzYyMjA4NTM1LCJleHAiOjE3Njk0NjYxM'
+            . 'zUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.WlzTtQi3vqVVcYUfRzXBSYEfvOMAFjcEhMuBPiS2gGqDEh5nPswnPkQ_H69FeXKjFsnCHahjSHVtojhNwNVU_g';
 
         $url = $this->makeJsonUrl();
         $this->debugLog(sprintf('Fetching data from API: %s', $url));


### PR DESCRIPTION
I updated the `AppleAppStoreBridge` to improve how it extracts authentication tokens for API requests. I replaced the previously hardcoded JWT token with dynamic extraction from the Apple App Store's JavaScript bundle, ensuring the bridge remains functional as token values change.