### PR TITLE
[SchweinfurtBuergerinformationenBridge] Fixes missing hostname in links.

### DIFF
--- a/bridges/SchweinfurtBuergerinformationenBridge.php
+++ b/bridges/SchweinfurtBuergerinformationenBridge.php
@@ -74,12 +74,21 @@ class SchweinfurtBuergerinformationenBridge extends BridgeAbstract
         $div = $html->find('div#artikel-detail', 0);
         $divContent = $div->find('.c-content', 0);
         $images = $divContent->find('img');
+        $links = $divContent->find('a');
 
         // Every external link has a little arrow symbol image attached to it.
         // Remove this image. This has to be done before building $content.
         foreach ($images as $image) {
             if ($image->class == 'imgextlink') {
                 $image->outertext = '';
+            }
+        }
+
+        // If a link is missing a host, prefix the URL with the base URL
+        foreach($links as $link) {
+            if (parse_url($link->href, PHP_URL_HOST) == NULL) {
+                    $prefix = substr(self::URI, 0, strrpos(self::URI, '/') + 1);
+                    $link->href = $prefix . $link->href;
             }
         }
 

--- a/bridges/SchweinfurtBuergerinformationenBridge.php
+++ b/bridges/SchweinfurtBuergerinformationenBridge.php
@@ -74,7 +74,6 @@ class SchweinfurtBuergerinformationenBridge extends BridgeAbstract
         $div = $html->find('div#artikel-detail', 0);
         $divContent = $div->find('.c-content', 0);
         $images = $divContent->find('img');
-        $links = $divContent->find('a');
 
         // Every external link has a little arrow symbol image attached to it.
         // Remove this image. This has to be done before building $content.
@@ -84,13 +83,8 @@ class SchweinfurtBuergerinformationenBridge extends BridgeAbstract
             }
         }
 
-        // If a link is missing a host, prefix the URL with the base URL
-        foreach ($links as $link) {
-            if (parse_url($link->href, PHP_URL_HOST) == null) {
-                    $prefix = substr(self::URI, 0, strrpos(self::URI, '/') + 1);
-                    $link->href = $prefix . $link->href;
-            }
-        }
+        // Make relative URLs in content container absolute
+        defaultLinkTo($divContent, self::URI);
 
         $title = $div->find('.c-title', 0)->innertext;
         $teaser = $div->find('.c-teaser', 0)->innertext;

--- a/bridges/SchweinfurtBuergerinformationenBridge.php
+++ b/bridges/SchweinfurtBuergerinformationenBridge.php
@@ -85,8 +85,8 @@ class SchweinfurtBuergerinformationenBridge extends BridgeAbstract
         }
 
         // If a link is missing a host, prefix the URL with the base URL
-        foreach($links as $link) {
-            if (parse_url($link->href, PHP_URL_HOST) == NULL) {
+        foreach ($links as $link) {
+            if (parse_url($link->href, PHP_URL_HOST) == null) {
                     $prefix = substr(self::URI, 0, strrpos(self::URI, '/') + 1);
                     $link->href = $prefix . $link->href;
             }


### PR DESCRIPTION
Sometimes anchors are given with no hostname (relative links). Add the hostname in this cases.