### PR TITLE
handleyoutube: fix youtube.com urls not matching

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -555,7 +555,7 @@ function handleYoutube(string $string)
     $useNocookie = Configuration::getConfig('youtube', 'nocookie');
 
     // sourced from https://gist.github.com/afeld/1254889?permalink_comment_id=3580082#gistcomment-3580082
-    $regex = '#(?:https?://|//)?(?:www\.|m\.|.+\.)?(?:youtu\.be/|youtube(?:-nocookie)\.com/(?:embed/|v/|shorts/|feeds/api/videos/|watch\?v=|watch\?.+&v=))([\w-]{11})#i';
+    $regex = '#(?:https?://|//)?(?:www\.|m\.|.+\.)?(?:youtu\.be/|youtube(?:-nocookie|)\.com/(?:embed/|v/|shorts/|feeds/api/videos/|watch\?v=|watch\?.+&v=))([\w-]{11})#i';
     if (preg_match($regex, $string, $matches) === 1) {
         $videoID = $matches[1];
     } elseif (preg_match('#[\w-]{11}#i', $string, $matches2) === 1) {


### PR DESCRIPTION
fixes #4968 

youtube.com is not matching with the current filter, only youtube-nocookie.com.

this patch fixes that.

old:
<img width="697" height="295" alt="Screenshot 2026-06-05 125424" src="https://github.com/user-attachments/assets/246dd4ca-bef2-4f03-9ca1-9a8c0e6add58" />

new:
<img width="694" height="313" alt="Screenshot 2026-06-05 125435" src="https://github.com/user-attachments/assets/2daef5a0-3e28-423d-9cb8-3fae238fc3e2" />
 