### PR TITLE
[gitignore] Ignore favicon files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,8 @@ config/*
 !config/nginx.conf
 !config/php-fpm.conf
 !config/php.ini
+favicon.gif
+favicon.ico
 
 ######################
 ## VisualStudioCode ##


### PR DESCRIPTION
There can be times that you want to supply your own favicon file within the root. This ignores those in git so that it doesn't show up with a `git status`.