### PR TITLE
Add Uber Engineering blog bridge

### DIFF
--- a/bridges/UberEngineeringBridge.php
+++ b/bridges/UberEngineeringBridge.php
@@ -1,0 +1,124 @@
+<?php
+
+class UberEngineeringBridge extends BridgeAbstract
+{
+    const NAME = 'Uber Engineering';
+    const URI = 'https://www.uber.com/us/en/blog/engineering/';
+    const DESCRIPTION = 'Returns posts from the Uber Engineering blog';
+    const MAINTAINER = 'zj';
+    const PARAMETERS = [];
+    const CACHE_TIMEOUT = 3600;
+    const ARTICLE_FEED_PATH = '/us/en/blog/engineering/';
+
+    public function collectData()
+    {
+        $html = getContents(self::URI);
+        $articles = self::extractArticleFeedFromHtml($html, self::ARTICLE_FEED_PATH);
+
+        foreach ($articles as $article) {
+            $title = trim($article['title'] ?? '');
+            $uri = self::normalizeUrl($article['fullURL'] ?? '');
+
+            if ($title === '' || $uri === '') {
+                continue;
+            }
+
+            $item = [];
+            $item['title'] = html_entity_decode($title, ENT_QUOTES | ENT_HTML5);
+            $item['uri'] = $uri;
+
+            if (!empty($article['publishedAt'])) {
+                $timestamp = strtotime($article['publishedAt']);
+                $item['timestamp'] = $timestamp !== false ? $timestamp : $article['publishedAt'];
+            }
+
+            $content = $this->buildItemContent($uri, $article['ogImageURL'] ?? '');
+            if ($content !== '') {
+                $item['content'] = $content;
+            }
+
+            if (!empty($article['ogImageURL'])) {
+                $item['enclosures'][] = $article['ogImageURL'];
+            }
+
+            $this->items[] = $item;
+        }
+    }
+
+    public static function extractArticleFeedFromHtml(string $html, string $path): array
+    {
+        $scriptId = '__LOCAL_REDUX_STATE_Newsroom_Article Feed Store_' . rawurlencode($path) . '__';
+        $pattern = '#<script type="application/json" id="' . preg_quote($scriptId, '#') . '">\s*(.*?)\s*</script>#s';
+
+        if (!preg_match($pattern, $html, $matches)) {
+            throw new \Exception('Unable to find article feed data');
+        }
+
+        $payload = rawurldecode(html_entity_decode(trim($matches[1]), ENT_QUOTES | ENT_HTML5));
+        $data = Json::decode($payload);
+        $articles = $data['relatedPages']['relatedPages'] ?? null;
+
+        if (!is_array($articles)) {
+            throw new \Exception('Unable to parse article feed data');
+        }
+
+        return $articles;
+    }
+
+    public static function normalizeUrl(string $url): string
+    {
+        if ($url === '') {
+            return '';
+        }
+
+        if (strpos($url, 'https://') === 0 || strpos($url, 'http://') === 0) {
+            return $url;
+        }
+
+        if (strpos($url, '//') === 0) {
+            return 'https:' . $url;
+        }
+
+        if (strpos($url, 'www.') === 0) {
+            return 'https://' . $url;
+        }
+
+        if (strpos($url, '/') === 0) {
+            return 'https://www.uber.com' . $url;
+        }
+
+        return 'https://www.uber.com/' . ltrim($url, '/');
+    }
+
+    private function buildItemContent(string $uri, string $imageUrl): string
+    {
+        $content = '';
+
+        if ($imageUrl !== '') {
+            $content .= '<p><img src="' . htmlspecialchars($imageUrl, ENT_QUOTES | ENT_HTML5) . '" /></p>';
+        }
+
+        $description = $this->fetchArticleDescription($uri);
+        if ($description !== '') {
+            $content .= '<p>' . htmlspecialchars($description, ENT_QUOTES | ENT_HTML5) . '</p>';
+        }
+
+        return $content;
+    }
+
+    private function fetchArticleDescription(string $uri): string
+    {
+        try {
+            $html = getSimpleHTMLDOMCached($uri, self::CACHE_TIMEOUT);
+        } catch (\Exception $e) {
+            return '';
+        }
+
+        $description = $html->find('meta[name=description], meta[property=og:description]', 0);
+        if ($description === null || !isset($description->content)) {
+            return '';
+        }
+
+        return trim(html_entity_decode($description->content, ENT_QUOTES | ENT_HTML5));
+    }
+}

--- a/bridges/UberEngineeringBridge.php
+++ b/bridges/UberEngineeringBridge.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 class UberEngineeringBridge extends BridgeAbstract
 {
     const NAME = 'Uber Engineering';
     const URI = 'https://www.uber.com/us/en/blog/engineering/';
     const DESCRIPTION = 'Returns posts from the Uber Engineering blog';
-    const MAINTAINER = 'zj';
+    const MAINTAINER = 'salty-flower';
     const PARAMETERS = [];
     const CACHE_TIMEOUT = 3600;
     const ARTICLE_FEED_PATH = '/us/en/blog/engineering/';
@@ -24,7 +26,7 @@ class UberEngineeringBridge extends BridgeAbstract
             }
 
             $item = [];
-            $item['title'] = html_entity_decode($title, ENT_QUOTES | ENT_HTML5);
+            $item['title'] = self::decode($title);
             $item['uri'] = $uri;
 
             if (!empty($article['publishedAt'])) {
@@ -54,7 +56,7 @@ class UberEngineeringBridge extends BridgeAbstract
             throw new \Exception('Unable to find article feed data');
         }
 
-        $payload = rawurldecode(html_entity_decode(trim($matches[1]), ENT_QUOTES | ENT_HTML5));
+        $payload = rawurldecode(self::decode($matches[1]));
         $data = Json::decode($payload);
         $articles = $data['relatedPages']['relatedPages'] ?? null;
 
@@ -119,6 +121,12 @@ class UberEngineeringBridge extends BridgeAbstract
             return '';
         }
 
-        return trim(html_entity_decode($description->content, ENT_QUOTES | ENT_HTML5));
+        return self::decode($description->content);
+    }
+
+    private static function decode(string $s): string
+    {
+        $s = trim($s);
+        return html_entity_decode($s, ENT_QUOTES | ENT_HTML5);
     }
 }

--- a/tests/UberEngineeringBridgeTest.php
+++ b/tests/UberEngineeringBridgeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class UberEngineeringBridgeTest extends TestCase
+{
+    public function testExtractArticleFeedFromHtml(): void
+    {
+        $payload = rawurlencode((string) json_encode([
+            'relatedPages' => [
+                'relatedPages' => [[
+                    'fullURL' => 'www.uber.com/us/en/blog/scaling-responsible-ai/',
+                    'ogImageURL' => 'https://tb-static.uber.com/prod/udam-assets/example.png',
+                    'publishedAt' => '2026-04-09T20:42:48.601Z',
+                    'title' => 'Under the Hood: Scaling Responsible AI at Uber',
+                ]],
+                'totalCount' => 1,
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        $html = sprintf(
+            '<html><body><script type="application/json" id="%s">%s</script></body></html>',
+            '__LOCAL_REDUX_STATE_Newsroom_Article Feed Store_%2Fus%2Fen%2Fblog%2Fengineering%2F__',
+            $payload
+        );
+
+        $actual = UberEngineeringBridge::extractArticleFeedFromHtml($html, '/us/en/blog/engineering/');
+
+        $this->assertCount(1, $actual);
+        $this->assertSame('Under the Hood: Scaling Responsible AI at Uber', $actual[0]['title']);
+        $this->assertSame(
+            'https://www.uber.com/us/en/blog/scaling-responsible-ai/',
+            UberEngineeringBridge::normalizeUrl($actual[0]['fullURL'])
+        );
+    }
+
+    public function testExtractArticleFeedFromHtmlThrowsWhenFeedScriptIsMissing(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unable to find article feed data');
+
+        UberEngineeringBridge::extractArticleFeedFromHtml('<html></html>', '/us/en/blog/engineering/');
+    }
+}


### PR DESCRIPTION
## Summary
- add `UberEngineeringBridge` for the localized Uber Engineering overview page
- extract metadata from the embedded `Article Feed Store` JSON and normalize URLs
- include article image/description and add a parser regression test

## Test Plan
- [x] nix shell nixpkgs#php83 nixpkgs#php83Packages.composer -c sh -lc "./vendor/bin/phpunit --filter UberEngineeringBridgeTest"
- [x] nix shell nixpkgs#php83 nixpkgs#php83Packages.composer -c sh -lc "./vendor/bin/phpunit tests/BridgeImplementationTest.php tests/UberEngineeringBridgeTest.php"
- [x] nix shell nixpkgs#php83 nixpkgs#php83Packages.composer -c sh -lc "./vendor/bin/phpcs --parallel=2 --standard=phpcs.xml --warning-severity=0 --extensions=php -p ./"
- [ ] full phpunit currently has unrelated pre-existing failures in `tests/Formats/FormatImplementationTest.php`
