### PR TITLE
[RaiPlaySound] Add RaiPlay Sound Bridge; [PlaySrf] Add Play SRF Bridge

### DIFF
--- a/bridges/PlaySrfBridge.php
+++ b/bridges/PlaySrfBridge.php
@@ -51,10 +51,16 @@ class PlaySrfBridge extends BridgeAbstract
         }
 
         foreach ($episodes as $ep) {
-            $content = $ep['description'] === '' ? '<p>' . $ep['lead'] . '</p>' : '<p>' . $ep['description'] . '</p>';
+            $content = '';
+
             if ($embed === true) {
-                $content = '<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;"><iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" width="560" height="315" src="https://www.srf.ch/play/embed?urn=' . $ep['urn'] . '&subdivisions=false" allowfullscreen="" allow="geolocation *; autoplay; encrypted-media"></iframe></div>' . $content;
+                $content .= '<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;">';
+                $content .= '<iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" width="560" height="315" ';
+                $content .= 'src="https://www.srf.ch/play/embed?urn=' . $ep['urn'] . '&subdivisions=false" allowfullscreen ';
+                $content .= 'allow="geolocation *; autoplay; encrypted-media"></iframe></div>';
             }
+
+            $content .= $ep['description'] === '' ? '<p>' . $ep['lead'] . '</p>' : '<p>' . $ep['description'] . '</p>';
 
             $item = [];
             $item['uri'] = 'https://www.srf.ch/play/tv/-/video/-?urn=' . $ep['urn'];

--- a/bridges/PlaySrfBridge.php
+++ b/bridges/PlaySrfBridge.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+class PlaySrfBridge extends BridgeAbstract
+{
+    const NAME = 'Play SRF';
+    const URI = 'https://www.srf.ch/play/tv';
+    const DESCRIPTION = 'Feed of any show in the Play SRF portal, specified by its ID';
+    const MAINTAINER = 'giodi';
+    const PARAMETERS = [
+    [
+      'showId' => [
+        'name' => 'Show Link or ID',
+        'required' => true,
+        'title' => 'Insert the URL to the page of a show.',
+        'exampleValue' => 'https://www.srf.ch/play/tv/sendung/arena?id=09784065-687b-4b60-bd23-9ed0d2d43cdc'
+      ],
+      'embed' => [
+        'type' => 'checkbox',
+        'name' => 'Embed',
+        'required' => false,
+        'title' => 'Check if you want to include an embed of the episode in the feed items.',
+      ],
+      'limit' => self::LIMIT,
+    ]
+    ];
+
+    /**
+     * Holds the title of the current show
+     *
+     * @var string
+     */
+    private $title;
+
+    public function collectData(): void
+    {
+        preg_match('/[a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}$/s', $this->getInput('showId'), $matches);
+        $url = $matches[0];
+        $embed = $this->getInput('embed');
+        $limit = $this->getInput('limit');
+
+        $raw = getContents('https://www.srf.ch/play/v3/api/srf/production/videos-by-show-id?showId=' . $url);
+        $jsonShowVideos = json_decode($raw, true);
+
+        $this->title = $jsonShowVideos['data']['data'][0]['show']['title'] ?? 'Play SRF';
+        $episodes = $jsonShowVideos['data']['data'];
+
+        if ($limit !== null) {
+            $episodes = array_slice($episodes, 0, $limit);
+        }
+
+        foreach ($episodes as $ep) {
+            $content = $ep['description'] === '' ? '<p>' . $ep['lead'] . '</p>' : '<p>' . $ep['description'] . '</p>';
+            if ($embed === true) {
+                $content = '<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;"><iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" width="560" height="315" src="https://www.srf.ch/play/embed?urn=' . $ep['urn'] . '&subdivisions=false" allowfullscreen="" allow="geolocation *; autoplay; encrypted-media"></iframe></div>' . $content;
+            }
+
+            $item = [];
+            $item['uri'] = 'https://www.srf.ch/play/tv/-/video/-?urn=' . $ep['urn'];
+            $item['title'] = $ep['title'];
+            $item['timestamp'] = $ep['date'];
+            $item['author'] = $ep['show']['title'];
+            $item['content'] = $content;
+            $item['uid'] = $ep['urn'];
+            $item['duration'] = $ep['duration'];
+            $this->items[] = $item;
+        }
+    }
+
+    /** {@inheritdoc} */
+    public function getName()
+    {
+        if (!empty($this->title)) {
+            return $this->title;
+        }
+        return parent::getName();
+    }
+}

--- a/bridges/PlaySrfBridge.php
+++ b/bridges/PlaySrfBridge.php
@@ -60,7 +60,7 @@ class PlaySrfBridge extends BridgeAbstract
                 $content .= 'allow="geolocation *; autoplay; encrypted-media"></iframe></div>';
             }
 
-            $content .= $ep['description'] === '' ? '<p>' . $ep['lead'] . '</p>' : '<p>' . $ep['description'] . '</p>';
+            $content .= $ep['description'] === '' ? '<p>' . nl2br($ep['lead'], false) . '</p>' : '<p>' . nl2br($ep['description'], false) . '</p>';
 
             $item = [];
             $item['uri'] = 'https://www.srf.ch/play/tv/-/video/-?urn=' . $ep['urn'];

--- a/bridges/RaiPlaySoundBridge.php
+++ b/bridges/RaiPlaySoundBridge.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+class RaiPlaySoundBridge extends BridgeAbstract
+{
+    const NAME = 'RaiPlay Sound';
+    const URI = 'https://www.raiplaysound.it';
+    const DESCRIPTION = 'Get feeds for shows in the Podcast and Audiolibri sections from RaiPlay Sound.';
+    const MAINTAINER = 'giodi';
+    const PARAMETERS = [
+    [
+      'path' => [
+        'name' => 'URL',
+        'required' => true,
+        'title' => 'Insert the URL to the page of a show.',
+        'exampleValue' => 'https://www.raiplaysound.it/programmi/ilfalso'
+      ],
+      'limit' => self::LIMIT,
+    ]
+    ];
+
+    /**
+     * Holds the title of the current show
+     *
+     * @var string
+     */
+    private $title;
+
+    public function collectData(): void
+    {
+        $url = $this->getInput('path');
+        $limit = $this->getInput('limit');
+        $html = getContents($url);
+
+        $dom = getSimpleHTMLDOM($url);
+        $h1 = $dom->find('h1');
+        $this->title = $h1[0]->plaintext . self::NAME;
+        $episodesJson = [];
+
+        foreach ($dom->find('rps-playlist-action') as $el) {
+            $episodesJson[] = json_decode($el->getAttribute('options'), true)['url'];
+        }
+
+        if ($limit !== null) {
+            $episodesJson = array_slice($episodesJson, 0, $limit);
+        }
+
+        foreach ($episodesJson as $ep) {
+            $data = json_decode(getContents(self::URI . $ep), true);
+            $item = [];
+            $item['uri'] = self::URI . $data['weblink'];
+            $item['title'] = $data['episode_title'];
+            $item['content'] = $data['description'];
+            $item['enclosures'] = [$data['audio']['url']];
+            $item['author'] = $data['podcast_info']['title'];
+            $this->items[] = $item;
+        }
+    }
+
+    /** {@inheritdoc} */
+    public function getName()
+    {
+        if (!empty($this->title)) {
+            return $this->title;
+        }
+        return parent::getName();
+    }
+}

--- a/bridges/RaiPlaySoundBridge.php
+++ b/bridges/RaiPlaySoundBridge.php
@@ -50,10 +50,13 @@ class RaiPlaySoundBridge extends BridgeAbstract
             $data = json_decode(getContents(self::URI . $ep), true);
             $item = [];
             $item['uri'] = self::URI . $data['weblink'];
-            $item['title'] = $data['episode_title'];
-            $item['content'] = $data['description'];
-            $item['enclosures'] = [$data['audio']['url']];
+            $item['title'] = $data['track_info']['episode_title'];
+            $item['timestamp'] = $data['track_info']['date'];
             $item['author'] = $data['podcast_info']['title'];
+            $item['content'] = $data['description'];
+            $item['enclosures'] = [$data['audio']['url'], self::URI . $data['images']['square']];
+            $item['categories'] = array_merge($data['track_info']['genres'], $data['track_info']['sub_genres']);
+            $item['uid'] = $data['podcast_info']['uniquename'];
             $this->items[] = $item;
         }
     }

--- a/bridges/RaiPlaySoundBridge.php
+++ b/bridges/RaiPlaySoundBridge.php
@@ -57,6 +57,7 @@ class RaiPlaySoundBridge extends BridgeAbstract
             $item['enclosures'] = [$data['audio']['url'], self::URI . $data['images']['square']];
             $item['categories'] = array_merge($data['track_info']['genres'], $data['track_info']['sub_genres']);
             $item['uid'] = $data['podcast_info']['uniquename'];
+            $item['duration'] = $data['audio']['duration'];
             $this->items[] = $item;
         }
     }


### PR DESCRIPTION
This bridges are for generating feeds for shows in the Podcast and Audiolibri sections from [RaiPlay Sound](https://www.raiplaysound.it/) and the [PlaySRF ](https://www.srf.ch/play/tv) Portal.