### PR TITLE
[EpicGamesFreeBridge] Fix enclosures as images

### DIFF
--- a/bridges/EpicGamesFreeBridge.php
+++ b/bridges/EpicGamesFreeBridge.php
@@ -69,7 +69,7 @@ class EpicGamesFreeBridge extends BridgeAbstract
             $item = [
                 'author' => $element['seller']['name'],
                 'content' => $element['description'],
-                'enclosures' => array_map(fn($item) => $item['url'], $element['keyImages']),
+                'enclosures' => array_map(fn($item) => $item['url'] . '#.image', $element['keyImages']), // Force image usage.
                 'timestamp' => strtotime($promo['startDate']),
                 'title' => $element['title'],
                 'uri' => $uri,


### PR DESCRIPTION
The Epic Games Free Bridge was listing the enclosures as streams. They're actually images, so we can append `#.image` to force them as images.
