### PR TITLE
Remove "Bridge" suffix from the names

### DIFF
--- a/bridges/ABCNewsBridge.php
+++ b/bridges/ABCNewsBridge.php
@@ -2,7 +2,7 @@
 
 class ABCNewsBridge extends BridgeAbstract
 {
-    const NAME = 'ABC News Bridge';
+    const NAME = 'ABC News';
     const URI = 'https://www.abc.net.au';
     const DESCRIPTION = 'Topics of the Australian Broadcasting Corporation';
     const MAINTAINER = 'yue-dongchen';

--- a/bridges/ARDAudiothekBridge.php
+++ b/bridges/ARDAudiothekBridge.php
@@ -2,7 +2,7 @@
 
 class ARDAudiothekBridge extends BridgeAbstract
 {
-    const NAME = 'ARD-Audiothek Bridge';
+    const NAME = 'ARD-Audiothek';
     const URI = 'https://www.ardaudiothek.de';
     const DESCRIPTION = 'Feed of any show in the ARD-Audiothek, specified by its path';
     const MAINTAINER = 'Mar-Koeh';

--- a/bridges/ARDMediathekBridge.php
+++ b/bridges/ARDMediathekBridge.php
@@ -2,7 +2,7 @@
 
 class ARDMediathekBridge extends BridgeAbstract
 {
-    const NAME = 'ARD-Mediathek Bridge';
+    const NAME = 'ARD-Mediathek';
     const URI = 'https://www.ardmediathek.de';
     const DESCRIPTION = 'Feed of any series in the ARD-Mediathek, specified by its path';
     const MAINTAINER = 'yue-dongchen';

--- a/bridges/ASRockNewsBridge.php
+++ b/bridges/ASRockNewsBridge.php
@@ -2,7 +2,7 @@
 
 class ASRockNewsBridge extends BridgeAbstract
 {
-    const NAME = 'ASRock News Bridge';
+    const NAME = 'ASRock News';
     const URI = 'https://www.asrock.com';
     const DESCRIPTION = 'Returns latest news articles';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/AcrimedBridge.php
+++ b/bridges/AcrimedBridge.php
@@ -3,7 +3,7 @@
 class AcrimedBridge extends FeedExpander
 {
     const MAINTAINER = 'qwertygc';
-    const NAME = 'Acrimed Bridge';
+    const NAME = 'Acrimed';
     const URI = 'https://www.acrimed.org/';
     const CACHE_TIMEOUT = 4800; //2hours
     const DESCRIPTION = 'Returns the newest articles';

--- a/bridges/AllocineFRBridge.php
+++ b/bridges/AllocineFRBridge.php
@@ -3,7 +3,7 @@
 class AllocineFRBridge extends BridgeAbstract
 {
     const MAINTAINER = 'superbaillot.net';
-    const NAME = 'Allo Cine Bridge';
+    const NAME = 'Allo Cine';
     const CACHE_TIMEOUT = 25200; // 7h
     const URI = 'https://www.allocine.fr';
     const DESCRIPTION = 'Bridge for allocine.fr';

--- a/bridges/AllocineFRSortiesBridge.php
+++ b/bridges/AllocineFRSortiesBridge.php
@@ -3,7 +3,7 @@
 class AllocineFRSortiesBridge extends BridgeAbstract
 {
     const MAINTAINER = 'Simounet';
-    const NAME = 'AlloCiné Sorties Bridge';
+    const NAME = 'AlloCiné Sorties';
     const CACHE_TIMEOUT = 25200; // 7h
     const BASE_URI = 'https://www.allocine.fr';
     const URI = self::BASE_URI . '/film/sorties-semaine/';

--- a/bridges/AnimeUltimeBridge.php
+++ b/bridges/AnimeUltimeBridge.php
@@ -125,7 +125,7 @@ class AnimeUltimeBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('type'))) {
-            return 'Latest ' . $this->getKey('type') . ' - Anime-Ultime Bridge';
+            return 'Latest ' . $this->getKey('type') . ' - Anime-Ultime';
         }
 
         return parent::getName();

--- a/bridges/AssociatedPressNewsBridge.php
+++ b/bridges/AssociatedPressNewsBridge.php
@@ -2,7 +2,7 @@
 
 class AssociatedPressNewsBridge extends BridgeAbstract
 {
-    const NAME = 'Associated Press News Bridge';
+    const NAME = 'Associated Press News';
     const URI = 'https://apnews.com/';
     const DESCRIPTION = 'Returns newest articles by topic';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/BAEBridge.php
+++ b/bridges/BAEBridge.php
@@ -3,7 +3,7 @@
 class BAEBridge extends BridgeAbstract
 {
     const MAINTAINER = 'couraudt';
-    const NAME = 'Bourse Aux Equipiers Bridge';
+    const NAME = 'Bourse Aux Equipiers';
     const URI = 'https://www.bourse-aux-equipiers.com';
     const DESCRIPTION = 'Returns the newest sailing offers.';
     const PARAMETERS = [

--- a/bridges/BadDragonBridge.php
+++ b/bridges/BadDragonBridge.php
@@ -2,7 +2,7 @@
 
 class BadDragonBridge extends BridgeAbstract
 {
-    const NAME = 'Bad Dragon Bridge';
+    const NAME = 'Bad Dragon';
     const URI = 'https://bad-dragon.com/';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Returns sales or new clearance items';

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -3,7 +3,7 @@
 class BandcampBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sebsauvage, Roliga';
-    const NAME = 'Bandcamp Bridge';
+    const NAME = 'Bandcamp';
     const URI = 'https://bandcamp.com/';
     const CACHE_TIMEOUT = 600; // 10min
     const DESCRIPTION = 'New bandcamp releases by tag, band or album';

--- a/bridges/BandcampDailyBridge.php
+++ b/bridges/BandcampDailyBridge.php
@@ -2,7 +2,7 @@
 
 class BandcampDailyBridge extends BridgeAbstract
 {
-    const NAME = 'Bandcamp Daily Bridge';
+    const NAME = 'Bandcamp Daily';
     const URI = 'https://daily.bandcamp.com';
     const DESCRIPTION = 'Returns newest articles';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/BastaBridge.php
+++ b/bridges/BastaBridge.php
@@ -3,7 +3,7 @@
 class BastaBridge extends BridgeAbstract
 {
     const MAINTAINER = 'qwertygc';
-    const NAME = 'Bastamag Bridge';
+    const NAME = 'Bastamag';
     const URI = 'https://www.bastamag.net/';
     const CACHE_TIMEOUT = 7200; // 2h
     const DESCRIPTION = 'Returns the newest articles.';

--- a/bridges/BazarakiBridge.php
+++ b/bridges/BazarakiBridge.php
@@ -2,7 +2,7 @@
 
 class BazarakiBridge extends BridgeAbstract
 {
-    const NAME = 'Bazaraki Bridge';
+    const NAME = 'Bazaraki';
     const URI = 'https://bazaraki.com';
     const DESCRIPTION = 'Fetch adverts from Bazaraki, a Cyprus-based classifieds website.';
     const MAINTAINER = 'danwain';

--- a/bridges/BlueskyBridge.php
+++ b/bridges/BlueskyBridge.php
@@ -4,7 +4,7 @@ class BlueskyBridge extends BridgeAbstract
 {
     //Initial PR by [RSSBridge contributors](https://github.com/RSS-Bridge/rss-bridge/issues/4058).
     //Modified from [©DIYgod and contributors at RSSHub](https://github.com/DIYgod/RSSHub/tree/master/lib/routes/bsky), MIT License';
-    const NAME = 'Bluesky Bridge';
+    const NAME = 'Bluesky';
     const URI = 'https://bsky.app';
     const DESCRIPTION = 'Fetches posts from Bluesky';
     const MAINTAINER = 'mruac';

--- a/bridges/BookMyShowBridge.php
+++ b/bridges/BookMyShowBridge.php
@@ -3,7 +3,7 @@
 class BookMyShowBridge extends BridgeAbstract
 {
     const MAINTAINER = 'captn3m0';
-    const NAME = 'BookMyShow Bridge';
+    const NAME = 'BookMyShow';
     const URI = 'https://in.bookmyshow.com';
     const MOVIES_IMAGE_BASE_FORMAT = 'https://in.bmscdn.com/iedb/movies/images/mobile/thumbnail/large/%s.jpg';
     const DESCRIPTION = 'Returns the latest events on BookMyShow';

--- a/bridges/BrutBridge.php
+++ b/bridges/BrutBridge.php
@@ -2,7 +2,7 @@
 
 class BrutBridge extends BridgeAbstract
 {
-    const NAME = 'Brut Bridge';
+    const NAME = 'Brut';
     const URI = 'https://www.brut.media';
     const DESCRIPTION = 'Returns 10 newest videos by category and edition';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/BugzillaBridge.php
+++ b/bridges/BugzillaBridge.php
@@ -2,7 +2,7 @@
 
 class BugzillaBridge extends BridgeAbstract
 {
-    const NAME = 'Bugzilla Bridge';
+    const NAME = 'Bugzilla';
     const URI = 'https://www.bugzilla.org/';
     const DESCRIPTION = 'Bridge for any Bugzilla instance';
     const MAINTAINER = 'Yaman Qalieh';

--- a/bridges/BundesbankBridge.php
+++ b/bridges/BundesbankBridge.php
@@ -7,7 +7,7 @@ class BundesbankBridge extends BridgeAbstract
     const LANG_EN = 'en';
     const LANG_DE = 'de';
 
-    const NAME = 'Bundesbank Bridge';
+    const NAME = 'Bundesbank';
     const URI = 'https://www.bundesbank.de/';
     const DESCRIPTION = 'Returns the latest studies of the Bundesbank (Germany)';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/CachetBridge.php
+++ b/bridges/CachetBridge.php
@@ -2,7 +2,7 @@
 
 class CachetBridge extends BridgeAbstract
 {
-    const NAME = 'Cachet Bridge';
+    const NAME = 'Cachet';
     const URI = 'https://cachethq.io/';
     const DESCRIPTION = 'Returns status updates from any Cachet installation';
     const MAINTAINER  = 'klimplant';

--- a/bridges/CaschyBridge.php
+++ b/bridges/CaschyBridge.php
@@ -3,7 +3,7 @@
 class CaschyBridge extends FeedExpander
 {
     const MAINTAINER = 'Tone866';
-    const NAME = 'Caschys Blog Bridge';
+    const NAME = 'Caschys Blog';
     const URI = 'https://stadt-bremerhaven.de/';
     const CACHE_TIMEOUT = 1800; // 30min
     const DESCRIPTION = 'Returns the full articles instead of only the intro';

--- a/bridges/CastorusBridge.php
+++ b/bridges/CastorusBridge.php
@@ -3,7 +3,7 @@
 class CastorusBridge extends BridgeAbstract
 {
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'Castorus Bridge';
+    const NAME = 'Castorus';
     const URI = 'https://www.castorus.com';
     const CACHE_TIMEOUT = 600; // 10min
     const DESCRIPTION = 'Returns the latest changes';

--- a/bridges/CdactionBridge.php
+++ b/bridges/CdactionBridge.php
@@ -2,7 +2,7 @@
 
 class CdactionBridge extends BridgeAbstract
 {
-    const NAME = 'CD-ACTION bridge';
+    const NAME = 'CD-ACTION';
     const URI = 'https://cdaction.pl';
     const DESCRIPTION = 'Fetches the latest posts from given category.';
     const MAINTAINER = 'tomaszkane';

--- a/bridges/CeskaTelevizeBridge.php
+++ b/bridges/CeskaTelevizeBridge.php
@@ -2,7 +2,7 @@
 
 class CeskaTelevizeBridge extends BridgeAbstract
 {
-    const NAME = 'Česká televize Bridge';
+    const NAME = 'Česká televize';
     const URI = 'https://www.ceskatelevize.cz';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'Return newest videos';

--- a/bridges/CodebergBridge.php
+++ b/bridges/CodebergBridge.php
@@ -2,7 +2,7 @@
 
 class CodebergBridge extends BridgeAbstract
 {
-    const NAME = 'Codeberg Bridge';
+    const NAME = 'Codeberg';
     const URI = 'https://codeberg.org/';
     const DESCRIPTION = 'Returns commits, issues, pull requests or releases for a repository.';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/CommonDreamsBridge.php
+++ b/bridges/CommonDreamsBridge.php
@@ -3,7 +3,7 @@
 class CommonDreamsBridge extends FeedExpander
 {
     const MAINTAINER = 'nyutag';
-    const NAME = 'CommonDreams Bridge';
+    const NAME = 'CommonDreams';
     const URI = 'https://www.commondreams.org/';
     const DESCRIPTION = 'Returns the newest articles.';
 

--- a/bridges/CourrierInternationalBridge.php
+++ b/bridges/CourrierInternationalBridge.php
@@ -3,7 +3,7 @@
 class CourrierInternationalBridge extends FeedExpander
 {
     const MAINTAINER = 'teromene';
-    const NAME = 'Courrier International Bridge';
+    const NAME = 'Courrier International';
     const URI = 'https://www.courrierinternational.com/';
     const CACHE_TIMEOUT = 300; // 5 min
     const DESCRIPTION = 'Returns the newest articles';

--- a/bridges/CraigslistBridge.php
+++ b/bridges/CraigslistBridge.php
@@ -2,7 +2,7 @@
 
 class CraigslistBridge extends BridgeAbstract
 {
-    const NAME = 'Craigslist Bridge';
+    const NAME = 'Craigslist';
     const URI = 'https://craigslist.org/';
     const DESCRIPTION = 'Returns craigslist search results';
 

--- a/bridges/CrewbayBridge.php
+++ b/bridges/CrewbayBridge.php
@@ -3,7 +3,7 @@
 class CrewbayBridge extends BridgeAbstract
 {
     const MAINTAINER = 'couraudt';
-    const NAME = 'Crewbay Bridge';
+    const NAME = 'Crewbay';
     const URI = 'https://www.crewbay.com';
     const DESCRIPTION = 'Returns the newest sailing offers.';
     const PARAMETERS = [

--- a/bridges/CssSelectorBridge.php
+++ b/bridges/CssSelectorBridge.php
@@ -3,7 +3,7 @@
 class CssSelectorBridge extends BridgeAbstract
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'CSS Selector Bridge';
+    const NAME = 'CSS Selector';
     const URI = 'https://github.com/RSS-Bridge/rss-bridge/';
     const DESCRIPTION = 'Convert any site to RSS feed using CSS selectors (Advanced Users)';
     const PARAMETERS = [

--- a/bridges/CssSelectorComplexBridge.php
+++ b/bridges/CssSelectorComplexBridge.php
@@ -3,7 +3,7 @@
 class CssSelectorComplexBridge extends BridgeAbstract
 {
     const MAINTAINER = 'Lars Stegman';
-    const NAME = 'CSS Selector Complex Bridge';
+    const NAME = 'CSS Selector Complex';
     const URI = 'https://github.com/RSS-Bridge/rss-bridge/';
     const DESCRIPTION = <<<EOT
         Convert any site to RSS feed using CSS selectors (Advanced Users). The bridge first selects 

--- a/bridges/DailymotionBridge.php
+++ b/bridges/DailymotionBridge.php
@@ -3,7 +3,7 @@
 class DailymotionBridge extends BridgeAbstract
 {
     const MAINTAINER = 'mitsukarenai';
-    const NAME = 'Dailymotion Bridge';
+    const NAME = 'Dailymotion';
     const URI = 'https://www.dailymotion.com/';
     const CACHE_TIMEOUT = 3600; // 1h
     const DESCRIPTION = 'Returns the 5 newest videos by username/playlist or search';

--- a/bridges/DarkReadingBridge.php
+++ b/bridges/DarkReadingBridge.php
@@ -3,7 +3,7 @@
 class DarkReadingBridge extends FeedExpander
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'Dark Reading Bridge';
+    const NAME = 'Dark Reading';
     const URI = 'https://www.darkreading.com/';
     const DESCRIPTION = 'Returns the newest articles from Dark Reading';
 

--- a/bridges/DauphineLibereBridge.php
+++ b/bridges/DauphineLibereBridge.php
@@ -3,7 +3,7 @@
 class DauphineLibereBridge extends FeedExpander
 {
     const MAINTAINER = 'qwertygc';
-    const NAME = 'Dauphine Bridge';
+    const NAME = 'Dauphine';
     const URI = 'https://www.ledauphine.com/';
     const CACHE_TIMEOUT = 7200; // 2h
     const DESCRIPTION = 'Returns the newest articles.';

--- a/bridges/DealabsBridge.php
+++ b/bridges/DealabsBridge.php
@@ -2,7 +2,7 @@
 
 class DealabsBridge extends PepperBridgeAbstract
 {
-    const NAME = 'Dealabs Bridge';
+    const NAME = 'Dealabs';
     const URI = 'https://www.dealabs.com/';
     const DESCRIPTION = 'Affiche les Deals de Dealabs';
     const MAINTAINER = 'sysadminstory';

--- a/bridges/DerpibooruBridge.php
+++ b/bridges/DerpibooruBridge.php
@@ -2,7 +2,7 @@
 
 class DerpibooruBridge extends BridgeAbstract
 {
-    const NAME = 'Derpibooru Bridge';
+    const NAME = 'Derpibooru';
     const URI = 'https://derpibooru.org/';
     const DESCRIPTION = 'Returns newest images from a Derpibooru search';
     const CACHE_TIMEOUT = 300; // 5min

--- a/bridges/DesoutterBridge.php
+++ b/bridges/DesoutterBridge.php
@@ -5,7 +5,7 @@ class DesoutterBridge extends BridgeAbstract
     const CATEGORY_NEWS = 'News & Events';
     const CATEGORY_INDUSTRY = 'Industry 4.0 News';
 
-    const NAME = 'Desoutter Bridge';
+    const NAME = 'Desoutter';
     const URI = 'https://www.desouttertools.com';
     const DESCRIPTION = 'Returns feeds for news from Desoutter';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/DeutscheWelleBridge.php
+++ b/bridges/DeutscheWelleBridge.php
@@ -3,7 +3,7 @@
 class DeutscheWelleBridge extends FeedExpander
 {
     const MAINTAINER = 'No maintainer';
-    const NAME = 'Deutsche Welle Bridge';
+    const NAME = 'Deutsche Welle';
     const URI = 'https://www.dw.com';
     const DESCRIPTION = 'Returns the full articles instead of only the intro';
     const CACHE_TIMEOUT = 3600;

--- a/bridges/DevToBridge.php
+++ b/bridges/DevToBridge.php
@@ -5,7 +5,7 @@ class DevToBridge extends BridgeAbstract
     const CONTEXT_BY_TAG = 'By tag';
     const CONTEXT_BY_USER = 'By user';
 
-    const NAME = 'dev.to Bridge';
+    const NAME = 'dev.to';
     const URI = 'https://dev.to';
     const DESCRIPTION = 'Returns feeds for tags';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/DockerHubBridge.php
+++ b/bridges/DockerHubBridge.php
@@ -2,7 +2,7 @@
 
 class DockerHubBridge extends BridgeAbstract
 {
-    const NAME = 'Docker Hub Bridge';
+    const NAME = 'Docker Hub';
     const URI = 'https://hub.docker.com';
     const DESCRIPTION = 'Returns new images for a container';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/DoujinStyleBridge.php
+++ b/bridges/DoujinStyleBridge.php
@@ -2,7 +2,7 @@
 
 class DoujinStyleBridge extends BridgeAbstract
 {
-    const NAME = 'DoujinStyle Bridge';
+    const NAME = 'DoujinStyle';
     const URI = 'https://doujinstyle.com/';
     const DESCRIPTION = 'Returns submissions from DoujinStyle';
     const MAINTAINER = 'mrtnvgr';

--- a/bridges/EconomistBridge.php
+++ b/bridges/EconomistBridge.php
@@ -3,7 +3,7 @@
 class EconomistBridge extends FeedExpander
 {
     const MAINTAINER = 'bockiii, sqrtminusone';
-    const NAME = 'Economist Bridge';
+    const NAME = 'Economist';
     const URI = 'https://www.economist.com/';
     const CACHE_TIMEOUT = 3600; //1hour
     const DESCRIPTION = 'Returns the latest articles for the selected category';

--- a/bridges/EconomistWorldInBriefBridge.php
+++ b/bridges/EconomistWorldInBriefBridge.php
@@ -3,7 +3,7 @@
 class EconomistWorldInBriefBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'Economist the World in Brief Bridge';
+    const NAME = 'Economist the World in Brief';
     const URI = 'https://www.economist.com/the-world-in-brief';
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/ElloBridge.php
+++ b/bridges/ElloBridge.php
@@ -3,7 +3,7 @@
 class ElloBridge extends BridgeAbstract
 {
     const MAINTAINER = 'teromene';
-    const NAME = 'Ello Bridge';
+    const NAME = 'Ello';
     const URI = 'https://ello.co/';
     const CACHE_TIMEOUT = 4800; //2hours
     const DESCRIPTION = 'Returns the newest posts for Ello';
@@ -127,7 +127,7 @@ class ElloBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('u'))) {
-            return $this->getInput('u') . ' - Ello Bridge';
+            return $this->getInput('u') . ' - Ello';
         }
 
         return parent::getName();

--- a/bridges/EngadgetBridge.php
+++ b/bridges/EngadgetBridge.php
@@ -3,7 +3,7 @@
 class EngadgetBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'Engadget Bridge';
+    const NAME = 'Engadget';
     const URI = 'https://www.engadget.com/';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'Article content for Engadget.';

--- a/bridges/ErowallBridge.php
+++ b/bridges/ErowallBridge.php
@@ -2,7 +2,7 @@
 
 class ErowallBridge extends BridgeAbstract
 {
-    const NAME = 'Erowall.com Bridge';
+    const NAME = 'Erowall.com';
     const URI = 'https://www.erowall.com/';
     const DESCRIPTION = 'Latest wallpapers from erowall.com';
     const MAINTAINER = 'kurz.junge';

--- a/bridges/EuronewsBridge.php
+++ b/bridges/EuronewsBridge.php
@@ -3,7 +3,7 @@
 class EuronewsBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'Euronews Bridge';
+    const NAME = 'Euronews';
     const URI = 'https://www.euronews.com/';
     const CACHE_TIMEOUT = 600; // 10 minutes
     const DESCRIPTION = 'Return articles from the "Just In" feed of Euronews.';

--- a/bridges/FDroidRepoBridge.php
+++ b/bridges/FDroidRepoBridge.php
@@ -2,7 +2,7 @@
 
 class FDroidRepoBridge extends BridgeAbstract
 {
-    const NAME = 'F-Droid Repository Bridge';
+    const NAME = 'F-Droid Repository';
     const URI = 'https://f-droid.org/';
     const DESCRIPTION = 'Query any F-Droid Repository for its latest updates.';
 

--- a/bridges/FM4Bridge.php
+++ b/bridges/FM4Bridge.php
@@ -3,7 +3,7 @@
 class FM4Bridge extends BridgeAbstract
 {
     const MAINTAINER = 'joni1993';
-    const NAME = 'FM4 Bridge';
+    const NAME = 'FM4';
     const URI = 'https://fm4.orf.at';
     const CACHE_TIMEOUT = 1800; // 30min
     const DESCRIPTION = 'Feed for FM4 articles by tags (authors)';

--- a/bridges/FarsideNitterBridge.php
+++ b/bridges/FarsideNitterBridge.php
@@ -2,7 +2,7 @@
 
 class FarsideNitterBridge extends FeedExpander
 {
-    const NAME = 'Farside Nitter Bridge';
+    const NAME = 'Farside Nitter';
     const DESCRIPTION = "Returns an user's recent tweets";
     const URI = 'https://farside.link/nitter/';
     const HOST = 'https://twitter.com/';

--- a/bridges/FeedExpanderTestBridge.php
+++ b/bridges/FeedExpanderTestBridge.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 class FeedExpanderTestBridge extends FeedExpander
 {
     const MAINTAINER = 'No maintainer';
-    const NAME = 'Unnamed bridge';
+    const NAME = 'Unnamed';
     const URI = 'https://esdf.com/';
     const DESCRIPTION = 'No description provided';
     const PARAMETERS = [];

--- a/bridges/FicbookBridge.php
+++ b/bridges/FicbookBridge.php
@@ -2,7 +2,7 @@
 
 class FicbookBridge extends BridgeAbstract
 {
-    const NAME = 'Ficbook Bridge';
+    const NAME = 'Ficbook';
     const URI = 'https://ficbook.net/';
     const DESCRIPTION = 'No description provided';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/FiderBridge.php
+++ b/bridges/FiderBridge.php
@@ -2,7 +2,7 @@
 
 class FiderBridge extends BridgeAbstract
 {
-    const NAME = 'Fider Bridge';
+    const NAME = 'Fider';
     const URI = 'https://fider.io/';
     const DESCRIPTION = 'Bridge for any Fider instance';
     const MAINTAINER = 'Oliver Nutter';

--- a/bridges/FinanzflussBridge.php
+++ b/bridges/FinanzflussBridge.php
@@ -3,7 +3,7 @@
 class FinanzflussBridge extends BridgeAbstract
 {
     const MAINTAINER = 'Tone866';
-    const NAME = 'finanzfluss Bridge';
+    const NAME = 'finanzfluss';
     const URI = 'https://www.finanzfluss.de/blog';
     const CACHE_TIMEOUT = 1800; // 30min
     const DESCRIPTION = 'Feed for finanzfluss';

--- a/bridges/FindACrewBridge.php
+++ b/bridges/FindACrewBridge.php
@@ -3,7 +3,7 @@
 class FindACrewBridge extends BridgeAbstract
 {
     const MAINTAINER = 'couraudt';
-    const NAME = 'Find A Crew Bridge';
+    const NAME = 'Find A Crew';
     const URI = 'https://www.findacrew.net';
     const DESCRIPTION = 'Returns the newest sailing offers.';
     const PARAMETERS = [

--- a/bridges/FirefoxAddonsBridge.php
+++ b/bridges/FirefoxAddonsBridge.php
@@ -2,7 +2,7 @@
 
 class FirefoxAddonsBridge extends BridgeAbstract
 {
-    const NAME = 'Firefox Add-ons Bridge';
+    const NAME = 'Firefox Add-ons';
     const URI = 'https://addons.mozilla.org/';
     const DESCRIPTION = 'Returns version history for a Firefox Add-on.';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/FlaschenpostBridge.php
+++ b/bridges/FlaschenpostBridge.php
@@ -2,7 +2,7 @@
 
 class FlaschenpostBridge extends BridgeAbstract
 {
-    const NAME = 'Flaschenpost Bridge';
+    const NAME = 'Flaschenpost';
     const URI = 'https://www.flaschenpost.de/';
     const DESCRIPTION = 'Aktuelle Angebote auf Flaschenpost.de';
     const MAINTAINER = 'sal0max';

--- a/bridges/FlickrBridge.php
+++ b/bridges/FlickrBridge.php
@@ -6,7 +6,7 @@
 class FlickrBridge extends BridgeAbstract
 {
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'Flickr Bridge';
+    const NAME = 'Flickr';
     const URI = 'https://www.flickr.com/';
     const CACHE_TIMEOUT = 21600; // 6 hours
     const DESCRIPTION = 'Returns images from Flickr';

--- a/bridges/ForGifsBridge.php
+++ b/bridges/ForGifsBridge.php
@@ -3,7 +3,7 @@
 class ForGifsBridge extends FeedExpander
 {
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'forgifs Bridge';
+    const NAME = 'forgifs';
     const URI = 'https://forgifs.com';
     const DESCRIPTION = 'Returns the forgifs feed with actual gifs instead of images';
 

--- a/bridges/Formula1Bridge.php
+++ b/bridges/Formula1Bridge.php
@@ -2,7 +2,7 @@
 
 class Formula1Bridge extends BridgeAbstract
 {
-    const NAME = 'Formula1 Bridge';
+    const NAME = 'Formula1';
     const URI = 'https://formula1.com/';
     const DESCRIPTION = 'Returns latest official Formula 1 news';
     const MAINTAINER = 'axor-mst';

--- a/bridges/FreeCodeCampBridge.php
+++ b/bridges/FreeCodeCampBridge.php
@@ -3,7 +3,7 @@
 class FreeCodeCampBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'FreeCodecamp Bridge';
+    const NAME = 'FreeCodecamp';
     const URI = 'https://www.freecodecamp.org';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'RSS feed for FreeCodeCamp';

--- a/bridges/FurAffinityBridge.php
+++ b/bridges/FurAffinityBridge.php
@@ -2,7 +2,7 @@
 
 class FurAffinityBridge extends BridgeAbstract
 {
-    const NAME = 'FurAffinity Bridge';
+    const NAME = 'FurAffinity';
     const URI = 'https://www.furaffinity.net';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Returns posts from various sections of FurAffinity';

--- a/bridges/FuturaSciencesBridge.php
+++ b/bridges/FuturaSciencesBridge.php
@@ -3,7 +3,7 @@
 class FuturaSciencesBridge extends FeedExpander
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'Futura-Sciences Bridge';
+    const NAME = 'Futura-Sciences';
     const URI = 'https://www.futura-sciences.com/';
     const DESCRIPTION = 'Returns the newest articles.';
 

--- a/bridges/GBAtempBridge.php
+++ b/bridges/GBAtempBridge.php
@@ -146,7 +146,7 @@ class GBAtempBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('type'))) {
-            return 'GBAtemp ' . $this->getKey('type') . '';
+            return 'GBAtemp ' . $this->getKey('type');
         }
 
         return parent::getName();

--- a/bridges/GBAtempBridge.php
+++ b/bridges/GBAtempBridge.php
@@ -146,7 +146,7 @@ class GBAtempBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('type'))) {
-            return 'GBAtemp ' . $this->getKey('type') . ' Bridge';
+            return 'GBAtemp ' . $this->getKey('type') . '';
         }
 
         return parent::getName();

--- a/bridges/GettrBridge.php
+++ b/bridges/GettrBridge.php
@@ -2,7 +2,7 @@
 
 class GettrBridge extends BridgeAbstract
 {
-    const NAME = 'Gettr.com bridge';
+    const NAME = 'Gettr.com';
     const URI = 'https://gettr.com';
     const DESCRIPTION = 'Fetches the latest posts from a GETTR user';
     const MAINTAINER = 'dvikan';

--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -3,7 +3,7 @@
 class GiphyBridge extends BridgeAbstract
 {
     const MAINTAINER = 'dvikan';
-    const NAME = 'Giphy Bridge';
+    const NAME = 'Giphy';
     const URI = 'https://giphy.com/';
     const CACHE_TIMEOUT = 60 * 60 * 8; // 8h
     const DESCRIPTION = 'Bridge for giphy.com';

--- a/bridges/GitHubGistBridge.php
+++ b/bridges/GitHubGistBridge.php
@@ -2,7 +2,7 @@
 
 class GitHubGistBridge extends BridgeAbstract
 {
-    const NAME = 'GitHubGist comment bridge';
+    const NAME = 'GitHubGist comment';
     const URI = 'https://gist.github.com';
     const DESCRIPTION = 'Generates feeds for Gist comments';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/GlassdoorBridge.php
+++ b/bridges/GlassdoorBridge.php
@@ -23,7 +23,7 @@ class GlassdoorBridge extends BridgeAbstract
     const PARAM_REVIEW_COMPANY = 'company';
 
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'Glassdoor Bridge';
+    const NAME = 'Glassdoor';
     const URI = 'https://www.glassdoor.com/';
     const DESCRIPTION = 'Returns feeds for blog posts and company reviews';
     const CACHE_TIMEOUT = 86400; // 24 hours

--- a/bridges/GlowficBridge.php
+++ b/bridges/GlowficBridge.php
@@ -3,7 +3,7 @@
 class GlowficBridge extends BridgeAbstract
 {
     const MAINTAINER = 'l1n';
-    const NAME = 'Glowfic Bridge';
+    const NAME = 'Glowfic';
     const URI = 'https://www.glowfic.com';
     const CACHE_TIMEOUT = 3600; // 1 hour
     const DESCRIPTION = 'Returns the latest replies on a glowfic post.';

--- a/bridges/GolemBridge.php
+++ b/bridges/GolemBridge.php
@@ -3,7 +3,7 @@
 class GolemBridge extends FeedExpander
 {
     const MAINTAINER = 'Mynacol';
-    const NAME = 'Golem Bridge';
+    const NAME = 'Golem';
     const URI = 'https://www.golem.de/';
     const CACHE_TIMEOUT = 1800; // 30min
     const DESCRIPTION = 'Returns the full articles instead of only the intro';

--- a/bridges/GoodreadsBridge.php
+++ b/bridges/GoodreadsBridge.php
@@ -3,7 +3,7 @@
 class GoodreadsBridge extends BridgeAbstract
 {
     const MAINTAINER = 'captn3m0';
-    const NAME = 'Goodreads Bridge';
+    const NAME = 'Goodreads';
     const URI = 'https://www.goodreads.com/';
     const CACHE_TIMEOUT = 0; // 30min
     const DESCRIPTION = 'Various RSS feeds from Goodreads';

--- a/bridges/GoogleGroupsBridge.php
+++ b/bridges/GoogleGroupsBridge.php
@@ -2,7 +2,7 @@
 
 class GoogleGroupsBridge extends XPathAbstract
 {
-    const NAME = 'Google Groups Bridge';
+    const NAME = 'Google Groups';
     const DESCRIPTION = 'Returns the latest posts on a Google Group';
     const URI = 'https://groups.google.com';
     const PARAMETERS = [ [

--- a/bridges/GrandComicsDatabaseBridge.php
+++ b/bridges/GrandComicsDatabaseBridge.php
@@ -3,7 +3,7 @@
 class GrandComicsDatabaseBridge extends BridgeAbstract
 {
     const MAINTAINER = 'corenting';
-    const NAME = 'Grand Comics Database Bridge';
+    const NAME = 'Grand Comics Database';
     const URI = 'https://www.comics.org/';
     const CACHE_TIMEOUT = 7200; // 2h
     const DESCRIPTION = 'Returns the latest comics added to a series timeline';

--- a/bridges/HDWallpapersBridge.php
+++ b/bridges/HDWallpapersBridge.php
@@ -3,7 +3,7 @@
 class HDWallpapersBridge extends BridgeAbstract
 {
     const MAINTAINER = 'nel50n';
-    const NAME = 'HD Wallpapers Bridge';
+    const NAME = 'HD Wallpapers';
     const URI = 'https://www.hdwallpapers.in/';
     const CACHE_TIMEOUT = 43200; //12h
     const DESCRIPTION = 'Returns the latests wallpapers from HDWallpapers';

--- a/bridges/HaveIBeenPwnedBridge.php
+++ b/bridges/HaveIBeenPwnedBridge.php
@@ -9,7 +9,7 @@
  * */
 class HaveIBeenPwnedBridge extends BridgeAbstract
 {
-    const NAME = 'Have I Been Pwned (HIBP) Bridge';
+    const NAME = 'Have I Been Pwned (HIBP)';
     const URI = 'https://haveibeenpwned.com';
     const DESCRIPTION = 'Returns list of Pwned websites';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -3,7 +3,7 @@
 class HeiseBridge extends FeedExpander
 {
     const MAINTAINER = 'Dreckiger-Dan';
-    const NAME = 'Heise Online Bridge';
+    const NAME = 'Heise Online';
     const URI = 'https://heise.de/';
     const CACHE_TIMEOUT = 1800; // 30min
     const DESCRIPTION = 'Returns the full articles instead of only the intro';

--- a/bridges/HotUKDealsBridge.php
+++ b/bridges/HotUKDealsBridge.php
@@ -2,7 +2,7 @@
 
 class HotUKDealsBridge extends PepperBridgeAbstract
 {
-    const NAME = 'HotUKDeals bridge';
+    const NAME = 'HotUKDeals';
     const URI = 'https://www.hotukdeals.com/';
     const DESCRIPTION = 'Return the HotUKDeals search result using keywords';
     const MAINTAINER = 'sysadminstory';

--- a/bridges/HuntShowdownNewsBridge.php
+++ b/bridges/HuntShowdownNewsBridge.php
@@ -2,7 +2,7 @@
 
 class HuntShowdownNewsBridge extends BridgeAbstract
 {
-    const NAME = 'Hunt Showdown News Bridge';
+    const NAME = 'Hunt Showdown News';
     const MAINTAINER = 'deffy92';
     const URI = 'https://www.huntshowdown.com';
     const DESCRIPTION = 'Returns the latest news from HuntShowdown.com/news';

--- a/bridges/HytaleBridge.php
+++ b/bridges/HytaleBridge.php
@@ -2,7 +2,7 @@
 
 class HytaleBridge extends BridgeAbstract
 {
-    const NAME = 'Hytale Bridge';
+    const NAME = 'Hytale';
     const URI = 'https://hytale.com/news';
     const DESCRIPTION = 'All blog posts from Hytale\'s news blog.';
     const MAINTAINER = 'llamasblade';

--- a/bridges/I4wifiBridge.php
+++ b/bridges/I4wifiBridge.php
@@ -7,7 +7,7 @@
 
 class I4wifiBridge extends BridgeAbstract
 {
-    const NAME = 'i4wifi Bridge';
+    const NAME = 'i4wifi';
     const URI = 'https://www.i4wifi.cz';
     const DESCRIPTION = 'Product news not only from the wireless, network and security technology sector from i4wifi.cz - Czech Republic';
     const MAINTAINER = 'pprenghyorg';

--- a/bridges/IGNBridge.php
+++ b/bridges/IGNBridge.php
@@ -3,7 +3,7 @@
 class IGNBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'IGN Bridge';
+    const NAME = 'IGN';
     const URI = 'https://www.ign.com/';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'RSS Feed For IGN';

--- a/bridges/IPBBridge.php
+++ b/bridges/IPBBridge.php
@@ -2,7 +2,7 @@
 
 class IPBBridge extends FeedExpander
 {
-    const NAME = 'IPB Bridge';
+    const NAME = 'IPB';
     const URI = 'https://www.invisionpower.com';
     const DESCRIPTION = 'Returns feeds for forums powered by IPB';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/IdealoBridge.php
+++ b/bridges/IdealoBridge.php
@@ -2,7 +2,7 @@
 
 class IdealoBridge extends BridgeAbstract
 {
-    const NAME = 'idealo.de / idealo.fr / idealo.es Bridge';
+    const NAME = 'idealo.de / idealo.fr / idealo.es';
     const URI = 'https://www.idealo.de';
     const DESCRIPTION = 'Tracks the price for a product on idealo.de / idealo.fr / idealo.es. Pricealarm if specific price is set';
     const MAINTAINER = 'SebLaus';

--- a/bridges/IdenticaBridge.php
+++ b/bridges/IdenticaBridge.php
@@ -3,7 +3,7 @@
 class IdenticaBridge extends BridgeAbstract
 {
     const MAINTAINER = 'mitsukarenai';
-    const NAME = 'Identica Bridge';
+    const NAME = 'Identica';
     const URI = 'https://identi.ca/';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Returns user timelines';
@@ -39,7 +39,7 @@ class IdenticaBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('u'))) {
-            return $this->getInput('u') . ' - Identica Bridge';
+            return $this->getInput('u') . ' - Identica';
         }
 
         return parent::getName();

--- a/bridges/ImgsedBridge.php
+++ b/bridges/ImgsedBridge.php
@@ -3,7 +3,7 @@
 class ImgsedBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sysadminstory';
-    const NAME = 'Imgsed Bridge';
+    const NAME = 'Imgsed';
     const URI = 'https://imgsed.com/';
     const INSTAGRAMURI = 'https://www.instagram.com/';
     const CACHE_TIMEOUT = 3600; // 1h
@@ -269,7 +269,7 @@ HTML,
                 $typesText .= ' & ' . $types[$i];
             }
 
-            return 'Username ' . $this->getInput('u') . ' - ' . $typesText . ' - Imgsed Bridge';
+            return 'Username ' . $this->getInput('u') . ' - ' . $typesText . ' - Imgsed';
         }
         return parent::getName();
     }

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -3,7 +3,7 @@
 class InstagramBridge extends BridgeAbstract
 {
     // const MAINTAINER = 'pauder';
-    const NAME = 'Instagram Bridge';
+    const NAME = 'Instagram';
     const URI = 'https://www.instagram.com/';
     const DESCRIPTION = 'Returns the newest images';
 
@@ -349,7 +349,7 @@ class InstagramBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('u'))) {
-            return $this->getInput('u') . ' - Instagram Bridge';
+            return $this->getInput('u') . ' - Instagram';
         }
 
         return parent::getName();

--- a/bridges/InstructablesBridge.php
+++ b/bridges/InstructablesBridge.php
@@ -13,7 +13,7 @@
 */
 class InstructablesBridge extends BridgeAbstract
 {
-    const NAME = 'Instructables Bridge';
+    const NAME = 'Instructables';
     const URI = 'https://www.instructables.com';
     const DESCRIPTION = 'Returns general feeds and feeds by category';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/InternationalInstituteForStrategicStudiesBridge.php
+++ b/bridges/InternationalInstituteForStrategicStudiesBridge.php
@@ -3,7 +3,7 @@
 class InternationalInstituteForStrategicStudiesBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'International Institute For Strategic Studies Bridge';
+    const NAME = 'International Institute For Strategic Studies';
     const URI = 'https://www.iiss.org';
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/InternetArchiveBridge.php
+++ b/bridges/InternetArchiveBridge.php
@@ -2,7 +2,7 @@
 
 class InternetArchiveBridge extends BridgeAbstract
 {
-    const NAME = 'Internet Archive Bridge';
+    const NAME = 'Internet Archive';
     const URI = 'https://archive.org';
     const DESCRIPTION = 'Returns newest uploads, posts and more from an account';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/ItakuBridge.php
+++ b/bridges/ItakuBridge.php
@@ -2,7 +2,7 @@
 
 class ItakuBridge extends BridgeAbstract
 {
-    const NAME = 'Itaku.ee Bridge';
+    const NAME = 'Itaku.ee';
     const URI = 'https://itaku.ee';
     const CACHE_TIMEOUT = 900; // 15mn
     const MAINTAINER = 'mruac';

--- a/bridges/IvooxBridge.php
+++ b/bridges/IvooxBridge.php
@@ -7,7 +7,7 @@
  */
 class IvooxBridge extends BridgeAbstract
 {
-    const NAME = 'Ivoox Bridge';
+    const NAME = 'Ivoox';
     const URI = 'https://www.ivoox.com/';
     const CACHE_TIMEOUT = 10800; // 3h
     const DESCRIPTION = 'Returns the 10 newest episodes by keyword search';

--- a/bridges/JustETFBridge.php
+++ b/bridges/JustETFBridge.php
@@ -2,7 +2,7 @@
 
 class JustETFBridge extends BridgeAbstract
 {
-    const NAME = 'justETF Bridge';
+    const NAME = 'justETF';
     const URI = 'https://www.justetf.com';
     const DESCRIPTION = 'Currently only supports the news feed';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/KilledbyGoogleBridge.php
+++ b/bridges/KilledbyGoogleBridge.php
@@ -2,7 +2,7 @@
 
 class KilledbyGoogleBridge extends BridgeAbstract
 {
-    const NAME = 'Killed by Google Bridge';
+    const NAME = 'Killed by Google';
     const URI = 'https://killedbygoogle.com';
     const DESCRIPTION = 'Returns list of recently discontinued Google services, products, devices, and apps.';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/KilledbyMicrosoftBridge.php
+++ b/bridges/KilledbyMicrosoftBridge.php
@@ -2,7 +2,7 @@
 
 class KilledbyMicrosoftBridge extends BridgeAbstract
 {
-    const NAME = 'Killed by Microsoft Bridge';
+    const NAME = 'Killed by Microsoft';
     const URI = 'https://killedbymicrosoft.info';
     const DESCRIPTION = 'Lists recently discontinued Microsoft products';
     const MAINTAINER = 'tillcash';

--- a/bridges/KleinanzeigenBridge.php
+++ b/bridges/KleinanzeigenBridge.php
@@ -3,7 +3,7 @@
 class KleinanzeigenBridge extends BridgeAbstract
 {
     const MAINTAINER = 'knrdl';
-    const NAME = 'Kleinanzeigen Bridge';
+    const NAME = 'Kleinanzeigen';
     const URI = 'https://www.kleinanzeigen.de';
     const CACHE_TIMEOUT = 3600; // 1h
     const DESCRIPTION = '(ebay) Kleinanzeigen';

--- a/bridges/KoFiBridge.php
+++ b/bridges/KoFiBridge.php
@@ -3,7 +3,7 @@
 class KoFiBridge extends BridgeAbstract
 {
     const MAINTAINER = 'walkero';
-    const NAME = 'Ko-Fi Bridge';
+    const NAME = 'Ko-Fi';
     const URI = 'https://ko-fi.com';
     const CACHE_TIMEOUT = 3600; // 1h
     const DESCRIPTION = 'Returns the newest articles.';

--- a/bridges/KununuBridge.php
+++ b/bridges/KununuBridge.php
@@ -3,7 +3,7 @@
 class KununuBridge extends BridgeAbstract
 {
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'Kununu Bridge';
+    const NAME = 'Kununu';
     const URI = 'https://www.kununu.com/';
     const CACHE_TIMEOUT = 86400; // 24h
     const DESCRIPTION = 'Returns the latest reviews for a company and site of your choice.';

--- a/bridges/ListverseBridge.php
+++ b/bridges/ListverseBridge.php
@@ -3,7 +3,7 @@
 class ListverseBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'Listverse Bridge';
+    const NAME = 'Listverse';
     const URI = 'https://listverse.com/';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'RSS feed for Listverse';

--- a/bridges/MallTvBridge.php
+++ b/bridges/MallTvBridge.php
@@ -2,7 +2,7 @@
 
 class MallTvBridge extends BridgeAbstract
 {
-    const NAME = 'MALL.TV Bridge';
+    const NAME = 'MALL.TV';
     const URI = 'https://www.mall.tv';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'Return newest videos';

--- a/bridges/MangaDexBridge.php
+++ b/bridges/MangaDexBridge.php
@@ -2,7 +2,7 @@
 
 class MangaDexBridge extends BridgeAbstract
 {
-    const NAME = 'MangaDex Bridge';
+    const NAME = 'MangaDex';
     const URI = 'https://mangadex.org/';
     const API_ROOT = 'https://api.mangadex.org/';
     const DESCRIPTION = 'Returns MangaDex items using the API';

--- a/bridges/MangaReaderBridge.php
+++ b/bridges/MangaReaderBridge.php
@@ -2,7 +2,7 @@
 
 class MangaReaderBridge extends BridgeAbstract
 {
-    const NAME = 'MangaReader Bridge';
+    const NAME = 'MangaReader';
     const URI = 'https://mangareader.to';
     const DESCRIPTION = 'Fetches the latest chapters from MangaReader.to.';
     const MAINTAINER = 'cubethethird';

--- a/bridges/MastodonBridge.php
+++ b/bridges/MastodonBridge.php
@@ -9,7 +9,7 @@ class MastodonBridge extends BridgeAbstract
     // so use the official feed: https://pixelfed.instance/users/username.atom (Posts only)
 
     const MAINTAINER = 'Austin Huang';
-    const NAME = 'ActivityPub Bridge';
+    const NAME = 'ActivityPub';
     const CACHE_TIMEOUT = 900; // 15mn
     const DESCRIPTION = 'Returns recent statuses. Supports Mastodon, Pleroma and Misskey, among others. Access to
     instances that have Authorized Fetch enabled requires

--- a/bridges/MediapartBridge.php
+++ b/bridges/MediapartBridge.php
@@ -3,7 +3,7 @@
 class MediapartBridge extends FeedExpander
 {
     const MAINTAINER = 'killruana';
-    const NAME = 'Mediapart Bridge';
+    const NAME = 'Mediapart';
     const URI = 'https://www.mediapart.fr/';
     const PARAMETERS = [
         [

--- a/bridges/MistralAIBridge.php
+++ b/bridges/MistralAIBridge.php
@@ -3,7 +3,7 @@
 class MistralAIBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'Mistral AI Bridge';
+    const NAME = 'Mistral AI';
     const URI = 'https://mistral.ai/';
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/MoinMoinBridge.php
+++ b/bridges/MoinMoinBridge.php
@@ -3,7 +3,7 @@
 class MoinMoinBridge extends BridgeAbstract
 {
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'MoinMoin Bridge';
+    const NAME = 'MoinMoin';
     const URI = 'https://moinmo.in';
     const DESCRIPTION = 'Generates feeds for pages of a MoinMoin (compatible) wiki';
     const PARAMETERS = [

--- a/bridges/MydealsBridge.php
+++ b/bridges/MydealsBridge.php
@@ -2,7 +2,7 @@
 
 class MydealsBridge extends PepperBridgeAbstract
 {
-    const NAME = 'Mydealz bridge';
+    const NAME = 'Mydealz';
     const URI = 'https://www.mydealz.de/';
     const DESCRIPTION = 'Zeigt die Deals von mydealz.de';
     const MAINTAINER = 'sysadminstory';

--- a/bridges/NHKWorldJapanShowBridge.php
+++ b/bridges/NHKWorldJapanShowBridge.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class NHKWorldJapanShowBridge extends BridgeAbstract
 {
-    const NAME = 'NHK World-Japan Show Bridge';
+    const NAME = 'NHK World-Japan Show';
     const URI = 'https://www3.nhk.or.jp';
     const CACHE_TIMEOUT = 14400; // 4h
     const DESCRIPTION = 'Returns available episodes from NHK World-Japan Shows';

--- a/bridges/NOSBridge.php
+++ b/bridges/NOSBridge.php
@@ -2,7 +2,7 @@
 
 class NOSBridge extends BridgeAbstract
 {
-    const NAME = 'NOS Nieuws & Sport Bridge';
+    const NAME = 'NOS Nieuws & Sport';
     const URI = 'https://www.nos.nl';
     const DESCRIPTION = 'NOS Nieuws & Sport';
     const MAINTAINER = 'wouterkoch';

--- a/bridges/NYTBridge.php
+++ b/bridges/NYTBridge.php
@@ -3,7 +3,7 @@
 class NYTBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'New York Times Bridge';
+    const NAME = 'New York Times';
     const URI = 'https://www.nytimes.com/';
     const CACHE_TIMEOUT = 900; // 15 minutes
     const DESCRIPTION = 'RSS feed for the New York Times';

--- a/bridges/NasaApodBridge.php
+++ b/bridges/NasaApodBridge.php
@@ -3,7 +3,7 @@
 class NasaApodBridge extends BridgeAbstract
 {
     const MAINTAINER = 'corenting';
-    const NAME = 'NASA APOD Bridge';
+    const NAME = 'NASA APOD';
     const URI = 'https://apod.nasa.gov/apod/';
     const CACHE_TIMEOUT = 43200; // 12h
     const DESCRIPTION = 'Returns the 3 latest NASA APOD pictures and explanations';

--- a/bridges/NasestrechaBridge.php
+++ b/bridges/NasestrechaBridge.php
@@ -8,7 +8,7 @@
 
 class NasestrechaBridge extends BridgeAbstract
 {
-    const NAME = 'Nasestrecha Bridge';
+    const NAME = 'Nasestrecha';
     const URI = 'https://www.nasestrecha.cz/';
     const DESCRIPTION = 'Articles from Nasestrecha.cz news site - Czech Republic / Spolehlivé informace pro Vaší střechu i stavbu';
     const MAINTAINER = 'pprenghyorg';

--- a/bridges/NautiljonBridge.php
+++ b/bridges/NautiljonBridge.php
@@ -2,7 +2,7 @@
 
 class NautiljonBridge extends BridgeAbstract
 {
-    const NAME = 'Nautiljon Bridge';
+    const NAME = 'Nautiljon';
     const URI = 'https://www.nautiljon.com';
     const DESCRIPTION = 'Actualités et Brèves de Nautiljon.';
     const MAINTAINER = 'papjul';

--- a/bridges/NewOnNetflixBridge.php
+++ b/bridges/NewOnNetflixBridge.php
@@ -2,7 +2,7 @@
 
 class NewOnNetflixBridge extends BridgeAbstract
 {
-    const NAME = 'NewOnNetflix removals bridge';
+    const NAME = 'NewOnNetflix removals';
     const URI = 'https://www.newonnetflix.info';
     const DESCRIPTION = 'Upcoming removals from Netflix (NewOnNetflix already provides additions as RSS)';
     const MAINTAINER = 'jdesgats';

--- a/bridges/NextInkBridge.php
+++ b/bridges/NextInkBridge.php
@@ -3,7 +3,7 @@
 class NextInkBridge extends FeedExpander
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'Next.Ink Bridge';
+    const NAME = 'Next.Ink';
     const URI = 'https://www.next.ink/';
     const DESCRIPTION = 'Returns the newest articles.';
 

--- a/bridges/NextgovBridge.php
+++ b/bridges/NextgovBridge.php
@@ -3,7 +3,7 @@
 class NextgovBridge extends FeedExpander
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'Nextgov Bridge';
+    const NAME = 'Nextgov';
     const URI = 'https://www.nextgov.com/';
     const DESCRIPTION = 'USA Federal technology news, best practices, and web 2.0 tools.';
 

--- a/bridges/NineGagBridge.php
+++ b/bridges/NineGagBridge.php
@@ -2,7 +2,7 @@
 
 class NineGagBridge extends BridgeAbstract
 {
-    const NAME = '9gag Bridge';
+    const NAME = '9gag';
     const URI = 'https://9gag.com/';
     const DESCRIPTION = 'Returns latest quotes from 9gag.';
     const MAINTAINER = 'ZeNairolf';

--- a/bridges/NotAlwaysBridge.php
+++ b/bridges/NotAlwaysBridge.php
@@ -3,7 +3,7 @@
 class NotAlwaysBridge extends BridgeAbstract
 {
     const MAINTAINER = 'mozes';
-    const NAME = 'Not Always family Bridge';
+    const NAME = 'Not Always family';
     const URI = 'https://notalwaysright.com/';
     const DESCRIPTION = 'Returns the latest stories';
     const CACHE_TIMEOUT = 1800; // 30 minutes
@@ -51,7 +51,7 @@ class NotAlwaysBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('filter'))) {
-            return $this->getInput('filter') . ' - NotAlways Bridge';
+            return $this->getInput('filter') . ' - NotAlways';
         }
 
         return parent::getName();

--- a/bridges/NovayaGazetaEuropeBridge.php
+++ b/bridges/NovayaGazetaEuropeBridge.php
@@ -3,7 +3,7 @@
 class NovayaGazetaEuropeBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'Novaya Gazeta Europe Bridge';
+    const NAME = 'Novaya Gazeta Europe';
     const URI = 'https://novayagazeta.eu';
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/OMonlineBridge.php
+++ b/bridges/OMonlineBridge.php
@@ -2,7 +2,7 @@
 
 class OMonlineBridge extends BridgeAbstract
 {
-    const NAME        = 'OM Online Bridge';
+    const NAME        = 'OM Online';
     const URI         = 'https://www.om-online.de';
     const DESCRIPTION = 'RSS feed for OM Online';
     const MAINTAINER  = 'jummo4@yahoo.de';

--- a/bridges/OllamaBridge.php
+++ b/bridges/OllamaBridge.php
@@ -3,7 +3,7 @@
 class OllamaBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'Ollama Blog Bridge';
+    const NAME = 'Ollama Blog';
     const URI = 'https://ollama.com';
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/OpenCVEBridge.php
+++ b/bridges/OpenCVEBridge.php
@@ -3,7 +3,7 @@
 class OpenCVEBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'OpenCVE Bridge';
+    const NAME = 'OpenCVE';
     const URI = 'https://opencve.io';
 
     const CACHE_TIMEOUT = 3600; // 1 hour

--- a/bridges/OpenwhydBridge.php
+++ b/bridges/OpenwhydBridge.php
@@ -3,7 +3,7 @@
 class OpenwhydBridge extends BridgeAbstract
 {
     const MAINTAINER = 'kranack';
-    const NAME = 'Openwhyd Bridge';
+    const NAME = 'Openwhyd';
     const URI = 'https://openwhyd.org';
     const CACHE_TIMEOUT = 600; // 10min
     const DESCRIPTION = 'Returns 10 newest music from user profile';
@@ -61,6 +61,6 @@ class OpenwhydBridge extends BridgeAbstract
 
     public function getName()
     {
-        return (!empty($this->userName) ? $this->userName . ' - ' : '') . 'Openwhyd Bridge';
+        return (!empty($this->userName) ? $this->userName . ' - ' : '') . 'Openwhyd';
     }
 }

--- a/bridges/ParlerBridge.php
+++ b/bridges/ParlerBridge.php
@@ -2,7 +2,7 @@
 
 final class ParlerBridge extends BridgeAbstract
 {
-    const NAME = 'Parler.com bridge';
+    const NAME = 'Parler.com';
     const URI = 'https://parler.com';
     const DESCRIPTION = 'Fetches the latest posts from a parler user';
     const MAINTAINER = 'dvikan';

--- a/bridges/PatreonBridge.php
+++ b/bridges/PatreonBridge.php
@@ -2,7 +2,7 @@
 
 class PatreonBridge extends BridgeAbstract
 {
-    const NAME = 'Patreon Bridge';
+    const NAME = 'Patreon';
     const URI = 'https://www.patreon.com/';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Returns posts by creators on Patreon';

--- a/bridges/PhoronixBridge.php
+++ b/bridges/PhoronixBridge.php
@@ -3,7 +3,7 @@
 class PhoronixBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'Phoronix Bridge';
+    const NAME = 'Phoronix';
     const URI = 'https://www.phoronix.com';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'RSS feed for Linux news website Phoronix';

--- a/bridges/PicalaBridge.php
+++ b/bridges/PicalaBridge.php
@@ -8,7 +8,7 @@ class PicalaBridge extends BridgeAbstract
         'Tests'      => 'tests',
         'Pratique'   => 'pratique',
     ];
-    const NAME          = 'Picala Bridge';
+    const NAME          = 'Picala';
     const URI           = 'https://www.picala.fr';
     const DESCRIPTION   = 'Dernière nouvelles du média indépendant sur le vélo électrique';
     const MAINTAINER    = 'Chouchen';

--- a/bridges/PickyWallpapersBridge.php
+++ b/bridges/PickyWallpapersBridge.php
@@ -3,7 +3,7 @@
 class PickyWallpapersBridge extends BridgeAbstract
 {
     const MAINTAINER = 'nel50n';
-    const NAME = 'PickyWallpapers Bridge';
+    const NAME = 'PickyWallpapers';
     const URI = 'https://www.pickywallpapers.com/';
     const CACHE_TIMEOUT = 43200; // 12h
     const DESCRIPTION = 'Returns the latests wallpapers from PickyWallpapers';

--- a/bridges/PicnobBridge.php
+++ b/bridges/PicnobBridge.php
@@ -3,7 +3,7 @@
 class PicnobBridge extends BridgeAbstract
 {
         const MAINTAINER = 'sysadminstory';
-        const NAME = 'Picnob Bridge';
+        const NAME = 'Picnob';
         const URI = 'https://www.picnob.com/';
         const CACHE_TIMEOUT = 3600; // 1h
         const DESCRIPTION = 'Returns Picnob (Instagram viewer) posts by user or by hashtag';
@@ -94,11 +94,11 @@ HTML,
         public function getName()
         {
             if (!is_null($this->getInput('u'))) {
-                    return 'Username ' . $this->getInput('u') . ' - Picnob Bridge';
+                    return 'Username ' . $this->getInput('u') . ' - Picnob';
             }
 
             if (!is_null($this->getInput('h'))) {
-                    return 'Hashtag ' . $this->getInput('h') . ' - Picnob Bridge';
+                    return 'Hashtag ' . $this->getInput('h') . ' - Picnob';
             }
 
                 return parent::getName();

--- a/bridges/PicukiBridge.php
+++ b/bridges/PicukiBridge.php
@@ -3,7 +3,7 @@
 class PicukiBridge extends BridgeAbstract
 {
     const MAINTAINER = 'marcus-at-localhost';
-    const NAME = 'Picuki Bridge';
+    const NAME = 'Picuki';
     const URI = 'https://www.picuki.com/';
     const CACHE_TIMEOUT = 3600; // 1h
     const DESCRIPTION = 'Returns Picuki (Instagram viewer) posts by user and by hashtag';
@@ -117,11 +117,11 @@ class PicukiBridge extends BridgeAbstract
     public function getName()
     {
         if (!is_null($this->getInput('u'))) {
-            return $this->getInput('u') . ' - Picuki Bridge';
+            return $this->getInput('u') . ' - Picuki';
         }
 
         if (!is_null($this->getInput('h'))) {
-            return $this->getInput('h') . ' - Picuki Bridge';
+            return $this->getInput('h') . ' - Picuki';
         }
 
         return parent::getName();

--- a/bridges/PinterestBridge.php
+++ b/bridges/PinterestBridge.php
@@ -3,7 +3,7 @@
 class PinterestBridge extends FeedExpander
 {
     const MAINTAINER = 'pauder';
-    const NAME = 'Pinterest Bridge';
+    const NAME = 'Pinterest';
     const URI = 'https://www.pinterest.com';
     const DESCRIPTION = 'Returns the newest images on a board';
 

--- a/bridges/PirateCommunityBridge.php
+++ b/bridges/PirateCommunityBridge.php
@@ -2,7 +2,7 @@
 
 class PirateCommunityBridge extends BridgeAbstract
 {
-    const NAME = 'Pirate-Community Bridge';
+    const NAME = 'Pirate-Community';
     const URI = 'https://raymanpc.com/';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Returns replies to topics';

--- a/bridges/PixivBridge.php
+++ b/bridges/PixivBridge.php
@@ -6,7 +6,7 @@
  */
 class PixivBridge extends BridgeAbstract
 {
-    const NAME = 'Pixiv Bridge';
+    const NAME = 'Pixiv';
     const URI = 'https://www.pixiv.net/';
     const DESCRIPTION = 'Returns the tag search from pixiv.net';
     const MAINTAINER = 'mruac';

--- a/bridges/RedditBridge.php
+++ b/bridges/RedditBridge.php
@@ -8,7 +8,7 @@
 class RedditBridge extends BridgeAbstract
 {
     const MAINTAINER = 'dawidsowa';
-    const NAME = 'Reddit Bridge';
+    const NAME = 'Reddit';
     const URI = 'https://old.reddit.com';
     const CACHE_TIMEOUT = 60 * 60 * 2; // 2h
     const DESCRIPTION = 'Return hot submissions from Reddit';

--- a/bridges/ReporterreBridge.php
+++ b/bridges/ReporterreBridge.php
@@ -6,7 +6,7 @@
 class ReporterreBridge extends BridgeAbstract
 {
     const MAINTAINER = 'nyutag';
-    const NAME = 'Reporterre Bridge';
+    const NAME = 'Reporterre';
     const URI = 'https://www.reporterre.net/';
     const DESCRIPTION = 'Returns the newest articles. See also their official feed https://reporterre.net/spip.php?page=backend-simple';
 

--- a/bridges/ReutersBridge.php
+++ b/bridges/ReutersBridge.php
@@ -3,7 +3,7 @@
 class ReutersBridge extends BridgeAbstract
 {
     const MAINTAINER = 'hollowleviathan, spraynard, csisoap';
-    const NAME = 'Reuters Bridge';
+    const NAME = 'Reuters';
     const URI = 'https://www.reuters.com';
     const CACHE_TIMEOUT = 3600; // 1h
     const DESCRIPTION = 'Returns news from Reuters';

--- a/bridges/RoadAndTrackBridge.php
+++ b/bridges/RoadAndTrackBridge.php
@@ -3,7 +3,7 @@
 class RoadAndTrackBridge extends BridgeAbstract
 {
     const MAINTAINER = 'teromene';
-    const NAME = 'Road And Track Bridge';
+    const NAME = 'Road And Track';
     const URI = 'https://www.roadandtrack.com/';
     const CACHE_TIMEOUT = 86400; // 24h
     const DESCRIPTION = 'Returns the latest news from Road & Track.';

--- a/bridges/RumbleBridge.php
+++ b/bridges/RumbleBridge.php
@@ -2,7 +2,7 @@
 
 class RumbleBridge extends BridgeAbstract
 {
-    const NAME = 'Rumble.com Bridge';
+    const NAME = 'Rumble.com';
     const URI = 'https://rumble.com/';
     const DESCRIPTION = 'Fetches the latest channel/user videos and livestreams.';
     const MAINTAINER = 'dvikan, NotsoanoNimus';

--- a/bridges/ScmbBridge.php
+++ b/bridges/ScmbBridge.php
@@ -3,7 +3,7 @@
 class ScmbBridge extends BridgeAbstract
 {
     const MAINTAINER = 'Astalaseven';
-    const NAME = 'Se Coucher Moins Bête Bridge';
+    const NAME = 'Se Coucher Moins Bête';
     const URI = 'https://secouchermoinsbete.fr';
     const CACHE_TIMEOUT = 21600; // 6h
     const DESCRIPTION = 'Returns the newest anecdotes.';

--- a/bridges/ScribdBridge.php
+++ b/bridges/ScribdBridge.php
@@ -2,7 +2,7 @@
 
 class ScribdBridge extends BridgeAbstract
 {
-    const NAME = 'Scribd Bridge';
+    const NAME = 'Scribd';
     const URI = 'https://www.scribd.com';
     const DESCRIPTION = 'Returns documents uploaded by a user.';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/SeznamZpravyBridge.php
+++ b/bridges/SeznamZpravyBridge.php
@@ -2,7 +2,7 @@
 
 class SeznamZpravyBridge extends BridgeAbstract
 {
-    const NAME = 'Seznam Zprávy Bridge';
+    const NAME = 'Seznam Zprávy';
     const URI = 'https://seznamzpravy.cz';
     const DESCRIPTION = 'Returns newest stories from Seznam Zprávy';
     const MAINTAINER = 'thezeroalpha';

--- a/bridges/ShanaprojectBridge.php
+++ b/bridges/ShanaprojectBridge.php
@@ -3,7 +3,7 @@
 class ShanaprojectBridge extends BridgeAbstract
 {
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'Shanaproject Bridge';
+    const NAME = 'Shanaproject';
     const URI = 'https://www.shanaproject.com';
     const DESCRIPTION = 'Returns a list of anime from the current Season Anime List';
     const PARAMETERS = [

--- a/bridges/SitemapBridge.php
+++ b/bridges/SitemapBridge.php
@@ -3,7 +3,7 @@
 class SitemapBridge extends CssSelectorBridge
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'Sitemap Bridge';
+    const NAME = 'Sitemap';
     const URI = 'https://github.com/RSS-Bridge/rss-bridge/';
     const DESCRIPTION = 'Convert any site to RSS feed using SEO Sitemap and CSS selectors (Advanced Users)';
     const PARAMETERS = [

--- a/bridges/SkimfeedBridge.php
+++ b/bridges/SkimfeedBridge.php
@@ -7,7 +7,7 @@ class SkimfeedBridge extends BridgeAbstract
     const CONTEXT_TECH_NEWS = 'Tech news';
     const CONTEXT_CUSTOM = 'Custom feed';
 
-    const NAME = 'Skimfeed Bridge';
+    const NAME = 'Skimfeed';
     const URI = 'https://skimfeed.com';
     const DESCRIPTION = 'Returns feeds from Skimfeed, also supports custom feeds!';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -3,7 +3,7 @@
 class SoundCloudBridge extends BridgeAbstract
 {
     const MAINTAINER = 'kranack, Roliga';
-    const NAME = 'Soundcloud Bridge';
+    const NAME = 'Soundcloud';
     const URI = 'https://soundcloud.com/';
     const CACHE_TIMEOUT = 600; // 10min
     const DESCRIPTION = 'Returns 10 newest music from user profile';

--- a/bridges/SplCenterBridge.php
+++ b/bridges/SplCenterBridge.php
@@ -2,7 +2,7 @@
 
 class SplCenterBridge extends FeedExpander
 {
-    const NAME = 'Southern Poverty Law Center Bridge';
+    const NAME = 'Southern Poverty Law Center';
     const URI = 'https://www.splcenter.org';
     const DESCRIPTION = 'Returns the newest posts from the Southern Poverty Law Center';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/SpottschauBridge.php
+++ b/bridges/SpottschauBridge.php
@@ -2,7 +2,7 @@
 
 class SpottschauBridge extends BridgeAbstract
 {
-    const NAME = 'Härringers Spottschau Bridge';
+    const NAME = 'Härringers Spottschau';
     const URI = 'https://spottschau.com/';
     const DESCRIPTION = 'Der Fußball-Comic';
     const MAINTAINER = 'sal0max';

--- a/bridges/SteamBridge.php
+++ b/bridges/SteamBridge.php
@@ -2,7 +2,7 @@
 
 class SteamBridge extends BridgeAbstract
 {
-    const NAME = 'Steam Bridge';
+    const NAME = 'Steam';
     const URI = 'https://store.steampowered.com/';
     const CACHE_TIMEOUT = 3600; // 1h
     const DESCRIPTION = 'Returns apps list';

--- a/bridges/StorytelBridge.php
+++ b/bridges/StorytelBridge.php
@@ -2,7 +2,7 @@
 
 class StorytelBridge extends BridgeAbstract
 {
-    const NAME = 'Storytel List Bridge';
+    const NAME = 'Storytel List';
     const URI = 'https://www.storytel.com/tr';
     const DESCRIPTION = 'Fetches books from a Storytel list, including title, author, and cover image.';
     const MAINTAINER = 'Okbaydere';

--- a/bridges/StravaBridge.php
+++ b/bridges/StravaBridge.php
@@ -2,7 +2,7 @@
 
 class StravaBridge extends BridgeAbstract
 {
-    const NAME = 'Strava Bridge';
+    const NAME = 'Strava';
     const DESCRIPTION = "Returns an athlete's recent activities";
     const URI = 'https://www.strava.com';
     const PARAMETERS = [

--- a/bridges/StreamCzBridge.php
+++ b/bridges/StreamCzBridge.php
@@ -2,7 +2,7 @@
 
 class StreamCzBridge extends BridgeAbstract
 {
-    const NAME = 'Stream.cz Bridge';
+    const NAME = 'Stream.cz';
     const URI = 'https://www.stream.cz';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'Return newest videos';

--- a/bridges/SubstackBridge.php
+++ b/bridges/SubstackBridge.php
@@ -3,7 +3,7 @@
 class SubstackBridge extends FeedExpander
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'Substack Bridge';
+    const NAME = 'Substack';
     const URI = 'https://substack.com/';
     const CACHE_TIMEOUT = 3600; //1hour
     const DESCRIPTION = 'Access Substack. Add full content for paywalled posts if you have a session cookie with an active subscription.';

--- a/bridges/SymfonyCastsBridge.php
+++ b/bridges/SymfonyCastsBridge.php
@@ -2,7 +2,7 @@
 
 class SymfonyCastsBridge extends BridgeAbstract
 {
-    const NAME = 'SymfonyCasts Bridge';
+    const NAME = 'SymfonyCasts';
     const URI = 'https://symfonycasts.com/';
     const DESCRIPTION = 'Follow new updates on symfonycasts.com';
     const MAINTAINER = 'Park0';

--- a/bridges/TCBScansBridge.php
+++ b/bridges/TCBScansBridge.php
@@ -2,7 +2,7 @@
 
 class TCBScansBridge extends BridgeAbstract
 {
-    const NAME = 'TCB Scans Bridge';
+    const NAME = 'TCB Scans';
     const URI = 'https://tcbscans.me/';
     const DESCRIPTION = 'Returns the latest chapter from a TCB Scans project';
     const MAINTAINER = 'osvfj';

--- a/bridges/TagesspiegelBridge.php
+++ b/bridges/TagesspiegelBridge.php
@@ -3,7 +3,7 @@
 class TagesspiegelBridge extends FeedExpander
 {
     const MAINTAINER = 'AlexanderS';
-    const NAME = 'Tagesspiegel Bridge';
+    const NAME = 'Tagesspiegel';
     const URI = 'https://www.tagesspiegel.de/';
     const CACHE_TIMEOUT = 3600; // 60min
     const DESCRIPTION = 'Returns the full articles instead of only the intro';

--- a/bridges/TarnkappeBridge.php
+++ b/bridges/TarnkappeBridge.php
@@ -3,7 +3,7 @@
 class TarnkappeBridge extends FeedExpander
 {
     const MAINTAINER = 'Tone866';
-    const NAME = 'tarnkappe Bridge';
+    const NAME = 'tarnkappe';
     const URI = 'https://tarnkappe.info/';
     const CACHE_TIMEOUT = 1800; // 30min
     const DESCRIPTION = 'Returns the full articles instead of only the intro';

--- a/bridges/TebeoBridge.php
+++ b/bridges/TebeoBridge.php
@@ -2,7 +2,7 @@
 
 class TebeoBridge extends FeedExpander
 {
-    const NAME = 'Tébéo Bridge';
+    const NAME = 'Tébéo';
     const URI = 'http://www.tebeo.bzh/';
     const CACHE_TIMEOUT = 21600; //6h
     const DESCRIPTION = 'Returns the newest Tébéo videos by category';

--- a/bridges/TelegramBridge.php
+++ b/bridges/TelegramBridge.php
@@ -2,7 +2,7 @@
 
 class TelegramBridge extends BridgeAbstract
 {
-    const NAME = 'Telegram Bridge';
+    const NAME = 'Telegram';
     const URI = 'https://t.me';
     const DESCRIPTION = 'Returns newest posts from a *public* Telegram channel';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/TheFarSideBridge.php
+++ b/bridges/TheFarSideBridge.php
@@ -2,7 +2,7 @@
 
 class TheFarSideBridge extends BridgeAbstract
 {
-    const NAME = 'The Far Side Bridge';
+    const NAME = 'The Far Side';
     const URI = 'https://www.thefarside.com';
     const DESCRIPTION = 'Returns the daily dose';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/TheGuardianBridge.php
+++ b/bridges/TheGuardianBridge.php
@@ -3,7 +3,7 @@
 class TheGuardianBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'The Guardian Bridge';
+    const NAME = 'The Guardian';
     const URI = 'https://www.theguardian.com/';
     const CACHE_TIMEOUT = 600; // This is a news site, so don't cache for more than 10 mins
     const DESCRIPTION = 'RSS feed for The Guardian';

--- a/bridges/TheHackerNewsBridge.php
+++ b/bridges/TheHackerNewsBridge.php
@@ -3,7 +3,7 @@
 class TheHackerNewsBridge extends BridgeAbstract
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'The Hacker News Bridge';
+    const NAME = 'The Hacker News';
     const URI = 'https://thehackernews.com/';
     const DESCRIPTION = 'Cyber Security, Hacking, Technology News.';
 

--- a/bridges/TicketioBridge.php
+++ b/bridges/TicketioBridge.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class TicketioBridge extends BridgeAbstract
 {
-    const NAME = 'Ticket.io Bridge';
+    const NAME = 'Ticket.io';
     const URI = 'https://www.ticket.io';
     const DESCRIPTION = 'Provides updates for available events in a specific ticketshop on ticket.io';
     const MAINTAINER = 'SebLaus';

--- a/bridges/TikTokBridge.php
+++ b/bridges/TikTokBridge.php
@@ -2,7 +2,7 @@
 
 class TikTokBridge extends BridgeAbstract
 {
-    const NAME = 'TikTok Bridge';
+    const NAME = 'TikTok';
     const URI = 'https://www.tiktok.com';
     const DESCRIPTION = 'Returns posts';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/TldrTechBridge.php
+++ b/bridges/TldrTechBridge.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 class TldrTechBridge extends BridgeAbstract
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'TLDR Tech Newsletter Bridge';
+    const NAME = 'TLDR Tech Newsletter';
     const URI = 'https://tldr.tech/';
     const DESCRIPTION = 'Return newsletter articles from TLDR Tech';
 

--- a/bridges/TorrentGalaxyBridge.php
+++ b/bridges/TorrentGalaxyBridge.php
@@ -2,7 +2,7 @@
 
 class TorrentGalaxyBridge extends BridgeAbstract
 {
-    const NAME = 'Torrent Galaxy Bridge';
+    const NAME = 'Torrent Galaxy';
     const URI = 'https://torrentgalaxy.to';
     const DESCRIPTION = 'Returns latest torrents';
     const MAINTAINER = 'GregThib';

--- a/bridges/TraktBridge.php
+++ b/bridges/TraktBridge.php
@@ -2,7 +2,7 @@
 
 class TraktBridge extends BridgeAbstract
 {
-    const NAME = 'Trakt Bridge';
+    const NAME = 'Trakt';
     const DESCRIPTION = "Returns a user's watch history";
     const URI = 'https://www.trakt.tv';
 

--- a/bridges/TrelloBridge.php
+++ b/bridges/TrelloBridge.php
@@ -2,7 +2,7 @@
 
 class TrelloBridge extends BridgeAbstract
 {
-    const NAME = 'Trello Bridge';
+    const NAME = 'Trello';
     const URI = 'https://trello.com/';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Returns activity on Trello boards or cards';

--- a/bridges/TwitScoopBridge.php
+++ b/bridges/TwitScoopBridge.php
@@ -2,7 +2,7 @@
 
 class TwitScoopBridge extends BridgeAbstract
 {
-    const NAME = 'TwitScoop Bridge';
+    const NAME = 'TwitScoop';
     const URI = 'https://www.twitscoop.com';
     const DESCRIPTION = 'Returns trending Twitter topics by country';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/TwitchBridge.php
+++ b/bridges/TwitchBridge.php
@@ -3,7 +3,7 @@
 class TwitchBridge extends BridgeAbstract
 {
     const MAINTAINER = 'Roliga';
-    const NAME = 'Twitch Bridge';
+    const NAME = 'Twitch';
     const URI = 'https://twitch.tv/';
     const CACHE_TIMEOUT = 300; // 5min
     const DESCRIPTION = 'Twitch channel videos';

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -2,7 +2,7 @@
 
 class TwitterBridge extends BridgeAbstract
 {
-    const NAME = 'Twitter Bridge';
+    const NAME = 'Twitter';
     const URI = 'https://twitter.com/';
     const API_URI = 'https://api.twitter.com';
     const GUEST_TOKEN_USES = 100;

--- a/bridges/TwitterV2Bridge.php
+++ b/bridges/TwitterV2Bridge.php
@@ -7,7 +7,7 @@
  */
 class TwitterV2Bridge extends BridgeAbstract
 {
-    const NAME = 'Twitter V2 Bridge';
+    const NAME = 'Twitter V2';
     const URI = 'https://twitter.com/';
     const API_URI = 'https://api.twitter.com/2';
     const DESCRIPTION = 'Returns tweets (using Twitter API v2). See the 

--- a/bridges/UberNewsroomBridge.php
+++ b/bridges/UberNewsroomBridge.php
@@ -2,7 +2,7 @@
 
 class UberNewsroomBridge extends BridgeAbstract
 {
-    const NAME = 'Uber Newsroom Bridge';
+    const NAME = 'Uber Newsroom';
     const URI = 'https://www.uber.com';
     const URI_API_DATA = 'https://newsroomapi.uber.com/wp-json/newsroom/v1/data?locale=';
     const URI_API_POST = 'https://newsroomapi.uber.com/wp-json/wp/v2/posts/';

--- a/bridges/UniverseTodayBridge.php
+++ b/bridges/UniverseTodayBridge.php
@@ -3,7 +3,7 @@
 class UniverseTodayBridge extends FeedExpander
 {
     const MAINTAINER = 'sqrtminusone';
-    const NAME = 'Universe Today Bridge';
+    const NAME = 'Universe Today';
     const URI = 'https://www.universetoday.com/';
     const DESCRIPTION = 'Returns the latest articles from Universe Today.';
 

--- a/bridges/UnogsBridge.php
+++ b/bridges/UnogsBridge.php
@@ -3,7 +3,7 @@
 class UnogsBridge extends BridgeAbstract
 {
     const MAINTAINER = 'csisoap';
-    const NAME = 'uNoGS Bridge';
+    const NAME = 'uNoGS';
     const URI = 'https://unogs.com';
     const DESCRIPTION = 'Return what\'s new or removal on Netflix';
 

--- a/bridges/UnsplashBridge.php
+++ b/bridges/UnsplashBridge.php
@@ -3,7 +3,7 @@
 class UnsplashBridge extends BridgeAbstract
 {
     const MAINTAINER = 'nel50n, langfingaz';
-    const NAME = 'Unsplash Bridge';
+    const NAME = 'Unsplash';
     const URI = 'https://unsplash.com/';
     const CACHE_TIMEOUT = 43200; // 12h
     const DESCRIPTION = 'Returns the latest photos from Unsplash';

--- a/bridges/UsbekEtRicaBridge.php
+++ b/bridges/UsbekEtRicaBridge.php
@@ -3,7 +3,7 @@
 class UsbekEtRicaBridge extends BridgeAbstract
 {
     const MAINTAINER = 'logmanoriginal';
-    const NAME = 'Usbek & Rica Bridge';
+    const NAME = 'Usbek & Rica';
     const URI = 'https://usbeketrica.com';
     const DESCRIPTION = 'Returns latest articles from the front page';
 

--- a/bridges/VarietyBridge.php
+++ b/bridges/VarietyBridge.php
@@ -3,7 +3,7 @@
 class VarietyBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'Variety Bridge';
+    const NAME = 'Variety';
     const URI = 'https://variety.com';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'RSS feed for Variety';

--- a/bridges/ViceBridge.php
+++ b/bridges/ViceBridge.php
@@ -3,7 +3,7 @@
 class ViceBridge extends FeedExpander
 {
     const MAINTAINER = 'IceWreck';
-    const NAME = 'Vice Bridge';
+    const NAME = 'Vice';
     const URI = 'https://www.vice.com/';
     const CACHE_TIMEOUT = 3600;
     const DESCRIPTION = 'RSS feed for vice publications like Vice News, Munchies, Motherboard, etc.';

--- a/bridges/VieDeMerdeBridge.php
+++ b/bridges/VieDeMerdeBridge.php
@@ -3,7 +3,7 @@
 class VieDeMerdeBridge extends BridgeAbstract
 {
     const MAINTAINER = 'floviolleau';
-    const NAME = 'VieDeMerde Bridge';
+    const NAME = 'VieDeMerde';
     const URI = 'https://www.viedemerde.fr';
     const DESCRIPTION = 'Returns latest quotes from VieDeMerde.';
     const CACHE_TIMEOUT = 7200;

--- a/bridges/VimeoBridge.php
+++ b/bridges/VimeoBridge.php
@@ -2,7 +2,7 @@
 
 class VimeoBridge extends BridgeAbstract
 {
-    const NAME = 'Vimeo Bridge';
+    const NAME = 'Vimeo';
     const URI = 'https://vimeo.com/';
     const DESCRIPTION = 'Returns search results from Vimeo';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/VixenBridge.php
+++ b/bridges/VixenBridge.php
@@ -2,7 +2,7 @@
 
 class VixenBridge extends BridgeAbstract
 {
-    const NAME = 'Vixen Network Bridge';
+    const NAME = 'Vixen Network';
     const URI = 'https://www.vixen.com';
     const DESCRIPTION = 'Latest videos from Vixen Network sites';
     const MAINTAINER = 'pubak42';

--- a/bridges/WallmineNewsBridge.php
+++ b/bridges/WallmineNewsBridge.php
@@ -2,7 +2,7 @@
 
 class WallmineNewsBridge extends BridgeAbstract
 {
-    const NAME = 'Wallmine News Bridge';
+    const NAME = 'Wallmine News';
     const URI = 'https://wallmine.com';
     const DESCRIPTION = 'Returns financial news';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/WiredBridge.php
+++ b/bridges/WiredBridge.php
@@ -3,7 +3,7 @@
 class WiredBridge extends FeedExpander
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'WIRED Bridge';
+    const NAME = 'WIRED';
     const URI = 'https://www.wired.com/';
     const DESCRIPTION = 'Returns the newest articles from WIRED';
 

--- a/bridges/WordPressBridge.php
+++ b/bridges/WordPressBridge.php
@@ -2,7 +2,7 @@
 
 class WordPressBridge extends FeedExpander
 {
-    const NAME = 'Wordpress Bridge';
+    const NAME = 'Wordpress';
     const URI = 'https://wordpress.org/';
     const DESCRIPTION = 'Returns the newest full posts of a WordPress powered website';
     const MAINTAINER = 'ORelio';

--- a/bridges/WordPressPluginUpdateBridge.php
+++ b/bridges/WordPressPluginUpdateBridge.php
@@ -3,7 +3,7 @@
 final class WordPressPluginUpdateBridge extends BridgeAbstract
 {
     const MAINTAINER = 'dvikan';
-    const NAME = 'WordPress Plugins Update Bridge';
+    const NAME = 'WordPress Plugins Update';
     const URI = 'https://wordpress.org/plugins/';
     const DESCRIPTION = 'Returns latest updates of wordpress.org plugins.';
 

--- a/bridges/XenForoBridge.php
+++ b/bridges/XenForoBridge.php
@@ -22,7 +22,7 @@ class XenForoBridge extends BridgeAbstract
     const XENFORO_VERSION_2 = '2.0';
 
     // RSS-Bridge constants
-    const NAME = 'XenForo Bridge';
+    const NAME = 'XenForo';
     const URI = 'https://xenforo.com/';
     const DESCRIPTION = 'Generates feeds for threads in forums powered by XenForo';
     const MAINTAINER = 'logmanoriginal';

--- a/bridges/YGGTorrentBridge.php
+++ b/bridges/YGGTorrentBridge.php
@@ -6,7 +6,7 @@
 class YGGTorrentBridge extends BridgeAbstract
 {
     const MAINTAINER = 'teromene';
-    const NAME = 'Yggtorrent Bridge';
+    const NAME = 'Yggtorrent';
     const URI = 'https://www3.yggtorrent.qa';
     const DESCRIPTION = 'Returns torrent search from Yggtorrent';
 

--- a/bridges/YandexZenBridge.php
+++ b/bridges/YandexZenBridge.php
@@ -2,7 +2,7 @@
 
 class YandexZenBridge extends BridgeAbstract
 {
-    const NAME = 'YandexZen Bridge';
+    const NAME = 'YandexZen';
     const URI = 'https://dzen.ru';
     const DESCRIPTION = 'Latest posts from the specified channel.';
     const MAINTAINER = 'llamasblade';

--- a/bridges/YouTubeCommunityTabBridge.php
+++ b/bridges/YouTubeCommunityTabBridge.php
@@ -2,7 +2,7 @@
 
 class YouTubeCommunityTabBridge extends BridgeAbstract
 {
-    const NAME = 'YouTube Posts Tab Bridge';
+    const NAME = 'YouTube Posts Tab';
     const URI = 'https://www.youtube.com';
     const DESCRIPTION = 'Returns posts from a channel\'s posts tab';
     const MAINTAINER = 'VerifiedJoseph';

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -2,7 +2,7 @@
 
 class YoutubeBridge extends BridgeAbstract
 {
-    const NAME = 'YouTube Bridge';
+    const NAME = 'YouTube';
     const URI = 'https://www.youtube.com';
     const CACHE_TIMEOUT = 60 * 60 * 3;
     const DESCRIPTION = 'Returns the 10 newest videos by username/channel/playlist or search';

--- a/bridges/ZDFMediathekBridge.php
+++ b/bridges/ZDFMediathekBridge.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class ZDFMediathekBridge extends BridgeAbstract
 {
-    const NAME = 'ZDF-Mediathek Bridge';
+    const NAME = 'ZDF-Mediathek';
     const URI = 'https://www.zdf.de/';
     const DESCRIPTION = 'Feed of any show,series,documentary etc. in the ZDF-Mediathek, specified by its path';
     const MAINTAINER = 'nabakolu';

--- a/bridges/ZDNetBridge.php
+++ b/bridges/ZDNetBridge.php
@@ -3,7 +3,7 @@
 class ZDNetBridge extends FeedExpander
 {
     const MAINTAINER = 'ORelio';
-    const NAME = 'ZDNet Bridge';
+    const NAME = 'ZDNet';
     const URI = 'https://www.zdnet.com/';
     const DESCRIPTION = 'Technology News, Analysis, Comments and Product Reviews for IT Professionals.';
 

--- a/bridges/ZeitBridge.php
+++ b/bridges/ZeitBridge.php
@@ -3,7 +3,7 @@
 class ZeitBridge extends FeedExpander
 {
     const MAINTAINER = 'Mynacol';
-    const NAME = 'Zeit Online Bridge';
+    const NAME = 'Zeit Online';
     const URI = 'https://www.zeit.de/';
     const CACHE_TIMEOUT = 1800; // 30min
     const DESCRIPTION = 'Returns the full articles instead of only the intro';

--- a/docs/05_Bridge_API/02_BridgeAbstract.md
+++ b/docs/05_Bridge_API/02_BridgeAbstract.md
@@ -133,7 +133,7 @@ Please remove any unnecessary comments and parameters.
 
 class MyBridge extends BridgeAbstract
 {
-    const NAME = 'Unnamed bridge';
+    const NAME = 'Unnamed';
     const URI = '';
     const DESCRIPTION = 'No description provided';
     const MAINTAINER = 'No maintainer';

--- a/docs/05_Bridge_API/03_FeedExpander.md
+++ b/docs/05_Bridge_API/03_FeedExpander.md
@@ -41,7 +41,7 @@ class MySiteBridge extends FeedExpander
 {
 
     const MAINTAINER = 'No maintainer';
-    const NAME = 'Unnamed bridge';
+    const NAME = 'Unnamed';
     const URI = '';
     const DESCRIPTION = 'No description provided';
     const PARAMETERS = [];

--- a/docs/09_Technical_recommendations/index.md
+++ b/docs/09_Technical_recommendations/index.md
@@ -15,7 +15,7 @@ and load a valid URL (not the base URL!).
 <?php
 class TestBridge extends BridgeAbstract
 {
-    const NAME = 'Unnamed bridge';
+    const NAME = 'Unnamed';
     const URI = '';
     const DESCRIPTION = 'No description provided';
     const MAINTAINER = 'No maintainer';


### PR DESCRIPTION
Since when you are using RSS-Bridge, it's implied that each site is a bridge. We don't need to have "Bridge" at the end of the names. The bridge name is "ABC News", not "ABC News Bridge".

This change removes all the "Bridge" suffixes to clean up the list.

## Before

<img width="963" height="1165" alt="Screenshot from 2026-01-21 13-11-25" src="https://github.com/user-attachments/assets/d4b4a947-3b38-4834-8768-c5da34ed54b7" />

## After
<img width="930" height="1221" alt="after" src="https://github.com/user-attachments/assets/42237584-6a42-42fc-9822-1c502d9eb085" />
