### PR TITLE
[YoutubeBridge] Add option to skip members-only videos

### DIFF
--- a/bridges/YoutubeBridge.php
+++ b/bridges/YoutubeBridge.php
@@ -61,6 +61,11 @@ class YoutubeBridge extends BridgeAbstract
                 'type' => 'number',
                 'title' => 'Maximum duration for the video in minutes',
                 'exampleValue' => 10
+            ],
+            'skip_members_only' => [
+                'name' => 'Skip members-only videos',
+                'type' => 'checkbox',
+                'title' => 'Hide videos that require a channel membership to watch'
             ]
         ]
     ];
@@ -515,6 +520,17 @@ class YoutubeBridge extends BridgeAbstract
         $title = $lockup->metadata->lockupMetadataViewModel->title->content ?? null;
         if (!$videoId || !$title) {
             return null;
+        }
+
+        if ($this->getInput('skip_members_only')) {
+            $rows = $lockup->metadata->lockupMetadataViewModel->metadata->contentMetadataViewModel->metadataRows ?? [];
+            foreach ($rows as $row) {
+                foreach ($row->badges ?? [] as $badge) {
+                    if (($badge->badgeViewModel->badgeStyle ?? null) === 'BADGE_MEMBERS_ONLY') {
+                        return null;
+                    }
+                }
+            }
         }
 
         $wrapper = new \stdClass();


### PR DESCRIPTION
Members-only videos appear in a channel's JSON listing but can't be played without a paid membership, so they're noise in a feed reader. This adds an opt-in `skip_members_only` checkbox, default off, that drops them.

The filter can't live in FilterBridge: membership status isn't in the title or description, only in a `BADGE_MEMBERS_ONLY` badge in YouTube's raw JSON. Members-only items use the lockupViewModel layout (parsed since #4982), so `wrapLockupViewModel` returns null for any item carrying that badge.

Only the lockupViewModel shape carries the badge, so this applies to channel/user/custom listings on the JSON path (used when `duration_min`/`duration_max` is set). The Atom path already filters members-only server-side and ignores the parameter.

## Test plan
Ran on 2026-06-29 against LMG (channel id `UCXuqSBlHAE6Xw-yeJA0Tunw`) on the JSON path:

- Without the flag: 30 items.
- With `&skip_members_only=on`: 23 items, the 7 members-only videos dropped, nothing else changed.

The 7 dropped ids match the `BADGE_MEMBERS_ONLY` markers in that channel's `ytInitialData` exactly. `php -l` passes.

The "By playlist Id" failure in the artifact table is pre-existing and fails identically on current; YouTube changed the playlist JSON shape. #5026 addresses it.
