### PR TITLE
fix(cache): cache was still saved with 0 TTL value

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -55,7 +55,7 @@ class DisplayAction implements ActionInterface
 
         if ($response->getCode() === 200) {
             $ttl = $request->get('_cache_timeout');
-            if (Configuration::getConfig('cache', 'custom_timeout') && $ttl) {
+            if (Configuration::getConfig('cache', 'custom_timeout') && isset($ttl)) {
                 $ttl = (int) $ttl;
             } else {
                 $ttl = $bridge->getCacheTimeout();


### PR DESCRIPTION
Since the $ttl may actually be of 0 value, need to use isset() to check if _cache_timeout was passed over as a request parameter.