### PR TITLE
[HeiseBridge] Support Mastodon embeds

### DIFF
--- a/bridges/HeiseBridge.php
+++ b/bridges/HeiseBridge.php
@@ -225,6 +225,24 @@ class HeiseBridge extends FeedExpander
             $article = str_get_html($article->outertext);
         }
 
+        // fix mastodon embeds
+        foreach ($article->find('embetty-mastodon') as &$post) {
+            $url = $post->status;
+            $parsedUrl = parse_url($url);
+            $baseUrl = $parsedUrl['scheme'] . '://' . $parsedUrl['host'];
+            if (isset($parsedUrl['port'])) {
+                $baseUrl .= ':' . $pasedurl['port'];
+            }
+            $post->innertext = <<<EOD
+<blockquote class='mastodon-embed' data-embed-url='$url/embed'
+    style='background: #FCF8FF; border-radius: 8px; border: 1px solid #C9C4DA;
+    margin: 0; max-width: 540px; min-width: 270px; overflow: hidden; padding: 0;'>
+<a href='$url' target='_blank'>Embedded Mastodon post: $url</a>
+</blockquote>
+<script data-allowed-prefixes='$baseUrl' async src='$baseUrl/embed.js'></script>
+EOD;
+        }
+
         $categories = $article->find('.article-footer__topics ul.topics li.topics__item a-topic a');
         foreach ($categories as $category) {
             $item['categories'][] = trim($category->plaintext);


### PR DESCRIPTION
The html content is a somewhat stripped version of the embed code mastodon recommends.
I also tried a lot with iframes, but then the width and height are always fixed to stupid values.

Test pages:
    https://www.heise.de/news/Kritik-an-historischer-Internetsperre-Irans-Praesidialamt-verteidigt-Blockade-11272937.html
    https://www.heise.de/news/Trotz-Kritik-an-X-EU-Spitzen-weiterhin-nicht-bei-Mastodon-11140102.html

@Tone866 do you want to test?