### PR TITLE
[HeiseBridge] Thema > Open Source added

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -29,6 +29,9 @@ class HeiseBridge extends FeedExpander
                 => 'https://www.heise.de/rss/heise-Rubrik-Wirtschaft-atom.xml',
                 'heise online Journal'
                 => 'https://www.heise.de/rss/heise-Rubrik-Journal-atom.xml',
+                // → https://www.heise.de/thema
+                'heise online > Thema > Open Source'
+                => 'https://www.heise.de/thema/Open-Source.xml',
                 'heise online Top-News'
                 => 'https://www.heise.de/rss/heise-top-atom.xml',
                 //'iMonitor – Internet-Störungen'


### PR DESCRIPTION
Please add the new category "Thema > Open Source".

FYI/for the future: There are a lot of _topics_  listed at https://www.heise.de/thema that can be subscribed and may become an extra _topics_ parameter, IMHO …

Thanks and KR