### PR TITLE
Fix Wikipedia links

### DIFF
--- a/bridges/WikipediaBridge.php
+++ b/bridges/WikipediaBridge.php
@@ -163,7 +163,7 @@ class WikipediaBridge extends BridgeAbstract
         }
 
         $item = [];
-        $item['uri'] = $this->getURI() . $target->href;
+        $item['uri'] = urljoin($this->getURI(), $target->href);
         $item['title'] = $target->title;
 
         if (!$fullArticle) {
@@ -184,7 +184,7 @@ class WikipediaBridge extends BridgeAbstract
             $item = [];
 
             // We can only use the first anchor, there is no way of finding the 'correct' one if there are multiple
-            $item['uri'] = $this->getURI() . $entry->find('a', 0)->href;
+            $item['uri'] = urljoin($this->getURI(), $entry->find('a', 0)->href);
             $item['title'] = strip_tags($entry->innertext);
 
             if (!$fullArticle) {


### PR DESCRIPTION
Presumably the website changed. I know they used to work properly.

The links were turned into this kind of thing:
```
https://fr.wikipedia.orghttps//fr.wikipedia.org/wiki/Triangle_(m%C3%A9tro_de_Rennes)
https://en.wikipedia.orghttps//en.wikipedia.org/wiki/Figure_skating_at_the_2002_Winter_Olympics_%E2%80%93_Pair_skating
```