### PR TITLE
[SpottschauBridge] Rewrite of the Spottschau Bridge

### DIFF
--- a/bridges/SpottschauBridge.php
+++ b/bridges/SpottschauBridge.php
@@ -21,13 +21,13 @@ class SpottschauBridge extends BridgeAbstract
         // Get URL from image src attribute
         $src = $strip->children(0)->src;
 
-        $this->items[] = array(
+        $this->items[] = [
             'uri' => self::URI,
             'title' => 'Strip der Woche',
             'content' => '<img src="' . $src . '">',
-            'enclosures' => array($src),
+            'enclosures' => [$src],
             'author' => 'Christoph Härringer',
             'uid' => $src,
-            );
+            ];
     }
 }

--- a/bridges/SpottschauBridge.php
+++ b/bridges/SpottschauBridge.php
@@ -11,8 +11,7 @@ class SpottschauBridge extends BridgeAbstract
 
     public function collectData()
     {
-        $html = getSimpleHTMLDOMCached(self::URI, self::CACHE_TIMEOUT)
-            or throwServerException('Could not retrieve ' . self::URI);
+        $html = getSimpleHTMLDOMCached(self::URI, self::CACHE_TIMEOUT);
 
         $strip = $html->find('div.strip > a', 0)
             or throwServerException('Could not find the proper HTML element of the strip.');

--- a/bridges/SpottschauBridge.php
+++ b/bridges/SpottschauBridge.php
@@ -12,10 +12,10 @@ class SpottschauBridge extends BridgeAbstract
     public function collectData()
     {
         $html = getSimpleHTMLDOMCached(self::URI, self::CACHE_TIMEOUT)
-            or returnServerError('Could not retrieve ' . self::URI);
+            or throwServerException('Could not retrieve ' . self::URI);
 
         $strip = $html->find('div.strip > a', 0)
-            or returnServerError('Could not find the proper HTML element of the strip.');
+            or throwServerException('Could not find the proper HTML element of the strip.');
 
         defaultLinkTo($strip, self::URI);
         // Get URL from image src attribute


### PR DESCRIPTION
This is basically a rewrite of the Spottschau bridge:

- A new strip is published once per week, so a cache timout of 1 h is overkill. Using 24 h now.
- The `<h2>` element is empty since at least 2022, so title is empty since then. Same with the `<img alt>` attribute.
- An empty title means no timestamp. I was getting a deprecated warning caused by providing null to a time function, probably somewhere downstream.
- Use defaultLinkTo() helper instead of urljoin'ing.