### PR TITLE
[BlueskyBridge] fix a TypeError on null for starter pack author with no display name

### DIFF
--- a/bridges/BlueskyBridge.php
+++ b/bridges/BlueskyBridge.php
@@ -677,7 +677,7 @@ END;
         $starterpackRecord = $record['record'];
         $starterpackName = e($starterpackRecord['name']);
         $starterpackDescription = e($starterpackRecord['description']);
-        $creatorDisplayName = e($record['creator']['displayName']);
+        $creatorDisplayName = e($record['creator']['displayName'] ?? '');
         $creatorHandle = e($record['creator']['handle']);
         preg_match('/\/([^\/]+)$/', $starterpackRecord['list'], $matches);
         $uri = e('https://bsky.app/starter-pack/' . $record['creator']['did'] . '/' . $matches[1]);


### PR DESCRIPTION
Author of a starter pack may have no display name like falalala50 for https://bsky.app/starter-pack/falalala50.bsky.social/3mtwc5lj26427

This PR just adds a null coalescing `?? ''` on the concern line.

``` php
Details
Type: TypeError
Code: 0
Message: e(): Argument #1 ($s) must be of type string, null given, called in bridges/BlueskyBridge.php on line 680
File: lib/html.php
Line: 63
Trace
#0 index.php(73): RssBridge->main()
#1 lib/RssBridge.php(39): RssBridge->{closure:RssBridge::main():37}()
#2 lib/RssBridge.php(37): BasicAuthMiddleware->__invoke()
#3 middlewares/BasicAuthMiddleware.php(13): RssBridge->{closure:RssBridge::main():37}()
#4 lib/RssBridge.php(37): CacheMiddleware->__invoke()
#5 middlewares/CacheMiddleware.php(44): RssBridge->{closure:RssBridge::main():37}()
#6 lib/RssBridge.php(37): ExceptionMiddleware->__invoke()
#7 middlewares/ExceptionMiddleware.php(17): RssBridge->{closure:RssBridge::main():37}()
#8 lib/RssBridge.php(37): SecurityMiddleware->__invoke()
#9 middlewares/SecurityMiddleware.php(19): RssBridge->{closure:RssBridge::main():37}()
#10 lib/RssBridge.php(37): MaintenanceMiddleware->__invoke()
#11 middlewares/MaintenanceMiddleware.php(10): RssBridge->{closure:RssBridge::main():37}()
#12 lib/RssBridge.php(37): TokenAuthenticationMiddleware->__invoke()
#13 middlewares/TokenAuthenticationMiddleware.php(31): RssBridge->{closure:RssBridge::main():33}()
#14 lib/RssBridge.php(34): DisplayAction->__invoke()
#15 actions/DisplayAction.php(54): DisplayAction->createResponse()
#16 actions/DisplayAction.php(89): BlueskyBridge->collectData()
#17 bridges/BlueskyBridge.php(423): BlueskyBridge->getStarterPackDescription()
#18 bridges/BlueskyBridge.php(680): e()
#19 lib/html.php(63)
```