### PR TITLE
[ScribbleHubBridge] Introduce new series feed logic

### DIFF
--- a/bridges/ScribbleHubBridge.php
+++ b/bridges/ScribbleHubBridge.php
@@ -7,13 +7,20 @@ class ScribbleHubBridge extends FeedExpander
     const URI = 'https://scribblehub.com/';
     const DESCRIPTION = 'Returns chapters from Scribble Hub.';
     const PARAMETERS = [
-        'All' => [],
         'Author' => [
             'uid' => [
                 'name' => 'uid',
                 'required' => true,
                 // Example: miriamrobern's stories
                 'exampleValue' => '149271',
+            ],
+        ],
+        'List' => [
+            'url' => [
+                'name' => 'url',
+                'required' => true,
+                // Example: latest stories with the 'Transgender' tag
+                'exampleValue' => 'https://www.scribblehub.com/series-finder/?sf=1&gi=6&tgi=1088&sort=dateadded',
             ],
         ],
         'Series' => [
@@ -24,121 +31,32 @@ class ScribbleHubBridge extends FeedExpander
                 'exampleValue' => '965299',
             ],
         ],
-        'List' => [
-            'url' => [
-                'name' => 'url',
-                'required' => true,
-                // Example: latest stories with the 'Transgender' tag
-                'exampleValue' => 'https://www.scribblehub.com/series-finder/?sf=1&gi=6&tgi=1088&sort=dateadded',
-            ],
-        ]
     ];
 
-    public function getIcon()
-    {
-        return self::URI . 'favicon.ico';
-    }
-
+    const FEEDURI = 'https://rssscribblehub.com/rssfeed.php?type=author&uid=';
     public function collectData()
     {
-        $url = 'https://rssscribblehub.com/rssfeed.php?type=';
+        if ($this->queriedContext === 'Author') {
+            $this->collectExpandableDatas(self::FEEDURI . $this->getInput('uid'));
+        }
         if ($this->queriedContext === 'List') {
             $this->collectList($this->getURI());
-            return;
         }
-        if ($this->queriedContext === 'Author') {
-            $url = $url . 'author&uid=' . $this->getInput('uid');
-        } else { //All and Series use the same source feed
-            $url = $url . 'main';
-        }
-        $this->collectExpandableDatas($url);
-    }
-
-    private function collectList($url)
-    {
-        $html = getSimpleHTMLDOMCached($url);
-        foreach ($html->find('.search_main_box') as $element) {
-            $item = [];
-
-            $item['author'] = $element->find('[title="Author"]', 0)->plaintext;
-            $item['enclosures'] = [$element->find('.search_img img', 0)->src];
-            $title = $element->find('.search_title a', 0);
-            $item['title'] = $title->plaintext;
-            $item['uri'] = $title->href;
-            $item['uid'] = $item['uri'];
-
-            $strdate = $element->find('[title="Last Updated"]', 0)->plaintext;
-            $item['timestamp'] = strtotime($strdate);
-
-            foreach ($element->find('.fic_genre') as $tag) {
-                $item['categories'][] = $tag->plaintext;
-            }
-
-            // Get minimal description in case further requests fail
-            $item['content'] = str_get_html($element->find('.search_body', 0));
-            foreach ($item['content']->firstChild()->children() as $child) {
-                $child->remove();
-            }
-
-            try {
-                $details = getSimpleHTMLDOMCached($item['uri']);
-            } catch (HttpException $e) {
-                // 403 Forbidden, This means we got anti-bot response
-                if ($e->getCode() === 403 || $e->getCode() === 429) {
-                    $this->items[] = $item;
-                    continue;
-                }
-                throw $e;
-            }
-            $item['enclosures'] = [$details->find('.fic_image img', 0)->src];
-            $item['content'] = $details->find('.wi_fic_desc', 0);
-
-            foreach ($details->find('.stag') as $tag) {
-                $item['categories'][] = $tag->plaintext;
-            }
-
-            $read_url = $details->find('.read_buttons a', 0)->href;
-            $item['comments'] = $read_url . '#comments';
-            try {
-                $read_html = getSimpleHTMLDOMCached($read_url);
-            } catch (HttpException $e) {
-                // 403 Forbidden, This means we got anti-bot response
-                if ($e->getCode() === 403 || $e->getCode() === 429) {
-                    $this->items[] = $item;
-                    continue;
-                }
-                throw $e;
-            }
-            $item['content'] .= "<hr><h3><a href=\"$read_url\">";
-            $item['content'] .= $read_html->find('.chapter-title', 0);
-            $item['content'] .= '</a></h3>';
-            $item['content'] .= $read_html->find('#chp_raw', 0);
-
-            $this->items[] = $item;
+        if ($this->queriedContext === 'Series') {
+            $this->collectSeries($this->getURI());
         }
     }
 
     protected $author = '';
-
     protected function parseItem(array $item)
     {
-        //For series, filter out other series from 'All' feed
-        if (
-            $this->queriedContext === 'Series'
-            && preg_match('/read\/' . $this->getInput('sid') . '-/', $item['uri']) !== 1
-        ) {
-            return [];
-        }
-
-        if ($this->queriedContext === 'Author') {
-            $this->author = $item['author'];
-        }
-
+        $this->author = $item['author'];
         $item['comments'] = $item['uri'] . '#comments';
         $item['uid'] = $item['uri'];
 
         try {
             $dom = getSimpleHTMLDOMCached($item['uri']);
+            $dom = defaultLinkTo($dom, self::URI);
         } catch (HttpException $e) {
             // 403 Forbidden, This means we got anti-bot response
             if ($e->getCode() === 403 || $e->getCode() === 429) {
@@ -147,7 +65,6 @@ class ScribbleHubBridge extends FeedExpander
             throw $e;
         }
 
-        $dom = defaultLinkTo($dom, self::URI);
 
         //Retrieve full description from page contents
         $item['content'] = $dom->find('#chp_raw', 0);
@@ -167,6 +84,118 @@ class ScribbleHubBridge extends FeedExpander
         return $item;
     }
 
+    private function collectList($url)
+    {
+        $html = getSimpleHTMLDOMCached($url);
+        foreach ($html->find('.search_main_box') as $element) {
+            $title = $element->find('.search_title a', 0);
+            $strdate = $element->find('[title="Last Updated"]', 0)->plaintext;
+            $item = [
+                'author' => $element->find('[title="Author"]', 0)->plaintext,
+                'content' => str_get_html($element->find('.search_body', 0)),
+                'enclosures' => [$element->find('.search_img img', 0)->src],
+                'timestamp' => strtotime($strdate),
+                'title' => $title->plaintext,
+                'uri' => $title->href,
+                'uid' => $title->href,
+            ];
+
+
+            foreach ($element->find('.fic_genre') as $tag) {
+                $item['categories'][] = $tag->plaintext;
+            }
+            // Need to clean listing content to get real description
+            foreach ($item['content']->firstChild()->children() as $child) {
+                $child->remove();
+            }
+
+            try {
+                $details = getSimpleHTMLDOMCached($item['uri']);
+                $details = defaultLinkTo($details, self::URI);
+            } catch (HttpException $e) {
+                // 403 Forbidden, This means we got anti-bot response
+                if ($e->getCode() === 403 || $e->getCode() === 429) {
+                    $this->items[] = $item;
+                    continue;
+                }
+                throw $e;
+            }
+            // Can get better description from full details page
+            $item['content'] = $details->find('.wi_fic_desc', 0);
+            $item['enclosures'] = [$details->find('.fic_image img', 0)->src];
+
+            foreach ($details->find('.stag') as $tag) {
+                $item['categories'][] = $tag->plaintext;
+            }
+
+            $read_url = $details->find('.read_buttons a', 0)->href;
+            $item['comments'] = $read_url . '#comments';
+            // Attempt to add first chapter
+            try {
+                $read_html = getSimpleHTMLDOMCached($read_url);
+                $read_html = defaultLinkTo($read_html, self::URI);
+            } catch (HttpException $e) {
+                // 403 Forbidden, This means we got anti-bot response
+                if ($e->getCode() === 403 || $e->getCode() === 429) {
+                    $this->items[] = $item;
+                    continue;
+                }
+                throw $e;
+            }
+            $item['content'] .= "<hr><h3><a href=\"$read_url\">";
+            $item['content'] .= $read_html->find('.chapter-title', 0);
+            $item['content'] .= '</a></h3>';
+            $item['content'] .= $read_html->find('#chp_raw', 0);
+
+            $this->items[] = $item;
+        }
+    }
+
+    protected $title = '';
+    private function collectSeries($url)
+    {
+        $html = getSimpleHTMLDOMCached($url, 86400, [], [CURLOPT_COOKIE => 'toc_show=999']);
+        $author = $html->find('.auth_name_fic', 0)->plaintext;
+        $this->title = $html->find('.fic_title', 0)->plaintext;
+        $categories = [
+            $author,
+            $this->title,
+            $this->getInput('sid'),
+        ];
+        foreach ($html->find('.fic_genre') as $tag) {
+            $categories[] = $tag->plaintext;
+        }
+        foreach ($html->find('.toc_w') as $chapter) {
+            $item = [
+                'author' => $author,
+                'categories' => $categories,
+                'comments' => $chapter->find('.toc_a', 0)->href . '#comments',
+                'timestamp' => strtotime($chapter->find('.fic_date_pub', 0)->title),
+                'title' => $chapter->find('.toc_a', 0)->plaintext,
+                'uri' => $chapter->find('.toc_a', 0)->href,
+            ];
+            try {
+                $chapter_html = getSimpleHTMLDOMCached($item['uri']);
+                $chapter_html = defaultLinkTo($chapter_html, self::URI);
+            } catch (HttpException $e) {
+                // 403 Forbidden, This means we got anti-bot response
+                if ($e->getCode() === 403 || $e->getCode() === 429) {
+                    $this->items[] = $item;
+                    continue;
+                }
+                throw $e;
+            }
+            $item['content'] = $chapter_html->find('#chp_raw', 0);
+
+            $this->items[] = $item;
+        }
+    }
+
+    public function getIcon()
+    {
+        return self::URI . 'favicon.ico';
+    }
+
     public function getName()
     {
         $name = parent::getName() . " $this->queriedContext";
@@ -174,22 +203,13 @@ class ScribbleHubBridge extends FeedExpander
             case 'Author':
                 $title = $this->author;
                 break;
-            case 'Series':
-                try {
-                    $page = getSimpleHTMLDOMCached(self::URI . 'series/' . $this->getInput('sid') . '/a');
-                } catch (HttpException $e) {
-                    // 403 Forbidden, This means we got anti-bot response
-                    if ($e->getCode() === 403) {
-                        return $name;
-                    }
-                    throw $e;
-                }
-                $title = html_entity_decode($page->find('.fic_title', 0)->plaintext);
-                break;
             case 'List':
                 $page = getSimpleHTMLDOMCached($this->getURI());
                 $title = $page->find('head > title', 0)->plaintext;
                 $title = explode(' |', $title)[0];
+                break;
+            case 'Series':
+                $title = $this->title;
                 break;
         }
         if (isset($title)) {
@@ -205,11 +225,11 @@ class ScribbleHubBridge extends FeedExpander
             case 'Author':
                 $uri = self::URI . 'profile/' . $this->getInput('uid');
                 break;
-            case 'Series':
-                $uri = self::URI . 'series/' . $this->getInput('sid') . '/a';
-                break;
             case 'List':
                 $uri = $this->getInput('url');
+                break;
+            case 'Series':
+                $uri = self::URI . 'series/' . $this->getInput('sid') . '/a';
                 break;
         }
         return $uri;


### PR DESCRIPTION
Rewrites the logic for making series feeds to pull from website contents to properly be able to populate all chapters of a series. `curl-impersonate` is now required to use that part of the bridge, but it is substantially more useful.