### PR TITLE
fix(http): missing user agent

### DIFF
--- a/lib/http.php
+++ b/lib/http.php
@@ -64,6 +64,9 @@ final class CurlHttpClient implements HttpClient
 {
     public function request(string $url, array $config = []): Response
     {
+        // Remove non-null values
+        $config = array_filter($config, fn ($value) => $value !== null);
+
         $ch = curl_init($url);
 
         $defaultConfig = [


### PR DESCRIPTION
This fixes a bug with missing http user agent on non-docker install.


fix #5029