### PR TITLE
fix(http): don't let null config values override curl request defaults

### DIFF
--- a/lib/http.php
+++ b/lib/http.php
@@ -90,12 +90,22 @@ final class CurlHttpClient implements HttpClient
             'TE' => 'trailers',
         ];
 
+        // array_merge() always takes the second array's value for a shared key, even if
+        // that value is null - so explicitly-null entries in the incoming $config (e.g.
+        // 'useragent' => Configuration::getConfig(...) resolving to null because it isn't
+        // set in config.ini.php, the default out-of-the-box state) would otherwise silently
+        // clobber the defaults set immediately below, leaving requests with NO User-Agent
+        // header at all despite the code's clear intent to send a realistic one. Verified
+        // this caused every request to 6abc.com to be blocked as a bot with zero UA, even
+        // though nothing here was ever configured to suppress it.
+        $config = array_filter($config, fn ($value) => $value !== null);
+
         if (curl_version()['ssl_version'] == 'BoringSSL') {
             $config = array_merge($defaultConfig, $config);
         } else {
             $defaultConfig['useragent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0';
             curl_setopt($ch, CURLOPT_HEADER, false);
-            $headers = array_merge($defaultHeaders, $config['headers']);
+            $headers = array_merge($defaultHeaders, $config['headers'] ?? []);
             $config = array_merge($defaultConfig, $config);
             $config['headers'] = $headers;
         }


### PR DESCRIPTION
## Summary

On a non-BoringSSL curl build (i.e. most non-Docker installs), with the default/unconfigured `[http] useragent` setting, every outgoing HTTP request rss-bridge makes goes out with **no `User-Agent` header at all** — despite `CurlHttpClient::request()` clearly intending to send a realistic browser-like default (there's even a comment crediting `curl-impersonate`'s captured Firefox 102 request).

Some sites' WAFs block requests with an empty `User-Agent` outright, which can present as a confusing, seemingly site-specific 403 that has nothing to do with anything the user configured.

## Root cause

In `lib/contents.php`, `getContents()` always builds its config with:

```php
'useragent' => Configuration::getConfig('http', 'useragent'),
```

This resolves to `null` unless `config.ini.php` explicitly sets `[http] useragent` — which it doesn't by default (the setting is commented out in `config.default.ini.php`).

In `lib/http.php`, `CurlHttpClient::request()`, on a non-BoringSSL build:

```php
$defaultConfig['useragent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0';
...
$config = array_merge($defaultConfig, $config);
```

`array_merge()` always takes the *second* array's value for a shared key, even when it's `null`. So the incoming `null` silently overwrites the Firefox default that was just set two lines above. The following check:

```php
if ($config['useragent']) {
    curl_setopt($ch, CURLOPT_USERAGENT, $config['useragent']);
}
```

then correctly sees `null` (falsy) and never calls `CURLOPT_USERAGENT` — so no `User-Agent` header is sent at all.

## Fix

Strip `null` values out of the incoming `$config` before merging, so only explicitly-configured values override the defaults:

```php
$config = array_filter($config, fn ($value) => $value !== null);
```

This applies uniformly to every config key (`useragent`, `proxy`, `if_not_modified_since`, `max_filesize`, etc.), not just `useragent` — any of them could theoretically hit the same silent-override issue if a caller passes an explicit `null`.

## How this was found

While testing a URL-discovery tool built on top of rss-bridge, a specific site (`6abc.com`) consistently returned 403 through rss-bridge while working fine via a plain `curl` command with the same headers, run on the same machine, same user. Isolating the difference eventually came down to comparing `tcpdump`-equivalent request contents — a raw PHP script replicating `CurlHttpClient`'s exact `curl_setopt()` calls succeeded, while the actual `getContents()` code path (identical intended behavior) failed. Tracing that discrepancy led to this `array_merge()` precedence bug. Confirmed directly that `6abc.com` returns 403 for a request with an empty `User-Agent`, and 200 for the exact same request with any real one.

## Test plan

- [x] Verified the fix resolves the 403 against a real site (`6abc.com`) that was blocking all traffic from an affected install
- [x] Regression-tested against ~8 other sites already working before this fix (Hacker News, lobste.rs, lwn.net, danluu.com, xkcd.com, nbcphiladelphia.com, GitHub, a HowToGeek FeedBurner feed via `FilterBridge`) — all unaffected
- [ ] Would appreciate a maintainer's sanity check on whether any config key is ever *intentionally* passed as `null` to override a default to "off" (I don't see one in the current codebase, but wanted to flag the assumption)