### PR TITLE
[lib/html.php] handleYoutube:  Add video link as text below image

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -601,6 +601,9 @@ EOD
         <img srcset="%s" src="%s" alt="Video thumbnail" title="YouTube video thumbnail" referrerpolicy="no-referrer" />
     </picture>
 </a>
-EOD, $videoUri, $webpSrcset, $jpegSrcset, $fallbackUri);
+<p>
+<a href="%s">%s</a>
+</p>
+EOD, $videoUri, $webpSrcset, $jpegSrcset, $fallbackUri, $videoUri, $videoUri);
     }
 }


### PR DESCRIPTION
Add the YouTube video link below the thumbnail image. This helps news readers that don't allow clicking on images with links. But it also makes it more obvious that this is a clickable thumbnail for a video.

@Tone866 does this suit you? Can we further improve the display?