### PR TITLE
[GoComicsBridge] Fix class for a-element

### DIFF
--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -34,21 +34,55 @@ class GoComicsBridge extends BridgeAbstract
     {
         $link = $this->getURI();
         $header = [
-            'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36'
+            'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36'
         ];
-        $landingpage = getSimpleHTMLDOM($link, $header);
+        try {
+            $landingpage = getSimpleHTMLDOM($link, $header);
+        } catch (HttpException $e) {
+            if ($e->getCode() === 403) {
+                throw new \Exception(<<<'MSG'
+                    The server returned 403 Forbidden.  
+                    This is likely GoComics\' use of Bunny Shield blocking requests from this bridge.  Try reducing your feed update 
+                    frequency, running your own RSS-Bridge instance, or hosting an instance from a different IP/location.
+                    MSG
+                    , 403);
+            }
+            throw $e;
+        }
+
         $element = $landingpage->find('div[data-post-url]', 0);
+        $comicFound = false;
         if ($element) {
             $link = $element->getAttribute('data-post-url');
-        } else { // fallback for comics without data-post-url (assumes daily comic)
-            $nextcomiclink = $landingpage->find('a[class*="ComicNavigation_controls__button_previous__"]', 0)->href;
-            preg_match('/(\d{4}\/\d{2}\/\d{2})/', $nextcomiclink, $nclmatches);
-            if (!empty($nclmatches[1])) {
+            $comicFound = true;
+        } else {
+            $conversationNode = $landingpage->find('vf-conversations', 0);
+            $conversationId = $conversationNode ? $conversationNode->getAttribute('vf-container-id') : null;
+
+            if ($conversationId !== null) {
+                $containerDate = '/^' . preg_quote($this->getInput('comicname'), '/') . '-(\d{4})-(\d{2})-(\d{2})$/';
+                if (preg_match($containerDate, $conversationId, $matches)) {
+                    $year = $matches[1];
+                    $month = $matches[2];
+                    $day = $matches[3];
+                    $link = sprintf('%s/%s/%s/%s', $link, $year, $month, $day);
+                    $comicFound = true;
+                }
+            }
+        }
+
+        if (!$comicFound) { // fallback if both methods failed (assumes daily comic)
+            $prevbutton = $landingpage->find('a[class*="ComicNavigation-module-scss-module__"]', 0);
+
+            if (!$prevbutton || empty($prevbutton->href)) {
+                throw new \Exception('Could not find the previous comic URL. Please create a new GitHub issue.');
+            }
+            if (preg_match('/(\d{4}\/\d{2}\/\d{2})/', $prevbutton->href, $nclmatches)) {
                 $nextdate = new DateTime($nclmatches[1]);
                 $nextdate = $nextdate->modify('+1 day')->format('Y/m/d');
                 $link = $link . '/' . $nextdate;
             } else {
-                throw new \Exception('Could not find the first comic URL. Please create a new GitHub issue.');
+                throw new \Exception('Could not parse the previous comic URL. Please create a new GitHub issue.');
             }
         }
 

--- a/bridges/GoComicsBridge.php
+++ b/bridges/GoComicsBridge.php
@@ -41,7 +41,7 @@ class GoComicsBridge extends BridgeAbstract
         if ($element) {
             $link = $element->getAttribute('data-post-url');
         } else { // fallback for comics without data-post-url (assumes daily comic)
-            $nextcomiclink = $landingpage->find('a[class*="ComicNavigation_controls__button_previous__"]', 0)->href;
+            $nextcomiclink = $landingpage->find('a[class*="ComicNavigation-module-scss-module__"]', 0)->href;
             preg_match('/(\d{4}\/\d{2}\/\d{2})/', $nextcomiclink, $nclmatches);
             if (!empty($nclmatches[1])) {
                 $nextdate = new DateTime($nclmatches[1]);


### PR DESCRIPTION
Changing/fixing the class for the a-element find from 'ComicNavigation_controls__button_previous__' to 'ComicNavigation-module-scss-module__'. 
This might be the fix for issue: [4947](https://github.com/RSS-Bridge/rss-bridge/issues/4947)