### PR TITLE
CI: Fix PR number retrieval on a488af45

### DIFF
--- a/.github/workflows/prhtmlupload.yml
+++ b/.github/workflows/prhtmlupload.yml
@@ -9,9 +9,41 @@ permissions:
   actions: read
 
 jobs:
+  # Github is stupid and doesn't provide the PR number in workflow_run contexts from forked repositories
+  # Workaround from https://github.com/orgs/community/discussions/25220#discussioncomment-11316244
+  get-pr-number:
+    name: Get PR number
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      pr-number: ${{ steps.pr-context.outputs.number }}
+    steps:
+      - name: 'Get PR context'
+        id: pr-context
+        env:
+          # Token required for GH CLI:
+          GH_TOKEN: ${{ github.token }}
+          # Best practice for scripts is to reference via ENV at runtime. Avoid using the expression syntax in the script content directly:
+          PR_TARGET_REPO: ${{ github.repository }}
+          # If the PR is from a fork, prefix it with `<owner-login>:`, otherwise only the PR branch name is relevant:
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+        # Query the PR number by repo + branch, then assign to step output:
+        run: |
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+             --json 'number' --jq '"number=\(.number)"' \
+             >> "${GITHUB_OUTPUT}"
+
   comment-pr:
     name: Create or update PR comment
     runs-on: ubuntu-slim
+    needs: get-pr-number
     permissions:
       pull-requests: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -30,7 +62,7 @@ jobs:
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ needs.get-pr-number.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
           body-includes: Pull request artifacts
       - name: Create or update comment
@@ -38,13 +70,14 @@ jobs:
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ needs.get-pr-number.outputs.pr-number }}
           body-file: comment.md
           edit-mode: replace
 
   upload-test-results:
     name: Upload to GitHub Pages repository
     runs-on: ubuntu-slim
+    needs: get-pr-number
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v5
@@ -64,7 +97,7 @@ jobs:
           github-token: ${{ github.token }}
       - name: Move test results
         run: |
-          DIRECTORY="$GITHUB_WORKSPACE/prs/${{ github.event.workflow_run.pull_requests[0].number || '-1' }}"
+          DIRECTORY="$GITHUB_WORKSPACE/prs/${{ needs.get-pr-number.outputs.pr-number }}"
           rm -rf $DIRECTORY
           mkdir -p $DIRECTORY
           cd $DIRECTORY
@@ -72,7 +105,7 @@ jobs:
           mv -f $GITHUB_WORKSPACE/*.html .
       - name: Commit and push test results
         run: |
-          export COMMIT_MESSAGE="Test results for PR ${{ github.event.workflow_run.pull_requests[0].number || '-1' }}"
+          export COMMIT_MESSAGE="Test results for PR ${{ needs.get-pr-number.outputs.pr-number }}"
           git add .
           git commit -m "$COMMIT_MESSAGE" || exit 0
           git push


### PR DESCRIPTION
Commit a488af45 split the PR HTML generation and upload into two workflows. Unfortunately, the PR number is only accessible in the workflow_run workflow if it is from a non-forked repository [1]. There are only workarounds and the safest one is copied verbatim from [1].

[1] https://github.com/orgs/community/discussions/25220