### PR TITLE
CI: Avoid persisting git credentials

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
         php-versions: ['7.4']
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
@@ -30,6 +32,8 @@ jobs:
         php-versions: ['7.4']
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
@@ -41,6 +45,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - run: |
           if find -name "*.php" -executable -type f -print -exec false {} +
           then

--- a/.github/workflows/prhtmlgenerator.yml
+++ b/.github/workflows/prhtmlgenerator.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: pr
+          persist-credentials: false
       - name: Build docker image - PR
         if: steps.configuration.outputs.number_bridges > 0
         run: docker build -t rss-bridge-pr pr/
@@ -42,6 +43,7 @@ jobs:
           ref: ${{github.event.pull_request.base.ref}}
           repository: ${{github.event.pull_request.base.repo.full_name}}
           path: current
+          persist-credentials: false
       - name: Build docker image - Current
         if: steps.configuration.outputs.number_bridges > 0
         run: docker build -t rss-bridge-current current/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}


### PR DESCRIPTION
Following zizmor recommendations. The prhtmlupload workflow needs the credentials to push git commits at the end.