### PR TITLE
[YoutubeBridge] handle new lockupViewModel layout

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -165,6 +165,7 @@
 * [pitchoule](https://github.com/pitchoule)
 * [pmaziere](https://github.com/pmaziere)
 * [Pofilo](https://github.com/Pofilo)
+* [polybjorn](https://github.com/polybjorn)
 * [prysme01](https://github.com/prysme01)
 * [pubak42](https://github.com/pubak42)
 * [Qluxzz](https://github.com/Qluxzz)

--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -441,8 +441,14 @@ class YoutubeBridge extends BridgeAbstract
                 $wrapper = $item->videoRenderer;
             } elseif (isset($item->playlistVideoRenderer)) {
                 $wrapper = $item->playlistVideoRenderer;
-            } elseif (isset($item->richItemRenderer)) {
+            } elseif (isset($item->richItemRenderer->content->videoRenderer)) {
                 $wrapper = $item->richItemRenderer->content->videoRenderer;
+            } elseif (isset($item->richItemRenderer->content->lockupViewModel)) {
+                // Newer YouTube layout: richItemRenderer can wrap a lockupViewModel rather than a videoRenderer.
+                $wrapper = $this->wrapLockupViewModel($item->richItemRenderer->content->lockupViewModel);
+                if ($wrapper === null) {
+                    continue;
+                }
             } else {
                 continue;
             }
@@ -501,6 +507,33 @@ class YoutubeBridge extends BridgeAbstract
                 break;
             }
         }
+    }
+
+    private function wrapLockupViewModel($lockup)
+    {
+        $videoId = $lockup->contentId ?? null;
+        $title = $lockup->metadata->lockupMetadataViewModel->title->content ?? null;
+        if (!$videoId || !$title) {
+            return null;
+        }
+
+        $wrapper = new \stdClass();
+        $wrapper->videoId = $videoId;
+        $wrapper->title = (object) ['runs' => [(object) ['text' => $title]]];
+        $wrapper->thumbnailOverlays = [];
+
+        // Duration sits on a thumbnail badge such as "12:07".
+        foreach ($lockup->contentImage->thumbnailViewModel->overlays ?? [] as $overlay) {
+            foreach ($overlay->thumbnailBottomOverlayViewModel->badges ?? [] as $badge) {
+                $text = $badge->thumbnailBadgeViewModel->text ?? null;
+                if (is_string($text) && preg_match('/^\d{1,2}(:\d{2}){1,2}$/', $text)) {
+                    $wrapper->lengthText = (object) ['simpleText' => $text];
+                    break 2;
+                }
+            }
+        }
+
+        return $wrapper;
     }
 
     private function addItem($videoId, $title, $author, $description, $timestamp, $thumbnail = '')


### PR DESCRIPTION
Feeds with `duration_min` or `duration_max` set return zero entries: YouTube changed the channel /videos listing to wrap each item in `lockupViewModel` instead of `videoRenderer`, and the bridge no longer recognises the shape. Items fall through with no readable duration, all parse to zero seconds, and the duration filter drops every one.

This adds a branch for the new shape. A small `wrapLockupViewModel` helper picks out the video ID, title, and duration badge (e.g. `12:07`) and packages them in a stdClass that matches the existing fields the rest of the loop reads. Description and timestamp aren't in lockupViewModel; `fetchVideoDetails` continues to fill those in.

The existing `richItemRenderer` branch is also tightened to require an inner `videoRenderer` — without that, the new shape enters the branch and crashes on `null->lengthText`.