### PR TITLE
[AlpinePackagesBridge] Fix/add different classes for edge packages.

### DIFF
--- a/bridges/AlpinePackagesBridge.php
+++ b/bridges/AlpinePackagesBridge.php
@@ -75,6 +75,15 @@ class AlpinePackagesBridge extends BridgeAbstract
             'bdate'
         ];
         $data = [];
+        // Multiple classes exist for the strong version element.
+        // The class can be 1 of 2 (later maybe more):
+        //  'hint--right hint--rounded text-success'
+        //  'hint--right hint--rounded text-grey'
+        $strongClasses = [
+             'hint--right hint--rounded text-success',
+             'hint--right hint--rounded text-grey'
+        ];
+        $strongClass = 0;
         // Get data from element which contains <a href=...>.
         foreach ($classes as $class) {
             $td = $this->getTdClassDom($element, $class);
@@ -89,7 +98,11 @@ class AlpinePackagesBridge extends BridgeAbstract
         }
         // Get version data in a <strong> element.
         $td = $this->getTdClassDom($element, 'version');
-        $strong = $td->find('strong[class=hint--right hint--rounded text-success]')[0];
+        // Loop to get non empty strong element
+        do {
+            $strong = $td->find('strong[class=' . $strongClasses[$strongClass] . ']')[0];
+            $strongClass++;
+        } while (!$strong && $strongClass < count($strongClasses));
         $data['version'] = trim($strong->plaintext);
         return $data;
     }

--- a/bridges/AlpinePackagesBridge.php
+++ b/bridges/AlpinePackagesBridge.php
@@ -76,12 +76,13 @@ class AlpinePackagesBridge extends BridgeAbstract
         ];
         $data = [];
         // Multiple classes exist for the strong version element.
-        // The class can be 1 of 2 (later maybe more):
-        //  'hint--right hint--rounded text-success'
-        //  'hint--right hint--rounded text-grey'
+        // Text classes found in: https://pkgs.alpinelinux.org/static/css/style.css
         $strongClasses = [
              'hint--right hint--rounded text-success',
-             'hint--right hint--rounded text-grey'
+             'hint--right hint--rounded text-danger',
+             'hint--right hint--rounded text-warning',
+             'hint--right hint--rounded text-secondary',
+             'hint--right hint--rounded text-grey',
         ];
         $strongClass = 0;
         // Get data from element which contains <a href=...>.


### PR DESCRIPTION
For edge packages found different classes being used. This caused no 'strong'-element to be found and triggering an error that 'trim()' was run with an empty string.

First found 'hint--right hint--rounded text-grey' and today found 'hint--right hint--rounded text-danger'.
Checked loaded CSS files for the site and found 2 more ('warning' and 'secondary').
Added a loop to check for the 5 classes.