### PR TITLE
[MinecraftBridge] Switch to new API

### DIFF
--- a/bridges/MinecraftBridge.php
+++ b/bridges/MinecraftBridge.php
@@ -15,10 +15,9 @@ class MinecraftBridge extends BridgeAbstract
                 'name' => 'Category',
                 'values' => [
                     'All' => 'all',
-                    'Deep Dives' => 'Deep Dives',
-                    'News' => 'News',
-                    'Marketplace' => 'Marketplace',
-                    'Merch' => 'Merch',
+                    'Deep Dives' => 'minecraft:stockholm/deep-dives',
+                    'News' => 'minecraft:stockholm/news',
+                    'Marketplace' => 'minecraft:stockholm/marketplace',
                 ],
                 'title' => 'Choose article category',
                 'defaultValue' => 'all',
@@ -33,41 +32,52 @@ class MinecraftBridge extends BridgeAbstract
 
     public function collectData()
     {
-        $json = getContents('https://www.minecraft.net/content/minecraftnet/language-masters/en-us/_jcr_content.articles.page-1.json');
+        /* Removing either "category=News" or "newsOnly=false" causes many articles to not be visible */
+        $json = getContents('https://net-secondary.web.minecraft-services.net/api/v1.0/en-us/search?sortType=Recent&category=News&newsOnly=false');
 
         $data = json_decode($json);
-        if ($data === null || empty($data->article_grid)) {
+        if ($data === null || empty($data->result->results)) {
             throwServerException('Invalid or empty content');
         }
 
         $category = $this->getInput('category');
 
-        foreach ($data->article_grid as $article) {
-            if ($category !== 'all' && $category !== $article->primary_category) {
+        foreach ($data->result->results as $article) {
+            if ($category !== 'all' && in_array($category, $article->tags)) {
                 continue;
             }
 
-            $imageUrl = $this->getEncodedImageUrl($article->default_tile->image->imageURL);
+            $imageUrl = $article->image;
+
+            /* All posts have this article-page tag. Removing it. */
+            $tags = array_filter($article->tags, function ($value) {
+                return $value !== 'article-page';
+            });
+            $tags = array_map([$this, 'normalizeTags'], $tags);
 
             $this->items[] = [
-                'title' => trim($article->default_tile->title),
-                'uid' => $article->article_url,
-                'uri' => urljoin(self::URI, $article->article_url),
-                'content' => $article->default_tile->sub_header,
-                'categories' => [$article->primary_category],
+                'title' => trim($article->title),
+                'uid' => parse_url($article->url, PHP_URL_PATH),
+                'uri' => $article->url,
+                'timestamp' => $article->time,
+                'author' => $article->author,
+                'content' => $article->description,
+                'categories' => $tags,
                 'enclosures' => $imageUrl ? [$imageUrl] : [],
             ];
         }
     }
-
-    private function getEncodedImageUrl(string $path): ?string
+    /**
+     * For compatibility for tags from before 2026-02-12
+     */
+    private function normalizeTags($tag)
     {
-        $path = explode('/', ltrim($path, '/'));
-        $path = array_map('rawurlencode', $path);
-        $path = implode('/', $path);
-
-        $url = urljoin(self::URI, $path);
-
-        return filter_var($url, FILTER_VALIDATE_URL) ? $url : null;
+        $index = strpos($tag, '/');
+        if ($index !== false) {
+            $tag = substr($tag, $index + 1);
+        }
+        $tag = str_replace('-', ' ', $tag);
+        # Backwards compatibility with old tags
+        return ucwords($tag);
     }
 }


### PR DESCRIPTION
It appears the original URL which this feed pulled content from is no longer being updated, and a new one is used instead.

This new API includes the author, timestamp, multiple tags per post, and permalink images so an encoded image function is not needed.

There are more tags/categories, like "Java", "Bedrock", or "Dungeons" however they're inconsistent. Many of the tags could be applied to posts which don't have them, and "bedrock" is written as `minecraft:stockholm/bedrock` as well as
`minecraft:games/minecraft-bedrock`

The original tags are kept, with the exception of "Merch" which either no longer exists, or hasn't been posted to in a while.

Tags are normalized by removing everything before the slash, converting dashes to spaces, and capitalizing words to be compatible with the original categories. `minecraft:stockholm/deep-dives` -> `Deep Dives`