### PR TITLE
[lib/html.php] set a parameter explicitly nullable

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -97,7 +97,7 @@ function html_option(string $name, $value, bool $selected = false): string
 
 function html_tag(
     string $name,
-    string $content = null,
+    ?string $content = null,
     array $attributes = []
 ): string {
     $strings = [


### PR DESCRIPTION
Implicit nullable parameters have been deprecated since PHP 8.4.
On my instance, a deprecation warning is added before the start of the xml, breaking it for my feed reader (feedbin).

```
<br />
<b>Deprecated</b>:  html_tag(): Implicitly marking parameter $content as nullable is deprecated, the explicit nullable type must be used instead in <b>[…]/lib/html.php</b> on line <b>100</b><br />
<?xml version="1.0" encoding="UTF-8"?>
<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
[…]
```