### PR TITLE
[BundestagParteispendenBridge] Fix bridge after URL change

### DIFF
--- a/bridges/BundestagParteispendenBridge.php
+++ b/bridges/BundestagParteispendenBridge.php
@@ -27,7 +27,7 @@ TMPL;
         // Get the main page
         $html = getSimpleHTMLDOMCached($ajaxUri, self::CACHE_TIMEOUT);
 
-        // Apply default base URL for relative links 
+        // Apply default base URL for relative links
         defaultLinkTo($html, $this->getURI());
 
         // Build the URL from the first anchor element. The list is sorted by year, descending, so the first element is the current year.

--- a/bridges/BundestagParteispendenBridge.php
+++ b/bridges/BundestagParteispendenBridge.php
@@ -23,16 +23,20 @@ TMPL;
     public function collectData()
     {
         $ajaxUri = <<<URI
-https://www.bundestag.de/ajax/filterlist/de/parlament/praesidium/parteienfinanzierung/fundstellen50000/462002-462002
+https://www.bundestag.de/parlament/praesidium/parteienfinanzierung/fundstellen50000
 URI;
         // Get the main page
         $html = getSimpleHTMLDOMCached($ajaxUri, self::CACHE_TIMEOUT);
 
         // Build the URL from the first anchor element. The list is sorted by year, descending, so the first element is the current year.
-        $firstAnchor = $html->find('a', 0)
+        $firstAnchor = $html->find('a.e-linkListItem__anchor', 0)
             or throwServerException('Could not find the proper HTML element.');
 
         $url = $firstAnchor->href;
+
+        if (substr($url, 0, 1) === '/') {
+            $url = 'https://www.bundestag.de' . $url;
+        }
 
         // Get the actual page with the soft money donations
         $html = getSimpleHTMLDOMCached($url, self::CACHE_TIMEOUT);

--- a/bridges/BundestagParteispendenBridge.php
+++ b/bridges/BundestagParteispendenBridge.php
@@ -22,11 +22,13 @@ TMPL;
 
     public function collectData()
     {
-        $ajaxUri = <<<URI
-https://www.bundestag.de/parlament/praesidium/parteienfinanzierung/fundstellen50000
-URI;
+        $ajaxUri = self::URI;
+
         // Get the main page
         $html = getSimpleHTMLDOMCached($ajaxUri, self::CACHE_TIMEOUT);
+
+        // Apply default base URL for relative links 
+        defaultLinkTo($html, $this->getURI());
 
         // Build the URL from the first anchor element. The list is sorted by year, descending, so the first element is the current year.
         $firstAnchor = $html->find('a.e-linkListItem__anchor', 0)
@@ -34,12 +36,10 @@ URI;
 
         $url = $firstAnchor->href;
 
-        if (substr($url, 0, 1) === '/') {
-            $url = 'https://www.bundestag.de' . $url;
-        }
-
         // Get the actual page with the soft money donations
         $html = getSimpleHTMLDOMCached($url, self::CACHE_TIMEOUT);
+
+        defaultLinkTo($html, $url);
 
         $rows = $html->find('table.table > tbody > tr')
             or throwServerException('Could not find the proper HTML elements.');


### PR DESCRIPTION
Solves:

```
HttpException: https://www.bundestag.de/ajax/filterlist/de/parlament/praesidium/parteienfinanzierung/fundstellen50000/462002-462002 resulted in 400 Bad Request in lib/http.php line 34

index.php(73): RssBridge->main()
lib/RssBridge.php(39): RssBridge->{closure}()
lib/RssBridge.php(37): BasicAuthMiddleware->__invoke()
middlewares/BasicAuthMiddleware.php(13): RssBridge->{closure}()
lib/RssBridge.php(37): CacheMiddleware->__invoke()
middlewares/CacheMiddleware.php(44): RssBridge->{closure}()
lib/RssBridge.php(37): ExceptionMiddleware->__invoke()
middlewares/ExceptionMiddleware.php(17): RssBridge->{closure}()
lib/RssBridge.php(37): SecurityMiddleware->__invoke()
middlewares/SecurityMiddleware.php(19): RssBridge->{closure}()
lib/RssBridge.php(37): MaintenanceMiddleware->__invoke()
middlewares/MaintenanceMiddleware.php(10): RssBridge->{closure}()
lib/RssBridge.php(37): TokenAuthenticationMiddleware->__invoke()
middlewares/TokenAuthenticationMiddleware.php(10): RssBridge->{closure}()
lib/RssBridge.php(34): DisplayAction->__invoke()
actions/DisplayAction.php(54): DisplayAction->createResponse()
actions/DisplayAction.php(89): BundestagParteispendenBridge->collectData()
bridges/BundestagParteispendenBridge.php(29): getSimpleHTMLDOMCached()
lib/contents.php(240): getContents()
lib/contents.php(131): HttpException::fromResponse()
lib/http.php(34)
```