### PR TITLE
[NewgroundsBridge] Repair NewgroundsBridge

### DIFF
--- a/bridges/NewgroundsBridge.php
+++ b/bridges/NewgroundsBridge.php
@@ -51,7 +51,7 @@ class NewgroundsBridge extends BridgeAbstract
         }
         */
 
-        $html = $this->postFASimpleHTMLDOM();
+        $html = $this->postFASimpleHTMLDOM($this->getURI());
 
         $posts = $html->find('.item-portalitem-art-medium');
 
@@ -65,6 +65,41 @@ class NewgroundsBridge extends BridgeAbstract
             $title = $post->find('h4')[0]->innertext;
             //This kind of sucks but it works so
             if ($this->getInput('Nsfw') === false && $Restricted == '<div class="nohue-ngicon-small-rated-a" title="Rated A"></div>') {
+                $item['title'] = 'NSFW: ' . $item['uri'];
+                $item['content'] = <<<EOD
+<a href="{$item['uri']}">
+{$item['title']}
+</a>
+EOD;
+            } else {
+                $item['title'] = $title;
+                $item['content'] = <<<EOD
+<a href="{$item['uri']}">
+<img
+    style="align:top; width:270px; border:1px solid black;"
+    alt="{$item['title']}"
+    src="{$post->find('img')[0]->src}"
+    title="{$item['title']}" />
+</a>
+EOD;
+            }
+
+            $this->items[] = $item;
+        }
+                $html = $this->postFASimpleHTMLDOM($this->getURImovies());
+
+        $posts = $html->find('.portalsubmission-cell');
+
+        foreach ($posts as $post) {
+            $item = [];
+
+            $item['author'] = $username;
+            $item['uri'] = $post->href;
+
+            $Restricted = $post->find('div')[2]->outertext;
+            $title = $post->find('h4')[0]->innertext;
+            //This kind of sucks but it works so
+            if ($this->getInput('Nsfw') === false && $Restricted == '<div class="nohue-ngicon-small-rated-a"></div>') {
                 $item['title'] = 'NSFW: ' . $item['uri'];
                 $item['content'] = <<<EOD
 <a href="{$item['uri']}">
@@ -103,6 +138,13 @@ EOD;
         }
         return parent::getURI();
     }
+    public function getURImovies()
+    {
+        if ($this->getInput('username')) {
+            return sprintf('https://%s.newgrounds.com/movies', $this->getInput('username'));
+        }
+        return parent::getURI();
+    }
 
     public function getURIMODIFIED()
     {
@@ -112,15 +154,15 @@ EOD;
         return parent::getURIMODIFIED();
     }
 
-    private function postFASimpleHTMLDOM()
+    private function postFASimpleHTMLDOM($url)
     {
         $header = [
                 'Host: ' . parse_url($this->getURIMODIFIED(), PHP_URL_HOST),
                 'Cookie: ' . $this->NG_AUTH_COOKIE
             ];
 
-        $html = getSimpleHTMLDOM($this->getURI(), $header);
-        $html = defaultLinkTo($html, $this->getURI());
+        $html = getSimpleHTMLDOM($url, $header);
+        $html = defaultLinkTo($html, $url);
         return $html;
     }
 }

--- a/bridges/NewgroundsBridge.php
+++ b/bridges/NewgroundsBridge.php
@@ -8,6 +8,17 @@ class NewgroundsBridge extends BridgeAbstract
     const URI = 'https://www.newgrounds.com';
     const DESCRIPTION = 'Get the latest art from a given user';
     const MAINTAINER = 'KamaleiZestri';
+    const CONFIGURATION = [
+        'newgrounds_session' => [
+            'required' => false,
+            'defaultValue' => ''
+
+        ],
+        'ng_session' => [
+            'required' => false,
+            'defaultValue' => ''
+        ]
+    ];
     const PARAMETERS = [
         'User' => [
             'username' => [
@@ -15,18 +26,32 @@ class NewgroundsBridge extends BridgeAbstract
                 'type' => 'text',
                 'required' => true,
                 'exampleValue' => 'TomFulp'
+            ],
+            'Nsfw' => [
+                'name' => 'Nsfw',
+                'type' => 'checkbox',
             ]
         ]
     ];
+    /*
+     * This was aquired by creating a new user on Newgrounds then
+     * extracting the cookie from the browsers dev console.
+     */
+    private $NG_AUTH_COOKIE;
 
     public function collectData()
     {
+        $this->NG_AUTH_COOKIE = /*'ng_user0=' . $this->getOption('ng_user0') . '; XSRF-TOKEN=' . $this->getOption('XSRF-TOKEN') .*/ 'newgrounds_session=' . $this->getOption('newgrounds_session') . '; ng_session=' . $this->getOption('ng_session');
         $username = $this->getInput('username');
+
+        //I dont think this is needed? There are plenty of usernames that dont match this style.
+        /*
         if (!preg_match('/^\w+$/', $username)) {
             throw new \Exception('Illegal username');
         }
+        */
 
-        $html = getSimpleHTMLDOM($this->getURI());
+        $html = $this->postFASimpleHTMLDOM();
 
         $posts = $html->find('.item-portalitem-art-medium');
 
@@ -36,10 +61,10 @@ class NewgroundsBridge extends BridgeAbstract
             $item['author'] = $username;
             $item['uri'] = $post->href;
 
-            $titleOrRestricted = $post->find('h4')[0]->innertext;
-
-            // Newgrounds doesn't show public previews for NSFW content.
-            if ($titleOrRestricted === 'Restricted Content: Sign in to view!') {
+            $Restricted = $post->find('div')[3]->outertext;
+            $title = $post->find('h4')[0]->innertext;
+            //This kind of sucks but it works so
+            if ($this->getInput('Nsfw') === false && $Restricted == '<div class="nohue-ngicon-small-rated-a" title="Rated A"></div>') {
                 $item['title'] = 'NSFW: ' . $item['uri'];
                 $item['content'] = <<<EOD
 <a href="{$item['uri']}">
@@ -47,7 +72,7 @@ class NewgroundsBridge extends BridgeAbstract
 </a>
 EOD;
             } else {
-                $item['title'] = $titleOrRestricted;
+                $item['title'] = $title;
                 $item['content'] = <<<EOD
 <a href="{$item['uri']}">
 <img
@@ -77,5 +102,25 @@ EOD;
             return sprintf('https://%s.newgrounds.com/art', $this->getInput('username'));
         }
         return parent::getURI();
+    }
+
+    public function getURIMODIFIED()
+    {
+        if ($this->getInput('username')) {
+            return sprintf('https://%s.newgrounds.com', $this->getInput('username'));
+        }
+        return parent::getURIMODIFIED();
+    }
+
+    private function postFASimpleHTMLDOM()
+    {
+        $header = [
+                'Host: ' . parse_url($this->getURIMODIFIED(), PHP_URL_HOST),
+                'Cookie: ' . $this->NG_AUTH_COOKIE
+            ];
+
+        $html = getSimpleHTMLDOM($this->getURI(), $header);
+        $html = defaultLinkTo($html, $this->getURI());
+        return $html;
     }
 }


### PR DESCRIPTION
Newgrounds now requires cookies to access, as any non-browser based program attempting to access it will throw a 403 forbidden error, just as rss-bridge does now. This commit modifies the bridge to accept cookies, as well as modifying the bridge to account for the new Nsfw capabilities that come with this update.

I should mention that I have no programing experience in php, however no AI was used in the production of this fix. Most of the code is butchered from the FurAffinityBridge and modified to work in the context of newgrounds. Everything has been tested and functions on my system.