### PR TITLE
[InstagramBridge] Serve img as base64 data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN set -xe && \
       nss-plugin-pem \
       php-curl \
       php-fpm \
+	  php-gd \
       php-intl \
       # php-json is enabled by default with PHP 8.2 in Debian 12
       php-mbstring \

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -202,7 +202,7 @@ class InstagramBridge extends BridgeAbstract
                     break;
                 case 'GraphImage':
                     $imageOriginal = imagecreatefromstring(file_get_contents($mediaURI));
-                    $imageSmall = imagescale($imageOriginal, 540);
+                    $imageSmall = imagescale($imageOriginal, 360);
                     $stream = fopen('php://temp', 'r+');
                     imagepng($imageSmall, $stream);
                     rewind($stream);
@@ -250,7 +250,7 @@ class InstagramBridge extends BridgeAbstract
                     continue; // check if not added yet
                 }
                 $imageOriginal = imagecreatefromstring(file_get_contents($singleMedia->display_url));
-                $imageSmall = imagescale($imageOriginal, 540);
+                $imageSmall = imagescale($imageOriginal, 360);
                 $stream = fopen('php://temp', 'r+');
                 imagepng($imageSmall, $stream);
                 rewind($stream);

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -201,9 +201,14 @@ class InstagramBridge extends BridgeAbstract
                     $item['enclosures'] = $data[1];
                     break;
                 case 'GraphImage':
-                    $item['content'] = '<a href="' . htmlentities($item['uri']) . '" target="_blank">';
-                    $image = file_get_contents($mediaURI);
-                    $imageData = 'data:image/jpeg;base64,' . base64_encode($image);
+                    $imageOriginal = imagecreatefromstring(file_get_contents($mediaURI));
+                    $imageSmall = imagescale($imageOriginal,540);
+                    $stream = fopen('php://temp','r+');
+                    imagepng($imageSmall,$stream);
+                    rewind($stream);
+                    $image = stream_get_contents($stream);
+                    $imageData = 'data:image/png;base64,' . base64_encode($image);
+                    $item['content'] = '<a href="' . htmlentities($mediaURI) . '" target="_blank">';
                     $item['content'] .= '<img src="' . $imageData . '" alt="' . $item['title'] . '" />';
                     $item['content'] .= '</a><br><br>' . nl2br(preg_replace($pattern, $replace, htmlentities($textContent)));
                     $item['enclosures'] = [$mediaURI];
@@ -244,9 +249,14 @@ class InstagramBridge extends BridgeAbstract
                 if (in_array($singleMedia->display_url, $enclosures)) {
                     continue; // check if not added yet
                 }
+                $imageOriginal = imagecreatefromstring(file_get_contents($singleMedia->display_url));
+                $imageSmall = imagescale($imageOriginal,540);
+                $stream = fopen('php://temp','r+');
+                imagepng($imageSmall,$stream);
+                rewind($stream);
+                $image = stream_get_contents($stream);
+                $imageData = 'data:image/png;base64,' . base64_encode($image);
                 $content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
-                $image = file_get_contents($singleMedia->display_url);
-                $imageData = 'data:image/jpeg;base64,' . base64_encode($image);
                 $content .= '<img src="' . $imageData . '" alt="' . $postTitle . '" />';
                 $content .= '</a><br>';
                 array_push($enclosures, $singleMedia->display_url);

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -202,7 +202,9 @@ class InstagramBridge extends BridgeAbstract
                     break;
                 case 'GraphImage':
                     $item['content'] = '<a href="' . htmlentities($item['uri']) . '" target="_blank">';
-                    $item['content'] .= '<img src="' . htmlentities($mediaURI) . '" alt="' . $item['title'] . '" />';
+                    $image = file_get_contents($mediaURI);
+                    $imageData = 'data:image/jpeg;base64,' . base64_encode($image);
+                    $item['content'] .= '<img src="' . $imageData . '" alt="' . $item['title'] . '" />';
                     $item['content'] .= '</a><br><br>' . nl2br(preg_replace($pattern, $replace, htmlentities($textContent)));
                     $item['enclosures'] = [$mediaURI];
                     break;
@@ -243,7 +245,9 @@ class InstagramBridge extends BridgeAbstract
                     continue; // check if not added yet
                 }
                 $content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
-                $content .= '<img src="' . $singleMedia->display_url . '" alt="' . $postTitle . '" />';
+                $image = file_get_contents($singleMedia->display_url);
+                $imageData = base64_encode($image);
+                $content .= '<img src="data:image/jpeg;base64,' . $imageData . '" alt="' . $postTitle . '" />';
                 $content .= '</a><br>';
                 array_push($enclosures, $singleMedia->display_url);
             }

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -246,8 +246,8 @@ class InstagramBridge extends BridgeAbstract
                 }
                 $content .= '<a href="' . $singleMedia->display_url . '" target="_blank">';
                 $image = file_get_contents($singleMedia->display_url);
-                $imageData = base64_encode($image);
-                $content .= '<img src="data:image/jpeg;base64,' . $imageData . '" alt="' . $postTitle . '" />';
+                $imageData = 'data:image/jpeg;base64,' . base64_encode($image);
+                $content .= '<img src="' . $imageData . '" alt="' . $postTitle . '" />';
                 $content .= '</a><br>';
                 array_push($enclosures, $singleMedia->display_url);
             }

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -202,9 +202,9 @@ class InstagramBridge extends BridgeAbstract
                     break;
                 case 'GraphImage':
                     $imageOriginal = imagecreatefromstring(file_get_contents($mediaURI));
-                    $imageSmall = imagescale($imageOriginal,540);
-                    $stream = fopen('php://temp','r+');
-                    imagepng($imageSmall,$stream);
+                    $imageSmall = imagescale($imageOriginal, 540);
+                    $stream = fopen('php://temp', 'r+');
+                    imagepng($imageSmall, $stream);
                     rewind($stream);
                     $image = stream_get_contents($stream);
                     $imageData = 'data:image/png;base64,' . base64_encode($image);
@@ -250,9 +250,9 @@ class InstagramBridge extends BridgeAbstract
                     continue; // check if not added yet
                 }
                 $imageOriginal = imagecreatefromstring(file_get_contents($singleMedia->display_url));
-                $imageSmall = imagescale($imageOriginal,540);
-                $stream = fopen('php://temp','r+');
-                imagepng($imageSmall,$stream);
+                $imageSmall = imagescale($imageOriginal, 540);
+                $stream = fopen('php://temp', 'r+');
+                imagepng($imageSmall, $stream);
                 rewind($stream);
                 $image = stream_get_contents($stream);
                 $imageData = 'data:image/png;base64,' . base64_encode($image);


### PR DESCRIPTION
Because of instagrams restrictive CORS same-origin policy images are not rendered when referenced directly.

This PR introduces fetching the image and serving it as base64 encoded data.

Fixes #2005