### PR TITLE
[HeiseBridge] remove newlines/double image description

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -221,6 +221,13 @@ class HeiseBridge extends FeedExpander
                 }
             }
         }
+
+        // strip p tags inside of figcaption to avoid doubling it
+        foreach ($article->find('figcaption p') as $key => $elem) {
+            $elem->outertext = $elem->plaintext;
+            $reloadneeded = 1;
+        }
+
         if (isset($reloadneeded)) {
             $article = str_get_html($article->outertext);
         }


### PR DESCRIPTION
some images have annoying image descriptions with unwanted newlines (through \<p>) and output the author twice.

before: 
<img width="714" height="508" alt="Bildschirmfoto 2026-04-22 um 23 26 20" src="https://github.com/user-attachments/assets/35fb6a95-3a4c-47e9-9256-253a99d802d3" />
after:
<img width="781" height="370" alt="Bildschirmfoto 2026-04-22 um 23 27 03" src="https://github.com/user-attachments/assets/abc9d77b-382c-4087-a5b9-89546107d370" />

tested with this arcticle:
https://www.heise.de/tests/Windrose-Spassiger-Jack-Sparrow-Simulator-fuer-kleines-Geld-11263221.html