### PR TITLE
[SQLiteCache] Fix check if directory is writable

### DIFF
--- a/lib/CacheFactory.php
+++ b/lib/CacheFactory.php
@@ -59,9 +59,6 @@ class CacheFactory
                 if (!extension_loaded('sqlite3')) {
                     throw new \Exception('"sqlite3" extension not loaded. Please check "php.ini"');
                 }
-                if (!is_writable(PATH_CACHE)) {
-                    throw new \Exception('The cache folder is not writable');
-                }
                 $file = Configuration::getConfig('SQLiteCache', 'file');
                 if (!$file) {
                     throw new \Exception(sprintf('Configuration for %s missing.', 'SQLiteCache'));
@@ -70,6 +67,9 @@ class CacheFactory
                     $file = PATH_CACHE . $file;
                 } elseif (!is_dir(dirname($file))) {
                     throw new \Exception(sprintf('Invalid configuration for %s', 'SQLiteCache'));
+                }
+                if (!is_writable(dirname($file))) {
+                    throw new \Exception('The directory of the SQLiteCache file is not writable');
                 }
                 return new SQLiteCache($this->logger, [
                     'file'          => $file,

--- a/lib/CacheFactory.php
+++ b/lib/CacheFactory.php
@@ -68,8 +68,12 @@ class CacheFactory
                 } elseif (!is_dir(dirname($file))) {
                     throw new \Exception(sprintf('Invalid configuration for %s', 'SQLiteCache'));
                 }
-                if (!is_writable(dirname($file))) {
-                    throw new \Exception('The directory of the SQLiteCache file is not writable');
+                $dir = dirname($file);
+                if (!is_writable($dir)) {
+                    throw new \Exception(sprintf('The directory for the SQLiteCache file is not writable: %s', $dir));
+                }
+                if (file_exists($file) && !is_writable($file)) {
+                    throw new \Exception(sprintf('The SQLiteCache file is not writable: %s', $file));
                 }
                 return new SQLiteCache($this->logger, [
                     'file'          => $file,


### PR DESCRIPTION
As reported in https://github.com/NixOS/nixpkgs/issues/467012, when trying to use the SQLite cache on a read-only installation, rss-bridge always errors out, because the directory it is in is not writable. This is checked even if the configured file path is an absolute path pointing to a completely different, writable folder.

This commit fixes the check to check the actual target directory.