### PR TITLE
[BandcampBridge] Fix JS challenge by setting User-Agent in apiGet()

### DIFF
--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -313,9 +313,14 @@ class BandcampBridge extends BridgeAbstract
     private function apiGet($endpoint, $query_data)
     {
         $url = self::URI . 'api/' . $endpoint . '?' . http_build_query($query_data);
-        // todo: 429 Too Many Requests happens a lot
-        $response = getContents($url);
+        $header = [
+            'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0',
+        ];
+        $response = getContents($url, $header);
         $data = json_decode($response);
+        if ($data === null) {
+            throwServerError('Bandcamp API returned an invalid response for: ' . $url);
+        }
         return $data;
     }
 

--- a/bridges/BandcampBridge.php
+++ b/bridges/BandcampBridge.php
@@ -63,7 +63,8 @@ class BandcampBridge extends BridgeAbstract
                 'name' => 'limit',
                 'type' => 'number',
                 'title' => 'Number of releases to return',
-                'defaultValue' => 5
+                'defaultValue' => 5,
+                'exampleValue' => 5
             ]
         ],
         'By album' => [


### PR DESCRIPTION
Bandcamp's mobile API returns a JavaScript challenge page when requests are made without a User-Agent header, causing json_decode() to return null and a subsequent count(null) TypeError.

Explicitly set a browser User-Agent in apiGet() to bypass this. Also add null check on the response to give a meaningful error instead of a TypeError if the API returns an unexpected response in the future.

Resolves #4978.