### PR TITLE
[HeiseBridge] Include figure captions

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -230,7 +230,8 @@ class HeiseBridge extends FeedExpander
         $content = $article->find('.article-content', 0);
         if ($content) {
             $contentElements = $content->find(
-                'p, h3, ul, ol, table, pre, noscript img, a-bilderstrecke h2, a-bilderstrecke figure, a-bilderstrecke figcaption, noscript iframe'
+                // phpcs:ignore
+                'p, h3, ul, ol, table, pre, noscript img, noscript iframe, a-bilderstrecke h2, a-bilderstrecke figure, a-bilderstrecke figcaption, figure figcaption.a-caption div.text'
             );
             $item['content'] .= implode('', $contentElements);
         }


### PR DESCRIPTION
Previously, the article [1] lacked the figure caption: "Will man nicht in einem PGP-Schlüssel entdecken: Heimlich dechiffrierter Klartext, der an den angeblichen Schlüsselserver übertragen würde."

This commit adds such captions.

[1] https://www.heise.de/hintergrund/Kritik-an-GnuPG-und-seinem-Umgang-mit-gemeldeten-Luecken-11132888.html?seite=all