### PR TITLE
fix and improve the identification of ARD Mediethek identifiers

### DIFF
--- a/bridges/ARDMediathekBridge.php
+++ b/bridges/ARDMediathekBridge.php
@@ -63,19 +63,15 @@ class ARDMediathekBridge extends BridgeAbstract
 
         date_default_timezone_set('Europe/Berlin');
 
-        $pathComponents = explode('/', $this->getInput('path'));
-        if (empty($pathComponents)) {
-            throwClientException('Path may not be empty');
+        // ARD IDs always start with Y3JpZDov that we can use for finding the correct part of the URL
+        // Extract ARD show ID from full URL or plain ID
+        preg_match('~(Y3JpZDov[^/]+)~', $this->getInput('path'), $matches);
+
+        if (empty($matches[1])) {
+            throwClientException('Could not extract show ID');
         }
-        if (count($pathComponents) < 2) {
-            $showID = $pathComponents[0];
-        } else {
-            $lastKey = count($pathComponents) - 1;
-            $showID = $pathComponents[$lastKey];
-            if (strlen($showID) === 0) {
-                $showID = $pathComponents[$lastKey - 1];
-            }
-        }
+
+        $showID = $matches[1];
 
         $url = self::APIENDPOINT . $showID . '?pageSize=' . self::PAGESIZE;
         $rawJSON = getContents($url);


### PR DESCRIPTION
This fixes https://github.com/RSS-Bridge/rss-bridge/issues/4478

# Fix show ID extraction for ARD-Mediathek URLs with trailing numbers

## Problem

The current code in `ARDMediathekBridge.php` assumes the show ID is always the last segment of the URL:

```php
$pathComponents = explode('/', $this->getInput('path'));
$showID = $pathComponents[last_non_empty_segment];
```

However, some ARD-Mediathek URLs append a numeric segment (e.g., `/1`) after the actual show ID, which relates to the selected season.  

**Example URL:**

```text
https://www.ardmediathek.de/serie/tage-die-es-nicht-gab-oder-staffel-2/staffel-1/Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhZ2UtZGllLWVzLW5pY2h0LWdhYg/1
```

`explode('/')` produces:

```php
[
  "https:",
  "",
  "www.ardmediathek.de",
  "serie",
  "tage-die-es-nicht-gab-oder-staffel-2",
  "staffel-1",
  "Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhZ2UtZGllLWVzLW5pY2h0LWdhYg",
  "1"
]
```

The current logic incorrectly picks the last segment `1` instead of the actual ID:

```text
Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhZ2UtZGllLWVzLW5pY2h0LWdhYg
```

---

## Solution: Regex-based extraction

The ARD IDs are always base64 encoded strings, with the prefix 'crid://'

Thus, ARD IDs always start with the prefix `Y3JpZDov`, a regex can directly extract them.

```php
preg_match('~(Y3JpZDov[^/]+)~', $this->getInput('path'), $matches);

if (empty($matches[1])) {
    throwClientException('Could not extract show ID');
}

$showID = $matches[1];
```

- Works with full URLs and plain IDs  
- More robust and future-proof  

---

## Impact

- Fixes broken feeds caused by extra numeric URL segments  
- Works for all ARD-Mediathek show URLs  
- Prevents `Could not extract show ID` errors  
