### PR TITLE
[YoutubeBridge] workaround for sorting by upload date no longer supported

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -4,7 +4,7 @@ class YoutubeBridge extends BridgeAbstract
 {
     const NAME = 'YouTube';
     const URI = 'https://www.youtube.com';
-    const CACHE_TIMEOUT = 60 * 60 * 3;
+    const CACHE_TIMEOUT = 60 * 60 * 3; // 3 hours
     const DESCRIPTION = 'Returns the 10 newest videos by username/channel/playlist or search';
 
     const PARAMETERS = [
@@ -183,8 +183,14 @@ class YoutubeBridge extends BridgeAbstract
             });
         } elseif ($search) {
             // search
-            $url_listing = self::URI . '/results?search_query=' . urlencode($search) . '&sp=CAI%253D';
-            $html = $this->fetch($url_listing);
+            $today_filter = 'EgIIAg'; // restrict the upload date to the last 24 hours
+            $url_listing = self::URI . '/results?sp=' . $today_filter . '&search_query=' . urlencode($search);
+            if (!preg_match("/\b(before|after):/i", $search)) {
+                // unless explicitly overridden, a special "after:yyyy-mm-dd" keyword is appended to restrict the upload date to the last 6-30 hours
+                $html = $this->fetch($url_listing . urlencode(' after:' . date('Y-m-d', strtotime('-6 hours'))));
+            } else {
+                $html = $this->fetch($url_listing);
+            }
             $jsonData = $this->extractJsonFromHtml($html);
             $jsonData = $jsonData->contents->twoColumnSearchResultsRenderer->primaryContents;
             $jsonData = $jsonData->sectionListRenderer->contents[0]->itemSectionRenderer->contents;


### PR DESCRIPTION
The `Search result` context of the `YoutubeBridge` relied on the videos being sorted by the upload/publish date. YouTube intentionally [removed the feature](https://x.com/TeamYouTube/status/2009744367834022320). The search now falls back to the default "Relevance" sorting, which can contain videos from few hours up to years old videos, which makes the bridge context useless.

This PR adds a workaround, by filtering by "Today" (restricting the upload date to the last 24 hours) and combine that with the special "after:yyyy-mm-dd" keyword to restrict the upload date to the last 6-30 hours. This combination returns videos sorted by "Relevance" of the last 6 to 24 hours (depending on the current time).

Not as good as before, but I think that's the best YoutTube allows us.