### PR TITLE
feat: optimize caching when TTL is zero

### DIFF
--- a/caches/ArrayCache.php
+++ b/caches/ArrayCache.php
@@ -25,6 +25,10 @@ class ArrayCache implements CacheInterface
 
     public function set(string $key, $value, ?int $ttl = null): void
     {
+        if ($ttl === 0) {
+            return; // TTL is 0, do nothing
+        }
+
         $this->data[$key] = [
             'key'           => $key,
             'value'         => $value,

--- a/caches/FileCache.php
+++ b/caches/FileCache.php
@@ -47,9 +47,13 @@ class FileCache implements CacheInterface
 
     public function set($key, $value, ?int $ttl = null): void
     {
+        if ($ttl === 0) {
+            return; // ttl is 0, do nothing
+        }
+
         $item = [
             'key'           => $key,
-            'expiration'    => $ttl === null ? 0 : time() + $ttl,
+            'expiration'    => $ttl === null ? 0 : time() + $ttl, // if ttl not provided, store forever
             'value'         => $value,
         ];
         $cacheFile = $this->createCacheFile($key);

--- a/caches/MemcachedCache.php
+++ b/caches/MemcachedCache.php
@@ -31,7 +31,11 @@ class MemcachedCache implements CacheInterface
 
     public function set(string $key, $value, $ttl = null): void
     {
-        $expiration = $ttl === null ? 0 : time() + $ttl;
+        if ($ttl === 0) {
+            return; // TTL is 0, do nothing
+        }
+
+        $expiration = $ttl === null ? 0 : time() + $ttl; // if ttl not provided, store forever
         $result = $this->conn->set($key, $value, $expiration);
         if ($result === false) {
             $this->logger->warning('Failed to store an item in memcached', [

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -78,9 +78,13 @@ class SQLiteCache implements CacheInterface
 
     public function set(string $key, $value, ?int $ttl = null): void
     {
+        if ($ttl === 0) {
+            return; // ttl is 0, do nothing
+        }
+
         $cacheKey = $this->createCacheKey($key);
         $blob = serialize($value);
-        $expiration = $ttl === null ? 0 : time() + $ttl;
+        $expiration = $ttl === null ? 0 : time() + $ttl; // if ttl not provided, store forever
         $stmt = $this->db->prepare('INSERT OR REPLACE INTO storage (key, value, updated) VALUES (:key, :value, :updated)');
         $stmt->bindValue(':key', $cacheKey, \SQLITE3_BLOB);
         $stmt->bindValue(':value', $blob, \SQLITE3_BLOB);

--- a/docs/01_General/05_FAQ.md
+++ b/docs/01_General/05_FAQ.md
@@ -14,9 +14,10 @@ You can specify a custom cache timeout for each bridge if
 
 ## How can I make a bridge update more frequently?
 
-You can only do that if you are hosting the RSS-Bridge instance:
-- Lower the bridge ttl: `CACHE_TIMEOUT` constant
-- Enable [`custom_timeout`](../03_For_Hosts/08_Custom_Configuration.md#customtimeout)
+You can adjust the cache TTL value only if you are hosting the RSS-Bridge instance:
+- programmatically, by adjusting the bridge's [`CACHE_TIMEOUT`](../05_Bridge_API/02_BridgeAbstract.md#Step_3_-_Add_general_constants_to_the_class) constant value;
+- by enabling the [`custom_timeout`](../03_For_Hosts/08_Custom_Configuration.md#customtimeout)
+  configuration option and using the bridge with additional [`Cache timeout in seconds`](../03_For_Hosts/07_Customizations.md#Customizable_cache_timeout) parameter.
 
 ## Firefox doesn't show feeds anymore, what can I do?
 

--- a/docs/03_For_Hosts/07_Customizations.md
+++ b/docs/03_For_Hosts/07_Customizations.md
@@ -9,6 +9,7 @@ than the bridge maintainer intended.
 In these cases the client may specify a custom cache timeout to prevent loading contents
 from cache earlier (or later).
 
-This option can be activated by setting the [`cache.custom_timeout`](08_Custom_Configuration.md#custom_timeout) option to `true`.
-When enabled each bridge receives an additional parameter `Cache timeout in seconds`
-that can be set to any value.
+This option can be activated by setting the [`cache.custom_timeout`](08_Custom_Configuration.md#custom_timeout)
+option to `true`. When enabled each bridge receives an additional parameter
+`Cache timeout in seconds` that can be set to any value. Setting the value to
+0 will altogether disable caching of that feed.

--- a/docs/05_Bridge_API/02_BridgeAbstract.md
+++ b/docs/05_Bridge_API/02_BridgeAbstract.md
@@ -68,7 +68,7 @@ const URI           // URI to the target website of the bridge (default: empty)
 const DESCRIPTION   // A brief description of the Bridge (default: "No description provided")
 const MAINTAINER    // Name of the maintainer, i.e. your name on GitHub (default: "No maintainer")
 const PARAMETERS    // (optional) Definition of additional parameters (default: empty)
-const CACHE_TIMEOUT // (optional) Defines the maximum duration for the cache in seconds (default: 3600)
+const CACHE_TIMEOUT // (optional) Defines the maximum duration for storing the cached feed result in seconds (default: 3600). 0 disables caching altogether. Note that this pertains to the feed itself, not the individual items you may want to save to/load from the cache using saveCacheValue()/loadCacheValue() helpers.
 ```
 
 <details><summary>Show example</summary><div>


### PR DESCRIPTION
Currently setting the feed's cache TTL value to 0 will still save a copy of that feed to cache
with an expiration set to now. This is needless, since it will never get a chance to be
retrieved.

This change fixes that, together with some slight optimizations based on the assumption that
TTL=0 disables caching.

It also updates the docs on caching explaining this behavior.

Depends on #4827  (rebased against here)