### PR TITLE
[PanneauPocketBridge] Refactor (Breaking Change)

### DIFF
--- a/bridges/PanneauPocketBridge.php
+++ b/bridges/PanneauPocketBridge.php
@@ -45,8 +45,8 @@ class PanneauPocketBridge extends BridgeAbstract
         }
 
         foreach ($notices as $notice) {
-            $action = $notice->find('.sign-preview__actions a.action', 0);
-            $url = $action->href ?? '';
+            $a = $notice->find('button.dropdown-item', 0);
+            $url = $a->href ?? '';
 
             if (empty($url) || !filter_var($url, FILTER_VALIDATE_URL)) {
                 continue;

--- a/bridges/PanneauPocketBridge.php
+++ b/bridges/PanneauPocketBridge.php
@@ -35,11 +35,11 @@ class PanneauPocketBridge extends BridgeAbstract
             throwServerException('Invalid city slug: ' . $citySlug);
         }
 
-        $html = getSimpleHTMLDOM($cityUrl);
+        $dom = getSimpleHTMLDOM($cityUrl);
 
-        $this->cityName = $this->extractCityName($html);
+        $this->cityName = $this->extractCityName($dom);
 
-        $notices = $html->find('div.sign-carousel--item');
+        $notices = $dom->find('div.sign-carousel--item');
         if (!is_array($notices)) {
             throwServerException('Invalid or empty content');
         }
@@ -66,19 +66,19 @@ class PanneauPocketBridge extends BridgeAbstract
         }
     }
 
-    private function extractCityName($html)
+    private function extractCityName($dom)
     {
-        $city = $html->find('.sign-preview__title .infos .city', 0);
+        $city = $dom->find('.sign-preview__title .infos .city', 0);
         if (!$city) {
-            return null;
+            return '';
         }
 
         $cityName = trim($city->plaintext);
         if ($cityName === '') {
-            return null;
+            return '';
         }
 
-        $postcode = $html->find('.sign-preview__title .infos .postcode', 0);
+        $postcode = $dom->find('.sign-preview__title .infos .postcode', 0);
         if ($postcode) {
             $postcodeValue = trim($postcode->plaintext);
             if ($postcodeValue !== '') {

--- a/bridges/PanneauPocketBridge.php
+++ b/bridges/PanneauPocketBridge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PanneauPocketBridge extends BridgeAbstract
 {
     const NAME = 'Panneau Pocket';
@@ -8,176 +10,99 @@ class PanneauPocketBridge extends BridgeAbstract
     const MAINTAINER = 'floviolleau';
     const PARAMETERS = [
         [
-            'cities' => [
-                'name' => 'Choisir une ville',
-                'type' => 'list',
-                'values' => self::CITIES,
+            'city' => [
+                'name' => 'City slug',
+                'exampleValue' => '508884409-hadol-88220',
+                'required' => true,
             ],
-            'cityName' => [
-                'name' => 'Ville',
-            ],
-            'cityId' => [
-                'name' => 'Identifiant',
-            ]
-        ]
+        ],
     ];
     const CACHE_TIMEOUT = 7200; // 2h
 
-    private const CITIES = [
-        'Andouillé-Neuville-35250' => '1455789521',
-        'Aubigné-35250' => '1814317005',
-        'Availles-sur-Seiche-35130' => '1892893207',
-        'Baulon-35580' => '605833540',
-        'Beaucé-35133' => '560906842',
-        'Boisgervilly-35360' => '1993806123',
-        'Bonnemain-35270' => '1099773691',
-        'Bonnemain - Ecole Privée Saint-Joseph-35270' => '538925534',
-        'Bonnemain - Ecole Publique Henri Matisse-35270' => '1820283844',
-        'Bourg-des-Comptes-35890' => '957084809',
-        'Breteil-35160' => '1206807553',
-        'Chanteloup-35150' => '65528978',
-        'Chavagne-35310' => '1825825704',
-        'Cintré-35310' => '857744989',
-        'Clayes-35590' => '1176604734',
-        'Comblessac-35330' => '799252614',
-        'Compagnie de Gendarmerie de Montfort-sur-Meu-35160' => '1310467096',
-        'Compagnie de Gendarmerie de Redon-35600' => '772555117',
-        'Compagnie de Gendarmerie de Saint-Malo-35400' => '212942271',
-        'Compagnie de Gendarmerie de Vitré-35500' => '2117121991',
-        'Dingé-35440' => '1146475327',
-        'Feins-35440' => '762081007',
-        'Gahard-35490' => '858141102',
-        'Gendarmerie BTA de Bain-de-Bretagne-35470' => '2125697119',
-        'Gendarmerie BTA de Mordelles-35310' => '1915843207',
-        'Gendarmerie BTA de Saint-Aubin-du-Cormier-35140' => '1325843950',
-        'Gendarmerie BTA de Vitré-35500' => '898672661',
-        'Gendarmerie BTA Maen-Roch-35460' => '1096873908',
-        'Gendarmerie COB Cancale-35260' => '1992410402',
-        'Gendarmerie COB de Chateaugiron-35410' => '1867528169',
-        'Gendarmerie COB de Combourg-35270' => '1045617593',
-        'Gendarmerie COB de Fougères-35300' => '177248581',
-        'Gendarmerie COB de Guichen-35580' => '557627842',
-        'Gendarmerie COB de Hédé-Bazouges-35630' => '519881302',
-        'Gendarmerie COB de Janzé-35150' => '533620097',
-        'Gendarmerie COB de La Guerche-de-Bretagne-35130' => '1282120307',
-        'Gendarmerie COB de Montauban de Bretagne-35360' => '137692263',
-        'Gendarmerie COB de Redon-35600' => '1027850906',
-        'Gendarmerie de Betton-35830' => '307605625',
-        'Gosné-35140' => '1261503624',
-        'Grand-Fougeray-35390' => '1687416796',
-        'Guignen-35580' => '75195882',
-        'L\'Hermitage-35590' => '1954292633',
-        'La Boussac-35120' => '162444335',
-        'La Chapelle-Bouëxic-35330' => '869117325',
-        'La Couyère-35320' => '2075958825',
-        'La Dominelais-35390' => '2065081911',
-        'La Fresnais-35111' => '2010636370',
-        'La Gouesnière-35350' => '1925923421',
-        'La Noé-Blanche-35470' => '224305391',
-        'La Nouaye-35137' => '1000733211',
-        'Lalleu-35320' => '1460101917',
-        'Landavran-35450' => '133549915',
-        'Langouet-35630' => '1523560503',
-        'Le Ferré-35420' => '1432943983',
-        'Le Verger-35160' => '1266074746',
-        'Les Brulais-35330' => '1854147921',
-        'Les Portes du Coglais-35460' => '413267621',
-        'Livré-sur-Changeon-35450' => '1850101087',
-        'Louvigné-de-Bais-35680' => '1676392257',
-        'Louvigné-de-Bais - Ecole Charles Perrault-35680' => '1180505145',
-        'Louvigné-de-Bais - Ecole Saint-Patern-35680' => '919443746',
-        'Maen Roch-35460' => '1112477040',
-        'Maison de Quartier Francisco Ferrer-35200' => '944171353',
-        'Marcillé-Raoul-35560' => '991970696',
-        'Maxent-35380' => '209041860',
-        'Meillac-35270' => '1841968856',
-        'Mernel-35330' => '1311137811',
-        'Monterfil-35160' => '873169651',
-        'Montreuil-sur-Ille-35440' => '550764994',
-        'Mouazé-35250' => '1931390548',
-        'Moutiers-35130' => '443526227',
-        'Parigné-35133' => '2013041755',
-        'Pleugueneuc-35720' => '748287926',
-        'Princé-35210' => '1765498088',
-        'Rives-du-Couesnon-35140' => '1609662849',
-        'Saint-Aubin-des-Landes-35500' => '1483721395',
-        'Saint-Germain-du-Pinel-35370' => '1357547548',
-        'Saint-Gonlay-35750' => '711639882',
-        'Saint-Péran-35380' => '1484951371',
-        'Saint-Séglin-35330' => '292665012',
-        'Saint-Thual-35190' => '427165321',
-        'Saint-Thurial-35310' => '940529156',
-        'Sens-de-Bretagne-35490' => '1055647650',
-        'Thourie-35134' => '1250885948',
-        'Torcé-35370' => '1927215543',
-        'Treffendel-35380' => '738532467',
-        'Val d\'Anast-35330' => '225564233',
-        'Vallons de Haute Bretagne Communauté-35580' => '1319050928',
-        'Vergéal-35680' => '389815752',
-        'Vieux-Vy-sur-Couesnon-35490' => '2016313694'
-    ];
+    private $cityName = '';
+
+    public function getName()
+    {
+        return $this->cityName !== '' ? $this->cityName : self::NAME;
+    }
 
     public function collectData()
     {
-        $cityId = $this->getInput('cityId');
-        if ($cityId != null) {
-            $cityName = $this->getInput('cityName');
-            $city = strtolower($cityId . '-' . $cityName);
-        } else {
-            $matchedCity = array_search($this->getInput('cities'), self::CITIES);
-            $city = strtolower($this->getInput('cities') . '-' . $matchedCity);
+        $citySlug = $this->getInput('city');
+        $cityUrl = self::URI . '/ville/' . $citySlug;
+
+        if (!filter_var($cityUrl, FILTER_VALIDATE_URL)) {
+            throwServerException('Invalid city slug: ' . $citySlug);
         }
-        $url = sprintf('https://app.panneaupocket.com/ville/%s', urlencode($city));
 
-        $html = getSimpleHTMLDOM($url);
+        $html = getSimpleHTMLDOM($cityUrl);
 
-        foreach ($html->find('.sign-carousel--item') as $itemDom) {
-            $item = [];
+        $this->cityName = $this->extractCityName($html);
 
-            $item['uri'] = $itemDom->find('button[type=button]', 0)->href;
-            $item['title'] = $itemDom->find('.sign-preview__content .title', 0)->innertext;
-            $item['author'] = 'floviolleau';
-            $item['content'] = $itemDom->find('.sign-preview__content .content', 0)->innertext;
+        $notices = $html->find('div.sign-carousel--item');
+        if (!is_array($notices)) {
+            throwServerException('Invalid or empty content');
+        }
 
-            $timestamp = $itemDom->find('span.date', 0)->plaintext;
-            if (preg_match('#(?<d>[0-9]+)/(?<m>[0-9]+)/(?<y>[0-9]+)#', $timestamp, $match)) {
-                $item['timestamp'] = "{$match['y']}-{$match['m']}-{$match['d']}";
+        foreach ($notices as $notice) {
+            $action = $notice->find('.sign-preview__actions a.action', 0);
+            $url = $action->href ?? '';
+
+            if (empty($url) || !filter_var($url, FILTER_VALIDATE_URL)) {
+                continue;
             }
 
-            $this->items[] = $item;
+            $title = $notice->find('.sign-preview__content .title', 0);
+            $content = $notice->find('.sign-preview__content .content', 0);
+            $date = $notice->find('span.date', 0);
+
+            $this->items[] = [
+                'uid' => $url,
+                'uri' => $url,
+                'title' => $title ? trim($title->plaintext) : '',
+                'timestamp' => $date ? $this->extractDate($date->plaintext) : '',
+                'content' => $content ? sanitize($content->innertext) : '',
+            ];
         }
     }
 
-    public function detectParameters($url)
+    private function extractCityName($html)
     {
-        $params = [];
-        $regex = '/\/ville\/(\d+)-([a-z0-9-]+)/';
-        if (preg_match($regex, $url, $matches)) {
-            $params['cityId'] = $matches[1];
-            $params['cityName'] = $matches[2];
-            return $params;
+        $city = $html->find('.sign-preview__title .infos .city', 0);
+        if (!$city) {
+            return null;
         }
-        return null;
-    }
 
-    /**
-     * Produce self::CITIES array
-     */
-    private static function getCities($zipcodeStartWith)
-    {
-        $cities = json_decode(getContents(self::URI . '/public-api/city'), true);
+        $cityName = trim($city->plaintext);
+        if ($cityName === '') {
+            return null;
+        }
 
-        $formattedCities = null;
-        $citiesString = '[<br>';
-        foreach ($cities as $city) {
-            if (str_starts_with($city['postCode'], $zipcodeStartWith)) {
-                $formattedCities[$city['name'] . ' - ' . $city['postCode']] = $city['id'];
-                $citiesString .= '    "' . $city['name'] . '-' . $city['postCode'] . '" => "' . $city['id'] . '",';
-                $citiesString .= '<br>';
+        $postcode = $html->find('.sign-preview__title .infos .postcode', 0);
+        if ($postcode) {
+            $postcodeValue = trim($postcode->plaintext);
+            if ($postcodeValue !== '') {
+                return $cityName . ' - ' . $postcodeValue;
             }
         }
-        $citiesString .= ']';
-        echo '<pre>' . $citiesString . '</pre>';
-        die();
+
+        return $cityName;
+    }
+
+    private function extractDate($text)
+    {
+        $text = trim($text);
+
+        if (!preg_match('~(\d{2})/(\d{2})/(\d{4})$~', $text, $match)) {
+            return '';
+        }
+
+        [, $day, $month, $year] = $match;
+
+        if (!checkdate((int)$month, (int)$day, (int)$year)) {
+            return '';
+        }
+
+        return mktime(0, 0, 0, (int)$month, (int)$day, (int)$year);
     }
 }


### PR DESCRIPTION
This refactor removes the previously hardcoded city value and replaces it
with a dynamic `city` parameter that expects the full city slug.

Example:
508884409-hadol-88220  
(from https://app.panneaupocket.com/ville/508884409-hadol-88220)

Reason:
- Restores flexibility by allowing the bridge to work with any PanneauPocket city.

close #3660 #4362 