### PR TITLE
docs: add Caddy installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,28 @@ composer create-project -v --no-dev --no-scripts rss-bridge/rss-bridge
 
 ### How to install with Caddy
 
-TODO. See https://github.com/RSS-Bridge/rss-bridge/issues/3785
+Follow the Debian installation steps above, but install and configure Caddy instead of nginx.
+
+Use the same PHP-FPM pool configuration shown above, then create the following Caddy configuration:
+
+```caddyfile
+# /etc/caddy/Caddyfile
+
+example.com {
+    root * /var/www/rss-bridge
+
+    php_fastcgi unix//run/php/rss-bridge.sock
+
+    file_server
+}
+```
+
+Validate the configuration, then restart both services:
+
+```bash
+php-fpm8.2 -t && systemctl restart php8.2-fpm
+caddy validate --config /etc/caddy/Caddyfile && systemctl restart caddy
+```
 
 ### Install from Docker Hub:
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,17 @@ Use the same PHP-FPM pool configuration shown above, then create the following C
 example.com {
     root * /var/www/rss-bridge
 
-    php_fastcgi unix//run/php/rss-bridge.sock
+    handle /static/* {
+        file_server
+    }
 
-    file_server
+    handle / {
+        php_fastcgi unix//run/php/rss-bridge.sock
+    }
+
+    handle {
+        respond 404
+    }
 }
 ```
 


### PR DESCRIPTION
### What

This PR adds Caddy installation instructions to the `README.md`, addressing the documentation request in #3785.

### Why

The `README.md` did not include proper instructions for installing and configuring RSS-Bridge with Caddy.

### How

- Added a minimal Caddy configuration to the installation section.
- Reused the existing Debian installation and PHP-FPM pool configuration.
- Tested the configuration before documenting it.

### Test

- Verified that RSS-Bridge runs correctly with the documented Caddy configuration.
- `./vendor/bin/phpunit`
- `./vendor/bin/phpcs --standard=phpcs.xml --warning-severity=0 --extensions=php -p ./`

Closes #3785