### PR TITLE
[AppleAppStoreBridge] replace regex with string search to extract serialized server data

### DIFF
--- a/bridges/AppleAppStoreBridge.php
+++ b/bridges/AppleAppStoreBridge.php
@@ -109,12 +109,19 @@ class AppleAppStoreBridge extends BridgeAbstract
         $this->debugLog(sprintf('Fetching HTML page for serialized data extraction: %s', $url));
         $content = getContents($url, $this->getHtmlRequestHeaders());
 
-        $matches = [];
-        if (!preg_match('#<script[^>]*id="serialized-server-data"[^>]*>(.*?)</script>#s', $content, $matches)) {
+        $startTag = '<script type="application/json" id="serialized-server-data">';
+        $startPos = strpos($content, $startTag);
+        if ($startPos === false) {
             throw new \Exception('Failed to locate serialized server data in HTML page');
         }
 
-        $serializedServerData = html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5);
+        $jsonStart = $startPos + strlen($startTag);
+        $endPos = strpos($content, '</script>', $jsonStart);
+        if ($endPos === false) {
+            throw new \Exception('Failed to locate end of serialized server data');
+        }
+
+        $serializedServerData = html_entity_decode(substr($content, $jsonStart, $endPos - $jsonStart), ENT_QUOTES | ENT_HTML5);
 
         try {
             $json = Json::decode($serializedServerData);


### PR DESCRIPTION
The `preg_match` regex used to extract the `serialized-server-data` JSON block from Apple's HTML page fails when the JSON payload exceeds ~1MB, hitting PHP's default PCRE backtrack limit (1,000,000). This causes a "Failed to locate serialized server data in HTML page" error on every request.

Replaced the regex-based extraction with `strpos/substr` string operations, which have no backtrack limit and handle arbitrarily large payloads reliably.