### PR TITLE
tests: Fix the tests by not using ARM

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   phpunit8:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']


### PR DESCRIPTION
In `composer test`, there were failing PHP extensions, I'm assuming since it was ARM. This PR changes it to not be ARM in an attempt to fix the currently broken tests.

### References
https://github.com/RSS-Bridge/rss-bridge/actions/runs/21226080444/job/61073284973
